### PR TITLE
Translation fix to 'Studied 1 card in...'

### DIFF
--- a/anki/stats.py
+++ b/anki/stats.py
@@ -153,7 +153,7 @@ from revlog where id > ? """+lim, (self.col.sched.dayCutoff-86400)*1000)
         # studied
         def bold(s):
             return "<b>"+unicode(s)+"</b>"
-        msgp1 = ngettext("%d card", "%d cards", cards) % cards
+        msgp1 = ngettext("<!--studied-->%d card", "<!--studied-->%d cards", cards) % cards
         b += _("Studied %(a)s in %(b)s today.") % dict(
             a=bold(msgp1), b=bold(fmtTimeSpan(thetime, unit=1)))
         # again/pass count

--- a/aqt/deckbrowser.py
+++ b/aqt/deckbrowser.py
@@ -152,7 +152,7 @@ select count(), sum(time)/1000 from revlog
 where id > ?""", (self.mw.col.sched.dayCutoff-86400)*1000)
         cards = cards or 0
         thetime = thetime or 0
-        msgp1 = ngettext("%d card", "%d cards", cards) % cards
+        msgp1 = ngettext("<!--studied-->%d card", "<!--studied-->%d cards", cards) % cards
         buf = _("Studied %(a)s in %(b)s today.") % dict(a=msgp1,
                                                         b=fmtTimeSpan(thetime, unit=1))
         return buf


### PR DESCRIPTION
I made a fix to Python sources to allow translators to properly translate the message 'Studied 1 card in ...'. In many languages '1 card' in this sentence will be in a different grammar case than nominative, so we shouldn't use the normal translation of '1 card'/'n cards'.
