### PR TITLE
Add id to the text input field when editing the template.

### DIFF
--- a/aqt/clayout.py
+++ b/aqt/clayout.py
@@ -227,7 +227,7 @@ Please create a new card type first."""))
 
     def maybeTextInput(self, txt, type='q'):
         if type == 'q':
-            repl = "<center><input type=text value=''></center>"
+            repl = "<input id='typeans' type=text value=''>"
         else:
             repl = _("(typing comparison appears here)")
         repl = "<center>%s</center>" % repl


### PR DESCRIPTION
Hi.
I use a non-white background and another background color for emphasis, for example for the text input field. I had noticed that nonetheless when you edited the card layout, that text input field was shown with a white background.

So i added the missing `id` attribute. Like this, the effect of styling to it can be seen in the layout editor.

I also removed what looks like an extra '<center></center>'. That is added three lines later.
