### PR TITLE
Fix the unused media test

### DIFF
--- a/anki/media.py
+++ b/anki/media.py
@@ -155,7 +155,7 @@ If the same name exists, compare checksums."""
         # generate card q/a and look through all references
         normrefs = {}
         def norm(s):
-            if isinstance(s, unicode):
+            if isinstance(s, unicode) and isMac:
                 return unicodedata.normalize('NFD', s)
             return s
         for f in self.allMedia():


### PR DESCRIPTION
Hi.
This is not a fix for the [issue #500](https://anki.lighthouseapp.com/projects/100923/tickets/500-anki-confused-about-some-file-names). Rather it should just reveal the problem.

As mentioned in the lighthouse thread, [only the Mac file system](http://m-a-tech.blogspot.de/2012/11/unicode-equivalence-may-not-be-handled.html) [stores file names](http://en.wikipedia.org/wiki/Filename#Unicode_interoperability) NFD-normalized. So do that normalization only there when looking for files there.
