### PR TITLE
Add hook for custom search commands.

### DIFF
--- a/anki/find.py
+++ b/anki/find.py
@@ -27,6 +27,7 @@ class Finder(object):
         self.search['prop'] = self._findProp
         self.search['rated'] = self._findRated
         self.search['tag'] = self._findTag
+        self._loadSearchHookPlugins()
 
 
     def _loadSearchHookPlugins(self):
@@ -125,7 +126,6 @@ select distinct(n.id) from cards c, notes n where c.nid=n.id and """+preds
     ######################################################################
 
     def _where(self, tokens):
-        self._loadSearchHookPlugins()
         # state and query
         s = dict(isnot=False, isor=False, join=False, q="", bad=False)
         args = []


### PR DESCRIPTION
Created a hook for add-ons to add custom search commands to the browser. An add-on creates a new command (e.g. kanji-grade) with the following code:

``` python
def onSearch(cmds):
     cmds['kanji-grade'] = findKanjiByGrade

def findKanjiByGrade((val, args):
     <write code here filter results>

addHook("search", onSearch)
```
