### PR TITLE
Some problems with waves files with mp3 codec

### DIFF
--- a/anki/sound.py
+++ b/anki/sound.py
@@ -69,7 +69,7 @@ if isWin:
     os.environ['PATH'] += ";" + dir + "\\..\\win\\top" # for testing
 else:
     mplayerCmd = ["mplayer"]
-mplayerCmd += ["-really-quiet", "-noautosub"]
+mplayerCmd += ["-really-quiet", "-noautosub", "-ac", "mp3"]
 
 # Mplayer in slave mode
 ##########################################################################


### PR DESCRIPTION
File: http://www.speedyshare.com/5Xptq/PerfectP-100.wav

I can listen this file in any player, but not in anki. Reads file but, not playing.

> PerfectP(100).wav
> Codec: MPEG 1 Audio, Layer 3 (MP3)
> Channels: Mono
> Sample rate: 44100 Hz
> Bitrate: 63 kbps

soxi:

```
soxi PerfectP\ \(100\).wav
soxi FAIL formats: can't open input file `PerfectP (100).wav': WAV file encoding `MP3' is not supported
```

mplayer:

```
mplayer -ac mp3 PerfectP\ \(100\).wav 
MPlayer svn r34540 (Ubuntu), built with gcc-4.6 (C) 2000-2012 MPlayer Team
mplayer: could not connect to socket
mplayer: No such file or directory
Failed to open LIRC support. You will not be able to use your remote control.

Playing mp3.
File not found: 'mp3'
Failed to open mp3.

Playing PerfectP (100).wav.
libavformat version 53.21.0 (external)
Mismatching header version 53.19.0
Audio only file format detected.
Load subtitles in ./
==========================================================================
Forced audio codec: mp3
Opening audio decoder: [mp3lib] MPEG layer-2, layer-3
AUDIO: 44100 Hz, 2 ch, s16le, 64.0 kbit/4.54% (ratio: 8000->176400)
Selected audio codec: [mp3] afm: mp3lib (mp3lib MPEG layer-2, layer-3)
==========================================================================
AO: [pulse] 44100Hz 2ch s16le (2 bytes per sample)
Video: no video
Starting playback...
A:   0.9 (00.8) of 1.0 (01.0)  0.2% 

Exiting... (End of file)
```
