### PR TITLE
I think I've found a typo.

### DIFF
--- a/aqt/sync.py
+++ b/aqt/sync.py
@@ -208,7 +208,7 @@ If you choose upload, Anki will upload your collection to AnkiWeb, and \
 any changes you have made on AnkiWeb or your other devices since the \
 last sync to this device will be lost.
 
-After all devices are in sync, future reviews and added cards can be merged
+After all devices are in sync, future reviews and added cards can be merged \
 automatically."""),
                 [_("Upload to AnkiWeb"),
                  _("Download from AnkiWeb"),


### PR DESCRIPTION
The longer full sync explanation was missing a backslash.
The "automatically" appeared on a line by itself.
