### PR TITLE
fix field outline overlaps with other fields

### DIFF
--- a/aqt/editor.py
+++ b/aqt/editor.py
@@ -31,7 +31,7 @@ _html = """
 }
 /* prevent floated images from being displayed outside field */
 .field:after {
-    content: ".";
+    content: "";
     display: block;
     height: 0;
     clear: both;


### PR DESCRIPTION
![fieldoutline](https://f.cloud.github.com/assets/194658/213608/8d52e4f0-8397-11e2-8b15-b80422b46b34.png)

This dot was causing my field outlines to go a bit whacky, see screenshot. I removed it. Tested adding float property to images, they still stayed within the field (but wouldn't stay when removing the :after entirely). So it should still work.

Adding the float property however caused an image only field to be recognized as duplicate. Probably has to do with Anki ignoring tags under certain conditions? Didn't track that one down...
