### PR TITLE
Filter the question and answer text before showing it.

### DIFF
--- a/aqt/reviewer.py
+++ b/aqt/reviewer.py
@@ -184,11 +184,11 @@ function _typeAnsPress() {
             q = _("""\
 The front of this card is empty. Please run Tools>Maintenance>Empty Cards.""")
         else:
-            q = c.q()
+            q = runFilter("filterQuestionText", c.q(), c)
         if self._autoplay(c):
             playFromText(q)
         # render & update bottom
-        q = runFilter("filterQuestionText", self._mungeQA(q), c)
+        q = self._mungeQA(q)
         klass = "card card%d" % (c.ord+1)
         self.web.eval("_updateQA(%s, false, '%s');" % (json.dumps(q), klass))
         self._toggleStar()
@@ -221,12 +221,12 @@ The front of this card is empty. Please run Tools>Maintenance>Empty Cards.""")
             return
         self.state = "answer"
         c = self.card
-        a = c.a()
+        a = runFilter("filterAnswerText", c.a(), c)
         # play audio?
         if self._autoplay(c):
             playFromText(a)
         # render and update bottom
-        a = runFilter("filterAnswerText", self._mungeQA(a), c)
+        a = self._mungeQA(a)
         self.web.eval("_updateQA(%s, true);" % json.dumps(a))
         self._showEaseButtons()
         # user hook


### PR DESCRIPTION
Filter the question and answer text before showing it.

This to me seems like the right spot to modify the question or answer text through an add-on. I pass along the card (`c`) so the add-on can get data about it. For example to print statistics right on the card. Or re-style it based on, say how well it was known in the past. 
