### PR TITLE
Use filter for the corrected typed text.

### DIFF
--- a/aqt/reviewer.py
+++ b/aqt/reviewer.py
@@ -7,7 +7,7 @@ import unicodedata as ucd
 import HTMLParser
 from aqt.qt import *
 from anki.utils import  stripHTML, isMac, json
-from anki.hooks import addHook, runHook
+from anki.hooks import addHook, runHook, runFilter
 from anki.sound import playFromText, clearAudioQueue, play
 from aqt.utils import mungeQA, getBase, openLink, tooltip
 from aqt.sound import getAudio
@@ -32,6 +32,7 @@ class Reviewer(object):
         self.delShortcut.setAutoRepeat(False)
         self.mw.connect(self.delShortcut, SIGNAL("activated()"), self.onDelete)
         addHook("leech", self.onLeech)
+        addHook("filterTypedAnswer", self.correct)
 
     def show(self):
         self.mw.col.reset()
@@ -387,7 +388,7 @@ Please run Tools>Maintenance>Empty Cards""")
         cor = parser.unescape(cor)
         given = self.typedAnswer
         # compare with typed answer
-        res = self.correct(cor, given)
+        res = runFilter("filterTypedAnswer", u'', cor, given, self.card)
         if cor != given:
             # Wrap the extra text in an id-ed span.
             res += u"<span id=rightanswer><br> {0} <br> {1} </span>".format(
@@ -446,10 +447,13 @@ Please run Tools>Maintenance>Empty Cards""")
             return self.ok(head(correct)) + self.bad(tail(correct) + wrong)
         return self.ok(correct) + self.bad(wrong)
 
-    def correct(self, a, b):
+    def correct(self, ret, a, b, crd):
         "Diff-corrects the typed-in answer."
         if b == "":
-            return "";
+            return ret
+        if ret:
+            # Someone else has already done some correcting.
+            return ret
         self.calculateOkBadStyle()
         ret = ""
         lastEqual = ""


### PR DESCRIPTION
Add filter so add-ons can cleanly modify the red/green corrected version of a typed answer.

I have already written two add-ons that both monkey-patch this `typeAnsAnswerFilter()` function where the `correct()` is called. Like this these add-ons would be much cleaner.

Here, too, the card is passed along so the add-ons can get an idea what is going on. (My add-ons only do their own correcting when the field had the right name.)
