### PR TITLE
Fix the return value of aqt.main.unloadCollection() 

### DIFF
--- a/aqt/main.py
+++ b/aqt/main.py
@@ -258,7 +258,13 @@ how to restore from a backup.""")
         self.moveToState("deckBrowser")
 
     def unloadCollection(self):
-        "True if unload successful."
+        """
+        Unload the collection.
+
+        This unloads a collection if ther is one and returns True if
+        there is no collection after the call. (Because the unload
+        worked or because there was no collection to start with.)
+        """
         if self.col:
             if not self.closeAllCollectionWindows():
                 return
@@ -268,7 +274,8 @@ how to restore from a backup.""")
             self.progress.start(immediate=True)
             self.backup()
             self.progress.finish()
-            return True
+        return True
+
 
     # Backup and auto-optimize
     ##########################################################################


### PR DESCRIPTION
I finally tried the newest changes and couldn’t get it to run with exactly one profile.

I found out that the newly added (0994bd332cb0597c6275b60d42b92b4cd58791f8) return value of `unloadCollection` prevented automatic loading of a profile.

According to `aqt.main.loadProfile()` calling onSync "[will load DB](https://github.com/dae/anki/blob/master/aqt/main.py#L212)". When starting Anki, at least with exactly one profile present, `loadProfile()` depends on this being true. To make sure we do, go on loading the db after the call to `unloadCollection()` when there isn't any collection during start-up.

Maybe the simplest way to achieve that was to un-indent the `return` so `unloadCollection()` returns `True` if we start without a collection. 

(Afais the point of not returning `True` there was to signal that there is a collection still open (with unsaved changes).)
