### PR TITLE
Check for self.typedAnswer only after it has been set.

### DIFF
--- a/aqt/reviewer.py
+++ b/aqt/reviewer.py
@@ -377,10 +377,10 @@ Please run Tools>Maintenance>Empty Cards""")
 """ % (self.typeFont, self.typeSize), buf)
 
     def typeAnsAnswerFilter(self, buf):
-        if not self.typeCorrect or not self.typedAnswer:
-            return re.sub(self.typeAnsPat, "", buf)
         # tell webview to call us back with the input content
         self.web.eval("_getTypedText();")
+        if not self.typeCorrect or not self.typedAnswer:
+            return re.sub(self.typeAnsPat, "", buf)
         # munge correct value
         parser = HTMLParser.HTMLParser()
         cor = stripHTML(self.mw.col.media.strip(self.typeCorrect))


### PR DESCRIPTION
It looks like 872cca14e947998461db96dc8deb0346805fa470 broke the whole type answer mechanism.
Afais `self.typedAnswer` is set in a roundabout way through the javascript `_getTypedText()` function, so you should check for it only after calling that.
