### PR TITLE
Turn method importing.ImportDialog._unicodeWarning() into a function.

### DIFF
--- a/aqt/importing.py
+++ b/aqt/importing.py
@@ -73,11 +73,6 @@ class ImportDialog(QDialog):
         self.frm.importMode.setCurrentIndex(self.mw.pm.profile.get('importMode', 0))
         self.exec_()
 
-    def _unicodeWarning(self):
-        showWarning(_(
-            "Selected file was not in UTF-8 format. Please see the "
-            " importing section of the manual."))
-
     def setupOptions(self):
         self.model = self.mw.col.models.current()
         self.modelChooser = aqt.modelchooser.ModelChooser(
@@ -155,7 +150,7 @@ you can enter it here. Use \\t to represent tab."""),
         try:
             self.importer.run()
         except UnicodeDecodeError:
-            self._unicodeWarning()
+            showUnicodeWarning()
             return
         except Exception, e:
             msg = _("Import failed.\n")
@@ -245,6 +240,14 @@ you can enter it here. Use \\t to represent tab."""),
     def helpRequested(self):
         openHelp("FileImport")
 
+
+def showUnicodeWarning():
+    """Shorthand to show a standard warning."""
+    showWarning(_(
+        "Selected file was not in UTF-8 format. Please see the "
+        "importing section of the manual."))
+
+
 def onImport(mw):
     filt = ";;".join([x[0] for x in importing.Importers])
     file = getFile(mw, _("Import"), None, key="import",
@@ -276,7 +279,7 @@ def importFile(mw, file):
         try:
             importer.open()
         except UnicodeDecodeError:
-            self._unicodeWarning()
+            showUnicodeWarning()
             return
         except Exception, e:
             msg = unicode(e)


### PR DESCRIPTION
Hi. This is one of a few problems i have spotted with pylint. This one is the only one were the fix is obvious and easy.

It looks like `importing.ImportDialog.importFile()` was turned into a function `importing.importFile()` at some time.

But then `importing.ImportDialog._unicodeWarning()`, which is called from there, must be turned into a function as well.
