### PR TITLE
use futuristic division

### DIFF
--- a/anki/utils.py
+++ b/anki/utils.py
@@ -2,6 +2,7 @@
 # Copyright: Damien Elmes <anki@ichi2.net>
 # License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
+from __future__ import division
 import re, os, random, time, math, htmlentitydefs, subprocess, \
     tempfile, shutil, string, httplib2, sys, locale
 from hashlib import sha1
@@ -90,15 +91,15 @@ def convertSecondsTo(seconds, type):
     if type == "seconds":
         return seconds
     elif type == "minutes":
-        return seconds / 60.0
+        return seconds / 60
     elif type == "hours":
-        return seconds / 3600.0
+        return seconds / 3600
     elif type == "days":
-        return seconds / 86400.0
+        return seconds / 86400
     elif type == "months":
-        return seconds / 2592000.0
+        return seconds / 2592000
     elif type == "years":
-        return seconds / 31536000.0
+        return seconds / 31536000
     assert False
 
 def _pluralCount(time, point):

--- a/aqt/reviewer.py
+++ b/aqt/reviewer.py
@@ -557,7 +557,7 @@ function showAnswer(txt) {
 </script>
 """ % dict(rem=self._remaining(), edit=_("Edit"),
            editkey=_("Shortcut key: %s") % "E",
-           more=_("More"), time=self.card.timeTaken()/1000)
+           more=_("More"), time=self.card.timeTaken() // 1000)
 
     def _showAnswerButton(self):
         self._bottomReady = True

--- a/aqt/sync.py
+++ b/aqt/sync.py
@@ -64,8 +64,8 @@ automatically."""))
         self.mw.progress.update(label="%s\n%s" % (
             self.label,
             _("%(a)dkB up, %(b)dkB down") % dict(
-                a=self.sentBytes/1024,
-                b=self.recvBytes/1024)))
+                a=self.sentBytes // 1024,
+                b=self.recvBytes // 1024)))
 
     def onEvent(self, evt, *args):
         pu = self.mw.progress.update


### PR DESCRIPTION
Python used to use C-style division, where division of two ints was
truncated, and division involving a float resulted in a float.

This is confusing, because you often can't tell from looking at a
line of code in isolation what sort of division it's supposed to do.

With `from __future__ import division` Python ensures that division is
always explicit.

`//` means (floored) integer division
`/` means float division

regardless of argument types.

This should make the source a bit clearer now, as well as removing one
obstacle if Anki is ever ported to Python 3.
