### PR TITLE
Add editFocusGained hook

### DIFF
--- a/aqt/editor.py
+++ b/aqt/editor.py
@@ -546,6 +546,7 @@ class Editor(object):
             (type, num) = str.split(":", 1)
             self.enableButtons()
             self.currentField = int(num)
+            runHook("editFocusGained", self.note, self.currentField)
         # state buttons changed?
         elif str.startswith("state"):
             (cmd, txt) = str.split(":", 1)


### PR DESCRIPTION
Sometimes, it would be useful for addons to be able to determine when an editor field gains focus.  This one line change adds that.
