### PR TITLE
repeating timers would randomly start firing every 100ms indefinitely

### DIFF
--- a/aqt/progress.py
+++ b/aqt/progress.py
@@ -64,7 +64,7 @@ Your pysqlite2 is too old. Anki will appear frozen during long operations."""
         def handler():
             if self.inDB:
                 # retry in 100ms
-                self.timer(100, func, repeat)
+                self.timer(100, func, False)
             else:
                 func()
         t = QTimer(self.mw)


### PR DESCRIPTION
When a repeating timer is unfortunate enough to hit the inDB case once, the timer duplicates into one that fires every 100ms. So I think repeat should always be false for the "retry in 100ms" case.
