### PR TITLE
Unused Media: take into account images referenced from templates

### DIFF
--- a/anki/media.py
+++ b/anki/media.py
@@ -220,6 +220,29 @@ If the same name exists, compare checksums."""
         for mid, flds in self.col.db.execute("select mid, flds from notes"):
             for f in self.filesInStr(mid, flds):
                 files.add(f)
+
+        def get_img_src(html):
+            """ Extract the src attribute from an <img> tag, which may use
+            single or double quotes. Return None if no <img> tag is found"""
+
+            regexp = "<\s*img\s+(.*?)" \
+                     "src\s*=\s*(?P<quote>['\"])(?P<path>.*)(?P=quote)" \
+                     ".*?\s*>"
+            match = re.search(regexp, html)
+            if match:
+                return match.group('path')
+            else:
+                return None
+
+        # Also find images referenced from templates
+        template_fields = ['qfmt', 'afmt', 'bqfmt', 'bafmt']
+        for model in self.col.models.all():
+            for template in model['tmpls']:
+                for field in template_fields:
+                    path = get_img_src(template[field])
+                    if path:
+                        files.add(path)
+
         return files
 
     # Copying on import


### PR DESCRIPTION
When removing unused media, Anki only pays attention to whether the files in the media directory are referenced from a note. However, it may be the case that a file is solely referenced from a template. For example, if we wanted to ask the user to locate a state on a US map, our Front Template could look like this:

```
<img src="empty-us-map.jpg">
<hr>
{{StateName}}
```

![front](https://f.cloud.github.com/assets/1575425/617564/355889ce-ce99-11e2-90b1-2381c1eb15bd.png)

And the Back Template could be:

```
{{StateLocation}}
<hr>
{{StateName}}
```

![back](https://f.cloud.github.com/assets/1575425/617565/3ed921f2-ce99-11e2-9d8c-6c7caf3bee43.png)

The image `empty-us-map.jpg`, if not referenced from any note, is reported by Anki as unused. Modify `MediaManager.allMedia()` so that it also returns those images referenced (HTML <img> tags) from templates.
