### PR TITLE
Run reviewer.Reviewer.correct as a filter. Should help add-on authors.

### DIFF
--- a/aqt/clayout.py
+++ b/aqt/clayout.py
@@ -242,7 +242,7 @@ Please create a new card type first."""))
         txt = txt.replace("<hr id=answer>", "")
         hadHR = origLen != len(txt)
         def answerRepl(match):
-            res = self.mw.reviewer.correct(u"exomple", u"an example")
+            res = self.mw.reviewer.correct(u"", u"exomple", u"an example")
             if hadHR:
                 res = "<hr id=answer>" + res
             return res


### PR DESCRIPTION
This is basically a repeat of #22, updated for version 2.0.10

Run `correct()` as a filter so add-ons can cleanly modify the red/green corrected version of a typed answer.

I have already written two add-ons that both monkey-patch the `typeAnsAnswerFilter()` function where the `correct()` is called. Like this these add-ons would be much cleaner. It might also be of help with [issue 1445](https://anki.tenderapp.com/discussions/ankidesktop/1445).

The card is passed along so the add-ons can get an idea what is going on. (My add-ons only do their own correcting when the field had the right name.)
