### PR TITLE
Pre-compile HTML-stripping regexes.

### DIFF
--- a/anki/utils.py
+++ b/anki/utils.py
@@ -122,17 +122,22 @@ def fmtFloat(float_value, point=1):
 
 # HTML
 ##############################################################################
+reStyle = re.compile("(?s)<style.*?>.*?</style>")
+reScript = re.compile("(?s)<script.*?>.*?</script>")
+reTag = re.compile("<.*?>")
+reEnts = re.compile("&#?\w+;")
+reMedia = re.compile("<img[^>]+src=[\"']?([^\"'>]+)[\"']?[^>]*>")
 
 def stripHTML(s):
-    s = re.sub("(?s)<style.*?>.*?</style>", "", s)
-    s = re.sub("(?s)<script.*?>.*?</script>", "", s)
-    s = re.sub("<.*?>", "", s)
+    s = reStyle.sub("", s)
+    s = reScript.sub("", s)
+    s = reTag.sub("", s)
     s = entsToTxt(s)
     return s
 
 def stripHTMLMedia(s):
     "Strip HTML but keep media filenames"
-    s = re.sub("<img[^>]+src=[\"']?([^\"'>]+)[\"']?[^>]*>", " \\1 ", s)
+    s = reMedia.sub(" \\1 ", s)
     return stripHTML(s)
 
 def minimizeHTML(s):
@@ -164,7 +169,7 @@ def entsToTxt(html):
             except KeyError:
                 pass
         return text # leave as is
-    return re.sub("&#?\w+;", fixup, html)
+    return reEnts.sub(fixup, html)
 
 # IDs
 ##############################################################################


### PR DESCRIPTION
I'm using the HTML-stripping function extensively in one of my add-ons, and it's proving to be the slowest part for some tasks. After pre-compiling the regular expressions used, I gain about a 25-45% speed boost for my particular use-case. I figured the rest of the application can benefit from this as well.
