### PR TITLE
Fix incorrect maintenance text

### DIFF
--- a/aqt/reviewer.py
+++ b/aqt/reviewer.py
@@ -191,7 +191,7 @@ function _typeAnsPress() {
         # grab the question and play audio
         if c.isEmpty():
             q = _("""\
-The front of this card is empty. Please run Tools>Maintenance>Empty Cards.""")
+The front of this card is empty. Please run Tools>Empty Cards.""")
         else:
             q = c.q()
         if self.autoplay(c):


### PR DESCRIPTION
(on finding an empty card, tells user to go to old location of the empty
cards tool)

If you want to wait until 2.1 to apply to avoid breaking the translations, that's probably okay, but the directions are wrong as they stand.
