### PR TITLE
Strip * from media file names.

### DIFF
--- a/anki/media.py
+++ b/anki/media.py
@@ -89,7 +89,7 @@ class MediaManager(object):
 If the same name exists, compare checksums."""
         mdir = self.dir()
         # remove any dangerous characters
-        base = re.sub(r"[][<>:/\\&?\"\|]", "", os.path.basename(opath))
+        base = re.sub(r"[][<>:/\\&?\"\|*]", "", os.path.basename(opath))
         (root, ext) = os.path.splitext(base)
         def repl(match):
             n = int(match.group(1))


### PR DESCRIPTION
Some filesystems, namely the FAT variants and NTFS, don't support the `*` character in file names. It is possible for a user to add a media file with that character on a machine that supports it (e.g., OS X or Linux), and fail to sync media on Windows or [some Android devices](https://code.google.com/p/ankidroid/issues/detail?id=1795#c4).

This commit just adds that character to the list of illegal characters.
