### PR TITLE
Add hooks for context menus

### DIFF
--- a/aqt/addcards.py
+++ b/aqt/addcards.py
@@ -8,7 +8,7 @@ import aqt.forms
 from aqt.utils import saveGeom, restoreGeom, showWarning, askUser, shortcut, \
     tooltip, openHelp, addCloseShortcut
 from anki.sound import clearAudioQueue
-from anki.hooks import addHook, remHook
+from anki.hooks import addHook, remHook, runHook
 from anki.utils import stripHTMLMedia, isMac
 import aqt.editor, aqt.modelchooser, aqt.deckchooser
 
@@ -123,6 +123,7 @@ class AddCards(QDialog):
             a = m.addAction(_("Edit %s") % txt)
             a.connect(a, SIGNAL("triggered()"),
                       lambda nid=nid: self.editHistory(nid))
+        runHook("AddCards.onHistory", self, m)
         m.exec_(self.historyButton.mapToGlobal(QPoint(0,0)))
 
     def editHistory(self, nid):

--- a/aqt/editor.py
+++ b/aqt/editor.py
@@ -1174,4 +1174,5 @@ class EditorWebView(AnkiWebView):
         a.connect(a, SIGNAL("triggered()"), self.onCopy)
         a = m.addAction(_("Paste"))
         a.connect(a, SIGNAL("triggered()"), self.onPaste)
+        runHook("EditorWebView.contextMenuEvent", self, m)
         m.popup(QCursor.pos())

--- a/aqt/reviewer.py
+++ b/aqt/reviewer.py
@@ -693,6 +693,7 @@ function showAnswer(txt) {
             a = m.addAction(label)
             a.setShortcut(QKeySequence(scut))
             a.connect(a, SIGNAL("triggered()"), func)
+        runHook("Reviewer.contextMenuEvent",self,m)
         m.exec_(QCursor.pos())
 
     def onOptions(self):

--- a/aqt/webview.py
+++ b/aqt/webview.py
@@ -3,6 +3,7 @@
 # License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
 import sys
+from anki.hooks import runHook
 from aqt.qt import *
 from aqt.utils import openLink
 from anki.utils import isMac, isWin
@@ -85,6 +86,7 @@ class AnkiWebView(QWebView):
         a = m.addAction(_("Copy"))
         a.connect(a, SIGNAL("triggered()"),
                   lambda: self.triggerPageAction(QWebPage.Copy))
+        runHook("AnkiWebView.contextMenuEvent", self, m)
         m.popup(QCursor.pos())
 
     def dropEvent(self, evt):


### PR DESCRIPTION
Hi Damien, As discussed on the tenderapp support site, these changes add some hooks to access various context menus. Thanks! Steve
