### PR TITLE
Add support for a random choice of sounds using [randomiseSounds]

### DIFF
--- a/anki/sound.py
+++ b/anki/sound.py
@@ -13,11 +13,15 @@ from anki.utils import  tmpdir, isWin, isMac
 _soundReg = "\[sound:(.*?)\]"
 
 def playFromText(text):
-    for match in re.findall(_soundReg, text):
-        play(match)
+    if text.find("[randomiseSounds]") >= 0:
+        if hasSound(text):
+            play(random.choice(re.findall(_soundReg, text)))
+    else:
+        for match in re.findall(_soundReg, text):
+            play(match)
 
 def stripSounds(text):
-    return re.sub(_soundReg, "", text)
+    return re.sub(_soundReg, "", text).replace("[randomiseSounds]", "")
 
 def hasSound(text):
     return re.search(_soundReg, text) is not None


### PR DESCRIPTION
This will modify Anki's behaviour when it encounters multiple `[sound:...]`s.
It will instead randomly choose one to play instead of playing all of them.

This can be useful when Anki is being used to help learn a language, and one wants to use multiple audio samples in each note and only wants a random one of them to be played rather than all of them.

The way I've done this is also backwards compatible with people who don't have this patch. Instead, they'll hear all sounds like it was originally, except the extra `[randomiseSounds]` that might stick out (though that may be hidden by hiding the property with the audio in a `display: none` `<span>` or `<div>`)
