### PR TITLE
make Anki use folder .config/Anki under Linux

### DIFF
--- a/aqt/profiles.py
+++ b/aqt/profiles.py
@@ -181,7 +181,7 @@ documentation for information on using a flash drive.""")
         elif isMac:
             return os.path.expanduser("~/Documents/Anki")
         else:
-            return os.path.expanduser("~/Anki")
+            return os.path.expanduser("~/.config/Anki")
 
     def _loadMeta(self):
         path = os.path.join(self.base, "prefs.db")


### PR DESCRIPTION
I did not find any discussion going on about this, but it seems cleaner to me if we would use .config
