### PR TITLE
use a saner, cleaner and standard default linux conf file storage location

### DIFF
--- a/aqt/profiles.py
+++ b/aqt/profiles.py
@@ -181,7 +181,10 @@ documentation for information on using a flash drive.""")
         elif isMac:
             return os.path.expanduser("~/Documents/Anki")
         else:
-            return os.path.expanduser("~/Anki")
+            legacy = os.path.expanduser("~/Anki")
+            if os.path.exists(legacy):
+                return legacy
+            return os.path.expanduser("~/.anki")
 
     def _loadMeta(self):
         path = os.path.join(self.base, "prefs.db")


### PR DESCRIPTION
Hi, thanks a lot for Anki ! Learning Chinese with anki support !

I'm a linux user, and well, I tidy my computer often and don't like to see that "Anki" stores its stuff by default in `~/Anki`. There's a widely used standards in linux world which is to use dotted files name to avoid clutering the home user directory with millions of subfolders. And BTW, use of uppercases is usually avoided. So I changed it to "~/.anki".

So, please consider my small contribution to this marvellous piece of code. It should'nt break existing installation neither. I'm open to all comments !

I'm aware that there is a `-b` option, but its is not very convenient to edit all the hidden shortcuts in Ubuntu ".desktop" files. And, well it's not working for me, and even if it was, I don't want to do this after any updates. I felt that this change was legitimate as all other package are using this convention. I'm ready to hear you on this topic if you think otherwise.

Thanks for reading !
