### PR TITLE
Import sys. Fix the profile manager's quit button.

### DIFF
--- a/aqt/main.py
+++ b/aqt/main.py
@@ -4,7 +4,8 @@
 
 import re
 import signal
-import  zipfile
+import sys
+import zipfile
 
 from send2trash import send2trash
 from aqt.qt import *


### PR DESCRIPTION
Looks like there was an `import sys` missing.
Without it the profile manager’s quit button (and failing on start-up, which also uses `sys.exit()`) did not work.
(I also removed an extra space for aesthetic reasons.)
