### PR TITLE
Fix for sys not defined on exit

### DIFF
--- a/aqt/main.py
+++ b/aqt/main.py
@@ -4,6 +4,7 @@
 
 import re
 import signal
+import sys
 import zipfile
 
 from send2trash import send2trash


### PR DESCRIPTION
Selecting Quit from the Profiles window after logging out shows "'sys' is not defined" for lambda: sys.exit(0) on line 119.
