### PR TITLE
Allow a saner, cleaner and standard default linux conf file storage location

### DIFF
--- a/aqt/profiles.py
+++ b/aqt/profiles.py
@@ -181,6 +181,9 @@ documentation for information on using a flash drive.""")
         elif isMac:
             return os.path.expanduser("~/Documents/Anki")
         else:
+            dotted = os.path.expanduser("~/.anki")
+            if os.path.exists(dotted):
+                return dotted
             return os.path.expanduser("~/Anki")
 
     def _loadMeta(self):


### PR DESCRIPTION
As discussed in PR #49, allow `~/.anki` to be used as a configuration directory without changing the default. Though I still think PR #49 would be the better solution.
