### PR TITLE
Speed up tests

### DIFF
--- a/tests/shared.py
+++ b/tests/shared.py
@@ -9,7 +9,24 @@ def assertException(exception, func):
         found = True
     assert found
 
-def getEmptyDeck(**kwargs):
+
+# Creating new decks is expensive. Just do it once, and then spin off
+# copies from the master.
+def getEmptyDeck():
+    if len(getEmptyDeck.master) == 0:
+        (fd, nam) = tempfile.mkstemp(suffix=".anki2")
+        os.unlink(nam)
+        col = aopen(nam)
+        col.db.close()
+        getEmptyDeck.master = nam
+    (fd, nam) = tempfile.mkstemp(suffix=".anki2")
+    shutil.copy(getEmptyDeck.master, nam)
+    return aopen(nam)
+
+getEmptyDeck.master = ""
+
+# Fallback for when the DB needs options passed in.
+def getEmptyDeckWith(**kwargs):
     (fd, nam) = tempfile.mkstemp(suffix=".anki2")
     os.unlink(nam)
     return aopen(nam, **kwargs)

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -5,7 +5,7 @@ import nose, os, shutil, time
 from anki import Collection as aopen, Collection
 from anki.utils import intTime
 from anki.sync import Syncer, LocalServer
-from tests.shared import getEmptyDeck
+from tests.shared import getEmptyDeck, getEmptyDeckWith
 
 # Local tests
 ##########################################################################
@@ -26,7 +26,7 @@ def setup_basic():
     # answer it
     deck1.reset(); deck1.sched.answerCard(deck1.sched.getCard(), 4)
     # repeat for deck2
-    deck2 = getEmptyDeck(server=True)
+    deck2 = getEmptyDeckWith(server=True)
     f = deck2.newNote()
     f['Front'] = u"bar"; f['Back'] = u"bar"; f.tags = [u"bar"]
     deck2.addNote(f)
@@ -325,7 +325,7 @@ def _test_speed():
         deck1.tags.tags[tx] = -1
     deck1._usn = -1
     deck1.save()
-    deck2 = getEmptyDeck(server=True)
+    deck2 = getEmptyDeckWith(server=True)
     deck1.scm = deck2.scm = 0
     server = LocalServer(deck2)
     client = Syncer(deck1, server)


### PR DESCRIPTION
Running the full suite of tests took me 5.5 minutes before; now it takes a smidge over 2.

It only speeds up tests that don't pass any arguments to getEmptyDeck, but that's nearly all of them!

test_remote_sync has four errors, but it had four errors beforehand, so I'm gonna call that a draw. 

test_new has errors "every once in a while" -- not sure what to do about that -- but that is also true independent of these changes.

There's one other unrelated failing test that I have a fix for. See my next PR.
