### PR TITLE
Fix supermemo import test

### DIFF
--- a/tests/test_importing.py
+++ b/tests/test_importing.py
@@ -297,7 +297,8 @@ def test_supermemo_xml_01_unicode():
     assert i.total == 1
     cid = deck.db.scalar("select id from cards")
     c = deck.getCard(cid)
-    assert c.factor == int(i._afactor2efactor(float(5.701))*1000)
+    # Applies A Factor-to-E Factor conversion
+    assert c.factor == 2879
     assert c.reps == 7
     deck.close()
 


### PR DESCRIPTION
The test was broken by the recent inclusion of A Factor-to-E Factor conversion.
