### PR TITLE
Add expand/collapse support for decks in browser tree.

### DIFF
--- a/anki/decks.py
+++ b/anki/decks.py
@@ -197,6 +197,12 @@ class DeckManager(object):
         deck['collapsed'] = not deck['collapsed']
         self.save(deck)
 
+    def collapseBrowser(self, did):
+        deck = self.get(did)
+        collapsed = deck.get('browserCollapsed', False)
+        deck['browserCollapsed'] = not collapsed
+        self.save(deck)
+
     def count(self):
         return len(self.decks)
 


### PR DESCRIPTION
Expand/collapse decks in the browser. The state is preserved in a new deck configuration key named '''browserCollapsed''''.
