### PR TITLE
Fixes behaviour for {{type:cloze:Field}}

### DIFF
--- a/anki/collection.py
+++ b/anki/collection.py
@@ -510,7 +510,7 @@ where c.nid = n.id and c.id in %s group by nid""" % ids2str(cids)):
         afmt = afmt or template['afmt']
         for (type, format) in (("q", qfmt), ("a", afmt)):
             if type == "q":
-                format = re.sub("{{(.*?)cloze:", r"{{\1cq-%d:" % (data[4]+1), format)
+                format = re.sub("{{(?!type:)(.*?)cloze:", r"{{\1cq-%d:" % (data[4]+1), format)
                 format = format.replace("<%cloze:", "<%%cq:%d:" % (
                     data[4]+1))
             else:

--- a/anki/template/template.py
+++ b/anki/template/template.py
@@ -168,11 +168,14 @@ class Template(object):
         txt = get_or_attr(context, tag)
         
         #Since 'text:' and other mods can affect html on which Anki relies to
-        #process Clozes and Types, we need to make sure cloze/type are always
+        #process clozes, we need to make sure clozes are always
         #treated after all the other mods, regardless of how they're specified
         #in the template, so that {{cloze:text: == {{text:cloze:
+        #For type:, we return directly since no other mod than cloze (or other
+        #pre-defined mods) can be present and those are treated separately
         mods.reverse()
-        mods.sort(key=lambda s: s.startswith("cq-") or s.startswith("ca-") or s=="type")
+        mods.sort(key=lambda s: not s=="type")
+        mods.sort(key=lambda s: s.startswith("cq-") or s.startswith("ca-"))
         
         for mod in mods:
             # built-in modifiers
@@ -182,7 +185,7 @@ class Template(object):
             elif mod == 'type':
                 # type answer field; convert it to [[type:...]] for the gui code
                 # to process
-                txt = "[[%s]]" % tag_name
+                return "[[%s]]" % tag_name
             elif mod.startswith('cq-') or mod.startswith('ca-'):
                 # cloze deletion
                 mod, extra = mod.split("-")


### PR DESCRIPTION
Previous change to support chained modifiers broke the only then supported chained modifier, {{type:cloze:Field}}. This pull request fixes it, with two assumptions (that were already assumed before support for chained modifiers was added):
1) type: can only be used as the leftmost modifiers. (and behaves just as before)
2) because of the nature of type: (doesn't transform the text displayed but replaces it with a text box, and cloze: is treated as an argument to it, rather than a modifier), only cloze: or other future pre-defined modifiers can come after.
