### PR TITLE
Fixes creation of Cloze when having a chained modifier

### DIFF
--- a/aqt/editor.py
+++ b/aqt/editor.py
@@ -690,7 +690,7 @@ class Editor(object):
 
     def onCloze(self):
         # check that the model is set up for cloze deletion
-        if '{{cloze:' not in self.note.model()['tmpls'][0]['qfmt']:
+        if not re.search('{{(.*:)*cloze:',self.note.model()['tmpls'][0]['qfmt']):
             if self.addMode:
                 tooltip(_("Warning, cloze deletions will not work until "
                 "you switch the type at the top to Cloze."))


### PR DESCRIPTION
When using chained modifiers, if the card template has a modifier on the left of cloze: (e.g. {{mod1:cloze:Text}}), creation of Cloze is impossible. The patch provided fixes this, while keeping {{cloze:Text}} and {{cloze:mod1:Text}} also working.
