### PR TITLE
Adding support for parameters in modifiers

### DIFF
--- a/anki/template/template.py
+++ b/anki/template/template.py
@@ -191,6 +191,7 @@ class Template(object):
                 txt = self.clozeText(txt, extra, mod[1]) if txt and extra else ""
             else:
                 # hook-based field modifier
+                mod, extra = re.search("^(.*?)(?:\((.*)\))?$", mod).groups()
                 txt = runFilter('fmod_' + mod, txt or '', extra, context,
                                 tag, tag_name);
                 if txt is None:


### PR DESCRIPTION
Following our discussion in https://github.com/dae/anki/pull/67 , I've implemented the change.. well, arguably it's just a one line change.

It allows templates to be written as such:
{{mod1(param1,param2):mod2(param3):field}}
as well as the original syntax:
{{mod1:mod2:field}}

It means three things:
1-for existing plug-ins relying on 1 modifier without parameter ({{mod:field}}), nothing to change.
2-for existing plug-ins relying on 1 modifier with parameter (which they wrote {{mod:param:field}}), the plug-in can continue as it was, but the templates need to be changed to {{mod(param):field}}
3-for new plug-ins, possibility of use arbitrary number of parameters for arbitrary number of modifiers. NOTE: to ensure backward compatibility with 2, the parameters of {{mod(p1,p2,p3):field}} are passed as "p1,p2,p3" rather than ["p1","p2","p3"]: it is up to the plug-in to then apply extra.split(","), or with any separator of their choice. In other words, there is technically only 1 parameter, what it contains is up to the plug-in. In addition to providing backward compatibility, it also means that plug-ins get more freedom to be creative.
