### PR TITLE
Fixes transition from old modifier syntax  to new one

### DIFF
--- a/anki/template/template.py
+++ b/anki/template/template.py
@@ -192,7 +192,7 @@ class Template(object):
             else:
                 # hook-based field modifier
                 mod, extra = re.search("^(.*?)(?:\((.*)\))?$", mod).groups()
-                txt = runFilter('fmod_' + mod, txt or '', extra, context,
+                txt = runFilter('fmod_' + mod, txt or '', extra or '', context,
                                 tag, tag_name);
                 if txt is None:
                     return '{unknown field %s}' % tag_name


### PR DESCRIPTION
Following the issues with ring.py add-on these days, I've realised that updating one's templates to do the transition wasn't easy: a person having a template {{ring:my_tag:field}} and a plug-in ring which uses my_tag as a parameter will always generate an exception window to pop-up, making it very difficult to reach the template window (and edit the template).

The proposed modification makes sure that an object of type str is sent to the plug-in (it is anyway the only sort of object the plug-in could ever receive, as far as I can see...), so that:
-templates using the old syntax will not crash (they may not work, but the template window can now be reached and edited)
-it makes both syntaxes {{ring():field}} and {{ring:field}} equivalent, and plug-ins don't have to treat {{ring:field}} as a special case (usually generating AttributeError)
