### PR TITLE
Makes the test agree with the current behaviour of chained mod 

### DIFF
--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -194,7 +194,7 @@ def test_chained_mods():
     #We replace the default Cloze template
     t = mm.newTemplate("ChainedCloze")
     t['qfmt'] = "{{cloze:text:Text}}"
-    t['afmt'] = "{{text:cloze:Text}}" #independent of the order of mods
+    t['afmt'] = "{{cloze:text:Text}}"
     mm.addTemplate(m, t)
     mm.save(m)
     d.models.remTemplate(m, m['tmpls'][0])


### PR DESCRIPTION
I initially had forced cloze to be always first, as I hadn't anticipated / wasn't aware / hadn't asked about kana:cloze modifier. It's been reverted in this commit https://github.com/dae/anki/commit/4c65c594ddc066ea015195c81ed2d2cca40ef4aa which I assume must have broken the test (while the general behaviour is still correct, of course).

This pull request therefore only fixes the test to reflect the behaviour of Anki, i.e. the order of chained modifiers IS important.
