### PR TITLE
shared random number between question and answer sides

### DIFF
--- a/anki/collection.py
+++ b/anki/collection.py
@@ -498,6 +498,9 @@ where c.nid = n.id and c.id in %s group by nid""" % ids2str(cids)):
         fields['Tags'] = data[5].strip()
         fields['Type'] = model['name']
         fields['Deck'] = self.decks.name(data[3])
+        fields['Rand']  = '%.15f' % (random.random());
+        fields['Rand2'] = '%.15f' % (random.random());
+        fields['Rand3'] = '%.15f' % (random.random());
         if model['type'] == MODEL_STD:
             template = model['tmpls'][data[4]]
         else:


### PR DESCRIPTION
_(Related to pull request https://github.com/ankidroid/Anki-Android/pull/292 for AnkiDroid.)_

It's unfeasible (and pretty useless) to generate cards for numbers individually. Having a shared random value between the question and the answer (which is impossible otherwise) would make it possible to create cards like "Numbers between 1 and 10" or "Tens: 10, 20, ..., 100" or "Factors of ten: 10, 100, 1000, ..."

A card, with javascript, can generate the number and the corresponding answer in the foreign language. Consider how fun it would be to be able to write something like this:

```
<script src="http://100.bryanesmith.com/js/knumbers.js"></script>
<script>
  // get a number and the number of zeroes between the set limits
  var number = Math.floor({{Rand}} * ({{Max}} - {{Min}} + 1) ) + {{Min}};
  var zeroes = Math.floor({{Rand2}} * ({{Zeroes Max}} - {{Zeroes Min}} + 1)) + {{Zeroes Min}};

  // compute the final number
  number = (number+{{Increment By}})*{{Multiplier}}*Math.pow(10,zeroes);

  document.getElementById("question").innerHTML = number;

  // set answer to the corresponding Sino-Korean number
  document.getElementById("answer").innerHTML = getSino(number);
</script>
```
