### PR TITLE
Close file descriptors before unlinking

### DIFF
--- a/tests/shared.py
+++ b/tests/shared.py
@@ -15,6 +15,7 @@ def assertException(exception, func):
 def getEmptyDeck():
     if len(getEmptyDeck.master) == 0:
         (fd, nam) = tempfile.mkstemp(suffix=".anki2")
+        os.close(fd)
         os.unlink(nam)
         col = aopen(nam)
         col.db.close()
@@ -28,6 +29,7 @@ getEmptyDeck.master = ""
 # Fallback for when the DB needs options passed in.
 def getEmptyDeckWith(**kwargs):
     (fd, nam) = tempfile.mkstemp(suffix=".anki2")
+    os.close(fd)
     os.unlink(nam)
     return aopen(nam, **kwargs)
 

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 
-import os
+import os, tempfile
 from tests.shared import assertException, getEmptyDeck
 from anki.stdmodels import addBasicModel
 
@@ -11,8 +11,9 @@ newMod = None
 
 def test_create():
     global newPath, newMod
-    path = "/tmp/test_attachNew.anki2"
+    (fd, path) = tempfile.mkstemp(suffix=".anki2", prefix="test_attachNew")
     try:
+        os.close(fd)
         os.unlink(path)
     except OSError:
         pass

--- a/tests/test_exporting.py
+++ b/tests/test_exporting.py
@@ -36,7 +36,9 @@ def test_export_anki():
     deck.decks.setConf(dobj, confId)
     # export
     e = AnkiExporter(deck)
-    newname = unicode(tempfile.mkstemp(prefix="ankitest", suffix=".anki2")[1])
+    fd, newname = tempfile.mkstemp(prefix="ankitest", suffix=".anki2")
+    newname = unicode(newname)
+    os.close(fd)
     os.unlink(newname)
     e.exportInto(newname)
     # exporting should not have changed conf for original deck
@@ -54,7 +56,9 @@ def test_export_anki():
     # conf should be 1
     assert dobj['conf'] == 1
     # try again, limited to a deck
-    newname = unicode(tempfile.mkstemp(prefix="ankitest", suffix=".anki2")[1])
+    fd, newname = tempfile.mkstemp(prefix="ankitest", suffix=".anki2")
+    newname = unicode(newname)
+    os.close(fd)
     os.unlink(newname)
     e.did = 1
     e.exportInto(newname)
@@ -69,7 +73,9 @@ def test_export_ankipkg():
     n['Front'] = u'[sound:今日.mp3]'
     deck.addNote(n)
     e = AnkiPackageExporter(deck)
-    newname = unicode(tempfile.mkstemp(prefix="ankitest", suffix=".apkg")[1])
+    fd, newname = tempfile.mkstemp(prefix="ankitest", suffix=".apkg")
+    newname = unicode(newname)
+    os.close(fd)
     os.unlink(newname)
     e.exportInto(newname)
 
@@ -92,7 +98,9 @@ def test_export_anki_due():
     # export
     e = AnkiExporter(deck)
     e.includeSched = True
-    newname = unicode(tempfile.mkstemp(prefix="ankitest", suffix=".anki2")[1])
+    fd, newname = tempfile.mkstemp(prefix="ankitest", suffix=".anki2")
+    newname = unicode(newname)
+    os.close(fd)
     os.unlink(newname)
     e.exportInto(newname)
     # importing into a new deck, the due date should be equivalent
@@ -115,7 +123,9 @@ def test_export_anki_due():
 @nose.with_setup(setup1)
 def test_export_textnote():
     e = TextNoteExporter(deck)
-    f = unicode(tempfile.mkstemp(prefix="ankitest")[1])
+    fd, f = tempfile.mkstemp(prefix="ankitest")
+    f = unicode(f)
+    os.close(fd)
     os.unlink(f)
     e.exportInto(f)
     e.includeTags = True

--- a/tests/test_upgrade.py
+++ b/tests/test_upgrade.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 
-import datetime, shutil
+import datetime, shutil, tempfile
 from anki import Collection
 from anki.consts import *
 from shared import getUpgradeDeckPath, testDir
@@ -63,8 +63,9 @@ def test_invalid_ords():
     assert deck.db.scalar("select count() from cards where ord = 1") == 1
 
 def test_upgrade2():
-    p = "/tmp/alpha-upgrade.anki2"
+    fd, p = tempfile.mkstemp(suffix=".anki2", prefix="alpha-upgrade")
     if os.path.exists(p):
+        os.close(fd)
         os.unlink(p)
     shutil.copy2(os.path.join(testDir, "support/anki2-alpha.anki2"), p)
     col = Collection(p)


### PR DESCRIPTION
Unlinking a file before closing may not be supported on non-POSIX systems such as Windows. This allows more tests to run to completion.

`test_collection.test_openReadOnly` and the cleanup function in `utils.tmpdir` still error because of unlinking-before-closing, likely because sqlite does not close the file upon closing the DB, but I am not certain this is the case.
