### PR TITLE
Add windows specific help to dev readme for running shell scripts

### DIFF
--- a/README.development
+++ b/README.development
@@ -5,10 +5,22 @@ tools (specifically pyrcc4 and pyuic4). These are often contained in a
 separate package on Linux, such as 'pyqt4-dev-tools' on Debian/Ubuntu. On a Mac
 they are part of the PyQt source install.
 
-WINDOWS USERS: I have not tested the UI build script on Windows, so you'll need
+
+WINDOWS USERS: 
+There may be alternate methods, but here is one way to run the shell scripts.
+1) Install "git bash".
+2) In the tools directory, modify build_ui.sh. Locate the line that reads
+"pyuic4 $i -o $py" and alter it to be of the following form:
+"<python-path-string>" "<pyuic-path-string>" $i -o $py
+These two paths must point to your python executable, and to pyuic.py, on your
+system. Typical paths would be:
+<python-path> = C:\\Python27\\python.exe
+<pyuic-path-string> = C:\\Python27\\Lib\\site-packages\\PyQt4\\uic\\pyuic.py
+In general, scripts have not been tested on Windows, so you'll need
 to fix any problems you encounter on your own. If you can't figure it out, you
 can still use the source packages of Anki, which contain pre-built copies
-of the UI.
+of the UI. You may also want to start a discussion at ankt.tenderapp.com.
+
 
 To use the development version:
 


### PR DESCRIPTION
When I first tried to setup an environment for working with Anki desktop, it was a challenge to figure out how to run the shell scripts. This request alters the development readme file to indicate how those scripts can be run with git bash on windows. Information thanks to @timrae
