### PR TITLE
Simplify new card count query.

### DIFF
--- a/anki/sched.py
+++ b/anki/sched.py
@@ -433,10 +433,8 @@ select count() from
         return max(0, c['new']['perDay'] - g['newToday'][1])
 
     def totalNewForCurrentDeck(self):
-        return self.col.db.scalar(
-            """
-select count() from cards where id in (
-select id from cards where did in %s and queue = 0 limit ?)"""
+        return self.col.db.scalar("""
+select count() from cards where did in %s and queue = 0 limit ?)"""
             % ids2str(self.col.decks.active()), self.reportLimit)
 
     # Learning queues


### PR DESCRIPTION
The altered query had an extraneous subquery that itself can be counted, rather than selecting a whole cursor of ids, to then select cards matching those ids and count them. If sqlite were able to optimize that out, there will be no performance benefit (though the query is more direct), but I suspect it was not optimized down to this version.
