### PR TITLE
Fixes an issue fields are not being escaped in doExport().

### DIFF
--- a/anki/exporting.py
+++ b/anki/exporting.py
@@ -20,10 +20,12 @@ class Exporter(object):
         file.close()
 
     def escapeText(self, text):
-        "Escape newlines, tabs and CSS."
+        "Escape newlines, tabs, CSS and quotechar."
         text = text.replace("\n", "<br>")
         text = text.replace("\t", " " * 8)
         text = re.sub("(?i)<style>.*?</style>", "", text)
+        if "\"" in text:
+        	text = "\"" + text.replace("\"", "\"\"") + "\""
         return text
 
     def cardIds(self):


### PR DESCRIPTION
Anki does not escape quotechar(")  in fields when exports cards and notes, then import following TSV file and export it, the output is not equivalent to the input.
- input, expected

```
a[tab]""""[tab]
```
- actual

```
a[tab]"[tab]
```
