### PR TITLE
In Preferences, enter/return key opens Help rather than closing the window on some platforms

### DIFF
--- a/aqt/preferences.py
+++ b/aqt/preferences.py
@@ -18,6 +18,7 @@ class Preferences(QDialog):
         self.prof = self.mw.pm.profile
         self.form = aqt.forms.preferences.Ui_Preferences()
         self.form.setupUi(self)
+        self.form.buttonBox.button(QDialogButtonBox.Close).setDefault(True)
         self.connect(self.form.buttonBox, SIGNAL("helpRequested()"),
                      lambda: openHelp("profileprefs"))
         self.setupCollection()


### PR DESCRIPTION
I've seen that on Linux (Xfce) and Mac OS X, pressing enter/return in the Preferences window launches the online help documentation rather than closing the window.

I believe that this is because QDialogButtonBox arranges its buttons based on the platform the software is running, and typically maps the enter/return key to the "Ok" button. Because the Preferences window in Anki does not technically have an "Ok" button, and instead uses a "Close" button, the enter/return key activates the "Help" button instead of "Close" on platforms that have "Help" as the left-most button.

Windows gets the right behavior because "Close" is to the left of "Help" there.

This change explicitly sets the "default" button on the Preferences window to ensure that a user who hits enter/return gets the right behavior. I've tested this on Linux, but I imagine it would work the same on the others.
