### PR TITLE
fix tooltip for inverted color schemes

### DIFF
--- a/aqt/utils.py
+++ b/aqt/utils.py
@@ -394,6 +394,7 @@ def tooltip(msg, period=3000, parent=None):
     lab.setWindowFlags(Qt.ToolTip)
     p = QPalette()
     p.setColor(QPalette.Window, QColor("#feffc4"))
+    p.setColor(QPalette.WindowText, QColor("#000000"))
     lab.setPalette(p)
     lab.move(
         aw.mapToGlobal(QPoint(0, -100 + aw.height())))


### PR DESCRIPTION
Text color may not always be black on users system, making tooltips unreadable. This change makes sure everyone can read tooltips.
