### PR TITLE
Remember state of Browser/AddCards window if already open

### DIFF
--- a/aqt/__init__.py
+++ b/aqt/__init__.py
@@ -53,7 +53,7 @@ class DialogManager(object):
     def open(self, name, *args):
         (creator, instance) = self._dialogs[name]
         if instance:
-            instance.setWindowState(Qt.WindowActive)
+            instance.setWindowState(instance.windowState() | Qt.WindowActive)
             instance.activateWindow()
             instance.raise_()
             return instance


### PR DESCRIPTION
Hello,

The source of this submission is the following topic: https://anki.tenderapp.com/discussions/ankidesktop/8091-search-duplicates-always-open-a-new-browser

In fact, Anki does not open a "new" browser as I thought it did. Instead it sets the WindowState (which is a combination of flags: http://qt-project.org/doc/qt-4.8/qt.html#WindowState-enum) to the WindowActive flag, thereby resetting all the other flags to 0. If the window was maximized (as one may frequently want to for the browser?) it instead gets to a non-maximised state. The present commit corrects this behaviour.

Any question or comment, please let me know.
