### PR TITLE
Allow better translations of '1 note deleted' browser tooltip

### DIFF
--- a/aqt/browser.py
+++ b/aqt/browser.py
@@ -1131,7 +1131,7 @@ where id in %s""" % ids2str(sf))
             self.model.focusedCard = self.model.cards[newRow]
         self.model.endReset()
         self.mw.requireReset()
-        tooltip(_("%s deleted.") % (ngettext("%d note", "%d notes", len(nids)) % len(nids)))
+        tooltip(ngettext("%d note deleted.", "%d notes deleted.", len(nids)) % len(nids))
 
     # Deck change
     ######################################################################


### PR DESCRIPTION
Currently it's hard to properly translate '1 note deleted' tooltip displayed when you use 'Delete' button in the card browser - the translation string ('%d note') lacks context you need to apply word inflexion.

I changed translating '%d note' to translating '%d note deleted', which is similar to an another translation string in [main.py](https://github.com/dae/anki/blob/591015417b6be67f535360496b7cdbc9abe74212/aqt/main.py#L1022).
