### PR TITLE
Use alternate pattern match during field changes

### DIFF
--- a/anki/models.py
+++ b/anki/models.py
@@ -304,7 +304,7 @@ and notes.mid = ? and cards.ord = ?""", m['id'], ord)
 
     def renameField(self, m, field, newName):
         self.col.modSchema(check=True)
-        pat = r'{{(.*)([:#^/]|[^:#/^}][^:}]*?:|)%s}}'
+        pat = r'{{([^{}]*)([:#^/]|[^:#/^}][^:}]*?:|)%s}}'
         def wrap(txt):
             def repl(match):
                 return '{{' + match.group(1) + match.group(2) + txt +  '}}'


### PR DESCRIPTION
Hello!

I'm including a patch here to solve a problem I ran into this weekend. I know you guys are in feature freeze with 2.0.x, so I won't be upset if it cannot be dealt with now, but I wanted to share what I found anyway.

I noticed that renaming or deleting fields breaks my templates whenever I have more than one braced construct on a single line. Specifically:
- during renames, only the last use of a field on a line would be renamed
- during deletes, _everything_ between the first braced construct and the field would be nuked

---

For example, try creating a note with a **Flag** field and a template like

```
{{#Flag}}
    ...
{{/Flag}}{{^Flag}}
    ...
{{/Flag}}
```

or

```
{{Front}} {{#Flag}}...{{/Flag}}
```

... and then renaming the **Flag** field to something else.

---

Or try creating a **Victim** field, a template like

```
{{Front}} Hello. {{Victim}}
```

... and then deleting the **Victim** field.

---

I took a quick look and it _looks_ like the leading `(.*)` in the regex pattern for `ModelManager#renameField` needs to be non-greedy and/or needs to specifically exclude braces... otherwise, it captures everything on the line between the first braced construct and the actual matching one.

I see that the `(.*)` was added for things like `{{type:cloze:Text}}`. I think the alternative should work just as well for those.

Cheers! Happy new year.
