### PR TITLE
Avoid reordering entire deck when importing notes

### DIFF
--- a/anki/importing/noteimp.py
+++ b/anki/importing/noteimp.py
@@ -197,8 +197,6 @@ class NoteImporter(Importer):
         # in order due?
         if conf['new']['order'] == NEW_CARDS_RANDOM:
             self.col.sched.randomizeCards(did)
-        else:
-            self.col.sched.orderCards(did)
 
         part1 = ngettext("%d note added", "%d notes added", len(new)) % len(new)
         part2 = ngettext("%d note updated", "%d notes updated",


### PR DESCRIPTION
No need to reorder existing cards, which may have been manually ordered by the user, when importing notes if we can give cards a proper due number from the start. Retrieving any sibling's due number for this is easy as all relevant cards will have already been queried for when generating the new cards.

There's also an issue with the card order setting, which will reorder the deck when changed, but I'm not sure if there's a simple way to fix that without disrupting something else.