### PR TITLE
Reinstate mungeHTML in editor.py

### DIFF
--- a/aqt/editor.py
+++ b/aqt/editor.py
@@ -254,6 +254,7 @@ class Editor:
                 return
             txt = urllib.parse.unquote(txt)
             txt = unicodedata.normalize("NFC", txt)
+            txt = self.mungeHTML(txt)
             # misbehaving apps may include a null byte in the text
             txt = txt.replace("\x00", "")
             # reverse the url quoting we added to get images to display
@@ -284,6 +285,10 @@ class Editor:
             self._links[cmd](self)
         else:
             print("uncaught cmd", cmd)
+
+    def mungeHTML(self, txt):
+        txt = re.sub(r"<br>$", "", txt)
+        return txt
 
     # Setting/unsetting the current note
     ######################################################################


### PR DESCRIPTION
The removal of this function in #270 causes `<br>` to remain in seemingly empty editor fields, which in turn prompts the "Close and lose current input?" dialog.

Maybe it would be best to determine, why `<br>` tags appear in the editor fields after adding a card in the first place, and to remove that "feature".