### PR TITLE
Make .ankiaddon files installable via the CLI, registering Anki as their default file type handler

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Run checks
         run: |
           # add requirements
-          sudo apt install portaudio19-dev gettext
+          sudo apt install portaudio19-dev gettext rename
           export UNOPT=1
           ./check
-          ./bundle
+          ./build

--- a/qt/anki.desktop
+++ b/qt/anki.desktop
@@ -9,4 +9,4 @@ Categories=Education;Languages;KDE;Qt;
 Terminal=false
 Type=Application
 Version=1.0
-MimeType=application/x-apkg;application/x-anki;
+MimeType=application/x-apkg;application/x-anki;application/x-ankiaddon;

--- a/qt/anki.xml
+++ b/qt/anki.xml
@@ -11,4 +11,9 @@
    <glob pattern="*.apkg"/>
    </mime-type>
 
+   <mime-type type="application/x-ankiaddon">  
+   <comment>Anki 2.1 add-on package</comment>
+   <glob pattern="*.ankiaddon"/>
+   </mime-type>
+
  </mime-info>

--- a/qt/aqt/__init__.py
+++ b/qt/aqt/__init__.py
@@ -261,7 +261,7 @@ def parseArgs(argv):
     if isMac and len(argv) > 1 and argv[1].startswith("-psn"):
         argv = [argv[0]]
     parser = argparse.ArgumentParser(description="Anki " + appVersion)
-    parser.usage = "%(prog)s [OPTIONS] [file to import]"
+    parser.usage = "%(prog)s [OPTIONS] [file to import/add-on to install]"
     parser.add_argument("-b", "--base", help="path to base folder", default="")
     parser.add_argument("-p", "--profile", help="profile name to load", default="")
     parser.add_argument("-l", "--lang", help="interface language (en, de, etc)")

--- a/qt/aqt/addons.py
+++ b/qt/aqt/addons.py
@@ -47,8 +47,8 @@ class AddonInstallationResult(NamedTuple):
 
 class AddonManager:
 
-    ext = ".ankiaddon"
-    _manifest_schema = {
+    ext: str = ".ankiaddon"
+    _manifest_schema: dict = {
         "type": "object",
         "properties": {
             "package": {"type": "string", "meta": False},

--- a/qt/aqt/addons.py
+++ b/qt/aqt/addons.py
@@ -666,7 +666,7 @@ class AddonsDialog(QDialog):
     def onGetAddons(self):
         GetAddons(self)
 
-    def onInstallFiles(self, paths: List[str] = None, external: bool = False):
+    def onInstallFiles(self, paths: Optional[List[str]] = None, external: bool = False):
         if not paths:
             key = _("Packaged Anki Add-on") + " (*{})".format(self.mgr.ext)
             paths = getFile(
@@ -864,14 +864,14 @@ def installAddonPackages(
 ) -> bool:
 
     if external:
-        names_str = ",<br>".join(f"<b>{os.path.basename(p)}</b>" for p in paths)
+        names = ",<br>".join(f"<b>{os.path.basename(p)}</b>" for p in paths)
         q = _(
             "<b>Important</b>: As add-ons are programs downloaded from the internet, "
             "they are potentially malicious."
             "<b>You should only install add-ons you trust.</b><br><br>"
             "Are you sure you want to proceed with the installation of the "
-            f"following add-on(s)?<br><br>{names_str}<i>"
-        )
+            "following add-on(s)?<br><br>%(names)s"
+        ) % dict(names=names)
         if (
             not showInfo(
                 q,
@@ -882,7 +882,6 @@ def installAddonPackages(
             )
             == QMessageBox.Yes
         ):
-            tooltip(_("Add-on installation aborted"), parent=parent)
             return False
 
     log, errs = addonsManager.processPackages(paths, parent=parent)

--- a/qt/aqt/main.py
+++ b/qt/aqt/main.py
@@ -1027,6 +1027,7 @@ QTreeWidget {
 
     def installAddon(self, path):
         from aqt.addons import installAddonPackages
+
         installAddonPackages(self.addonManager, [path], external=True, parent=self)
 
     # Cramming
@@ -1482,7 +1483,7 @@ will be lost. Continue?"""
 
     def onAppMsg(self, buf: str) -> Optional[QTimer]:
         is_addon = buf.endswith(".ankiaddon")
-        
+
         if self.state == "startup":
             # try again in a second
             return self.progress.timer(
@@ -1521,13 +1522,13 @@ Please ensure a profile is open and Anki is not busy, then try again."""
             self.raise_()
         if buf == "raise":
             return None
-        
+
         # import / add-on installation
         if is_addon:
             self.installAddon(buf)
         else:
             self.handleImport(buf)
-        
+
         return None
 
     # GC

--- a/qt/aqt/utils.py
+++ b/qt/aqt/utils.py
@@ -57,7 +57,7 @@ def showInfo(
     type="info",
     title="Anki",
     textFormat=None,
-    customBtns=None
+    customBtns=None,
 ):
     "Show a small info window with an OK button."
     if parent is False:

--- a/qt/aqt/utils.py
+++ b/qt/aqt/utils.py
@@ -50,7 +50,15 @@ def showCritical(text, parent=None, help="", title="Anki", textFormat=None):
     return showInfo(text, parent, help, "critical", title=title, textFormat=textFormat)
 
 
-def showInfo(text, parent=False, help="", type="info", title="Anki", textFormat=None):
+def showInfo(
+    text,
+    parent=False,
+    help="",
+    type="info",
+    title="Anki",
+    textFormat=None,
+    customBtns=None
+):
     "Show a small info window with an OK button."
     if parent is False:
         parent = aqt.mw.app.activeWindow() or aqt.mw
@@ -70,8 +78,16 @@ def showInfo(text, parent=False, help="", type="info", title="Anki", textFormat=
     mb.setText(text)
     mb.setIcon(icon)
     mb.setWindowTitle(title)
-    b = mb.addButton(QMessageBox.Ok)
-    b.setDefault(True)
+    if customBtns:
+        default = None
+        for btn in customBtns:
+            b = mb.addButton(btn)
+            if not default:
+                default = b
+        mb.setDefaultButton(default)
+    else:
+        b = mb.addButton(QMessageBox.Ok)
+        b.setDefault(True)
     if help:
         b = mb.addButton(QMessageBox.Help)
         b.clicked.connect(lambda: openHelp(help))


### PR DESCRIPTION
Extends Anki's CLI with the ability to install `.ankiaddon` files and registers Anki as their file-type handler. This will allow users to conveniently install downloaded add-on packages right from their file manager without walking through a more complex installation procedure.

In order to prevent accidental installations and address potential security concerns, users are prompted for confirmation before Anki parses the `.ankiaddon` file in any way. The messaging is the same as on AnkiWeb:

![](https://user-images.githubusercontent.com/5459332/71739830-d729da00-2e5a-11ea-8d7b-7ff861c28817.png)

In their current state, these changes only assign Anki to `.ankiaddon` files on Linux. Further adjustments on the packaging side of things will be necessary to do the same on Windows and macOS.

Full disclosure: These changes were written as part of my work with AMBOSS and their rights of use lie with AMBOSS MD Inc.