### PR TITLE
Ignore buildhash when checking formatting with black

### DIFF
--- a/pylib/Makefile
+++ b/pylib/Makefile
@@ -6,7 +6,7 @@ MAKEFLAGS += --warn-undefined-variables
 MAKEFLAGS += --no-builtin-rules
 RUNARGS :=
 .SUFFIXES:
-BLACKARGS := -t py36 anki tests --exclude='backend_pb2|buildinfo'
+BLACKARGS := -t py36 anki tests --exclude='backend_pb2|buildinfo|buildhash'
 ISORTARGS := anki tests
 
 $(shell mkdir -p .build ../dist)


### PR DESCRIPTION
Not sure what's different compared to the checks performed by the GitHub workflow, but without this modification `./check` always fails for me locally.