### PR TITLE
Follow-up to .ankiaddon file-type handling

### DIFF
--- a/qt/aqt/addons.py
+++ b/qt/aqt/addons.py
@@ -861,7 +861,8 @@ def installAddonPackages(
     paths: List[str],
     parent: Optional[QWidget] = None,
     warn: bool = False,
-    strictly_modal: bool = False
+    strictly_modal: bool = False,
+    advise_restart: bool = False,
 ) -> bool:
 
     if warn:
@@ -889,6 +890,10 @@ def installAddonPackages(
 
     if log:
         log_html = "<br>".join(log)
+        if advise_restart:
+            log_html += "<br><br>" + _(
+                "<b>Please restart Anki to complete the installation.</b>"
+            )
         if len(log) == 1 and not strictly_modal:
             tooltip(log_html, parent=parent)
         else:

--- a/qt/aqt/addons.py
+++ b/qt/aqt/addons.py
@@ -859,18 +859,19 @@ class ConfigEditor(QDialog):
 def installAddonPackages(
     addonsManager: AddonManager,
     paths: List[str],
-    parent: QWidget = None,
-    external: bool = False,
+    parent: Optional[QWidget] = None,
+    warn: bool = False,
+    strictly_modal: bool = False
 ) -> bool:
 
-    if external:
+    if warn:
         names = ",<br>".join(f"<b>{os.path.basename(p)}</b>" for p in paths)
         q = _(
             "<b>Important</b>: As add-ons are programs downloaded from the internet, "
             "they are potentially malicious."
             "<b>You should only install add-ons you trust.</b><br><br>"
             "Are you sure you want to proceed with the installation of the "
-            "following add-on(s)?<br><br>%(names)s"
+            "following Anki add-on(s)?<br><br>%(names)s"
         ) % dict(names=names)
         if (
             not showInfo(
@@ -888,11 +889,7 @@ def installAddonPackages(
 
     if log:
         log_html = "<br>".join(log)
-        if external:
-            log_html += "<br><br>" + _(
-                "<b>Please restart Anki to complete the installation.</b>"
-            )
-        if len(log) == 1:
+        if len(log) == 1 and not strictly_modal:
             tooltip(log_html, parent=parent)
         else:
             showInfo(

--- a/qt/aqt/addons.py
+++ b/qt/aqt/addons.py
@@ -385,7 +385,7 @@ and have been disabled: %(found)s"
             strings.append(
                 _("The following conflicting add-ons were disabled:")
                 + " "
-                + " ".join(result.conflicts)
+                + ", ".join(self.addonName(f) for f in result.conflicts)
             )
 
         return strings

--- a/qt/aqt/addons.py
+++ b/qt/aqt/addons.py
@@ -345,7 +345,7 @@ and have been disabled: %(found)s"
     ######################################################################
 
     def _installationErrorReport(
-        self, result: AddonInstallationResult, base: str, mode="download"
+        self, result: AddonInstallationResult, base: str, mode: str = "download"
     ) -> List[str]:
 
         messages = {
@@ -370,7 +370,7 @@ and have been disabled: %(found)s"
         return [template % dict(base=name, id=name, error=msg)]
 
     def _installationSuccessReport(
-        self, result: AddonInstallationResult, base: str, mode="download"
+        self, result: AddonInstallationResult, base: str, mode: str = "download"
     ) -> List[str]:
 
         if mode == "download":  # preserve old format strings for i18n
@@ -666,7 +666,7 @@ class AddonsDialog(QDialog):
     def onGetAddons(self):
         GetAddons(self)
 
-    def onInstallFiles(self, paths: Optional[List[str]] = None, external: bool = False):
+    def onInstallFiles(self, paths: Optional[List[str]] = None):
         if not paths:
             key = _("Packaged Anki Add-on") + " (*{})".format(self.mgr.ext)
             paths = getFile(

--- a/qt/aqt/main.py
+++ b/qt/aqt/main.py
@@ -334,7 +334,10 @@ close the profile or restart Anki."""
 
         # import pending?
         if self.pendingImport:
-            self.handleImport(self.pendingImport)
+            if self._isAddon(self.pendingImport):
+                self.installAddon(self.pendingImport)
+            else:
+                self.handleImport(self.pendingImport)
             self.pendingImport = None
         runHook("profileLoaded")
         if onsuccess:
@@ -1482,7 +1485,7 @@ will be lost. Continue?"""
         self.app.appMsg.connect(self.onAppMsg)
 
     def onAppMsg(self, buf: str) -> Optional[QTimer]:
-        is_addon = buf.endswith(".ankiaddon")
+        is_addon = self._isAddon(buf)
 
         if self.state == "startup":
             # try again in a second
@@ -1530,6 +1533,9 @@ Please ensure a profile is open and Anki is not busy, then try again."""
             self.handleImport(buf)
 
         return None
+
+    def _isAddon(self, buf: str) -> bool:
+        return buf.endswith(self.addonManager.ext)
 
     # GC
     ##########################################################################

--- a/qt/aqt/main.py
+++ b/qt/aqt/main.py
@@ -1035,10 +1035,13 @@ QTreeWidget {
     def installAddon(self, path: str, startup: bool = False):
         from aqt.addons import installAddonPackages
 
-        parent = None if startup else self
-
         installAddonPackages(
-            self.addonManager, [path], warn=True, strictly_modal=startup, parent=parent
+            self.addonManager,
+            [path],
+            warn=True,
+            advise_restart=not startup,
+            strictly_modal=startup,
+            parent=None if startup else self,
         )
 
     # Cramming

--- a/qt/aqt/main.py
+++ b/qt/aqt/main.py
@@ -72,7 +72,7 @@ class AnkiQt(QMainWindow):
         self.safeMode = self.app.queryKeyboardModifiers() & Qt.ShiftModifier
         try:
             self.setupUI()
-            self.setupAddons()
+            self.setupAddons(args)
         except:
             showInfo(_("Error during startup:\n%s") % traceback.format_exc())
             sys.exit(1)
@@ -85,7 +85,7 @@ class AnkiQt(QMainWindow):
                 )
             )
         # were we given a file to import?
-        if args and args[0]:
+        if args and args[0] and not self._isAddon(args[0]):
             self.onAppMsg(args[0])
         # Load profile in a timer so we can let the window finish init and not
         # close on profile load error.
@@ -750,10 +750,14 @@ title="%s" %s>%s</button>""" % (
 
         self.errorHandler = aqt.errors.ErrorHandler(self)
 
-    def setupAddons(self) -> None:
+    def setupAddons(self, args: Optional[List]) -> None:
         import aqt.addons
 
         self.addonManager = aqt.addons.AddonManager(self)
+
+        if args and args[0] and self._isAddon(args[0]):
+            self.installAddon(args[0], startup=True)
+
         if not self.safeMode:
             self.addonManager.loadAddons()
 
@@ -1028,10 +1032,14 @@ QTreeWidget {
     # Installing add-ons from CLI / mimetype handler
     ##########################################################################
 
-    def installAddon(self, path):
+    def installAddon(self, path: str, startup: bool = False):
         from aqt.addons import installAddonPackages
 
-        installAddonPackages(self.addonManager, [path], external=True, parent=self)
+        parent = None if startup else self
+
+        installAddonPackages(
+            self.addonManager, [path], warn=True, strictly_modal=startup, parent=parent
+        )
 
     # Cramming
     ##########################################################################


### PR DESCRIPTION
Hey Damien,

Sorry for not adding these changes earlier, but after some further testing I ended up with a number of small fixes and additional tweaks, namely:

- Fix add-on installation from failing when deferred via pendingImports
- Whenever possible, perform add-on installation ahead of add-on loading
- Some minor messaging improvements

In summary, the add-on installation scenarios now look as follows:

- **Anki is not running**: add-on is installed ahead of addonManager.loadAddons, making away with the need for a restart
- **Anki is running, but in profileManager / startup state / otherwise blocked**: Add-on installation is deferred until loadProfile. Restart is required
- **Anki is running and ready**: Add-on installation is performed immediately. Restart is required.

Regarding our earlier discussion about window activation & positioning concerns before the main window is loaded: I ended up adjusting the parent handling and use of tooltips vs modal info dialogs, and everything seems to be working very well now.

---

Full disclosure: These changes were written as part of my work with AMBOSS and their rights of use lie with AMBOSS MD Inc.