### PR TITLE
BUGFIX: QLineEdit doesn't have .toPlainText()

### DIFF
--- a/qt/aqt/importing.py
+++ b/qt/aqt/importing.py
@@ -181,7 +181,7 @@ you can enter it here. Use \\t to represent tab."""
         self.importer.allowHTML = self.frm.allowHTML.isChecked()
         self.mw.pm.profile["allowHTML"] = self.importer.allowHTML
         if self.frm.tagModifiedCheck.isChecked():
-            self.importer.tagModified = self.frm.tagModifiedTag.toPlainText()
+            self.importer.tagModified = self.frm.tagModifiedTag.text()
         self.mw.pm.profile["tagModified"] = self.importer.tagModified
         did = self.deck.selectedId()
         if did != self.importer.model["did"]:


### PR DESCRIPTION
My apologies, this seems to have fallen through the cracks of changing and testing https://github.com/ankitects/anki/pull/408.