### PR TITLE
Compare models more thoroughly when importing

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -21,6 +21,7 @@ support site, it would be great if you could add your name below as well.
 Erez Volk <erez.volk@gmail.com>
 Aristotelis P. <glutanimate.com/contact>
 AMBOSS MD Inc. <https://www.amboss.com/>
+zjosua <zjosua@hotmail.com>
 
 ********************
 

--- a/pylib/anki/models.py
+++ b/pylib/anki/models.py
@@ -546,11 +546,13 @@ select id from notes where mid = ?)"""
 
     def scmhash(self, m: NoteType) -> str:
         "Return a hash of the schema, to see if models are compatible."
-        s = ""
+        s = m["css"]
         for f in m["flds"]:
             s += f["name"]
         for t in m["tmpls"]:
             s += t["name"]
+            for fmt in ("qfmt", "afmt"):
+                s += t[fmt]
         return checksum(s)
 
     # Required field/text cache


### PR DESCRIPTION
A while back, I've lost changes to my note types when importing decks that included notes of the same type, beacuse Anki quietly discards changes to some note type attributes.

I wasn't sure if I should include "bqfmt" and "bafmt" in the checksum, but I decided against it, because I've never seen a dialog that allows to change them.