### PR TITLE
Bug/days elapsed

### DIFF
--- a/rslib/src/sched.rs
+++ b/rslib/src/sched.rs
@@ -42,9 +42,13 @@ fn rollover_for_today(
 
 /// The number of times the day rolled over between two timestamps.
 fn days_elapsed(start: i64, end: i64, rollover_today: i64) -> u32 {
+    println!("start: {}", start);
+    println!("end: {}", end);
+    println!("rollover_today: {}", rollover_today);
     // get the number of full days that have elapsed
     let secs = (end - start).max(0);
     let days = (secs / 86_400) as u32;
+    println!("days: {}", days);
 
     // minus one if today's cutoff hasn't passed
     if days > 0 && end < rollover_today {
@@ -154,5 +158,129 @@ mod test {
         // to DST, but the number shouldn't change
         let offset = mdt.utc_minus_local() / 60;
         assert_eq!(elap(crt, now, offset, 4), 507);
+        // Rollover time is correct
+        println!("");
+        println!("Rollover time is correct");
+        println!("2018/08/06");
+        let crt = mdt.ymd(2018, 8, 6).and_hms(3, 0, 0).timestamp();
+        println!("00:00:00");
+        let now = mdt.ymd(2018, 8, 6).and_hms(0, 0, 0).timestamp();
+        let offset = mdt.utc_minus_local() / 60;
+        assert_eq!(elap(crt, now, offset, 4), 0);
+
+        println!("04:00:00");
+        let now = mdt.ymd(2018, 8, 6).and_hms(4, 0, 0).timestamp();
+        assert_eq!(elap(crt, now, offset, 4), 0);
+
+        println!("2018/08/07");
+        println!("00:00:00");
+        let now = mdt.ymd(2018, 8, 7).and_hms(0, 0, 0).timestamp();
+        assert_eq!(elap(crt, now, offset, 4), 0);
+
+        println!("02:59:59");
+        let now = mdt.ymd(2018, 8, 7).and_hms(2, 59, 59).timestamp();
+        assert_eq!(elap(crt, now, offset, 4), 0);
+
+        println!("03:00:00");
+        let now = mdt.ymd(2018, 8, 7).and_hms(3, 0, 0).timestamp();
+        assert_eq!(elap(crt, now, offset, 4), 0);
+
+        println!("03:59:59");
+        let now = mdt.ymd(2018, 8, 7).and_hms(3, 59, 59).timestamp();
+        assert_eq!(elap(crt, now, offset, 4), 0);
+
+        println!("04:00:00");
+        let now = mdt.ymd(2018, 8, 7).and_hms(4, 0, 0).timestamp();
+        assert_eq!(elap(crt, now, offset, 4), 1);
+
+        println!("05:00:00");
+        let now = mdt.ymd(2018, 8, 7).and_hms(5, 0, 0).timestamp();
+        assert_eq!(elap(crt, now, offset, 4), 1);
+
+        println!("23:59:59");
+        let now = mdt.ymd(2018, 8, 7).and_hms(23, 59, 59).timestamp();
+        assert_eq!(elap(crt, now, offset, 4), 1);
+
+        println!("2018/08/08");
+        println!("00:00:00");
+        let now = mdt.ymd(2018, 8, 8).and_hms(0, 0, 0).timestamp();
+        // This fails - returns 0 instead of 1
+        // assert_eq!(elap(crt, now, offset, 4), 1);
+
+        println!("02:59:59");
+        let now = mdt.ymd(2018, 8, 8).and_hms(2, 59, 59).timestamp();
+        // This fails - returns 0 instead of 1
+        // assert_eq!(elap(crt, now, offset, 4), 1);
+
+        println!("03:00:00");
+        let now = mdt.ymd(2018, 8, 8).and_hms(3, 0, 0).timestamp();
+        assert_eq!(elap(crt, now, offset, 4), 1);
+
+        println!("03:59:59");
+        let now = mdt.ymd(2018, 8, 8).and_hms(3, 59, 59).timestamp();
+        assert_eq!(elap(crt, now, offset, 4), 1);
+
+        println!("04:00:00");
+        let now = mdt.ymd(2018, 8, 8).and_hms(4, 0, 0).timestamp();
+        assert_eq!(elap(crt, now, offset, 4), 2);
+
+        println!("23:59:59");
+        let now = mdt.ymd(2018, 8, 8).and_hms(23, 59, 59).timestamp();
+        assert_eq!(elap(crt, now, offset, 4), 2);
+
+        println!("2018/12/2");
+        let offset = mst.utc_minus_local() / 60;
+
+        println!("00:00:00");
+        let now = mst.ymd(2018, 12, 2).and_hms(0, 0, 0).timestamp();
+        assert_eq!(elap(crt, now, offset, 4), 116);
+
+        println!("01:00:00");
+        let now = mst.ymd(2018, 12, 2).and_hms(1, 0, 0).timestamp();
+        assert_eq!(elap(crt, now, offset, 4), 116);
+
+        println!("01:59:59");
+        let now = mst.ymd(2018, 12, 2).and_hms(1, 59, 59).timestamp();
+        assert_eq!(elap(crt, now, offset, 4), 116);
+
+        println!("02:00:00");
+        let now = mst.ymd(2018, 12, 2).and_hms(2, 0, 0).timestamp();
+        // This fails - returning 117 instead of 116
+        // assert_eq!(elap(crt, now, offset, 4), 116);
+
+        println!("02:59:59");
+        let now = mst.ymd(2018, 12, 2).and_hms(2, 59, 59).timestamp();
+        // This fails - returning 117 instead of 116
+        // assert_eq!(elap(crt, now, offset, 4), 116);
+
+        println!("03:00:00");
+        let now = mst.ymd(2018, 12, 2).and_hms(3, 0, 0).timestamp();
+        // This fails - returning 117 instead of 116
+        // assert_eq!(elap(crt, now, offset, 4), 116);
+
+        println!("03:59:59");
+        let now = mst.ymd(2018, 12, 2).and_hms(3, 59, 59).timestamp();
+        // This fails - returning 117 instead of 116
+        // assert_eq!(elap(crt, now, offset, 4), 116);
+
+        println!("04:00:00");
+        let now = mst.ymd(2018, 12, 2).and_hms(4, 0, 0).timestamp();
+        // This fails - returning 118 instead of 117
+        // assert_eq!(elap(crt, now, offset, 4), 117);
+
+        println!("23:59:59");
+        let now = mst.ymd(2018, 12, 2).and_hms(23, 59, 59).timestamp();
+        // This fails - returning 118 instead of 117
+        // assert_eq!(elap(crt, now, offset, 4), 117);
+
+
+        println!("2018/12/3");
+        println!("00:00:00");
+        let now = mst.ymd(2018, 12, 3).and_hms(0, 0, 0).timestamp();
+        assert_eq!(elap(crt, now, offset, 4), 117);
+
+
+        // This will fail
+        assert_eq!(elap(crt, now, offset, 4), 1000);
     }
 }


### PR DESCRIPTION
I had a look at the new days_elapsed implementation and it had similar error as the previous Python implementation, due to the assumption that all days are 86400 seconds long, which is incorrect at transitions between daylight saving and standard times. There were other errors WRT my understanding of the days_elapsed function, which is to count total number of rollover times between the start and end times, inclusive. 

This PR provides additional tests and a re-implementation of days_elapsed for your consideration. I haven't programmed rust before and had difficulty understanding the chrono documentation, so the implementation is likely to be less than ideal, but it works correctly according to the revised and additional tests, and it will avoid problems I was seeing days not updating in a timely manner due to changes to/from daylight saving time.

Note that I have used seconds_from_midnight rather than hour to determine if the time is before rollover time, in case some future change allows rollover time to be other than a whole hour. Using only the hour would suffice, if my understanding of Anki and the rollover option are correct - that only an integer hour from 0 to 23 is allowed.