### PR TITLE
Order by creation of note

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -22,6 +22,7 @@ Erez Volk <erez.volk@gmail.com>
 Aristotelis P. <https://glutanimate.com/contact>
 AMBOSS MD Inc. <https://www.amboss.com/>
 zjosua <zjosua@hotmail.com>
+Arthur Milchior <arthur@milchior.fr>
 
 ********************
 

--- a/pylib/anki/sched.py
+++ b/pylib/anki/sched.py
@@ -1578,7 +1578,7 @@ and due >= ? and queue = 0"""
         self.sortCards(cids, shuffle=True)
 
     def orderCards(self, did):
-        cids = self.col.db.list("select id from cards where did = ? order by id", did)
+        cids = self.col.db.list("select id from cards where did = ? order by nid", did)
         self.sortCards(cids)
 
     def resortConf(self, conf):

--- a/pylib/anki/schedv2.py
+++ b/pylib/anki/schedv2.py
@@ -1832,7 +1832,7 @@ and due >= ? and queue = 0"""
         self.sortCards(cids, shuffle=True)
 
     def orderCards(self, did: int) -> None:
-        cids = self.col.db.list("select id from cards where did = ? order by id", did)
+        cids = self.col.db.list("select id from cards where did = ? order by nid", did)
         self.sortCards(cids)
 
     def resortConf(self, conf) -> None:


### PR DESCRIPTION
This commit solve a problem I actually have for some strange
reason. Here is how to reproduce the problem

1. Create a note of type Basic (and reversed card) in a deck D with front "First" and no back
2. Wait a day (or install an add-on which show hour and minutes of creation time in browser)
3. create a second note, with front "Last" and no back
4. In first note, add in back field "First" and delete the front field
5. Use "Empty card".
6. In the setting of the deck D, set in random order, and then back in the "order added"
7. Review deck D. You'll see card 1 of the second note. (Don't review it)
8. Open the browser. Show the column "due" and created. You'll see that the first card (first) have due value 2, while it was created before according to the created date. The card "last" have due value

This is due to the fact that the value "created" is linked to note creation, while the order is linked to the card creation time, and card may be created after other note