### PR TITLE
Add card_answered hook

### DIFF
--- a/pylib/anki/hooks.py
+++ b/pylib/anki/hooks.py
@@ -28,6 +28,30 @@ from anki.template import TemplateRenderContext
 # @@AUTOGEN@@
 
 
+class _CardAnsweredHook:
+    _hooks: List[Callable[[Card, int], None]] = []
+
+    def append(self, cb: Callable[[Card, int], None]) -> None:
+        """(card: Card, ease: int)"""
+        self._hooks.append(cb)
+
+    def remove(self, cb: Callable[[Card, int], None]) -> None:
+        if cb in self._hooks:
+            self._hooks.remove(cb)
+
+    def __call__(self, card: Card, ease: int) -> None:
+        for hook in self._hooks:
+            try:
+                hook(card, ease)
+            except:
+                # if the hook fails, remove it
+                self._hooks.remove(hook)
+                raise
+
+
+card_answered = _CardAnsweredHook()
+
+
 class _CardDidLeechHook:
     _hooks: List[Callable[[Card], None]] = []
 

--- a/pylib/anki/sched.py
+++ b/pylib/anki/sched.py
@@ -97,6 +97,7 @@ class Scheduler:
         card.mod = intTime()
         card.usn = self.col.usn()
         card.flushSched()
+        hooks.card_answered(card, ease)
 
     def counts(self, card=None):
         counts = [self.newCount, self.lrnCount, self.revCount]

--- a/pylib/anki/schedv2.py
+++ b/pylib/anki/schedv2.py
@@ -87,6 +87,7 @@ class Scheduler:
         card.mod = intTime()
         card.usn = self.col.usn()
         card.flushSched()
+        hooks.card_answered(card, ease)
 
     def _answerCard(self, card: Card, ease: int) -> None:
         if self._previewingCard(card):

--- a/pylib/tools/genhooks.py
+++ b/pylib/tools/genhooks.py
@@ -19,6 +19,7 @@ from hookslib import Hook, update_file
 hooks = [
     Hook(name="card_did_leech", args=["card: Card"], legacy_hook="leech"),
     Hook(name="card_odue_was_invalid"),
+    Hook(name="card_answered", args=["card: Card", "ease: int"]),
     Hook(name="schema_will_change", args=["proceed: bool"], return_type="bool"),
     Hook(
         name="notes_will_be_deleted",


### PR DESCRIPTION
One use case would be in [Puppy Reinforcement](https://github.com/glutanimate/puppy-reinforcement/blob/master/src/puppy_reinforcement/views.py#L67), but this seems like a fairly popular point to latch on to in general: https://github.com/search?q=wrap%28sched.answercard&type=Code

Quick proof-of-concept (for demo purposes and debug console testing)

```python
from anki.hooks import card_answered

def onCardAnswered(card, ease):
    print(card, ease)

card_answered.append(onCardAnswered)
```