### PR TITLE
Prevent "msgfmt: command not found" error

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -23,6 +23,7 @@ Aristotelis P. <https://glutanimate.com/contact>
 Erez Volk <erez.volk@gmail.com>
 zjosua <zjosua@hotmail.com>
 Arthur Milchior <arthur@milchior.fr>
+Yngve Hoiseth <yngve@hoiseth.net>
 
 ********************
 

--- a/README.development
+++ b/README.development
@@ -74,3 +74,4 @@ You can use homebrew to install some dependencies:
 
 $ brew install python mpv lame portaudio protobuf npm rustup-init gettext rename
 
+$ brew link gettext --force


### PR DESCRIPTION
When following the instructions, I got:

```
🔗 Found pyo3 bindings
🐍 Found CPython 3.7m at python
    Finished release [optimized] target(s) in 0.18s
make[1]: Leaving directory `/Users/yngve/Repositories/ankitects/anki/rspy'
make[1]: Entering directory `/Users/yngve/Repositories/ankitects/anki/pylib'
make[1]: Nothing to be done for `develop'.
make[1]: Leaving directory `/Users/yngve/Repositories/ankitects/anki/pylib'
make[1]: Entering directory `/Users/yngve/Repositories/ankitects/anki/qt'
(cd i18n && ./build-mo-files && ./copy-qt-files)
Compiling *.po...
./build-mo-files: line 16: msgfmt: command not found
./build-mo-files: line 16: msgfmt: command not found
…
./build-mo-files: line 16: msgfmt: command not found
./build-mo-files: line 16: msgfmt: command not found
make[1]: *** [.build/i18n] Error 127
make[1]: Leaving directory `/Users/yngve/Repositories/ankitects/anki/qt'
make: *** [develop] Error 2
```

Running `brew link gettext --force` solved the issue.