### PR TITLE
"unused" variable become optional.

### DIFF
--- a/qt/aqt/addcards.py
+++ b/qt/aqt/addcards.py
@@ -89,7 +89,7 @@ class AddCards(QDialog):
     def setAndFocusNote(self, note: Note) -> None:
         self.editor.setNote(note, focusTo=0)
 
-    def onModelChange(self, unused) -> None:
+    def onModelChange(self, unused=None) -> None:
         oldNote = self.editor.note
         note = self.mw.col.newNote()
         self.previousNote = None

--- a/qt/aqt/deckchooser.py
+++ b/qt/aqt/deckchooser.py
@@ -66,7 +66,7 @@ class DeckChooser(QHBoxLayout):
     def cleanup(self) -> None:
         gui_hooks.current_note_type_did_change.remove(self.onModelChangeNew)
 
-    def onModelChangeNew(self, unused):
+    def onModelChangeNew(self, unused=None):
         self.onModelChange()
 
     def onModelChange(self):


### PR DESCRIPTION
Adding this parameter broke one of my add-on, see
https://github.com/Arthur-Milchior/anki-keep-model-in-add-cards/issues/1

Since those parameters are not used, setting them to None by default,
as was done in some other method, seems acceptable