### PR TITLE
Equip Reviewer._showAnswer with hooks covering common add-on usages

### DIFF
--- a/qt/aqt/reviewer.py
+++ b/qt/aqt/reviewer.py
@@ -242,7 +242,13 @@ The front of this card is empty. Please run Tools>Empty Cards."""
             return
         if self.mw.col.sched.answerButtons(self.card) < ease:
             return
+        proceed, ease = gui_hooks.reviewer_will_answer_card(
+            (True, ease), self, self.card
+        )
+        if not proceed:
+            return
         self.mw.col.sched.answerCard(self.card, ease)
+        gui_hooks.reviewer_did_answer_card(self, self.card, ease)
         self._answeredIds.append(self.card.id)
         self.mw.autosave()
         self.nextCard()

--- a/qt/tools/genhooks_gui.py
+++ b/qt/tools/genhooks_gui.py
@@ -32,6 +32,27 @@ hooks = [
         legacy_no_args=True,
     ),
     Hook(
+        name="reviewer_will_answer_card",
+        args=[
+            "ease_tuple: Tuple[bool, int]",
+            "reviewer: aqt.reviewer.Reviewer", "card: Card",
+        ],
+        return_type="Tuple[bool, int]",
+        doc="""Used to modify the ease at which a card is rated or to bypass
+        rating the card completely.
+        
+        ease_tuple is a tuple consisting of a boolean expressing whether the reviewer
+        should continue with rating the card, and an integer expressing the ease at
+        which the card should be rated.
+        
+        If your code just needs to be notified of the card rating event, you should use
+        the reviewer_did_answer_card hook instead.""",
+    ),
+    Hook(
+        name="reviewer_did_answer_card",
+        args=["reviewer: aqt.reviewer.Reviewer", "card: Card", "ease: int"],
+    ),
+    Hook(
         name="reviewer_will_show_context_menu",
         args=["reviewer: aqt.reviewer.Reviewer", "menu: QMenu"],
         legacy_hook="Reviewer.contextMenuEvent",

--- a/qt/tools/genhooks_gui.py
+++ b/qt/tools/genhooks_gui.py
@@ -35,7 +35,8 @@ hooks = [
         name="reviewer_will_answer_card",
         args=[
             "ease_tuple: Tuple[bool, int]",
-            "reviewer: aqt.reviewer.Reviewer", "card: Card",
+            "reviewer: aqt.reviewer.Reviewer",
+            "card: Card",
         ],
         return_type="Tuple[bool, int]",
         doc="""Used to modify the ease at which a card is rated or to bypass


### PR DESCRIPTION
Follow-up to #424

Demo code:

```python
from aqt import gui_hooks

def onHook(reviewer, card, ease):
   print(reviewer, card, ease)

def onFilter(ease_tuple, reviewer, card):
   print(ease_tuple, reviewer, card)
   return ease_tuple

gui_hooks.reviewer_did_answer_card.append(onHook)
gui_hooks.reviewer_will_answer_card.append(onFilter)
```