### PR TITLE
Allow to add css/js to the editor easily

### DIFF
--- a/qt/aqt/editor.py
+++ b/qt/aqt/editor.py
@@ -93,7 +93,14 @@ class Editor:
         self.widget.setLayout(l)
         self.outerLayout = l
 
-    def setupWeb(self) -> None:
+    def setupWeb(self, head: str = "") -> None:
+        """Head -- some string to put in the html's head.
+
+
+        Allows add-ons to add css/js by redefining setupWeb and
+        appending it to the input head, then calling this method.
+
+        """
         self.web = EditorWebView(self.widget, self)
         self.web.title = "editor"
         self.web.allowDrops = True
@@ -167,6 +174,7 @@ class Editor:
             _html % (bgcol, bgcol, topbuts, _("Show Duplicates")),
             css=["editor.css"],
             js=["jquery.js", "editor.js"],
+            head=head,
         )
 
     # Top buttons


### PR DESCRIPTION
At least four add-ons need to add css or js to the editor.
* Multi column note by HSSM
* Frozen field by Glutanimate
* Tex in editor by me
* Resize image in editor (by me, not yet published)
* Add-on 2064123047 merging the three first add-ons

One related problem each add-on have is that they need to add some
js/css to the editor. Which can be done mostly by changing the whole
method setupWeb. This is actually overkill, and allowing an extra
parameter to this method would solve this problem and allow for a more
beautiful add-on code.

This is why I suggest this extra parameter.

I want to emphasize that the default value here is the same as the one
in webview.py's stdHtml function.

I should not that an even more elegant solution would be to allow more
css/js file to be incorporated into the window. But that would lead to
more complex anki code and not much improvement in add-ons, so I don't
suggest spending time on it