### PR TITLE
Allow add-on authors to easily inject their own content into Anki's web views

### DIFF
--- a/qt/aqt/browser.py
+++ b/qt/aqt/browser.py
@@ -1639,7 +1639,7 @@ where id in %s"""
             "reviewer.js",
         ]
         self._previewWeb.stdHtml(
-            self.mw.reviewer.revHtml(), css=["reviewer.css"], js=jsinc
+            self.mw.reviewer.revHtml(), css=["reviewer.css"], js=jsinc, caller=self
         )
         self._previewWeb.set_bridge_command(self._on_preview_bridge_cmd, "preview")
 

--- a/qt/aqt/browser.py
+++ b/qt/aqt/browser.py
@@ -1374,7 +1374,7 @@ by clicking on one on the left."""
         d = CardInfoDialog(self)
         l = QVBoxLayout()
         l.setContentsMargins(0, 0, 0, 0)
-        w = AnkiWebView()
+        w = AnkiWebView(title="browser_card_info")
         l.addWidget(w)
         w.stdHtml(info + "<p>" + reps)
         bb = QDialogButtonBox(QDialogButtonBox.Close)
@@ -1543,7 +1543,7 @@ where id in %s"""
         self._previewWindow.silentlyClose = True
         vbox = QVBoxLayout()
         vbox.setContentsMargins(0, 0, 0, 0)
-        self._previewWeb = AnkiWebView()
+        self._previewWeb = AnkiWebView(title="previewer")
         vbox.addWidget(self._previewWeb)
         bbox = QDialogButtonBox()
 
@@ -2129,6 +2129,7 @@ update cards set usn=?, mod=?, did=? where id in """
         frm.fields.addItems(fields)
         self._dupesButton = None
         # links
+        frm.webView.title = "find_dupes"
         frm.webView.set_bridge_command(self.dupeLinkClicked, "find_dupes")
 
         def onFin(code):

--- a/qt/aqt/clayout.py
+++ b/qt/aqt/clayout.py
@@ -215,10 +215,10 @@ class CardLayout(QDialog):
             "reviewer.js",
         ]
         pform.frontWeb.stdHtml(
-            self.mw.reviewer.revHtml(), css=["reviewer.css"], js=jsinc
+            self.mw.reviewer.revHtml(), css=["reviewer.css"], js=jsinc, caller=self
         )
         pform.backWeb.stdHtml(
-            self.mw.reviewer.revHtml(), css=["reviewer.css"], js=jsinc
+            self.mw.reviewer.revHtml(), css=["reviewer.css"], js=jsinc, caller=self
         )
         pform.frontWeb.set_bridge_command(self._on_bridge_cmd, "card_layout")
         pform.backWeb.set_bridge_command(self._on_bridge_cmd, "card_layout")

--- a/qt/aqt/clayout.py
+++ b/qt/aqt/clayout.py
@@ -203,9 +203,9 @@ class CardLayout(QDialog):
 
     def setupWebviews(self):
         pform = self.pform
-        pform.frontWeb = AnkiWebView()
+        pform.frontWeb = AnkiWebView(title="clayout_front")
         pform.frontPrevBox.addWidget(pform.frontWeb)
-        pform.backWeb = AnkiWebView()
+        pform.backWeb = AnkiWebView(title="clayout_back")
         pform.backPrevBox.addWidget(pform.backWeb)
         jsinc = [
             "jquery.js",

--- a/qt/aqt/deckbrowser.py
+++ b/qt/aqt/deckbrowser.py
@@ -100,6 +100,8 @@ class DeckBrowser:
             self._body % dict(tree=tree, stats=stats, countwarn=self._countWarn()),
             css=["deckbrowser.css"],
             js=["jquery.js", "jquery-ui.js", "deckbrowser.js"],
+            caller=self,
+            view_name="deckbrowser",
         )
         self.web.key = "deckBrowser"
         self._drawButtons()

--- a/qt/aqt/editor.py
+++ b/qt/aqt/editor.py
@@ -166,6 +166,7 @@ class Editor:
             _html % (bgcol, bgcol, topbuts, _("Show Duplicates")),
             css=["editor.css"],
             js=["jquery.js", "editor.js"],
+            caller=self,
         )
 
     # Top buttons

--- a/qt/aqt/editor.py
+++ b/qt/aqt/editor.py
@@ -95,7 +95,6 @@ class Editor:
 
     def setupWeb(self) -> None:
         self.web = EditorWebView(self.widget, self)
-        self.web.title = "editor"
         self.web.allowDrops = True
         self.web.set_bridge_command(self.onBridgeCmd, "editor")
         self.outerLayout.addWidget(self.web, 1)
@@ -936,7 +935,7 @@ to a cloze type first, via Edit>Change Note Type."""
 
 class EditorWebView(AnkiWebView):
     def __init__(self, parent, editor):
-        AnkiWebView.__init__(self)
+        AnkiWebView.__init__(self, title="editor")
         self.editor = editor
         self.strip = self.editor.mw.pm.profile["stripHTML"]
         self.setAcceptDrops(True)

--- a/qt/aqt/gui_hooks.py
+++ b/qt/aqt/gui_hooks.py
@@ -151,6 +151,52 @@ class _AvPlayerWillPlayHook:
 av_player_will_play = _AvPlayerWillPlayHook()
 
 
+class _BottomToolbarWillSetWebContentFilter:
+    _hooks: List[
+        Callable[
+            ["aqt.webview.ModifiableWebContent", "aqt.toolbar.BottomBar"],
+            aqt.webview.ModifiableWebContent,
+        ]
+    ] = []
+
+    def append(
+        self,
+        cb: Callable[
+            ["aqt.webview.ModifiableWebContent", "aqt.toolbar.BottomBar"],
+            aqt.webview.ModifiableWebContent,
+        ],
+    ) -> None:
+        """(web_content: aqt.webview.ModifiableWebContent, bottom_toolbar: aqt.toolbar.BottomBar)"""
+        self._hooks.append(cb)
+
+    def remove(
+        self,
+        cb: Callable[
+            ["aqt.webview.ModifiableWebContent", "aqt.toolbar.BottomBar"],
+            aqt.webview.ModifiableWebContent,
+        ],
+    ) -> None:
+        if cb in self._hooks:
+            self._hooks.remove(cb)
+
+    def __call__(
+        self,
+        web_content: aqt.webview.ModifiableWebContent,
+        bottom_toolbar: aqt.toolbar.BottomBar,
+    ) -> aqt.webview.ModifiableWebContent:
+        for filter in self._hooks:
+            try:
+                web_content = filter(web_content, bottom_toolbar)
+            except:
+                # if the hook fails, remove it
+                self._hooks.remove(filter)
+                raise
+        return web_content
+
+
+bottom_toolbar_will_set_web_content = _BottomToolbarWillSetWebContentFilter()
+
+
 class _BrowserDidChangeRowHook:
     _hooks: List[Callable[["aqt.browser.Browser"], None]] = []
 
@@ -256,6 +302,98 @@ class _CardWillShowFilter:
 
 
 card_will_show = _CardWillShowFilter()
+
+
+class _ClayoutBackWillSetWebContentFilter:
+    _hooks: List[
+        Callable[
+            ["aqt.webview.ModifiableWebContent", "aqt.clayout.CardLayout"],
+            aqt.webview.ModifiableWebContent,
+        ]
+    ] = []
+
+    def append(
+        self,
+        cb: Callable[
+            ["aqt.webview.ModifiableWebContent", "aqt.clayout.CardLayout"],
+            aqt.webview.ModifiableWebContent,
+        ],
+    ) -> None:
+        """(web_content: aqt.webview.ModifiableWebContent, clayout: aqt.clayout.CardLayout)"""
+        self._hooks.append(cb)
+
+    def remove(
+        self,
+        cb: Callable[
+            ["aqt.webview.ModifiableWebContent", "aqt.clayout.CardLayout"],
+            aqt.webview.ModifiableWebContent,
+        ],
+    ) -> None:
+        if cb in self._hooks:
+            self._hooks.remove(cb)
+
+    def __call__(
+        self,
+        web_content: aqt.webview.ModifiableWebContent,
+        clayout: aqt.clayout.CardLayout,
+    ) -> aqt.webview.ModifiableWebContent:
+        for filter in self._hooks:
+            try:
+                web_content = filter(web_content, clayout)
+            except:
+                # if the hook fails, remove it
+                self._hooks.remove(filter)
+                raise
+        return web_content
+
+
+clayout_back_will_set_web_content = _ClayoutBackWillSetWebContentFilter()
+
+
+class _ClayoutFrontWillSetWebContentFilter:
+    _hooks: List[
+        Callable[
+            ["aqt.webview.ModifiableWebContent", "aqt.clayout.CardLayout"],
+            aqt.webview.ModifiableWebContent,
+        ]
+    ] = []
+
+    def append(
+        self,
+        cb: Callable[
+            ["aqt.webview.ModifiableWebContent", "aqt.clayout.CardLayout"],
+            aqt.webview.ModifiableWebContent,
+        ],
+    ) -> None:
+        """(web_content: aqt.webview.ModifiableWebContent, clayout: aqt.clayout.CardLayout)"""
+        self._hooks.append(cb)
+
+    def remove(
+        self,
+        cb: Callable[
+            ["aqt.webview.ModifiableWebContent", "aqt.clayout.CardLayout"],
+            aqt.webview.ModifiableWebContent,
+        ],
+    ) -> None:
+        if cb in self._hooks:
+            self._hooks.remove(cb)
+
+    def __call__(
+        self,
+        web_content: aqt.webview.ModifiableWebContent,
+        clayout: aqt.clayout.CardLayout,
+    ) -> aqt.webview.ModifiableWebContent:
+        for filter in self._hooks:
+            try:
+                web_content = filter(web_content, clayout)
+            except:
+                # if the hook fails, remove it
+                self._hooks.remove(filter)
+                raise
+        return web_content
+
+
+clayout_front_will_set_web_content = _ClayoutFrontWillSetWebContentFilter()
 
 
 class _CollectionDidLoadHook:
@@ -519,6 +657,50 @@ class _EditorDidUpdateTagsHook:
 editor_did_update_tags = _EditorDidUpdateTagsHook()
 
 
+class _EditorWillSetWebContentFilter:
+    _hooks: List[
+        Callable[
+            ["aqt.webview.ModifiableWebContent", "aqt.editor.Editor"],
+            aqt.webview.ModifiableWebContent,
+        ]
+    ] = []
+
+    def append(
+        self,
+        cb: Callable[
+            ["aqt.webview.ModifiableWebContent", "aqt.editor.Editor"],
+            aqt.webview.ModifiableWebContent,
+        ],
+    ) -> None:
+        """(web_content: aqt.webview.ModifiableWebContent, editor: aqt.editor.Editor)"""
+        self._hooks.append(cb)
+
+    def remove(
+        self,
+        cb: Callable[
+            ["aqt.webview.ModifiableWebContent", "aqt.editor.Editor"],
+            aqt.webview.ModifiableWebContent,
+        ],
+    ) -> None:
+        if cb in self._hooks:
+            self._hooks.remove(cb)
+
+    def __call__(
+        self, web_content: aqt.webview.ModifiableWebContent, editor: aqt.editor.Editor
+    ) -> aqt.webview.ModifiableWebContent:
+        for filter in self._hooks:
+            try:
+                web_content = filter(web_content, editor)
+            except:
+                # if the hook fails, remove it
+                self._hooks.remove(filter)
+                raise
+        return web_content
+
+
+editor_will_set_web_content = _EditorWillSetWebContentFilter()
+
+
 class _EditorWillShowContextMenuHook:
     _hooks: List[Callable[["aqt.editor.EditorWebView", QMenu], None]] = []
 
@@ -570,6 +752,234 @@ class _EditorWillUseFontForFieldFilter:
 
 
 editor_will_use_font_for_field = _EditorWillUseFontForFieldFilter()
+
+
+class _MainDeckbrowserWillSetWebContentFilter:
+    _hooks: List[
+        Callable[
+            ["aqt.webview.ModifiableWebContent", "aqt.deckbrowser.DeckBrowser"],
+            aqt.webview.ModifiableWebContent,
+        ]
+    ] = []
+
+    def append(
+        self,
+        cb: Callable[
+            ["aqt.webview.ModifiableWebContent", "aqt.deckbrowser.DeckBrowser"],
+            aqt.webview.ModifiableWebContent,
+        ],
+    ) -> None:
+        """(web_content: aqt.webview.ModifiableWebContent, deckbrowser: aqt.deckbrowser.DeckBrowser)"""
+        self._hooks.append(cb)
+
+    def remove(
+        self,
+        cb: Callable[
+            ["aqt.webview.ModifiableWebContent", "aqt.deckbrowser.DeckBrowser"],
+            aqt.webview.ModifiableWebContent,
+        ],
+    ) -> None:
+        if cb in self._hooks:
+            self._hooks.remove(cb)
+
+    def __call__(
+        self,
+        web_content: aqt.webview.ModifiableWebContent,
+        deckbrowser: aqt.deckbrowser.DeckBrowser,
+    ) -> aqt.webview.ModifiableWebContent:
+        for filter in self._hooks:
+            try:
+                web_content = filter(web_content, deckbrowser)
+            except:
+                # if the hook fails, remove it
+                self._hooks.remove(filter)
+                raise
+        return web_content
+
+
+main_deckbrowser_will_set_web_content = _MainDeckbrowserWillSetWebContentFilter()
+
+
+class _MainOverviewWillSetWebContentFilter:
+    _hooks: List[
+        Callable[
+            ["aqt.webview.ModifiableWebContent", "aqt.overview.Overview"],
+            aqt.webview.ModifiableWebContent,
+        ]
+    ] = []
+
+    def append(
+        self,
+        cb: Callable[
+            ["aqt.webview.ModifiableWebContent", "aqt.overview.Overview"],
+            aqt.webview.ModifiableWebContent,
+        ],
+    ) -> None:
+        """(web_content: aqt.webview.ModifiableWebContent, overview: aqt.overview.Overview)"""
+        self._hooks.append(cb)
+
+    def remove(
+        self,
+        cb: Callable[
+            ["aqt.webview.ModifiableWebContent", "aqt.overview.Overview"],
+            aqt.webview.ModifiableWebContent,
+        ],
+    ) -> None:
+        if cb in self._hooks:
+            self._hooks.remove(cb)
+
+    def __call__(
+        self,
+        web_content: aqt.webview.ModifiableWebContent,
+        overview: aqt.overview.Overview,
+    ) -> aqt.webview.ModifiableWebContent:
+        for filter in self._hooks:
+            try:
+                web_content = filter(web_content, overview)
+            except:
+                # if the hook fails, remove it
+                self._hooks.remove(filter)
+                raise
+        return web_content
+
+
+main_overview_will_set_web_content = _MainOverviewWillSetWebContentFilter()
+
+
+class _MainResetWillSetWebContentFilter:
+    _hooks: List[
+        Callable[
+            ["aqt.webview.ModifiableWebContent", "aqt.AnkiQt"],
+            aqt.webview.ModifiableWebContent,
+        ]
+    ] = []
+
+    def append(
+        self,
+        cb: Callable[
+            ["aqt.webview.ModifiableWebContent", "aqt.AnkiQt"],
+            aqt.webview.ModifiableWebContent,
+        ],
+    ) -> None:
+        """(web_content: aqt.webview.ModifiableWebContent, mw: aqt.AnkiQt)"""
+        self._hooks.append(cb)
+
+    def remove(
+        self,
+        cb: Callable[
+            ["aqt.webview.ModifiableWebContent", "aqt.AnkiQt"],
+            aqt.webview.ModifiableWebContent,
+        ],
+    ) -> None:
+        if cb in self._hooks:
+            self._hooks.remove(cb)
+
+    def __call__(
+        self, web_content: aqt.webview.ModifiableWebContent, mw: aqt.AnkiQt
+    ) -> aqt.webview.ModifiableWebContent:
+        for filter in self._hooks:
+            try:
+                web_content = filter(web_content, mw)
+            except:
+                # if the hook fails, remove it
+                self._hooks.remove(filter)
+                raise
+        return web_content
+
+
+main_reset_will_set_web_content = _MainResetWillSetWebContentFilter()
+
+
+class _MainReviewerWillSetWebContentFilter:
+    _hooks: List[
+        Callable[
+            ["aqt.webview.ModifiableWebContent", "aqt.reviewer.Reviewer"],
+            aqt.webview.ModifiableWebContent,
+        ]
+    ] = []
+
+    def append(
+        self,
+        cb: Callable[
+            ["aqt.webview.ModifiableWebContent", "aqt.reviewer.Reviewer"],
+            aqt.webview.ModifiableWebContent,
+        ],
+    ) -> None:
+        """(web_content: aqt.webview.ModifiableWebContent, reviewer: aqt.reviewer.Reviewer)"""
+        self._hooks.append(cb)
+
+    def remove(
+        self,
+        cb: Callable[
+            ["aqt.webview.ModifiableWebContent", "aqt.reviewer.Reviewer"],
+            aqt.webview.ModifiableWebContent,
+        ],
+    ) -> None:
+        if cb in self._hooks:
+            self._hooks.remove(cb)
+
+    def __call__(
+        self,
+        web_content: aqt.webview.ModifiableWebContent,
+        reviewer: aqt.reviewer.Reviewer,
+    ) -> aqt.webview.ModifiableWebContent:
+        for filter in self._hooks:
+            try:
+                web_content = filter(web_content, reviewer)
+            except:
+                # if the hook fails, remove it
+                self._hooks.remove(filter)
+                raise
+        return web_content
+
+
+main_reviewer_will_set_web_content = _MainReviewerWillSetWebContentFilter()
+
+
+class _PreviewerWillSetWebContentFilter:
+    _hooks: List[
+        Callable[
+            ["aqt.webview.ModifiableWebContent", "aqt.browser.Browser"],
+            aqt.webview.ModifiableWebContent,
+        ]
+    ] = []
+
+    def append(
+        self,
+        cb: Callable[
+            ["aqt.webview.ModifiableWebContent", "aqt.browser.Browser"],
+            aqt.webview.ModifiableWebContent,
+        ],
+    ) -> None:
+        """(web_content: aqt.webview.ModifiableWebContent, browser: aqt.browser.Browser)"""
+        self._hooks.append(cb)
+
+    def remove(
+        self,
+        cb: Callable[
+            ["aqt.webview.ModifiableWebContent", "aqt.browser.Browser"],
+            aqt.webview.ModifiableWebContent,
+        ],
+    ) -> None:
+        if cb in self._hooks:
+            self._hooks.remove(cb)
+
+    def __call__(
+        self,
+        web_content: aqt.webview.ModifiableWebContent,
+        browser: aqt.browser.Browser,
+    ) -> aqt.webview.ModifiableWebContent:
+        for filter in self._hooks:
+            try:
+                web_content = filter(web_content, browser)
+            except:
+                # if the hook fails, remove it
+                self._hooks.remove(filter)
+                raise
+        return web_content
+
+
+previewer_will_set_web_content = _PreviewerWillSetWebContentFilter()
 
 
 class _ProfileDidOpenHook:
@@ -961,6 +1371,52 @@ class _StateWillChangeHook:
 state_will_change = _StateWillChangeHook()
 
 
+class _StatsWillSetWebContentFilter:
+    _hooks: List[
+        Callable[
+            ["aqt.webview.ModifiableWebContent", "aqt.stats.DeckStats"],
+            aqt.webview.ModifiableWebContent,
+        ]
+    ] = []
+
+    def append(
+        self,
+        cb: Callable[
+            ["aqt.webview.ModifiableWebContent", "aqt.stats.DeckStats"],
+            aqt.webview.ModifiableWebContent,
+        ],
+    ) -> None:
+        """(web_content: aqt.webview.ModifiableWebContent, deckstats: aqt.stats.DeckStats)"""
+        self._hooks.append(cb)
+
+    def remove(
+        self,
+        cb: Callable[
+            ["aqt.webview.ModifiableWebContent", "aqt.stats.DeckStats"],
+            aqt.webview.ModifiableWebContent,
+        ],
+    ) -> None:
+        if cb in self._hooks:
+            self._hooks.remove(cb)
+
+    def __call__(
+        self,
+        web_content: aqt.webview.ModifiableWebContent,
+        deckstats: aqt.stats.DeckStats,
+    ) -> aqt.webview.ModifiableWebContent:
+        for filter in self._hooks:
+            try:
+                web_content = filter(web_content, deckstats)
+            except:
+                # if the hook fails, remove it
+                self._hooks.remove(filter)
+                raise
+        return web_content
+
+
+stats_will_set_web_content = _StatsWillSetWebContentFilter()
+
+
 class _StyleDidInitFilter:
     _hooks: List[Callable[[str], str]] = []
 
@@ -986,6 +1442,52 @@ class _StyleDidInitFilter:
 
 
 style_did_init = _StyleDidInitFilter()
+
+
+class _TopToolbarWillSetWebContentFilter:
+    _hooks: List[
+        Callable[
+            ["aqt.webview.ModifiableWebContent", "aqt.toolbar.Toolbar"],
+            aqt.webview.ModifiableWebContent,
+        ]
+    ] = []
+
+    def append(
+        self,
+        cb: Callable[
+            ["aqt.webview.ModifiableWebContent", "aqt.toolbar.Toolbar"],
+            aqt.webview.ModifiableWebContent,
+        ],
+    ) -> None:
+        """(web_content: aqt.webview.ModifiableWebContent, top_toolbar: aqt.toolbar.Toolbar)"""
+        self._hooks.append(cb)
+
+    def remove(
+        self,
+        cb: Callable[
+            ["aqt.webview.ModifiableWebContent", "aqt.toolbar.Toolbar"],
+            aqt.webview.ModifiableWebContent,
+        ],
+    ) -> None:
+        if cb in self._hooks:
+            self._hooks.remove(cb)
+
+    def __call__(
+        self,
+        web_content: aqt.webview.ModifiableWebContent,
+        top_toolbar: aqt.toolbar.Toolbar,
+    ) -> aqt.webview.ModifiableWebContent:
+        for filter in self._hooks:
+            try:
+                web_content = filter(web_content, top_toolbar)
+            except:
+                # if the hook fails, remove it
+                self._hooks.remove(filter)
+                raise
+        return web_content
+
+
+top_toolbar_will_set_web_content = _TopToolbarWillSetWebContentFilter()
 
 
 class _UndoStateDidChangeHook:

--- a/qt/aqt/main.py
+++ b/qt/aqt/main.py
@@ -707,19 +707,16 @@ title="%s" %s>%s</button>""" % (
         self.form = aqt.forms.main.Ui_MainWindow()
         self.form.setupUi(self)
         # toolbar
-        tweb = self.toolbarWeb = aqt.webview.AnkiWebView()
-        tweb.title = "top toolbar"
+        tweb = self.toolbarWeb = aqt.webview.AnkiWebView(title="top toolbar")
         tweb.setFocusPolicy(Qt.WheelFocus)
         self.toolbar = aqt.toolbar.Toolbar(self, tweb)
         self.toolbar.draw()
         # main area
-        self.web = aqt.webview.AnkiWebView()
-        self.web.title = "main webview"
+        self.web = aqt.webview.AnkiWebView(title="main webview")
         self.web.setFocusPolicy(Qt.WheelFocus)
         self.web.setMinimumWidth(400)
         # bottom area
-        sweb = self.bottomWeb = aqt.webview.AnkiWebView()
-        sweb.title = "bottom toolbar"
+        sweb = self.bottomWeb = aqt.webview.AnkiWebView(title="bottom toolbar")
         sweb.setFocusPolicy(Qt.WheelFocus)
         # add in a layout
         self.mainLayout = QVBoxLayout()

--- a/qt/aqt/main.py
+++ b/qt/aqt/main.py
@@ -707,16 +707,16 @@ title="%s" %s>%s</button>""" % (
         self.form = aqt.forms.main.Ui_MainWindow()
         self.form.setupUi(self)
         # toolbar
-        tweb = self.toolbarWeb = aqt.webview.AnkiWebView(title="top toolbar")
+        tweb = self.toolbarWeb = aqt.webview.AnkiWebView(title="top_toolbar")
         tweb.setFocusPolicy(Qt.WheelFocus)
         self.toolbar = aqt.toolbar.Toolbar(self, tweb)
         self.toolbar.draw()
         # main area
-        self.web = aqt.webview.AnkiWebView(title="main webview")
+        self.web = aqt.webview.AnkiWebView(title="main")
         self.web.setFocusPolicy(Qt.WheelFocus)
         self.web.setMinimumWidth(400)
         # bottom area
-        sweb = self.bottomWeb = aqt.webview.AnkiWebView(title="bottom toolbar")
+        sweb = self.bottomWeb = aqt.webview.AnkiWebView(title="bottom_toolbar")
         sweb.setFocusPolicy(Qt.WheelFocus)
         # add in a layout
         self.mainLayout = QVBoxLayout()

--- a/qt/aqt/main.py
+++ b/qt/aqt/main.py
@@ -666,7 +666,9 @@ from the profile screen."
 %s</div></div></center>
 <script>$('#resume').focus()</script>
 """
-            % (i, b)
+            % (i, b),
+            caller=self,
+            view_name="reset",
         )
         self.bottomWeb.hide()
         self.web.setFocus()

--- a/qt/aqt/overview.py
+++ b/qt/aqt/overview.py
@@ -144,6 +144,8 @@ class Overview:
             ),
             css=["overview.css"],
             js=["jquery.js", "overview.js"],
+            caller=self,
+            view_name="overview",
         )
 
     def _desc(self, deck):

--- a/qt/aqt/reviewer.py
+++ b/qt/aqt/reviewer.py
@@ -146,6 +146,8 @@ class Reviewer:
                 "mathjax/MathJax.js",
                 "reviewer.js",
             ],
+            caller=self,
+            view_name="reviewer",
         )
         # show answer / ease buttons
         self.bottom.web.show()
@@ -153,6 +155,7 @@ class Reviewer:
             self._bottomHTML(),
             css=["toolbar-bottom.css", "reviewer-bottom.css"],
             js=["jquery.js", "reviewer-bottom.js"],
+            caller=self,
         )
 
     # Showing the question

--- a/qt/aqt/stats.py
+++ b/qt/aqt/stats.py
@@ -97,6 +97,8 @@ class DeckStats(QDialog):
         self.report = stats.report(type=self.period)
         self.form.web.title = "stats"
         self.form.web.stdHtml(
-            "<html><body>" + self.report + "</body></html>", js=["jquery.js", "plot.js"]
+            "<html><body>" + self.report + "</body></html>",
+            js=["jquery.js", "plot.js"],
+            caller=self,
         )
         self.mw.progress.finish()

--- a/qt/aqt/stats.py
+++ b/qt/aqt/stats.py
@@ -95,6 +95,7 @@ class DeckStats(QDialog):
         stats = self.mw.col.stats()
         stats.wholeCollection = self.wholeCollection
         self.report = stats.report(type=self.period)
+        self.form.web.title = "stats"
         self.form.web.stdHtml(
             "<html><body>" + self.report + "</body></html>", js=["jquery.js", "plot.js"]
         )

--- a/qt/aqt/toolbar.py
+++ b/qt/aqt/toolbar.py
@@ -27,7 +27,9 @@ class Toolbar:
 
     def draw(self):
         self.web.set_bridge_command(self._linkHandler, "top_toolbar")
-        self.web.stdHtml(self._body % self._centerLinks(), css=["toolbar.css"])
+        self.web.stdHtml(
+            self._body % self._centerLinks(), css=["toolbar.css"], caller=self
+        )
         self.web.adjustHeightToFit()
 
     # Available links
@@ -114,6 +116,8 @@ class BottomBar(Toolbar):
         # note: some screens may override this
         self.web.set_bridge_command(self._linkHandler, "bottom_toolbar")
         self.web.stdHtml(
-            self._centerBody % buf, css=["toolbar.css", "toolbar-bottom.css"]
+            self._centerBody % buf,
+            css=["toolbar.css", "toolbar-bottom.css"],
+            caller=self,
         )
         self.web.adjustHeightToFit()

--- a/qt/aqt/webview.py
+++ b/qt/aqt/webview.py
@@ -275,7 +275,7 @@ class AnkiWebView(QWebEngineView):  # type: ignore
         caller: Optional[Any],
         view_name: Optional[str],
     ) -> ModifiableWebContent:
-        name = self.title.replace(" ", "_") + f"_{view_name}" if view_name else ""
+        name = self.title.replace(" ", "_") + (f"_{view_name}" if view_name else "")
         hook_name = f"{name}_will_set_web_content"
         hook: Callable[
             [ModifiableWebContent, Optional[Any]], ModifiableWebContent

--- a/qt/aqt/webview.py
+++ b/qt/aqt/webview.py
@@ -275,7 +275,7 @@ class AnkiWebView(QWebEngineView):  # type: ignore
         caller: Optional[Any],
         view_name: Optional[str],
     ) -> ModifiableWebContent:
-        name = view_name or self.title.replace(" ", "_")
+        name = self.title.replace(" ", "_") + f"_{view_name}" if view_name else ""
         hook_name = f"{name}_will_set_web_content"
         hook: Callable[
             [ModifiableWebContent, Optional[Any]], ModifiableWebContent
@@ -298,7 +298,7 @@ class AnkiWebView(QWebEngineView):  # type: ignore
         if js is None:
             js = ["jquery.js"]
 
-        if self.title != "default" or not view_name:
+        if self.title != "default":
             # only allow add-on modifications to named web views
             web_content = self._filterWebContent(
                 ModifiableWebContent(body=body, head=head, addon_js=[], addon_css=[]),

--- a/qt/aqt/webview.py
+++ b/qt/aqt/webview.py
@@ -270,9 +270,12 @@ class AnkiWebView(QWebEngineView):  # type: ignore
         return self.style().standardPalette().color(QPalette.Window)
 
     def _filterWebContent(
-        self, web_content: ModifiableWebContent, caller: Optional[Any]
+        self,
+        web_content: ModifiableWebContent,
+        caller: Optional[Any],
+        view_name: Optional[str],
     ) -> ModifiableWebContent:
-        name = self.title.replace(" ", "_")
+        name = view_name or self.title.replace(" ", "_")
         hook_name = f"{name}_will_set_web_content"
         hook: Callable[
             [ModifiableWebContent, Optional[Any]], ModifiableWebContent
@@ -288,17 +291,19 @@ class AnkiWebView(QWebEngineView):  # type: ignore
         js: Optional[List[str]] = None,
         head: str = "",
         caller: Optional[Any] = None,
+        view_name: Optional[str] = None,
     ):
         if css is None:
             css = []
         if js is None:
             js = ["jquery.js"]
 
-        if self.title != "default":
+        if self.title != "default" or not view_name:
             # only allow add-on modifications to named web views
             web_content = self._filterWebContent(
                 ModifiableWebContent(body=body, head=head, addon_js=[], addon_css=[]),
                 caller,
+                view_name,
             )
             body = web_content.body
             head = web_content.head

--- a/qt/aqt/webview.py
+++ b/qt/aqt/webview.py
@@ -101,9 +101,11 @@ class AnkiWebPage(QWebEnginePage):  # type: ignore
 
 
 class AnkiWebView(QWebEngineView):  # type: ignore
-    def __init__(self, parent: Optional[QWidget] = None) -> None:
+    def __init__(
+        self, parent: Optional[QWidget] = None, title: str = "default"
+    ) -> None:
         QWebEngineView.__init__(self, parent=parent)  # type: ignore
-        self.title = "default"
+        self.title = title
         self._page = AnkiWebPage(self._onBridgeCmd)
         self._page.setBackgroundColor(self._getWindowColor())  # reduce flicker
 

--- a/qt/tools/genhooks_gui.py
+++ b/qt/tools/genhooks_gui.py
@@ -239,6 +239,93 @@ hooks = [
         args=["menu: QMenu", "deck_id: int"],
         legacy_hook="showDeckOptions",
     ),
+    # Web view content
+    ###################
+    Hook(
+        name="editor_will_set_web_content",
+        args=[
+            "web_content: aqt.webview.ModifiableWebContent",
+            "editor: aqt.editor.Editor",
+        ],
+        return_type="aqt.webview.ModifiableWebContent",
+    ),
+    Hook(
+        name="main_deckbrowser_will_set_web_content",
+        args=[
+            "web_content: aqt.webview.ModifiableWebContent",
+            "deckbrowser: aqt.deckbrowser.DeckBrowser",
+        ],
+        return_type="aqt.webview.ModifiableWebContent",
+    ),
+    Hook(
+        name="main_overview_will_set_web_content",
+        args=[
+            "web_content: aqt.webview.ModifiableWebContent",
+            "overview: aqt.overview.Overview",
+        ],
+        return_type="aqt.webview.ModifiableWebContent",
+    ),
+    Hook(
+        name="main_reviewer_will_set_web_content",
+        args=[
+            "web_content: aqt.webview.ModifiableWebContent",
+            "reviewer: aqt.reviewer.Reviewer",
+        ],
+        return_type="aqt.webview.ModifiableWebContent",
+    ),
+    Hook(
+        name="main_reset_will_set_web_content",
+        args=["web_content: aqt.webview.ModifiableWebContent", "mw: aqt.AnkiQt",],
+        return_type="aqt.webview.ModifiableWebContent",
+    ),
+    Hook(
+        name="stats_will_set_web_content",
+        args=[
+            "web_content: aqt.webview.ModifiableWebContent",
+            "deckstats: aqt.stats.DeckStats",
+        ],
+        return_type="aqt.webview.ModifiableWebContent",
+    ),
+    Hook(
+        name="top_toolbar_will_set_web_content",
+        args=[
+            "web_content: aqt.webview.ModifiableWebContent",
+            "top_toolbar: aqt.toolbar.Toolbar",
+        ],
+        return_type="aqt.webview.ModifiableWebContent",
+    ),
+    Hook(
+        name="bottom_toolbar_will_set_web_content",
+        args=[
+            "web_content: aqt.webview.ModifiableWebContent",
+            "bottom_toolbar: aqt.toolbar.BottomBar",
+        ],
+        return_type="aqt.webview.ModifiableWebContent",
+    ),
+    Hook(
+        name="previewer_will_set_web_content",
+        args=[
+            "web_content: aqt.webview.ModifiableWebContent",
+            "browser: aqt.browser.Browser",
+        ],
+        return_type="aqt.webview.ModifiableWebContent",
+    ),
+    Hook(
+        name="clayout_front_will_set_web_content",
+        args=[
+            "web_content: aqt.webview.ModifiableWebContent",
+            "clayout: aqt.clayout.CardLayout",
+        ],
+        return_type="aqt.webview.ModifiableWebContent",
+    ),
+    Hook(
+        name="clayout_back_will_set_web_content",
+        args=[
+            "web_content: aqt.webview.ModifiableWebContent",
+            "clayout: aqt.clayout.CardLayout",
+        ],
+        return_type="aqt.webview.ModifiableWebContent",
+    ),
 ]
 
 if __name__ == "__main__":


### PR DESCRIPTION
**Overview**

This is a reworked version of #258 prompted by Arthur's thoughtful changes in #438.

Just like #258, this PR seeks to simplify the process of writing add-ons that modify Anki's web views. To do so it adds a series of easy-to-use filters that allow injecting custom HTML, CSS, and JS with as little inter-addon friction as possible.

**Details**

Web content filters are passed two arguments, a data class instance storing a number of modifiable fields (`ModifiableWebContent` type), and the original caller that initiated the web view update (i.e. an Anki object like a Reviewer or Editor instance).

Here is `ModifiableWebContent`'s in-line documentation, for your convenience:

```python
"""Data exchange class for web content that is modifiable by add-on filters

Attributes:
    body {str} -- HTML body
    head {str} -- HTML head
    addon_css {List[str]} -- List of subpaths, each pointing to an add-on-provided
                             CSS file
    addon_js {List[str]} -- List of subpaths, each pointing to an add-on-provided
                            JavaScript file

Important Notes:
    - When modifying the body or head of a web view, please make sure your changes
      only perform the minimum-required edits to make your add-on work. You should
      attempt to preserve as much of the original HTML as possible in order to
      avoid clashes with Anki's code or that of other add-ons. If possible, please
      only append or prepend your changes to the existing HTML. E.g.:
      
      > def on_view_will_set_web_content(web_content: ModifiableWebContent, view):
      >    web_content.body += "<your_html>"
      >    return web_content
    
    - The paths specified in `addon_css` and `addon_js` need to be accessible by
      Anki's media server. I.e., they should match the web export patterns you have
      specified via aqt.addons.AddonManager.setWebExports()
      
      E.g., to allow access to an `addon.js` and `addon.css` residing in a "web"
      subfolder in your add-on package, first register the corresponding web export:
      
      > from aqt import mw
      > mw.addonManager.setWebExports(__name__, r"web/.*(css|js)")
      
      Then append the subpaths to the corresponding web_content fields within the
      filter implemented by your add-on:
      
      > def on_view_will_set_web_content(web_content: ModifiableWebContent, view):
      >     web_content.addon_css.append(
      >         f"{mw.addonManager.addonFromModule(__name__)}/web/addon.css")
      >     web_content.addon_js.append(
      >         f"{mw.addonManager.addonFromModule(__name__)}/web/addon.js")
      >     return web_content
"""
```

Rather than calling the filters from each Anki view, as in #258, the changes in this PR move all calls to `AnkiWebView` (as suggested in the original PR's comments). The filter names are thus constructed dynamically, taking the form of `<caller>[_<view_name>]_will_set_web_content`.

The in-line docs in AnkiWebView dive more into this:

```python
"""Runs web content through addon-defined filters that are specific to
individual web views

Arguments:
    web_content {ModifiableWebContent} -- Data class storing web view HTML and
                                          addon-provided JS and CSS additions
    caller {Optional[Any]} -- Anki object that sets the web view's contents
                              (e.g. a Reviewer or Editor instance)
    view_name {Optional[str]} -- In case of web views that are reused across
                                 multiple GUI views – the name of that view
                                 (e.g. "deckbrowser", "overview", or "reviewer"
                                 for the main webview)

Notes:
    - Filter names are constructed dynamically from the web view title
      and, optionally, a `view_name` specified by the caller. The general
      form is: `<caller>[_<view_name>]_will_set_web_content`
      
      E.g.:
      - aqt.reviewer.Reviewer: `main_reviewer_will_set_web_content`
      - aqt.editor.Editor: `editor_will_set_web_content`
      
      For a list of all web content hooks please either see the
      "Web view content" section in qt/tools/genhooks_gui.py or
      look through the actual filters generated in gui_hooks.py

Returns:
    ModifiableWebContent -- Web content, with changes applied by add-ons
                            (if available)
"""
```

**Proof-of-concept**

If you'd like to give these changes a quick try, here's a small script I've written for Anki's debug console:

```python
from aqt import gui_hooks

def on_view_will_set_web_content(web_content, view):
    print(view)
    web_content.body += "<br><h1><font color=green>Hello World</font></h1>"
    web_content.head += "<script>console.log('hello world')</script>"
    return web_content

for view_name in ["editor", "main_deckbrowser", "main_overview", "main_reviewer", "main_reset", "stats", "top_toolbar", "bottom_toolbar", "previewer", "clayout_front", "clayout_back"]:
    hook = getattr(gui_hooks, f"{view_name}_will_set_web_content")
    hook.append(on_view_will_set_web_content)
```

