### PR TITLE
Adding an option to an hook

### DIFF
--- a/pylib/anki/exporting.py
+++ b/pylib/anki/exporting.py
@@ -408,7 +408,14 @@ class AnkiCollectionPackageExporter(AnkiPackageExporter):
 ##########################################################################
 
 
-def exporters() -> List[Tuple[str, Any]]:
+def exporters(options: Any = None) -> List[Tuple[str, Any]]:
+    """Options -- some option sent to hooks to decide how to update.
+    e.g. the string "browser" may be used to state that this was
+    called from the browser, and an option may be added to export
+    selected cards from browser.
+
+    """
+
     def id(obj):
         return ("%s (*%s)" % (obj.key, obj.ext), obj)
 
@@ -419,4 +426,5 @@ def exporters() -> List[Tuple[str, Any]]:
         id(TextCardExporter),
     ]
     hooks.exporters_list_created(exps)
+    hooks.exporters_list_created_with_options(exps, options)
     return exps

--- a/pylib/anki/hooks.py
+++ b/pylib/anki/hooks.py
@@ -185,6 +185,30 @@ class _ExportersListCreatedHook:
 exporters_list_created = _ExportersListCreatedHook()
 
 
+class _ExportersListCreatedWithOptionsHook:
+    _hooks: List[Callable[[List[Tuple[str, Any]], Any], None]] = []
+
+    def append(self, cb: Callable[[List[Tuple[str, Any]], Any], None]) -> None:
+        """(exporters: List[Tuple[str, Any]], options: Any)"""
+        self._hooks.append(cb)
+
+    def remove(self, cb: Callable[[List[Tuple[str, Any]], Any], None]) -> None:
+        if cb in self._hooks:
+            self._hooks.remove(cb)
+
+    def __call__(self, exporters: List[Tuple[str, Any]], options: Any) -> None:
+        for hook in self._hooks:
+            try:
+                hook(exporters, options)
+            except:
+                # if the hook fails, remove it
+                self._hooks.remove(hook)
+                raise
+
+
+exporters_list_created_with_options = _ExportersListCreatedWithOptionsHook()
+
+
 class _FieldFilterFilter:
     """Allows you to define custom {{filters:..}}
         

--- a/pylib/tools/genhooks.py
+++ b/pylib/tools/genhooks.py
@@ -38,6 +38,10 @@ hooks = [
         legacy_hook="exportersList",
     ),
     Hook(
+        name="exporters_list_created_with_options",
+        args=["exporters: List[Tuple[str, Any]]", "options: Any",],
+    ),
+    Hook(
         name="search_terms_prepared",
         args=["searches: Dict[str, Callable]"],
         legacy_hook="search",

--- a/qt/aqt/exporting.py
+++ b/qt/aqt/exporting.py
@@ -14,18 +14,24 @@ from aqt.utils import checkInvalidFilename, getSaveFile, showInfo, showWarning, 
 
 
 class ExportDialog(QDialog):
-    def __init__(self, mw, did=None):
+    def __init__(self, mw, did=None, options=None):
+        """did -- the deck on which "export" was clicked.
+        options -- some opton which may be used to compute
+        the list of exporters (used by add-on only currently)"""
         QDialog.__init__(self, mw, Qt.Window)
         self.mw = mw
         self.col = mw.col
         self.frm = aqt.forms.exporting.Ui_ExportDialog()
         self.frm.setupUi(self)
         self.exporter = None
-        self.setup(did)
+        self.setup(did, options)
         self.exec_()
 
-    def setup(self, did):
-        self.exporters = exporters()
+    def setup(self, did, options=None):
+        """did -- the deck on which "export" was clicked.
+        options -- some opton which may be used to compute
+        the list of exporters (used by add-on only currently)"""
+        self.exporters = exporters(options)
         # if a deck specified, start with .apkg type selected
         idx = 0
         if did:


### PR DESCRIPTION
As stated in
https://github.com/ankitects/anki/pull/438#issuecomment-583168521 I'm
trying to change anki (as little as possible) to remove monkey
patching from my add-ons.

Add-on 1983204951 does monkey patching because it needs to take into
account whether the export window is called from browser or
not. Ideally, I'd like that, when I call the export window, I can add
an option. This option will then be passed to exporters_list_created
to decide how to edit the list. (In the present case, it means:
whether or not to add "export selected card)

Since exporters_list_created calls the legacy hook exportersList, I
can't directly edit it. So I prefer to add a new hook.