### PR TITLE
Allow to change main window when overview/deckbrowser is shown

### DIFF
--- a/qt/aqt/deckbrowser.py
+++ b/qt/aqt/deckbrowser.py
@@ -92,6 +92,7 @@ class DeckBrowser:
             self.__renderPage(None)
             return
         self.web.evalWithCallback("window.pageYOffset", self.__renderPage)
+        gui_hooks.deck_browser_did_render(self)
 
     def __renderPage(self, offset):
         tree = self._renderDeckTree(self._dueTree)

--- a/qt/aqt/gui_hooks.py
+++ b/qt/aqt/gui_hooks.py
@@ -310,6 +310,32 @@ class _CurrentNoteTypeDidChangeHook:
 current_note_type_did_change = _CurrentNoteTypeDidChangeHook()
 
 
+class _DeckBrowserDidRenderHook:
+    """Allow to update the deck browser window. E.g. change its title."""
+
+    _hooks: List[Callable[["aqt.deckbrowser.DeckBrowser"], None]] = []
+
+    def append(self, cb: Callable[["aqt.deckbrowser.DeckBrowser"], None]) -> None:
+        """(deck_browser: aqt.deckbrowser.DeckBrowser)"""
+        self._hooks.append(cb)
+
+    def remove(self, cb: Callable[["aqt.deckbrowser.DeckBrowser"], None]) -> None:
+        if cb in self._hooks:
+            self._hooks.remove(cb)
+
+    def __call__(self, deck_browser: aqt.deckbrowser.DeckBrowser) -> None:
+        for hook in self._hooks:
+            try:
+                hook(deck_browser)
+            except:
+                # if the hook fails, remove it
+                self._hooks.remove(hook)
+                raise
+
+
+deck_browser_did_render = _DeckBrowserDidRenderHook()
+
+
 class _DeckBrowserWillShowOptionsMenuHook:
     _hooks: List[Callable[[QMenu, int], None]] = []
 
@@ -570,6 +596,33 @@ class _EditorWillUseFontForFieldFilter:
 
 
 editor_will_use_font_for_field = _EditorWillUseFontForFieldFilter()
+
+
+class _OverviewDidRefreshHook:
+    """Allow to update the overview window. E.g. add the deck name in the
+        title."""
+
+    _hooks: List[Callable[["aqt.overview.Overview"], None]] = []
+
+    def append(self, cb: Callable[["aqt.overview.Overview"], None]) -> None:
+        """(overview: aqt.overview.Overview)"""
+        self._hooks.append(cb)
+
+    def remove(self, cb: Callable[["aqt.overview.Overview"], None]) -> None:
+        if cb in self._hooks:
+            self._hooks.remove(cb)
+
+    def __call__(self, overview: aqt.overview.Overview) -> None:
+        for hook in self._hooks:
+            try:
+                hook(overview)
+            except:
+                # if the hook fails, remove it
+                self._hooks.remove(hook)
+                raise
+
+
+overview_did_refresh = _OverviewDidRefreshHook()
 
 
 class _ProfileDidOpenHook:

--- a/qt/aqt/overview.py
+++ b/qt/aqt/overview.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import aqt
 from anki.lang import _
+from aqt import gui_hooks
 from aqt.sound import av_player
 from aqt.toolbar import BottomBar
 from aqt.utils import askUserDialog, openLink, shortcut, tooltip
@@ -30,6 +31,7 @@ class Overview:
         self._renderPage()
         self._renderBottom()
         self.mw.web.setFocus()
+        gui_hooks.overview_did_refresh(self)
 
     # Handlers
     ############################################################

--- a/qt/tools/genhooks_gui.py
+++ b/qt/tools/genhooks_gui.py
@@ -20,6 +20,17 @@ hooks = [
     # Reviewing
     ###################
     Hook(
+        name="overview_did_refresh",
+        args=["overview: aqt.overview.Overview"],
+        doc="""Allow to update the overview window. E.g. add the deck name in the
+        title.""",
+    ),
+    Hook(
+        name="deck_browser_did_render",
+        args=["deck_browser: aqt.deckbrowser.DeckBrowser"],
+        doc="""Allow to update the deck browser window. E.g. change its title.""",
+    ),
+    Hook(
         name="reviewer_did_show_question",
         args=["card: Card"],
         legacy_hook="showQuestion",


### PR DESCRIPTION
This would allow to remove monkey patch to "Deck name in title 2.1". That's a 2.0 add-on I uploaded as 2.1, ad it seems quite successful. 1817 download.
(I'm trying to consider add-ons which are both successful and easy to consider with hooks)