### PR TITLE
Pre flush hooks

### DIFF
--- a/pylib/anki/cards.py
+++ b/pylib/anki/cards.py
@@ -84,7 +84,7 @@ class Card:
         self._render_output = None
         self._note = None
 
-    def flush(self) -> None:
+    def _preFlush(self) -> none:
         self.mod = intTime()
         self.usn = self.col.usn()
         # bug check
@@ -95,6 +95,9 @@ class Card:
         ):
             hooks.card_odue_was_invalid()
         assert self.due < 4294967296
+
+    def flush(self) -> None:
+        self._preFlush()
         self.col.db.execute(
             """
 insert or replace into cards values
@@ -121,16 +124,8 @@ insert or replace into cards values
         self.col.log(self)
 
     def flushSched(self) -> None:
-        self.mod = intTime()
-        self.usn = self.col.usn()
+        self._preFlush()
         # bug checks
-        if (
-            self.queue == QUEUE_TYPE_REV
-            and self.odue
-            and not self.col.decks.isDyn(self.did)
-        ):
-            hooks.card_odue_was_invalid()
-        assert self.due < 4294967296
         self.col.db.execute(
             """update cards set
 mod=?, usn=?, type=?, queue=?, due=?, ivl=?, factor=?, reps=?,

--- a/pylib/anki/cards.py
+++ b/pylib/anki/cards.py
@@ -84,7 +84,8 @@ class Card:
         self._render_output = None
         self._note = None
 
-    def _preFlush(self) -> none:
+    def _preFlush(self) -> None:
+        hooks.card_will_flush(self)
         self.mod = intTime()
         self.usn = self.col.usn()
         # bug check

--- a/pylib/anki/hooks.py
+++ b/pylib/anki/hooks.py
@@ -134,6 +134,32 @@ class _CardOdueWasInvalidHook:
 card_odue_was_invalid = _CardOdueWasInvalidHook()
 
 
+class _CardWillFlushHook:
+    """Allow to change a card before it is added/updated in the database."""
+
+    _hooks: List[Callable[[Card], None]] = []
+
+    def append(self, cb: Callable[[Card], None]) -> None:
+        """(card: Card)"""
+        self._hooks.append(cb)
+
+    def remove(self, cb: Callable[[Card], None]) -> None:
+        if cb in self._hooks:
+            self._hooks.remove(cb)
+
+    def __call__(self, card: Card) -> None:
+        for hook in self._hooks:
+            try:
+                hook(card)
+            except:
+                # if the hook fails, remove it
+                self._hooks.remove(hook)
+                raise
+
+
+card_will_flush = _CardWillFlushHook()
+
+
 class _DeckAddedHook:
     _hooks: List[Callable[[Dict[str, Any]], None]] = []
 

--- a/pylib/anki/notes.py
+++ b/pylib/anki/notes.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 from typing import Any, Dict, List, Optional, Tuple
 
 import anki  # pylint: disable=unused-import
+from anki import hooks
 from anki.models import Field, NoteType
 from anki.utils import (
     fieldChecksum,
@@ -202,6 +203,7 @@ insert or replace into notes values (?,?,?,?,?,?,?,?,?,?,?)""",
     ##################################################
 
     def _preFlush(self) -> None:
+        hooks.note_will_flush(self)
         # have we been added yet?
         self.newlyAdded = not self.col.db.scalar(
             "select 1 from cards where nid = ?", self.id

--- a/pylib/tools/genhooks.py
+++ b/pylib/tools/genhooks.py
@@ -68,6 +68,11 @@ hooks = [
         field_text or not before returning it.""",
     ),
     Hook(
+        name="note_will_flush",
+        args=["note: Note"],
+        doc="Allow to change a note before it is added/updated in the database.",
+    ),
+    Hook(
         name="card_did_render",
         args=[
             "output: anki.template.TemplateRenderOutput",

--- a/pylib/tools/genhooks.py
+++ b/pylib/tools/genhooks.py
@@ -73,6 +73,11 @@ hooks = [
         doc="Allow to change a note before it is added/updated in the database.",
     ),
     Hook(
+        name="card_will_flush",
+        args=["card: Card"],
+        doc="Allow to change a card before it is added/updated in the database.",
+    ),
+    Hook(
         name="card_did_render",
         args=[
             "output: anki.template.TemplateRenderOutput",


### PR DESCRIPTION
In this PR I added two similar hooks. Applying some actions to card/notes before they get flushed.
Example of use cases are given in both commits.

I should note that in this case, I did not consider my most downloaded add-ons. But the one where I use monkey patching and that are used a lot are:
* enhance main window, 
which entirely change the way the deck browser is displayed. So it seems had to create ways to edit it. Unless I totally change the way nodes are computed in the scheduler (which would be a good thing according to me. I'm not a fan of using tuples to store information)
* open the same window multiple time. 
It seems hard to use hooks here, since this add-on entirely change the system used to open/close windows and actually replace the window manager class by a new one.
