### PR TITLE
Allow add-on authors to easily inject their own content into Anki's web views – take 3

### DIFF
--- a/qt/aqt/about.py
+++ b/qt/aqt/about.py
@@ -219,5 +219,5 @@ suggestions, bug reports and donations."
     abt.label.setMinimumWidth(800)
     abt.label.setMinimumHeight(600)
     dialog.show()
-    abt.label.stdHtml(abouttext, js=" ")
+    abt.label.stdHtml(abouttext, js=[])
     return dialog

--- a/qt/aqt/browser.py
+++ b/qt/aqt/browser.py
@@ -2478,6 +2478,7 @@ Are you sure you want to continue?"""
 # Card Info Dialog
 ######################################################################
 
+
 class CardInfoDialog(QDialog):
     silentlyClose = True
 

--- a/qt/aqt/browser.py
+++ b/qt/aqt/browser.py
@@ -1382,27 +1382,20 @@ by clicking on one on the left."""
         info, cs = self._cardInfoData()
         reps = self._revlogData(cs)
 
-        class CardInfoDialog(QDialog):
-            silentlyClose = True
-
-            def reject(self):
-                saveGeom(self, "revlog")
-                return QDialog.reject(self)
-
-        d = CardInfoDialog(self)
+        card_info_dialog = CardInfoDialog(self)
         l = QVBoxLayout()
         l.setContentsMargins(0, 0, 0, 0)
         w = AnkiWebView(title="browser card info")
         l.addWidget(w)
-        w.stdHtml(info + "<p>" + reps)
+        w.stdHtml(info + "<p>" + reps, context=card_info_dialog)
         bb = QDialogButtonBox(QDialogButtonBox.Close)
         l.addWidget(bb)
-        bb.rejected.connect(d.reject)
-        d.setLayout(l)
-        d.setWindowModality(Qt.WindowModal)
-        d.resize(500, 400)
-        restoreGeom(d, "revlog")
-        d.show()
+        bb.rejected.connect(card_info_dialog.reject)
+        card_info_dialog.setLayout(l)
+        card_info_dialog.setWindowModality(Qt.WindowModal)
+        card_info_dialog.resize(500, 400)
+        restoreGeom(card_info_dialog, "revlog", CardInfoDialog)
+        card_info_dialog.show()
 
     def _cardInfoData(self):
         from anki.stats import CardStats
@@ -2480,3 +2473,18 @@ Are you sure you want to continue?"""
 
     def onHelp(self):
         openHelp("browsermisc")
+
+
+# Card Info Dialog
+######################################################################
+
+class CardInfoDialog(QDialog):
+    silentlyClose = True
+
+    def __init__(self, browser: Browser, *args, **kwargs):
+        super().__init__(browser, *args, **kwargs)
+        self.browser = browser
+
+    def reject(self):
+        saveGeom(self, "revlog")
+        return QDialog.reject(self)

--- a/qt/aqt/browser.py
+++ b/qt/aqt/browser.py
@@ -1392,7 +1392,7 @@ by clicking on one on the left."""
         d = CardInfoDialog(self)
         l = QVBoxLayout()
         l.setContentsMargins(0, 0, 0, 0)
-        w = AnkiWebView()
+        w = AnkiWebView(title="browser card info")
         l.addWidget(w)
         w.stdHtml(info + "<p>" + reps)
         bb = QDialogButtonBox(QDialogButtonBox.Close)
@@ -1561,7 +1561,7 @@ where id in %s"""
         self._previewWindow.silentlyClose = True
         vbox = QVBoxLayout()
         vbox.setContentsMargins(0, 0, 0, 0)
-        self._previewWeb = AnkiWebView()
+        self._previewWeb = AnkiWebView(title="previewer")
         vbox.addWidget(self._previewWeb)
         bbox = QDialogButtonBox()
 
@@ -2158,6 +2158,7 @@ update cards set usn=?, mod=?, did=? where id in """
         frm.fields.addItems(fields)
         self._dupesButton = None
         # links
+        frm.webView.title = "find duplicates"
         frm.webView.set_bridge_command(
             self.dupeLinkClicked, FindDupesDialog(dialog=d, browser=self)
         )

--- a/qt/aqt/browser.py
+++ b/qt/aqt/browser.py
@@ -1643,16 +1643,16 @@ where id in %s"""
 
     def _setupPreviewWebview(self):
         jsinc = [
-            "_anki/jquery.js",
-            "_anki/browsersel.js",
-            "_anki/mathjax/conf.js",
-            "_anki/mathjax/MathJax.js",
-            "_anki/reviewer.js",
+            "jquery.js",
+            "browsersel.js",
+            "mathjax/conf.js",
+            "mathjax/MathJax.js",
+            "reviewer.js",
         ]
         web_context = PreviewDialog(dialog=self._previewWindow, browser=self)
         self._previewWeb.stdHtml(
             self.mw.reviewer.revHtml(),
-            css=["_anki/reviewer.css"],
+            css=["reviewer.css"],
             js=jsinc,
             context=web_context,
         )

--- a/qt/aqt/clayout.py
+++ b/qt/aqt/clayout.py
@@ -215,10 +215,16 @@ class CardLayout(QDialog):
             "_anki/reviewer.js",
         ]
         pform.frontWeb.stdHtml(
-            self.mw.reviewer.revHtml(), css=["_anki/reviewer.css"], js=jsinc, context=self
+            self.mw.reviewer.revHtml(),
+            css=["_anki/reviewer.css"],
+            js=jsinc,
+            context=self,
         )
         pform.backWeb.stdHtml(
-            self.mw.reviewer.revHtml(), css=["_anki/reviewer.css"], js=jsinc, context=self
+            self.mw.reviewer.revHtml(),
+            css=["_anki/reviewer.css"],
+            js=jsinc,
+            context=self,
         )
         pform.frontWeb.set_bridge_command(self._on_bridge_cmd, self)
         pform.backWeb.set_bridge_command(self._on_bridge_cmd, self)

--- a/qt/aqt/clayout.py
+++ b/qt/aqt/clayout.py
@@ -208,23 +208,17 @@ class CardLayout(QDialog):
         pform.backWeb = AnkiWebView(title="card layout back")
         pform.backPrevBox.addWidget(pform.backWeb)
         jsinc = [
-            "_anki/jquery.js",
-            "_anki/browsersel.js",
-            "_anki/mathjax/conf.js",
-            "_anki/mathjax/MathJax.js",
-            "_anki/reviewer.js",
+            "jquery.js",
+            "browsersel.js",
+            "mathjax/conf.js",
+            "mathjax/MathJax.js",
+            "reviewer.js",
         ]
         pform.frontWeb.stdHtml(
-            self.mw.reviewer.revHtml(),
-            css=["_anki/reviewer.css"],
-            js=jsinc,
-            context=self,
+            self.mw.reviewer.revHtml(), css=["reviewer.css"], js=jsinc, context=self,
         )
         pform.backWeb.stdHtml(
-            self.mw.reviewer.revHtml(),
-            css=["_anki/reviewer.css"],
-            js=jsinc,
-            context=self,
+            self.mw.reviewer.revHtml(), css=["reviewer.css"], js=jsinc, context=self,
         )
         pform.frontWeb.set_bridge_command(self._on_bridge_cmd, self)
         pform.backWeb.set_bridge_command(self._on_bridge_cmd, self)

--- a/qt/aqt/clayout.py
+++ b/qt/aqt/clayout.py
@@ -203,9 +203,9 @@ class CardLayout(QDialog):
 
     def setupWebviews(self):
         pform = self.pform
-        pform.frontWeb = AnkiWebView()
+        pform.frontWeb = AnkiWebView(title="card layout front")
         pform.frontPrevBox.addWidget(pform.frontWeb)
-        pform.backWeb = AnkiWebView()
+        pform.backWeb = AnkiWebView(title="card layout back")
         pform.backPrevBox.addWidget(pform.backWeb)
         jsinc = [
             "jquery.js",

--- a/qt/aqt/clayout.py
+++ b/qt/aqt/clayout.py
@@ -208,17 +208,17 @@ class CardLayout(QDialog):
         pform.backWeb = AnkiWebView(title="card layout back")
         pform.backPrevBox.addWidget(pform.backWeb)
         jsinc = [
-            "jquery.js",
-            "browsersel.js",
-            "mathjax/conf.js",
-            "mathjax/MathJax.js",
-            "reviewer.js",
+            "_anki/jquery.js",
+            "_anki/browsersel.js",
+            "_anki/mathjax/conf.js",
+            "_anki/mathjax/MathJax.js",
+            "_anki/reviewer.js",
         ]
         pform.frontWeb.stdHtml(
-            self.mw.reviewer.revHtml(), css=["reviewer.css"], js=jsinc
+            self.mw.reviewer.revHtml(), css=["_anki/reviewer.css"], js=jsinc, context=self
         )
         pform.backWeb.stdHtml(
-            self.mw.reviewer.revHtml(), css=["reviewer.css"], js=jsinc
+            self.mw.reviewer.revHtml(), css=["_anki/reviewer.css"], js=jsinc, context=self
         )
         pform.frontWeb.set_bridge_command(self._on_bridge_cmd, self)
         pform.backWeb.set_bridge_command(self._on_bridge_cmd, self)

--- a/qt/aqt/deckbrowser.py
+++ b/qt/aqt/deckbrowser.py
@@ -107,8 +107,9 @@ class DeckBrowser:
         stats = self._renderStats()
         self.web.stdHtml(
             self._body % dict(tree=tree, stats=stats, countwarn=self._countWarn()),
-            css=["deckbrowser.css"],
-            js=["jquery.js", "jquery-ui.js", "deckbrowser.js"],
+            css=["_anki/deckbrowser.css"],
+            js=["_anki/jquery.js", "_anki/jquery-ui.js", "_anki/deckbrowser.js"],
+            context=self,
         )
         self.web.key = "deckBrowser"
         self._drawButtons()
@@ -340,9 +341,10 @@ where id > ?""",
 <button title='%s' onclick='pycmd(\"%s\");'>%s</button>""" % tuple(
                 b
             )
-        self.bottom.draw(buf)
-        self.bottom.web.set_bridge_command(
-            self._linkHandler, DeckBrowserBottomBar(self)
+        self.bottom.draw(
+            buf=buf,
+            link_handler=self._linkHandler,
+            web_context=DeckBrowserBottomBar(self),
         )
 
     def _onShared(self):

--- a/qt/aqt/deckbrowser.py
+++ b/qt/aqt/deckbrowser.py
@@ -107,8 +107,8 @@ class DeckBrowser:
         stats = self._renderStats()
         self.web.stdHtml(
             self._body % dict(tree=tree, stats=stats, countwarn=self._countWarn()),
-            css=["_anki/deckbrowser.css"],
-            js=["_anki/jquery.js", "_anki/jquery-ui.js", "_anki/deckbrowser.js"],
+            css=["deckbrowser.css"],
+            js=["jquery.js", "jquery-ui.js", "deckbrowser.js"],
             context=self,
         )
         self.web.key = "deckBrowser"

--- a/qt/aqt/editor.py
+++ b/qt/aqt/editor.py
@@ -95,7 +95,6 @@ class Editor:
 
     def setupWeb(self) -> None:
         self.web = EditorWebView(self.widget, self)
-        self.web.title = "editor"
         self.web.allowDrops = True
         self.web.set_bridge_command(self.onBridgeCmd, self)
         self.outerLayout.addWidget(self.web, 1)
@@ -937,7 +936,7 @@ to a cloze type first, via Edit>Change Note Type."""
 
 class EditorWebView(AnkiWebView):
     def __init__(self, parent, editor):
-        AnkiWebView.__init__(self)
+        AnkiWebView.__init__(self, title="editor")
         self.editor = editor
         self.strip = self.editor.mw.pm.profile["stripHTML"]
         self.setAcceptDrops(True)

--- a/qt/aqt/editor.py
+++ b/qt/aqt/editor.py
@@ -164,8 +164,8 @@ class Editor:
         # then load page
         self.web.stdHtml(
             _html % (bgcol, bgcol, topbuts, _("Show Duplicates")),
-            css=["_anki/editor.css"],
-            js=["_anki/jquery.js", "_anki/editor.js"],
+            css=["editor.css"],
+            js=["jquery.js", "editor.js"],
             context=self,
         )
 

--- a/qt/aqt/editor.py
+++ b/qt/aqt/editor.py
@@ -164,8 +164,9 @@ class Editor:
         # then load page
         self.web.stdHtml(
             _html % (bgcol, bgcol, topbuts, _("Show Duplicates")),
-            css=["editor.css"],
-            js=["jquery.js", "editor.js"],
+            css=["_anki/editor.css"],
+            js=["_anki/jquery.js", "_anki/editor.js"],
+            context=self,
         )
 
     # Top buttons

--- a/qt/aqt/gui_hooks.py
+++ b/qt/aqt/gui_hooks.py
@@ -1140,14 +1140,25 @@ class _WebviewWillSetContentHook:
         in, and to get a reference to the screen. For example, if your
         code wishes to function only in the review screen, you could do:
 
-            if not isinstance(context, aqt.reviewer.Reviewer):
-                # not reviewer, do not modify content
-                return
+            def on_webview_will_set_content(web_content: WebContent, context):
+                
+                if not isinstance(context, aqt.reviewer.Reviewer):
+                    # not reviewer, do not modify content
+                    return
+                
+                # reviewer, perform changes to content
+                
+                context: aqt.reviewer.Reviewer
+                
+                addon_package = mw.addonManager.addonFromModule(__name__)
+                
+                web_content.css.append(
+                    f"/_addons/{addon_package}/web/my-addon.css")
+                web_content.js.append(
+                    f"/_addons/{addon_package}/web/my-addon.js")
 
-            web_content.js.append("my_addon.js")
-            web_content.css.append("my_addon.css")
-            web_content.head += "<script>console.log('my_addon')</script>"
-            web_content.body += "<div id='my-addon'></div>"
+                web_content.head += "<script>console.log('my-addon')</script>"
+                web_content.body += "<div id='my-addon'></div>"
         """
 
     _hooks: List[Callable[["aqt.webview.WebContent", Optional[Any]], None]] = []

--- a/qt/aqt/gui_hooks.py
+++ b/qt/aqt/gui_hooks.py
@@ -7,7 +7,7 @@ See pylib/anki/hooks.py
 
 from __future__ import annotations
 
-from typing import Any, Callable, Dict, List, Tuple
+from typing import Any, Callable, Dict, List, Optional, Tuple
 
 import anki
 import aqt

--- a/qt/aqt/main.py
+++ b/qt/aqt/main.py
@@ -717,19 +717,16 @@ title="%s" %s>%s</button>""" % (
         self.form = aqt.forms.main.Ui_MainWindow()
         self.form.setupUi(self)
         # toolbar
-        tweb = self.toolbarWeb = aqt.webview.AnkiWebView()
-        tweb.title = "top toolbar"
+        tweb = self.toolbarWeb = aqt.webview.AnkiWebView(title="top toolbar")
         tweb.setFocusPolicy(Qt.WheelFocus)
         self.toolbar = aqt.toolbar.Toolbar(self, tweb)
         self.toolbar.draw()
         # main area
-        self.web = aqt.webview.AnkiWebView()
-        self.web.title = "main webview"
+        self.web = aqt.webview.AnkiWebView(title="main webview")
         self.web.setFocusPolicy(Qt.WheelFocus)
         self.web.setMinimumWidth(400)
         # bottom area
-        sweb = self.bottomWeb = aqt.webview.AnkiWebView()
-        sweb.title = "bottom toolbar"
+        sweb = self.bottomWeb = aqt.webview.AnkiWebView(title="bottom toolbar")
         sweb.setFocusPolicy(Qt.WheelFocus)
         # add in a layout
         self.mainLayout = QVBoxLayout()

--- a/qt/aqt/main.py
+++ b/qt/aqt/main.py
@@ -663,9 +663,8 @@ from the profile screen."
         if self.resetModal:
             # we don't have to change the webview, as we have a covering window
             return
-        self.web.set_bridge_command(
-            lambda url: self.delayedMaybeReset(), ResetRequired(self)
-        )
+        web_context = ResetRequired(self)
+        self.web.set_bridge_command(lambda url: self.delayedMaybeReset(), web_context)
         i = _("Waiting for editing to finish.")
         b = self.button("refresh", _("Resume Now"), id="resume")
         self.web.stdHtml(
@@ -676,7 +675,8 @@ from the profile screen."
 %s</div></div></center>
 <script>$('#resume').focus()</script>
 """
-            % (i, b)
+            % (i, b),
+            context=web_context,
         )
         self.bottomWeb.hide()
         self.web.setFocus()

--- a/qt/aqt/overview.py
+++ b/qt/aqt/overview.py
@@ -149,8 +149,8 @@ class Overview:
                 desc=self._desc(deck),
                 table=self._table(),
             ),
-            css=["_anki/overview.css"],
-            js=["_anki/jquery.js", "_anki/overview.js"],
+            css=["overview.css"],
+            js=["jquery.js", "overview.js"],
             context=self,
         )
 

--- a/qt/aqt/overview.py
+++ b/qt/aqt/overview.py
@@ -149,8 +149,9 @@ class Overview:
                 desc=self._desc(deck),
                 table=self._table(),
             ),
-            css=["overview.css"],
-            js=["jquery.js", "overview.js"],
+            css=["_anki/overview.css"],
+            js=["_anki/jquery.js", "_anki/overview.js"],
+            context=self,
         )
 
     def _desc(self, deck):
@@ -243,8 +244,9 @@ to their original deck."""
 <button title="%s" onclick='pycmd("%s")'>%s</button>""" % tuple(
                 b
             )
-        self.bottom.draw(buf)
-        self.bottom.web.set_bridge_command(self._linkHandler, OverviewBottomBar(self))
+        self.bottom.draw(
+            buf=buf, link_handler=self._linkHandler, web_context=OverviewBottomBar(self)
+        )
 
     # Studying more
     ######################################################################

--- a/qt/aqt/reviewer.py
+++ b/qt/aqt/reviewer.py
@@ -145,21 +145,23 @@ class Reviewer:
         # main window
         self.web.stdHtml(
             self.revHtml(),
-            css=["reviewer.css"],
+            css=["_anki/reviewer.css"],
             js=[
-                "jquery.js",
-                "browsersel.js",
-                "mathjax/conf.js",
-                "mathjax/MathJax.js",
-                "reviewer.js",
+                "_anki/jquery.js",
+                "_anki/browsersel.js",
+                "_anki/mathjax/conf.js",
+                "_anki/mathjax/MathJax.js",
+                "_anki/reviewer.js",
             ],
+            context=self,
         )
         # show answer / ease buttons
         self.bottom.web.show()
         self.bottom.web.stdHtml(
             self._bottomHTML(),
-            css=["toolbar-bottom.css", "reviewer-bottom.css"],
-            js=["jquery.js", "reviewer-bottom.js"],
+            css=["_anki/toolbar-bottom.css", "_anki/reviewer-bottom.css"],
+            js=["_anki/jquery.js", "_anki/reviewer-bottom.js"],
+            context=ReviewerBottomBar(self),
         )
 
     # Showing the question

--- a/qt/aqt/reviewer.py
+++ b/qt/aqt/reviewer.py
@@ -145,13 +145,13 @@ class Reviewer:
         # main window
         self.web.stdHtml(
             self.revHtml(),
-            css=["_anki/reviewer.css"],
+            css=["reviewer.css"],
             js=[
-                "_anki/jquery.js",
-                "_anki/browsersel.js",
-                "_anki/mathjax/conf.js",
-                "_anki/mathjax/MathJax.js",
-                "_anki/reviewer.js",
+                "jquery.js",
+                "browsersel.js",
+                "mathjax/conf.js",
+                "mathjax/MathJax.js",
+                "reviewer.js",
             ],
             context=self,
         )
@@ -159,8 +159,8 @@ class Reviewer:
         self.bottom.web.show()
         self.bottom.web.stdHtml(
             self._bottomHTML(),
-            css=["_anki/toolbar-bottom.css", "_anki/reviewer-bottom.css"],
-            js=["_anki/jquery.js", "_anki/reviewer-bottom.js"],
+            css=["toolbar-bottom.css", "reviewer-bottom.css"],
+            js=["jquery.js", "reviewer-bottom.js"],
             context=ReviewerBottomBar(self),
         )
 

--- a/qt/aqt/stats.py
+++ b/qt/aqt/stats.py
@@ -98,7 +98,7 @@ class DeckStats(QDialog):
         self.form.web.title = "deck stats"
         self.form.web.stdHtml(
             "<html><body>" + self.report + "</body></html>",
-            js=["_anki/jquery.js", "_anki/plot.js"],
+            js=["jquery.js", "plot.js"],
             context=self,
         )
         self.mw.progress.finish()

--- a/qt/aqt/stats.py
+++ b/qt/aqt/stats.py
@@ -95,6 +95,7 @@ class DeckStats(QDialog):
         stats = self.mw.col.stats()
         stats.wholeCollection = self.wholeCollection
         self.report = stats.report(type=self.period)
+        self.form.web.title = "deck stats"
         self.form.web.stdHtml(
             "<html><body>" + self.report + "</body></html>", js=["jquery.js", "plot.js"]
         )

--- a/qt/aqt/stats.py
+++ b/qt/aqt/stats.py
@@ -97,6 +97,8 @@ class DeckStats(QDialog):
         self.report = stats.report(type=self.period)
         self.form.web.title = "deck stats"
         self.form.web.stdHtml(
-            "<html><body>" + self.report + "</body></html>", js=["jquery.js", "plot.js"]
+            "<html><body>" + self.report + "</body></html>",
+            js=["_anki/jquery.js", "_anki/plot.js"],
+            context=self,
         )
         self.mw.progress.finish()

--- a/qt/aqt/toolbar.py
+++ b/qt/aqt/toolbar.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from typing import Optional, Any
+from typing import Any, Optional
 
 import aqt
 from anki.lang import _
@@ -49,7 +49,9 @@ class Toolbar:
         link_handler = link_handler or self._linkHandler
         self.web.set_bridge_command(link_handler, web_context)
         self.web.stdHtml(
-            self._body % self._centerLinks(), css=["_anki/toolbar.css"], context=web_context
+            self._body % self._centerLinks(),
+            css=["_anki/toolbar.css"],
+            context=web_context,
         )
         self.web.adjustHeightToFit()
 

--- a/qt/aqt/toolbar.py
+++ b/qt/aqt/toolbar.py
@@ -4,6 +4,8 @@
 
 from __future__ import annotations
 
+from typing import Optional, Any
+
 import aqt
 from anki.lang import _
 from aqt.qt import *
@@ -37,9 +39,18 @@ class Toolbar:
         self.web.setFixedHeight(30)
         self.web.requiresCol = False
 
-    def draw(self):
-        self.web.set_bridge_command(self._linkHandler, TopToolbar(self))
-        self.web.stdHtml(self._body % self._centerLinks(), css=["toolbar.css"])
+    def draw(
+        self,
+        buf: str = "",
+        web_context: Optional[Any] = None,
+        link_handler: Optional[Callable[[str], Any]] = None,
+    ):
+        web_context = web_context or TopToolbar(self)
+        link_handler = link_handler or self._linkHandler
+        self.web.set_bridge_command(link_handler, web_context)
+        self.web.stdHtml(
+            self._body % self._centerLinks(), css=["_anki/toolbar.css"], context=web_context
+        )
         self.web.adjustHeightToFit()
 
     # Available links
@@ -122,10 +133,19 @@ class BottomBar(Toolbar):
 %s</td></tr></table></center>
 """
 
-    def draw(self, buf):
+    def draw(
+        self,
+        buf: str = "",
+        web_context: Optional[Any] = None,
+        link_handler: Optional[Callable[[str], Any]] = None,
+    ):
         # note: some screens may override this
-        self.web.set_bridge_command(self._linkHandler, BottomToolbar(self))
+        web_context = web_context or BottomToolbar(self)
+        link_handler = link_handler or self._linkHandler
+        self.web.set_bridge_command(link_handler, web_context)
         self.web.stdHtml(
-            self._centerBody % buf, css=["toolbar.css", "toolbar-bottom.css"]
+            self._centerBody % buf,
+            css=["_anki/toolbar.css", "_anki/toolbar-bottom.css"],
+            context=web_context,
         )
         self.web.adjustHeightToFit()

--- a/qt/aqt/toolbar.py
+++ b/qt/aqt/toolbar.py
@@ -49,9 +49,7 @@ class Toolbar:
         link_handler = link_handler or self._linkHandler
         self.web.set_bridge_command(link_handler, web_context)
         self.web.stdHtml(
-            self._body % self._centerLinks(),
-            css=["_anki/toolbar.css"],
-            context=web_context,
+            self._body % self._centerLinks(), css=["toolbar.css"], context=web_context,
         )
         self.web.adjustHeightToFit()
 
@@ -147,7 +145,7 @@ class BottomBar(Toolbar):
         self.web.set_bridge_command(link_handler, web_context)
         self.web.stdHtml(
             self._centerBody % buf,
-            css=["_anki/toolbar.css", "_anki/toolbar-bottom.css"],
+            css=["toolbar.css", "toolbar-bottom.css"],
             context=web_context,
         )
         self.web.adjustHeightToFit()

--- a/qt/aqt/webview.py
+++ b/qt/aqt/webview.py
@@ -103,50 +103,52 @@ class AnkiWebPage(QWebEnginePage):  # type: ignore
 
 @dataclasses.dataclass
 class WebContent:
-    """Stores all dynamically modified content that a particular web view will be
-    populated with.
+    """Stores all dynamically modified content that a particular web view
+    will be populated with.
 
     Attributes:
         body {str} -- HTML body
         head {str} -- HTML head
-        css {List[str]} -- List of media server subpaths, each pointing to a CSS file
-        js {List[str]} -- List of media server subpaths, each pointing to a JS file
+        css {List[str]} -- List of media server subpaths,
+                           each pointing to a CSS file
+        js {List[str]} -- List of media server subpaths,
+                          each pointing to a JS file
 
     Important Notes:
-        - When modifying the attributes specified above, please make sure your changes
-        only perform the minimum requried edits to make your add-on work. You should
-        avoid overwriting or interfering with existing data as much as possible,
-        instead opting to append your own changes, e.g.:
+        - When modifying the attributes specified above, please make sure your
+        changes only perform the minimum requried edits to make your add-on work.
+        You should avoid overwriting or interfering with existing data as much
+        as possible, instead opting to append your own changes, e.g.:
         
             def on_webview_will_set_content(web_content: WebContent, context):
                 web_content.body += "<my_html>"
                 web_content.head += "<my_head>"
-                web_content.css.append("my_addon.css")
-                web_content.js.append("my_addon.js")
 
-        - The paths specified in `css` and `js` need to be accessible by Anki's media
-          server. Web components shipping with Anki are located under the `_anki`
-          subpath.
+        - The paths specified in `css` and `js` need to be accessible by Anki's
+          media server. All list members without a specified subpath are assumed
+          to be located under `/_anki`, which is the media server subpath used
+          for all web assets shipped with Anki.
           
-          Add-ons may expose their own web components by utilizing
-          aqt.addons.AddonManager.setWebExports(). Web exports registered in this
-          manner may then be accessed under the `_addons` subpath.
+          Add-ons may expose their own web assets by utilizing
+          aqt.addons.AddonManager.setWebExports(). Web exports registered
+          in this manner may then be accessed under the `/_addons` subpath.
           
-          E.g., to allow access to an `addon.js` and `addon.css` residing in a "web"
-          subfolder in your add-on package, first register the corresponding web export:
+          E.g., to allow access to a `my-addon.js` and `my-addon.css` residing
+          in a "web" subfolder in your add-on package, first register the
+          corresponding web export:
           
           > from aqt import mw
           > mw.addonManager.setWebExports(__name__, r"web/.*(css|js)")
           
-          Then append the subpaths to the corresponding web_content fields within a
-          function subscribing to gui_hooks.webview_will_set_content:
+          Then append the subpaths to the corresponding web_content fields
+          within a function subscribing to gui_hooks.webview_will_set_content:
           
               def on_webview_will_set_content(web_content: WebContent, context):
                   addon_package = mw.addonManager.addonFromModule(__name__)
                   web_content.css.append(
-                      f"_addons/{addon_package}/web/addon.css")
+                      f"/_addons/{addon_package}/web/my-addon.css")
                   web_content.js.append(
-                      f"_addons/{addon_package}/web/addon.js")
+                      f"/_addons/{addon_package}/web/my-addon.js")
     """
 
     body: str = ""

--- a/qt/aqt/webview.py
+++ b/qt/aqt/webview.py
@@ -327,8 +327,8 @@ class AnkiWebView(QWebEngineView):  # type: ignore
         web_content = WebContent(
             body=body,
             head=head,
-            js=["_anki/webview.js"] + (["_anki/jquery.js"] if js is None else js),
-            css=["_anki/webview.css"] + ([] if css is None else css),
+            js=["webview.js"] + (["jquery.js"] if js is None else js),
+            css=["webview.css"] + ([] if css is None else css),
         )
 
         gui_hooks.webview_will_set_content(web_content, context)
@@ -411,7 +411,12 @@ body {{ zoom: {}; background: {}; {} }}
     def webBundlePath(self, path: str) -> str:
         from aqt import mw
 
-        return "http://127.0.0.1:%d/%s" % (mw.mediaServer.getPort(), path)
+        if path.startswith("/"):
+            subpath = ""
+        else:
+            subpath = "/_anki/"
+
+        return f"http://127.0.0.1:{mw.mediaServer.getPort()}{subpath}{path}"
 
     def bundledScript(self, fname: str) -> str:
         return '<script src="%s"></script>' % self.webBundlePath(fname)

--- a/qt/aqt/webview.py
+++ b/qt/aqt/webview.py
@@ -101,9 +101,11 @@ class AnkiWebPage(QWebEnginePage):  # type: ignore
 
 
 class AnkiWebView(QWebEngineView):  # type: ignore
-    def __init__(self, parent: Optional[QWidget] = None) -> None:
+    def __init__(
+        self, parent: Optional[QWidget] = None, title: str = "default"
+    ) -> None:
         QWebEngineView.__init__(self, parent=parent)  # type: ignore
-        self.title = "default"
+        self.title = title
         self._page = AnkiWebPage(self._onBridgeCmd)
         self._page.setBackgroundColor(self._getWindowColor())  # reduce flicker
 

--- a/qt/tools/genhooks_gui.py
+++ b/qt/tools/genhooks_gui.py
@@ -164,6 +164,29 @@ hooks = [
         """,
     ),
     Hook(
+        name="webview_will_set_content",
+        args=["web_content: aqt.webview.WebContent", "context: Optional[Any]",],
+        doc="""Used to modify web content before it is rendered.
+
+        Web_content contains the HTML, JS, and CSS the web view will be
+        populated with.
+
+        Context is the instance that was passed to stdHtml().
+        It can be inspected to check which screen this hook is firing
+        in, and to get a reference to the screen. For example, if your
+        code wishes to function only in the review screen, you could do:
+
+            if not isinstance(context, aqt.reviewer.Reviewer):
+                # not reviewer, do not modify content
+                return
+
+            web_content.js.append("my_addon.js")
+            web_content.css.append("my_addon.css")
+            web_content.head += "<script>console.log('my_addon')</script>"
+            web_content.body += "<div id='my-addon'></div>"
+        """,
+    ),
+    Hook(
         name="webview_will_show_context_menu",
         args=["webview: aqt.webview.AnkiWebView", "menu: QMenu"],
         legacy_hook="AnkiWebView.contextMenuEvent",

--- a/qt/tools/genhooks_gui.py
+++ b/qt/tools/genhooks_gui.py
@@ -176,14 +176,25 @@ hooks = [
         in, and to get a reference to the screen. For example, if your
         code wishes to function only in the review screen, you could do:
 
-            if not isinstance(context, aqt.reviewer.Reviewer):
-                # not reviewer, do not modify content
-                return
+            def on_webview_will_set_content(web_content: WebContent, context):
+                
+                if not isinstance(context, aqt.reviewer.Reviewer):
+                    # not reviewer, do not modify content
+                    return
+                
+                # reviewer, perform changes to content
+                
+                context: aqt.reviewer.Reviewer
+                
+                addon_package = mw.addonManager.addonFromModule(__name__)
+                
+                web_content.css.append(
+                    f"/_addons/{addon_package}/web/my-addon.css")
+                web_content.js.append(
+                    f"/_addons/{addon_package}/web/my-addon.js")
 
-            web_content.js.append("my_addon.js")
-            web_content.css.append("my_addon.css")
-            web_content.head += "<script>console.log('my_addon')</script>"
-            web_content.body += "<div id='my-addon'></div>"
+                web_content.head += "<script>console.log('my-addon')</script>"
+                web_content.body += "<div id='my-addon'></div>"
         """,
     ),
     Hook(


### PR DESCRIPTION
Continued from #439 

Adds a `webview_will_set_content` hook that allows add-on authors to modify web view content before it gets rendered. Uses the same `context` passing approach as `webview_did_receive_js_message`.

(also preserves some of last PR's changes to how web view titles are set)