### PR TITLE
Add hooks for modifying HTML body sections in the deck browser and overview screens

### DIFF
--- a/qt/aqt/deckbrowser.py
+++ b/qt/aqt/deckbrowser.py
@@ -5,7 +5,7 @@
 from __future__ import annotations
 
 from copy import deepcopy
-from enum import Enum
+from dataclasses import dataclass
 from typing import Any
 
 import aqt
@@ -24,10 +24,20 @@ class DeckBrowserBottomBar:
         self.deck_browser = deck_browser
 
 
-class DeckBrowserSection(Enum):
-    TREE = 0
-    STATS = 1
-    WARN = 2
+@dataclass
+class DeckBrowserContent:
+    """Stores sections of HTML content that the deck browser will be
+    populated with.
+    
+    Attributes:
+        tree {str} -- HTML of the deck tree section
+        stats {str} -- HTML of the stats section
+        countwarn {str} -- HTML of the deck count warning section
+    """
+
+    tree: str
+    stats: str
+    countwarn: str
 
 
 class DeckBrowser:
@@ -110,17 +120,14 @@ class DeckBrowser:
         gui_hooks.deck_browser_did_render(self)
 
     def __renderPage(self, offset):
-        tree = gui_hooks.deck_browser_will_render_section(
-            self._renderDeckTree(self._dueTree), DeckBrowserSection.TREE, self
+        content = DeckBrowserContent(
+            tree=self._renderDeckTree(self._dueTree),
+            stats=self._renderStats(),
+            countwarn=self._countWarn(),
         )
-        stats = gui_hooks.deck_browser_will_render_section(
-            self._renderStats(), DeckBrowserSection.STATS, self
-        )
-        warn = gui_hooks.deck_browser_will_render_section(
-            self._countWarn(), DeckBrowserSection.WARN, self
-        )
+        gui_hooks.deck_browser_will_render_content(self, content)
         self.web.stdHtml(
-            self._body % dict(tree=tree, stats=stats, countwarn=warn),
+            self._body % content.__dict__,
             css=["deckbrowser.css"],
             js=["jquery.js", "jquery-ui.js", "deckbrowser.js"],
             context=self,

--- a/qt/aqt/deckbrowser.py
+++ b/qt/aqt/deckbrowser.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 from copy import deepcopy
+from enum import Enum
 from typing import Any
 
 import aqt
@@ -21,6 +22,12 @@ from aqt.utils import askUser, getOnlyText, openHelp, openLink, shortcut, showWa
 class DeckBrowserBottomBar:
     def __init__(self, deck_browser: DeckBrowser):
         self.deck_browser = deck_browser
+
+
+class DeckBrowserSection(Enum):
+    TREE = 0
+    STATS = 1
+    WARN = 2
 
 
 class DeckBrowser:
@@ -103,10 +110,17 @@ class DeckBrowser:
         gui_hooks.deck_browser_did_render(self)
 
     def __renderPage(self, offset):
-        tree = self._renderDeckTree(self._dueTree)
-        stats = self._renderStats()
+        tree = gui_hooks.deck_browser_will_render_section(
+            self._renderDeckTree(self._dueTree), DeckBrowserSection.TREE, self
+        )
+        stats = gui_hooks.deck_browser_will_render_section(
+            self._renderStats(), DeckBrowserSection.STATS, self
+        )
+        warn = gui_hooks.deck_browser_will_render_section(
+            self._countWarn(), DeckBrowserSection.WARN, self
+        )
         self.web.stdHtml(
-            self._body % dict(tree=tree, stats=stats, countwarn=self._countWarn()),
+            self._body % dict(tree=tree, stats=stats, countwarn=warn),
             css=["deckbrowser.css"],
             js=["jquery.js", "jquery-ui.js", "deckbrowser.js"],
             context=self,

--- a/qt/aqt/gui_hooks.py
+++ b/qt/aqt/gui_hooks.py
@@ -781,6 +781,55 @@ class _OverviewDidRefreshHook:
 overview_did_refresh = _OverviewDidRefreshHook()
 
 
+class _OverviewWillRenderContentHook:
+    """Used to modify HTML content sections in the overview body
+
+        'content' contains the sections of HTML content the overview body
+        will be updated with.
+
+        When modifying the content of a particular section, please make sure your
+        changes only perform the minimum required edits to make your add-on work.
+        You should avoid overwriting or interfering with existing data as much
+        as possible, instead opting to append your own changes, e.g.:
+
+            def on_overview_will_render_content(overview, content):
+                content.table += "
+<div>my html</div>"
+        """
+
+    _hooks: List[
+        Callable[["aqt.overview.Overview", "aqt.overview.OverviewContent"], None]
+    ] = []
+
+    def append(
+        self,
+        cb: Callable[["aqt.overview.Overview", "aqt.overview.OverviewContent"], None],
+    ) -> None:
+        """(overview: aqt.overview.Overview, content: aqt.overview.OverviewContent)"""
+        self._hooks.append(cb)
+
+    def remove(
+        self,
+        cb: Callable[["aqt.overview.Overview", "aqt.overview.OverviewContent"], None],
+    ) -> None:
+        if cb in self._hooks:
+            self._hooks.remove(cb)
+
+    def __call__(
+        self, overview: aqt.overview.Overview, content: aqt.overview.OverviewContent
+    ) -> None:
+        for hook in self._hooks:
+            try:
+                hook(overview, content)
+            except:
+                # if the hook fails, remove it
+                self._hooks.remove(hook)
+                raise
+
+
+overview_will_render_content = _OverviewWillRenderContentHook()
+
+
 class _ProfileDidOpenHook:
     _hooks: List[Callable[[], None]] = []
 

--- a/qt/aqt/overview.py
+++ b/qt/aqt/overview.py
@@ -21,6 +21,16 @@ class OverviewBottomBar:
 
 @dataclass
 class OverviewContent:
+    """Stores sections of HTML content that the overview will be
+    populated with.
+
+    Attributes:
+        deck {str} -- Plain text deck name
+        shareLink {str} -- HTML of the share link section
+        desc {str} -- HTML of the deck description section
+        table {str} -- HTML of the deck stats table section
+    """
+
     deck: str
     shareLink: str
     desc: str

--- a/qt/aqt/overview.py
+++ b/qt/aqt/overview.py
@@ -4,6 +4,8 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+
 import aqt
 from anki.lang import _
 from aqt import gui_hooks
@@ -15,6 +17,14 @@ from aqt.utils import askUserDialog, openLink, shortcut, tooltip
 class OverviewBottomBar:
     def __init__(self, overview: Overview):
         self.overview = overview
+
+
+@dataclass
+class OverviewContent:
+    deck: str
+    shareLink: str
+    desc: str
+    table: str
 
 
 class Overview:
@@ -141,14 +151,15 @@ class Overview:
             shareLink = '<a class=smallLink href="review">Reviews and Updates</a>'
         else:
             shareLink = ""
+        content = OverviewContent(
+            deck=deck["name"],
+            shareLink=shareLink,
+            desc=self._desc(deck),
+            table=self._table(),
+        )
+        gui_hooks.overview_will_render_content(self, content)
         self.web.stdHtml(
-            self._body
-            % dict(
-                deck=deck["name"],
-                shareLink=shareLink,
-                desc=self._desc(deck),
-                table=self._table(),
-            ),
+            self._body % content.__dict__,
             css=["overview.css"],
             js=["jquery.js", "overview.js"],
             context=self,

--- a/qt/tools/genhooks_gui.py
+++ b/qt/tools/genhooks_gui.py
@@ -31,6 +31,36 @@ hooks = [
         doc="""Allow to update the deck browser window. E.g. change its title.""",
     ),
     Hook(
+        name="deck_browser_will_render_section",
+        args=[
+            "html: str",
+            "section: aqt.deckbrowser.DeckBrowserSection",
+            "deck_browser: aqt.deckbrowser.DeckBrowser",
+        ],
+        return_type="str",
+        doc="""Used to modify HTML content sections in the deck browser body
+        
+        'html' is the content a particular section will be populated with
+        
+        'section' is an enum describing the current section. For an overview
+        of all the possible values please see aqt.deckbrowser.DeckBrowserSection.
+
+        If you do not want to modify the content of a particular section,
+        return 'html' unmodified, e.g.:
+        
+            def on_deck_browser_will_render_section(html, section, deck_browser):
+                
+                if section != DeckBrowserSection.TREE:
+                    # not the tree section we want to modify, return unchanged
+                    return html
+
+                # tree section, perform changes to html
+                html += "<div>my code</div>"
+                
+                return html
+        """,
+    ),
+    Hook(
         name="reviewer_did_show_question",
         args=["card: Card"],
         legacy_hook="showQuestion",

--- a/qt/tools/genhooks_gui.py
+++ b/qt/tools/genhooks_gui.py
@@ -31,33 +31,23 @@ hooks = [
         doc="""Allow to update the deck browser window. E.g. change its title.""",
     ),
     Hook(
-        name="deck_browser_will_render_section",
+        name="deck_browser_will_render_content",
         args=[
-            "html: str",
-            "section: aqt.deckbrowser.DeckBrowserSection",
             "deck_browser: aqt.deckbrowser.DeckBrowser",
+            "content: aqt.deckbrowser.DeckBrowserContent",
         ],
-        return_type="str",
         doc="""Used to modify HTML content sections in the deck browser body
         
-        'html' is the content a particular section will be populated with
+        'content' contains the sections of HTML content the deck browser body
+        will be updated with.
         
-        'section' is an enum describing the current section. For an overview
-        of all the possible values please see aqt.deckbrowser.DeckBrowserSection.
-
-        If you do not want to modify the content of a particular section,
-        return 'html' unmodified, e.g.:
+        When modifying the content of a particular section, please make sure your
+        changes only perform the minimum required edits to make your add-on work.
+        You should avoid overwriting or interfering with existing data as much
+        as possible, instead opting to append your own changes, e.g.:
         
-            def on_deck_browser_will_render_section(html, section, deck_browser):
-                
-                if section != DeckBrowserSection.TREE:
-                    # not the tree section we want to modify, return unchanged
-                    return html
-
-                # tree section, perform changes to html
-                html += "<div>my code</div>"
-                
-                return html
+            def on_deck_browser_will_render_content(deck_browser, content):
+                content.stats += "\n<div>my html</div>"
         """,
     ),
     Hook(

--- a/qt/tools/genhooks_gui.py
+++ b/qt/tools/genhooks_gui.py
@@ -26,6 +26,26 @@ hooks = [
         title.""",
     ),
     Hook(
+        name="overview_will_render_content",
+        args=[
+            "overview: aqt.overview.Overview",
+            "content: aqt.overview.OverviewContent",
+        ],
+        doc="""Used to modify HTML content sections in the overview body
+
+        'content' contains the sections of HTML content the overview body
+        will be updated with.
+
+        When modifying the content of a particular section, please make sure your
+        changes only perform the minimum required edits to make your add-on work.
+        You should avoid overwriting or interfering with existing data as much
+        as possible, instead opting to append your own changes, e.g.:
+
+            def on_overview_will_render_content(overview, content):
+                content.table += "\n<div>my html</div>"
+        """,
+    ),
+    Hook(
         name="deck_browser_did_render",
         args=["deck_browser: aqt.deckbrowser.DeckBrowser"],
         doc="""Allow to update the deck browser window. E.g. change its title.""",


### PR DESCRIPTION
Allows add-on authors to specifically target and modify individual sections of the deck browser and overview HTML body at string composition time.

~~For the time being the changes in this PR only apply to the deck browser, but if they look good to you, I'd like to follow up with more of the same for the overview screen~~ Overview changes added

My goal with this PR is to offer add-on authors an easy way to modify individual sections of these screens without running into conflicts as the ones described in #258.

With #445 being merged, this might seem a bit redundant. However, the main advantage offered by the hooks in this PR is that they don't require add-on authors to perform error-prone regex replacements or DOM modifications through JS to insert their content at specific positions in each view.

My thinking is that both types of hooks serve different purposes: `webview_will_set_content` for large-scale modifications and/or extending web views with additional JS and CSS assets, and these section hooks for performing more targeted HTML modifications and additions.

**Sample add-on (updated)**

```python
from aqt import gui_hooks
from aqt.deckbrowser import DeckBrowser, DeckBrowserContent
from aqt.overview import Overview, OverviewContent

def on_deck_browser_will_render_content(
    deck_browser: DeckBrowser,
    content: DeckBrowserContent
):
    content.stats += "<div>my html</div>"

def on_overview_will_render_content(
    overview: Overview,
    content: OverviewContent
):
    content.table += "<div>my html</div>"

gui_hooks.deck_browser_will_render_content.append(
    on_deck_browser_will_render_content
)
gui_hooks.overview_will_render_content.append(
    on_overview_will_render_content
)

```