### PR TITLE
Current card get selected in browser

### DIFF
--- a/qt/aqt/browser.py
+++ b/qt/aqt/browser.py
@@ -778,10 +778,11 @@ class Browser(QMainWindow):
     def search(self) -> None:
         if "is:current" in self._lastSearchTxt:
             # show current card if there is one
-            c = self.mw.reviewer.card
-            self.card = self.mw.reviewer.card
+            c = self.card = self.mw.reviewer.card
             nid = c and c.nid or 0
-            self.model.search("nid:%d" % nid)
+            if nid:
+                self.model.search("nid:%d" % nid)
+                self.focusCid(c.id)
         else:
             self.model.search(self._lastSearchTxt)
 


### PR DESCRIPTION
I'm pretty sure it was the way it worked before. I'm surprised that
it's not the case anymore.

If you open the browser from the reviewer, the current card get
selected if it exists. The current note is still entirely displayed.

Personally, I want to know easily which is the current card. Opening
the browser is the easiest way to do it; assuming I can see the
current card selected