### PR TITLE
No default deck in browser

### DIFF
--- a/qt/aqt/browser.py
+++ b/qt/aqt/browser.py
@@ -21,7 +21,7 @@ from anki import hooks
 from anki.cards import Card
 from anki.collection import _Collection
 from anki.consts import *
-from anki.decks import WITHOUT_LEAF_DEFAULT
+from anki.decks import WITHOUT_EMPTY_DEFAULT
 from anki.lang import _, ngettext
 from anki.models import NoteType
 from anki.notes import Note
@@ -1160,6 +1160,12 @@ by clicking on one on the left."""
                 baseName = g[0]
                 did = g[1]
                 children = g[5]
+                if str(did) == "1" and not children:
+                    if not self.mw.col.decks.shouldDefaultBeDisplayed(
+                        WITHOUT_EMPTY_DEFAULT
+                    ):
+                        # No need to test for children, we know there are not
+                        continue
                 item = SidebarItem(
                     baseName,
                     ":/icons/deck.svg",

--- a/qt/aqt/browser.py
+++ b/qt/aqt/browser.py
@@ -21,6 +21,7 @@ from anki import hooks
 from anki.cards import Card
 from anki.collection import _Collection
 from anki.consts import *
+from anki.decks import WITHOUT_LEAF_DEFAULT
 from anki.lang import _, ngettext
 from anki.models import NoteType
 from anki.notes import Note
@@ -1312,7 +1313,12 @@ by clicking on one on the left."""
                     subm.addSeparator()
                     addDecks(subm, children)
                 else:
-                    parent.addItem(shortname, self._filterFunc("deck", name))
+                    if did != 1 or self.col.decks.shouldDefaultBeDisplayed(
+                        WITHOUT_EMPTY_DEFAULT
+                        # no need to check for children, we know
+                        # there are none in this else branch
+                    ):
+                        parent.addItem(shortname, self._filterFunc("deck", name))
 
         # fixme: could rewrite to avoid calculating due # in the future
         alldecks = self.col.sched.deckDueTree()

--- a/qt/aqt/browser.py
+++ b/qt/aqt/browser.py
@@ -1157,16 +1157,19 @@ by clicking on one on the left."""
 
         def fillGroups(root, grps, head=""):
             for g in grps:
+                baseName = g[0]
+                did = g[1]
+                children = g[5]
                 item = SidebarItem(
-                    g[0],
+                    baseName,
                     ":/icons/deck.svg",
-                    lambda g=g: self.setFilter("deck", head + g[0]),
-                    lambda expanded, g=g: self.mw.col.decks.collapseBrowser(g[1]),
+                    lambda baseName=baseName: self.setFilter("deck", head + baseName),
+                    lambda expanded, did=did: self.mw.col.decks.collapseBrowser(did),
                     not self.mw.col.decks.get(g[1]).get("browserCollapsed", False),
                 )
                 root.addChild(item)
-                newhead = head + g[0] + "::"
-                fillGroups(item, g[5], newhead)
+                newhead = head + baseName + "::"
+                fillGroups(item, children, newhead)
 
         fillGroups(root, grps)
 

--- a/qt/aqt/studydeck.py
+++ b/qt/aqt/studydeck.py
@@ -3,6 +3,7 @@
 # License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
 import aqt
+from anki.decks import WITHOUT_EMPTY_LEAF_DEFAULT
 from anki.lang import _
 from aqt import gui_hooks
 from aqt.qt import *
@@ -51,7 +52,11 @@ class StudyDeck(QDialog):
         if title:
             self.setWindowTitle(title)
         if not names:
-            names = sorted(self.mw.col.decks.allNames(dyn=dyn, forceDefault=False))
+            names = sorted(
+                self.mw.col.decks.allNames(
+                    dyn=dyn, forceDefault=WITHOUT_EMPTY_LEAF_DEFAULT
+                )
+            )
             self.nameFunc = None
             self.origNames = names
         else:


### PR DESCRIPTION
This PR is similar to https://github.com/ankitects/anki/pull/359
It deals with decks in browser. Both left window and filter

I realized a mistake in the previous PR (not a big one). If the default deck has no card but has child, it should have been displayed. Because in this case it's displayed in the deck browser, and you may want to review all children of default deck.

To help with this, I created two methods. One to check whether default deck should be displayed. One to check whether current deck should be displayed. It has three options. Show all deck. Don't show empty default deck (as it is now in reviewer). Don't show empty default deck without children (as in deck browser)
I changed the option of the method all. 0 and 1 means the same thing as false and true. 2 is the new value.