### PR TITLE
Hook when class is initialized

### DIFF
--- a/pylib/anki/cards.py
+++ b/pylib/anki/cards.py
@@ -10,6 +10,7 @@ from typing import List, Optional
 import anki  # pylint: disable=unused-import
 from anki import hooks
 from anki.consts import *
+from anki.hooks import HookOnInit
 from anki.models import NoteType, Template
 from anki.notes import Note
 from anki.sound import AVTag
@@ -27,7 +28,7 @@ from anki.utils import intTime, joinFields, timestampID
 # - lrn queue: integer timestamp
 
 
-class Card:
+class Card(HookOnInit):
     _note: Optional[Note]
     timerStarted: Optional[float]
     lastIvl: int
@@ -36,6 +37,7 @@ class Card:
     def __init__(
         self, col: anki.collection._Collection, id: Optional[int] = None
     ) -> None:
+        # pylint: disable=W0231
         self.col = col
         self.timerStarted = None
         self._render_output: Optional[anki.template.TemplateRenderOutput] = None

--- a/pylib/anki/collection.py
+++ b/pylib/anki/collection.py
@@ -22,6 +22,7 @@ from anki.consts import *
 from anki.db import DB
 from anki.decks import DeckManager
 from anki.errors import AnkiError
+from anki.hooks import HookOnInit
 from anki.lang import _, ngettext
 from anki.media import MediaManager
 from anki.models import ModelManager, NoteType, Template
@@ -62,7 +63,7 @@ defaultConf = {
 
 
 # this is initialized by storage.Collection
-class _Collection:
+class _Collection(HookOnInit):
     db: Optional[DB]
     sched: Union[V1Scheduler, V2Scheduler]
     crt: int
@@ -82,6 +83,7 @@ class _Collection:
         server: Optional["anki.storage.ServerData"] = None,
         log: bool = False,
     ) -> None:
+        # pylint: disable=W0231
         self.backend = backend
         self._debugLog = log
         self.db = db

--- a/pylib/anki/hooks.py
+++ b/pylib/anki/hooks.py
@@ -17,8 +17,6 @@ from typing import Any, Callable, Dict, List, Tuple
 import decorator
 
 import anki
-from anki.cards import Card
-from anki.notes import Note
 
 # New hook/filter handling
 ##############################################################################
@@ -56,17 +54,17 @@ bg_thread_progress_callback = _BgThreadProgressCallbackFilter()
 
 
 class _CardDidLeechHook:
-    _hooks: List[Callable[[Card], None]] = []
+    _hooks: List[Callable[["anki.cards.Card"], None]] = []
 
-    def append(self, cb: Callable[[Card], None]) -> None:
-        """(card: Card)"""
+    def append(self, cb: Callable[["anki.cards.Card"], None]) -> None:
+        """(card: anki.cards.Card)"""
         self._hooks.append(cb)
 
-    def remove(self, cb: Callable[[Card], None]) -> None:
+    def remove(self, cb: Callable[["anki.cards.Card"], None]) -> None:
         if cb in self._hooks:
             self._hooks.remove(cb)
 
-    def __call__(self, card: Card) -> None:
+    def __call__(self, card: anki.cards.Card) -> None:
         for hook in self._hooks:
             try:
                 hook(card)
@@ -164,17 +162,17 @@ card_odue_was_invalid = _CardOdueWasInvalidHook()
 class _CardWillFlushHook:
     """Allow to change a card before it is added/updated in the database."""
 
-    _hooks: List[Callable[[Card], None]] = []
+    _hooks: List[Callable[["anki.cards.Card"], None]] = []
 
-    def append(self, cb: Callable[[Card], None]) -> None:
-        """(card: Card)"""
+    def append(self, cb: Callable[["anki.cards.Card"], None]) -> None:
+        """(card: anki.cards.Card)"""
         self._hooks.append(cb)
 
-    def remove(self, cb: Callable[[Card], None]) -> None:
+    def remove(self, cb: Callable[["anki.cards.Card"], None]) -> None:
         if cb in self._hooks:
             self._hooks.remove(cb)
 
-    def __call__(self, card: Card) -> None:
+    def __call__(self, card: anki.cards.Card) -> None:
         for hook in self._hooks:
             try:
                 hook(card)
@@ -334,17 +332,17 @@ note_type_added = _NoteTypeAddedHook()
 class _NoteWillFlushHook:
     """Allow to change a note before it is added/updated in the database."""
 
-    _hooks: List[Callable[[Note], None]] = []
+    _hooks: List[Callable[["anki.cards.Note"], None]] = []
 
-    def append(self, cb: Callable[[Note], None]) -> None:
-        """(note: Note)"""
+    def append(self, cb: Callable[["anki.cards.Note"], None]) -> None:
+        """(note: anki.cards.Note)"""
         self._hooks.append(cb)
 
-    def remove(self, cb: Callable[[Note], None]) -> None:
+    def remove(self, cb: Callable[["anki.cards.Note"], None]) -> None:
         if cb in self._hooks:
             self._hooks.remove(cb)
 
-    def __call__(self, note: Note) -> None:
+    def __call__(self, note: anki.cards.Note) -> None:
         for hook in self._hooks:
             try:
                 hook(note)

--- a/pylib/anki/notes.py
+++ b/pylib/anki/notes.py
@@ -19,7 +19,8 @@ from anki.utils import (
 )
 
 
-class Note:
+class Note(hooks.HookOnInit):
+    # pylint: disable=W0231
     col: anki.storage._Collection
     newlyAdded: bool
     id: int

--- a/pylib/anki/sync.py
+++ b/pylib/anki/sync.py
@@ -14,6 +14,7 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 import anki
 from anki.consts import *
 from anki.db import DB
+from anki.hooks import HookOnInit
 from anki.utils import checksum, devMode, ids2str, intTime, platDesc, versionWithBuild
 
 from . import hooks
@@ -31,7 +32,8 @@ class UnexpectedSchemaChange(Exception):
 ##########################################################################
 
 
-class Syncer:
+class Syncer(HookOnInit):
+    # pylint: disable=W0231
     cursor: Optional[sqlite3.Cursor]
 
     def __init__(self, col: anki.storage._Collection, server=None) -> None:
@@ -465,8 +467,9 @@ from notes where %s"""
 ##########################################################################
 
 
-class HttpSyncer:
+class HttpSyncer(HookOnInit):
     def __init__(self, hkey=None, client=None, hostNum=None) -> None:
+        # pylint: disable=W0231
         self.hkey = hkey
         self.skey = checksum(str(random.random()))[:8]
         self.client = client or HttpClient()
@@ -561,8 +564,9 @@ Content-Type: application/octet-stream\r\n\r\n"""
 ######################################################################
 
 
-class RemoteServer(HttpSyncer):
+class RemoteServer(HttpSyncer, HookOnInit):
     def __init__(self, hkey, hostNum) -> None:
+        # pylint: disable=W0231
         HttpSyncer.__init__(self, hkey, hostNum=hostNum)
 
     def hostKey(self, user, pw) -> Any:
@@ -632,8 +636,9 @@ class RemoteServer(HttpSyncer):
 ##########################################################################
 
 
-class FullSyncer(HttpSyncer):
+class FullSyncer(HttpSyncer, HookOnInit):
     def __init__(self, col, hkey, client, hostNum) -> None:
+        # pylint: disable=W0231
         HttpSyncer.__init__(self, hkey, client, hostNum=hostNum)
         self.postVars = dict(
             k=self.hkey, v="ankidesktop,%s,%s" % (anki.version, platDesc()),

--- a/pylib/anki/tags.py
+++ b/pylib/anki/tags.py
@@ -17,15 +17,17 @@ from typing import Callable, Dict, List, Tuple
 
 import anki  # pylint: disable=unused-import
 from anki import hooks
+from anki.hooks import HookOnInit
 from anki.utils import ids2str, intTime
 
 
-class TagManager:
+class TagManager(HookOnInit):
 
     # Registry save/load
     #############################################################
 
     def __init__(self, col: anki.storage._Collection) -> None:
+        # pylint: disable=W0231
         self.col = col
         self.tags: Dict[str, int] = {}
 

--- a/pylib/tools/genhooks.py
+++ b/pylib/tools/genhooks.py
@@ -17,7 +17,7 @@ from hookslib import Hook, update_file
 ######################################################################
 
 hooks = [
-    Hook(name="card_did_leech", args=["card: Card"], legacy_hook="leech"),
+    Hook(name="card_did_leech", args=["card: anki.cards.Card"], legacy_hook="leech"),
     Hook(name="card_odue_was_invalid"),
     Hook(name="schema_will_change", args=["proceed: bool"], return_type="bool"),
     Hook(
@@ -75,12 +75,12 @@ hooks = [
     ),
     Hook(
         name="note_will_flush",
-        args=["note: Note"],
+        args=["note: anki.cards.Note"],
         doc="Allow to change a note before it is added/updated in the database.",
     ),
     Hook(
         name="card_will_flush",
-        args=["card: Card"],
+        args=["card: anki.cards.Card"],
         doc="Allow to change a card before it is added/updated in the database.",
     ),
     Hook(

--- a/qt/aqt/about.py
+++ b/qt/aqt/about.py
@@ -5,6 +5,7 @@ import platform
 import time
 
 import aqt.forms
+from anki.hooks import HookOnInit
 from anki.lang import _
 from anki.utils import versionWithBuild
 from aqt.addons import AddonManager, AddonMeta
@@ -12,7 +13,7 @@ from aqt.qt import *
 from aqt.utils import supportText, tooltip
 
 
-class ClosableQDialog(QDialog):
+class ClosableQDialog(QDialog, HookOnInit):
     def reject(self):
         aqt.dialogs.markClosed("About")
         QDialog.reject(self)

--- a/qt/aqt/addcards.py
+++ b/qt/aqt/addcards.py
@@ -7,6 +7,7 @@ import aqt.deckchooser
 import aqt.editor
 import aqt.forms
 import aqt.modelchooser
+from anki.hooks import HookOnInit
 from anki.lang import _
 from anki.notes import Note
 from anki.utils import htmlToTextLine, isMac
@@ -26,8 +27,9 @@ from aqt.utils import (
 )
 
 
-class AddCards(QDialog):
+class AddCards(QDialog, HookOnInit):
     def __init__(self, mw: AnkiQt) -> None:
+        # pylint: disable=W0231
         QDialog.__init__(self, None, Qt.Window)
         mw.setupDialogGC(self)
         self.mw = mw

--- a/qt/aqt/addons.py
+++ b/qt/aqt/addons.py
@@ -24,6 +24,7 @@ from send2trash import send2trash
 import anki
 import aqt
 import aqt.forms
+from anki.hooks import HookOnInit
 from anki.httpclient import HttpClient
 from anki.lang import _, ngettext
 from aqt.qt import *
@@ -138,7 +139,7 @@ class AddonMeta:
 
 
 # fixme: this class should not have any GUI code in it
-class AddonManager:
+class AddonManager(HookOnInit):
 
     ext: str = ".ankiaddon"
     _manifest_schema: dict = {
@@ -166,6 +167,7 @@ class AddonManager:
     }
 
     def __init__(self, mw: aqt.main.AnkiQt):
+        # pylint: disable=W0231
         self.mw = mw
         self.dirty = False
         f = self.mw.form

--- a/qt/aqt/browser.py
+++ b/qt/aqt/browser.py
@@ -21,6 +21,7 @@ from anki import hooks
 from anki.cards import Card
 from anki.collection import _Collection
 from anki.consts import *
+from anki.hooks import HookOnInit
 from anki.lang import _, ngettext
 from anki.models import NoteType
 from anki.notes import Note
@@ -73,8 +74,9 @@ class FindDupesDialog:
 ##########################################################################
 
 
-class DataModel(QAbstractTableModel):
+class DataModel(QAbstractTableModel, HookOnInit):
     def __init__(self, browser):
+        # pylint: disable=W0231
         QAbstractTableModel.__init__(self)
         self.browser = browser
         self.col = browser.col
@@ -565,13 +567,14 @@ class SidebarModel(QAbstractItemModel):
 # fixme: respond to reset+edit hooks
 
 
-class Browser(QMainWindow):
+class Browser(QMainWindow, HookOnInit):
     model: DataModel
     mw: AnkiQt
     col: _Collection
     editor: Optional[Editor]
 
     def __init__(self, mw: AnkiQt) -> None:
+        # pylint: disable=W0231
         QMainWindow.__init__(self, None, Qt.Window)
         self.mw = mw
         self.col = self.mw.col
@@ -2328,8 +2331,9 @@ update cards set usn=?, mod=?, did=? where id in """
 ######################################################################
 
 
-class ChangeModel(QDialog):
+class ChangeModel(QDialog, HookOnInit):
     def __init__(self, browser, nids) -> None:
+        # pylint: disable=W0231
         QDialog.__init__(self, browser)
         self.browser = browser
         self.nids = nids
@@ -2511,7 +2515,8 @@ Are you sure you want to continue?"""
 ######################################################################
 
 
-class CardInfoDialog(QDialog):
+class CardInfoDialog(QDialog, HookOnInit):
+    # pylint: disable=W0231
     silentlyClose = True
 
     def __init__(self, browser: Browser, *args, **kwargs):

--- a/qt/aqt/clayout.py
+++ b/qt/aqt/clayout.py
@@ -10,6 +10,7 @@ from typing import Optional
 import aqt
 from anki.cards import Card
 from anki.consts import *
+from anki.hooks import HookOnInit
 from anki.lang import _, ngettext
 from anki.utils import isMac, isWin, joinFields
 from aqt import gui_hooks
@@ -29,7 +30,8 @@ from aqt.utils import (
 from aqt.webview import AnkiWebView
 
 
-class CardLayout(QDialog):
+class CardLayout(QDialog, HookOnInit):
+    # pylint: disable=W0231
     card: Optional[Card]
 
     def __init__(self, mw, note, ord=0, parent=None, addMode=False):

--- a/qt/aqt/customstudy.py
+++ b/qt/aqt/customstudy.py
@@ -4,6 +4,7 @@
 
 import aqt
 from anki.consts import *
+from anki.hooks import HookOnInit
 from anki.lang import _
 from aqt.qt import *
 from aqt.utils import showInfo, showWarning
@@ -21,8 +22,9 @@ TYPE_REVIEW = 2
 TYPE_ALL = 3
 
 
-class CustomStudy(QDialog):
+class CustomStudy(QDialog, HookOnInit):
     def __init__(self, mw) -> None:
+        # pylint: disable=W0231
         QDialog.__init__(self, mw)
         self.mw = mw
         self.deck = self.mw.col.decks.current()

--- a/qt/aqt/deckbrowser.py
+++ b/qt/aqt/deckbrowser.py
@@ -10,6 +10,7 @@ from typing import Any
 
 import aqt
 from anki.errors import DeckRenameError
+from anki.hooks import HookOnInit
 from anki.lang import _, ngettext
 from anki.rsbackend import StringsGroup
 from anki.utils import fmtTimeSpan, ids2str
@@ -49,7 +50,8 @@ class DeckBrowserContent:
     countwarn: str
 
 
-class DeckBrowser:
+class DeckBrowser(HookOnInit):
+    # pylint: disable=W0231
     _dueTree: Any
 
     def __init__(self, mw: AnkiQt) -> None:

--- a/qt/aqt/deckchooser.py
+++ b/qt/aqt/deckchooser.py
@@ -2,14 +2,16 @@
 # Copyright: Ankitects Pty Ltd and contributors
 # License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
+from anki.hooks import HookOnInit
 from anki.lang import _
 from aqt import gui_hooks
 from aqt.qt import *
 from aqt.utils import shortcut
 
 
-class DeckChooser(QHBoxLayout):
+class DeckChooser(QHBoxLayout, HookOnInit):
     def __init__(self, mw, widget: QWidget, label=True, start=None) -> None:
+        # pylint: disable=W0231
         QHBoxLayout.__init__(self)
         self.widget = widget  # type: ignore
         self.mw = mw

--- a/qt/aqt/deckconf.py
+++ b/qt/aqt/deckconf.py
@@ -5,6 +5,7 @@ from operator import itemgetter
 
 import aqt
 from anki.consts import NEW_CARDS_RANDOM
+from anki.hooks import HookOnInit
 from anki.lang import _, ngettext
 from aqt.qt import *
 from aqt.utils import (
@@ -19,8 +20,9 @@ from aqt.utils import (
 )
 
 
-class DeckConf(QDialog):
+class DeckConf(QDialog, HookOnInit):
     def __init__(self, mw, deck):
+        # pylint: disable=W0231
         QDialog.__init__(self, mw)
         self.mw = mw
         self.deck = deck

--- a/qt/aqt/dyndeckconf.py
+++ b/qt/aqt/dyndeckconf.py
@@ -3,13 +3,15 @@
 # License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
 import aqt
+from anki.hooks import HookOnInit
 from anki.lang import _
 from aqt.qt import *
 from aqt.utils import askUser, openHelp, restoreGeom, saveGeom, showWarning
 
 
-class DeckConf(QDialog):
+class DeckConf(QDialog, HookOnInit):
     def __init__(self, mw, first=False, search="", deck=None):
+        # pylint: disable=W0231
         QDialog.__init__(self, mw)
         self.mw = mw
         self.deck = deck or self.mw.col.decks.current()

--- a/qt/aqt/editcurrent.py
+++ b/qt/aqt/editcurrent.py
@@ -3,14 +3,16 @@
 # License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
 import aqt.editor
+from anki.hooks import HookOnInit
 from anki.lang import _
 from aqt import gui_hooks
 from aqt.qt import *
 from aqt.utils import restoreGeom, saveGeom, tooltip
 
 
-class EditCurrent(QDialog):
+class EditCurrent(QDialog, HookOnInit):
     def __init__(self, mw) -> None:
+        # pylint: disable=W0231
         QDialog.__init__(self, None, Qt.Window)
         mw.setupDialogGC(self)
         self.mw = mw

--- a/qt/aqt/editor.py
+++ b/qt/aqt/editor.py
@@ -19,7 +19,7 @@ from bs4 import BeautifulSoup
 
 import aqt
 import aqt.sound
-from anki.hooks import runFilter
+from anki.hooks import HookOnInit, runFilter
 from anki.httpclient import HttpClient
 from anki.lang import _
 from anki.notes import Note
@@ -68,8 +68,9 @@ html { background: %s; }
 """
 
 # caller is responsible for resetting note on reset
-class Editor:
+class Editor(HookOnInit):
     def __init__(self, mw: AnkiQt, widget, parentWindow, addMode=False) -> None:
+        # pylint: disable=W0231
         self.mw = mw
         self.widget = widget
         self.parentWindow = parentWindow

--- a/qt/aqt/fields.py
+++ b/qt/aqt/fields.py
@@ -3,13 +3,15 @@
 
 import aqt
 from anki.consts import *
+from anki.hooks import HookOnInit
 from anki.lang import _, ngettext
 from aqt.qt import *
 from aqt.utils import askUser, getOnlyText, openHelp, showWarning
 
 
-class FieldDialog(QDialog):
+class FieldDialog(QDialog, HookOnInit):
     def __init__(self, mw, note, ord=0, parent=None):
+        # pylint: disable=W0231
         QDialog.__init__(self, parent or mw)  # , Qt.Window)
         self.mw = aqt.mw
         self.parent = parent or mw

--- a/qt/aqt/gui_hooks.py
+++ b/qt/aqt/gui_hooks.py
@@ -11,7 +11,6 @@ from typing import Any, Callable, Dict, List, Optional, Tuple
 
 import anki
 import aqt
-from anki.cards import Card
 from anki.hooks import runFilter, runHook
 from aqt.qt import QMenu
 
@@ -331,17 +330,17 @@ browser_will_show_context_menu = _BrowserWillShowContextMenuHook()
 class _CardWillShowFilter:
     """Can modify card text before review/preview."""
 
-    _hooks: List[Callable[[str, Card, str], str]] = []
+    _hooks: List[Callable[[str, "anki.cards.Card", str], str]] = []
 
-    def append(self, cb: Callable[[str, Card, str], str]) -> None:
-        """(text: str, card: Card, kind: str)"""
+    def append(self, cb: Callable[[str, "anki.cards.Card", str], str]) -> None:
+        """(text: str, card: anki.cards.Card, kind: str)"""
         self._hooks.append(cb)
 
-    def remove(self, cb: Callable[[str, Card, str], str]) -> None:
+    def remove(self, cb: Callable[[str, "anki.cards.Card", str], str]) -> None:
         if cb in self._hooks:
             self._hooks.remove(cb)
 
-    def __call__(self, text: str, card: Card, kind: str) -> str:
+    def __call__(self, text: str, card: anki.cards.Card, kind: str) -> str:
         for filter in self._hooks:
             try:
                 text = filter(text, card, kind)
@@ -957,17 +956,23 @@ review_did_undo = _ReviewDidUndoHook()
 
 
 class _ReviewerDidAnswerCardHook:
-    _hooks: List[Callable[["aqt.reviewer.Reviewer", Card, int], None]] = []
+    _hooks: List[Callable[["aqt.reviewer.Reviewer", "anki.cards.Card", int], None]] = []
 
-    def append(self, cb: Callable[["aqt.reviewer.Reviewer", Card, int], None]) -> None:
-        """(reviewer: aqt.reviewer.Reviewer, card: Card, ease: int)"""
+    def append(
+        self, cb: Callable[["aqt.reviewer.Reviewer", "anki.cards.Card", int], None]
+    ) -> None:
+        """(reviewer: aqt.reviewer.Reviewer, card: anki.cards.Card, ease: int)"""
         self._hooks.append(cb)
 
-    def remove(self, cb: Callable[["aqt.reviewer.Reviewer", Card, int], None]) -> None:
+    def remove(
+        self, cb: Callable[["aqt.reviewer.Reviewer", "anki.cards.Card", int], None]
+    ) -> None:
         if cb in self._hooks:
             self._hooks.remove(cb)
 
-    def __call__(self, reviewer: aqt.reviewer.Reviewer, card: Card, ease: int) -> None:
+    def __call__(
+        self, reviewer: aqt.reviewer.Reviewer, card: anki.cards.Card, ease: int
+    ) -> None:
         for hook in self._hooks:
             try:
                 hook(reviewer, card, ease)
@@ -981,17 +986,17 @@ reviewer_did_answer_card = _ReviewerDidAnswerCardHook()
 
 
 class _ReviewerDidShowAnswerHook:
-    _hooks: List[Callable[[Card], None]] = []
+    _hooks: List[Callable[["anki.cards.Card"], None]] = []
 
-    def append(self, cb: Callable[[Card], None]) -> None:
-        """(card: Card)"""
+    def append(self, cb: Callable[["anki.cards.Card"], None]) -> None:
+        """(card: anki.cards.Card)"""
         self._hooks.append(cb)
 
-    def remove(self, cb: Callable[[Card], None]) -> None:
+    def remove(self, cb: Callable[["anki.cards.Card"], None]) -> None:
         if cb in self._hooks:
             self._hooks.remove(cb)
 
-    def __call__(self, card: Card) -> None:
+    def __call__(self, card: anki.cards.Card) -> None:
         for hook in self._hooks:
             try:
                 hook(card)
@@ -1007,17 +1012,17 @@ reviewer_did_show_answer = _ReviewerDidShowAnswerHook()
 
 
 class _ReviewerDidShowQuestionHook:
-    _hooks: List[Callable[[Card], None]] = []
+    _hooks: List[Callable[["anki.cards.Card"], None]] = []
 
-    def append(self, cb: Callable[[Card], None]) -> None:
-        """(card: Card)"""
+    def append(self, cb: Callable[["anki.cards.Card"], None]) -> None:
+        """(card: anki.cards.Card)"""
         self._hooks.append(cb)
 
-    def remove(self, cb: Callable[[Card], None]) -> None:
+    def remove(self, cb: Callable[["anki.cards.Card"], None]) -> None:
         if cb in self._hooks:
             self._hooks.remove(cb)
 
-    def __call__(self, card: Card) -> None:
+    def __call__(self, card: anki.cards.Card) -> None:
         for hook in self._hooks:
             try:
                 hook(card)
@@ -1044,29 +1049,37 @@ class _ReviewerWillAnswerCardFilter:
         the reviewer_did_answer_card hook instead."""
 
     _hooks: List[
-        Callable[[Tuple[bool, int], "aqt.reviewer.Reviewer", Card], Tuple[bool, int]]
+        Callable[
+            [Tuple[bool, int], "aqt.reviewer.Reviewer", "anki.cards.Card"],
+            Tuple[bool, int],
+        ]
     ] = []
 
     def append(
         self,
         cb: Callable[
-            [Tuple[bool, int], "aqt.reviewer.Reviewer", Card], Tuple[bool, int]
+            [Tuple[bool, int], "aqt.reviewer.Reviewer", "anki.cards.Card"],
+            Tuple[bool, int],
         ],
     ) -> None:
-        """(ease_tuple: Tuple[bool, int], reviewer: aqt.reviewer.Reviewer, card: Card)"""
+        """(ease_tuple: Tuple[bool, int], reviewer: aqt.reviewer.Reviewer, card: anki.cards.Card)"""
         self._hooks.append(cb)
 
     def remove(
         self,
         cb: Callable[
-            [Tuple[bool, int], "aqt.reviewer.Reviewer", Card], Tuple[bool, int]
+            [Tuple[bool, int], "aqt.reviewer.Reviewer", "anki.cards.Card"],
+            Tuple[bool, int],
         ],
     ) -> None:
         if cb in self._hooks:
             self._hooks.remove(cb)
 
     def __call__(
-        self, ease_tuple: Tuple[bool, int], reviewer: aqt.reviewer.Reviewer, card: Card
+        self,
+        ease_tuple: Tuple[bool, int],
+        reviewer: aqt.reviewer.Reviewer,
+        card: anki.cards.Card,
     ) -> Tuple[bool, int]:
         for filter in self._hooks:
             try:

--- a/qt/aqt/importing.py
+++ b/qt/aqt/importing.py
@@ -14,6 +14,7 @@ import anki.importing as importing
 import aqt.deckchooser
 import aqt.forms
 import aqt.modelchooser
+from anki.hooks import HookOnInit
 from anki.lang import _, ngettext
 from aqt import AnkiQt, gui_hooks
 from aqt.qt import *
@@ -29,8 +30,9 @@ from aqt.utils import (
 )
 
 
-class ChangeMap(QDialog):
+class ChangeMap(QDialog, HookOnInit):
     def __init__(self, mw: AnkiQt, model, current):
+        # pylint: disable=W0231
         QDialog.__init__(self, mw, Qt.Window)
         self.mw = mw
         self.model = model
@@ -72,8 +74,9 @@ class ChangeMap(QDialog):
         self.accept()
 
 
-class ImportDialog(QDialog):
+class ImportDialog(QDialog, HookOnInit):
     def __init__(self, mw: AnkiQt, importer) -> None:
+        # pylint: disable=W0231
         QDialog.__init__(self, mw, Qt.Window)
         self.mw = mw
         self.importer = importer

--- a/qt/aqt/main.py
+++ b/qt/aqt/main.py
@@ -26,7 +26,7 @@ import aqt.toolbar
 import aqt.webview
 from anki import hooks
 from anki.collection import _Collection
-from anki.hooks import runHook
+from anki.hooks import HookOnInit, runHook
 from anki.lang import _, ngettext
 from anki.sound import AVTag, SoundOrVideoTag
 from anki.storage import Collection
@@ -65,7 +65,7 @@ class ResetRequired:
         self.mw = mw
 
 
-class AnkiQt(QMainWindow):
+class AnkiQt(QMainWindow, HookOnInit):
     col: _Collection
     pm: ProfileManagerType
     web: aqt.webview.AnkiWebView
@@ -78,6 +78,7 @@ class AnkiQt(QMainWindow):
         opts: Namespace,
         args: List[Any],
     ) -> None:
+        # pylint: disable=W0231
         QMainWindow.__init__(self)
         self.state = "startup"
         self.opts = opts

--- a/qt/aqt/mediacheck.py
+++ b/qt/aqt/mediacheck.py
@@ -10,6 +10,7 @@ from typing import Iterable, List, Optional, TypeVar
 
 import aqt
 from anki import hooks
+from anki.hooks import HookOnInit
 from anki.rsbackend import (
     Interrupted,
     MediaCheckOutput,
@@ -37,10 +38,11 @@ def check_media_db(mw: aqt.AnkiQt) -> None:
     c.check()
 
 
-class MediaChecker:
+class MediaChecker(HookOnInit):
     progress_dialog: Optional[aqt.progress.ProgressDialog]
 
     def __init__(self, mw: aqt.AnkiQt) -> None:
+        # pylint: disable=W0231
         self.mw = mw
 
     def check(self) -> None:

--- a/qt/aqt/modelchooser.py
+++ b/qt/aqt/modelchooser.py
@@ -2,14 +2,16 @@
 # Copyright: Ankitects Pty Ltd and contributors
 # License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
+from anki.hooks import HookOnInit
 from anki.lang import _
 from aqt import gui_hooks
 from aqt.qt import *
 from aqt.utils import shortcut
 
 
-class ModelChooser(QHBoxLayout):
+class ModelChooser(QHBoxLayout, HookOnInit):
     def __init__(self, mw, widget, label=True) -> None:
+        # pylint: disable=W0231
         QHBoxLayout.__init__(self)
         self.widget = widget  # type: ignore
         self.mw = mw

--- a/qt/aqt/models.py
+++ b/qt/aqt/models.py
@@ -5,6 +5,7 @@ from operator import itemgetter
 
 import aqt.clayout
 from anki import stdmodels
+from anki.hooks import HookOnInit
 from anki.lang import _, ngettext
 from aqt import AnkiQt
 from aqt.qt import *
@@ -19,8 +20,9 @@ from aqt.utils import (
 )
 
 
-class Models(QDialog):
+class Models(QDialog, HookOnInit):
     def __init__(self, mw: AnkiQt, parent=None, fromMain=False):
+        # pylint: disable=W0231
         self.mw = mw
         parent = parent or mw
         self.fromMain = fromMain
@@ -170,8 +172,9 @@ class Models(QDialog):
         QDialog.reject(self)
 
 
-class AddModel(QDialog):
+class AddModel(QDialog, HookOnInit):
     def __init__(self, mw, parent=None):
+        # pylint: disable=W0231
         self.parent = parent or mw
         self.mw = mw
         self.col = mw.col

--- a/qt/aqt/overview.py
+++ b/qt/aqt/overview.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 import aqt
+from anki.hooks import HookOnInit
 from anki.lang import _
 from aqt import gui_hooks
 from aqt.sound import av_player
@@ -37,10 +38,11 @@ class OverviewContent:
     table: str
 
 
-class Overview:
+class Overview(HookOnInit):
     "Deck overview."
 
     def __init__(self, mw: aqt.AnkiQt) -> None:
+        # pylint: disable=W0231
         self.mw = mw
         self.web = mw.web
         self.bottom = BottomBar(mw, mw.bottomWeb)

--- a/qt/aqt/preferences.py
+++ b/qt/aqt/preferences.py
@@ -7,14 +7,16 @@ import time
 
 import anki.lang
 import aqt
+from anki.hooks import HookOnInit
 from anki.lang import _
 from aqt import AnkiQt
 from aqt.qt import *
 from aqt.utils import askUser, openHelp, showInfo, showWarning
 
 
-class Preferences(QDialog):
+class Preferences(QDialog, HookOnInit):
     def __init__(self, mw: AnkiQt):
+        # pylint: disable=W0231
         QDialog.__init__(self, mw, Qt.Window)
         self.mw = mw
         self.prof = self.mw.pm.profile

--- a/qt/aqt/profiles.py
+++ b/qt/aqt/profiles.py
@@ -19,6 +19,7 @@ import anki.lang
 import aqt.forms
 import aqt.sound
 from anki.db import DB
+from anki.hooks import HookOnInit
 from anki.lang import _
 from anki.utils import intTime, isMac, isWin
 from aqt import appHelpSite
@@ -66,8 +67,9 @@ class LoadMetaResult:
     loadError: bool
 
 
-class ProfileManager:
+class ProfileManager(HookOnInit):
     def __init__(self, base=None):
+        # pylint: disable=W0231
         self.name = None
         self.db = None
         # instantiate base folder

--- a/qt/aqt/progress.py
+++ b/qt/aqt/progress.py
@@ -8,6 +8,7 @@ import time
 from typing import Optional
 
 import aqt.forms
+from anki.hooks import HookOnInit
 from anki.lang import _
 from aqt.qt import *
 
@@ -19,8 +20,9 @@ from aqt.qt import *
 ##########################################################################
 
 
-class ProgressManager:
+class ProgressManager(HookOnInit):
     def __init__(self, mw):
+        # pylint: disable=W0231
         self.mw = mw
         self.app = QApplication.instance()
         self.inDB = False
@@ -190,8 +192,9 @@ class ProgressManager:
         return self._levels
 
 
-class ProgressDialog(QDialog):
+class ProgressDialog(QDialog, HookOnInit):
     def __init__(self, parent):
+        # pylint: disable=W0231
         QDialog.__init__(self, parent)
         self.form = aqt.forms.progress.Ui_Dialog()
         self.form.setupUi(self)

--- a/qt/aqt/reviewer.py
+++ b/qt/aqt/reviewer.py
@@ -14,6 +14,7 @@ from typing import List, Optional
 
 from anki import hooks
 from anki.cards import Card
+from anki.hooks import HookOnInit
 from anki.lang import _, ngettext
 from anki.utils import stripHTML
 from aqt import AnkiQt, gui_hooks
@@ -29,10 +30,11 @@ class ReviewerBottomBar:
         self.reviewer = reviewer
 
 
-class Reviewer:
+class Reviewer(HookOnInit):
     "Manage reviews.  Maintains a separate state."
 
     def __init__(self, mw: AnkiQt) -> None:
+        # pylint: disable=W0231
         self.mw = mw
         self.web = mw.web
         self.card: Optional[Card] = None

--- a/qt/aqt/stats.py
+++ b/qt/aqt/stats.py
@@ -5,6 +5,7 @@
 import time
 
 import aqt
+from anki.hooks import HookOnInit
 from anki.lang import _
 from aqt.qt import *
 from aqt.theme import theme_manager
@@ -21,8 +22,9 @@ from aqt.utils import (
 ######################################################################
 
 
-class DeckStats(QDialog):
+class DeckStats(QDialog, HookOnInit):
     def __init__(self, mw):
+        # pylint: disable=W0231
         QDialog.__init__(self, mw, Qt.Window)
         mw.setupDialogGC(self)
         self.mw = mw

--- a/qt/aqt/studydeck.py
+++ b/qt/aqt/studydeck.py
@@ -3,13 +3,14 @@
 # License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
 import aqt
+from anki.hooks import HookOnInit
 from anki.lang import _
 from aqt import gui_hooks
 from aqt.qt import *
 from aqt.utils import getOnlyText, openHelp, restoreGeom, saveGeom, shortcut, showInfo
 
 
-class StudyDeck(QDialog):
+class StudyDeck(QDialog, HookOnInit):
     def __init__(
         self,
         mw,
@@ -24,6 +25,7 @@ class StudyDeck(QDialog):
         buttons=None,
         geomKey="default",
     ) -> None:
+        # pylint: disable=W0231
         QDialog.__init__(self, parent or mw)
         if buttons is None:
             buttons = []

--- a/qt/aqt/sync.py
+++ b/qt/aqt/sync.py
@@ -5,6 +5,7 @@ import gc
 import time
 
 from anki import hooks
+from anki.hooks import HookOnInit
 from anki.lang import _
 from anki.storage import Collection
 from anki.sync import FullSyncer, RemoteServer, Syncer
@@ -15,8 +16,9 @@ from aqt.utils import askUserDialog, showInfo, showText, showWarning, tooltip
 ######################################################################
 
 
-class SyncManager(QObject):
+class SyncManager(QObject, HookOnInit):
     def __init__(self, mw, pm):
+        # pylint: disable=W0231
         QObject.__init__(self, mw)
         self.mw = mw
         self.pm = pm
@@ -342,12 +344,13 @@ Check Database, then sync again."""
 ######################################################################
 
 
-class SyncThread(QThread):
+class SyncThread(QThread, HookOnInit):
 
     _event = pyqtSignal(str, str)
     progress_event = pyqtSignal(int, int)
 
     def __init__(self, path, hkey, auth=None, hostNum=None):
+        # pylint: disable=W0231
         QThread.__init__(self)
         self.path = path
         self.hkey = hkey

--- a/qt/aqt/tagedit.py
+++ b/qt/aqt/tagedit.py
@@ -3,15 +3,17 @@
 
 import re
 
+from anki.hooks import HookOnInit
 from aqt.qt import *
 
 
-class TagEdit(QLineEdit):
+class TagEdit(QLineEdit, HookOnInit):
 
     lostFocus = pyqtSignal()
 
     # 0 = tags, 1 = decks
     def __init__(self, parent, type=0):
+        # pylint: disable=W0231
         QLineEdit.__init__(self, parent)
         self.col = None
         self.model = QStringListModel()
@@ -92,8 +94,9 @@ class TagEdit(QLineEdit):
         self.completer.popup().hide()
 
 
-class TagCompleter(QCompleter):
+class TagCompleter(QCompleter, HookOnInit):
     def __init__(self, model, parent, edit, *args):
+        # pylint: disable=W0231
         QCompleter.__init__(self, model, parent)
         self.tags = []
         self.edit = edit

--- a/qt/aqt/taglimit.py
+++ b/qt/aqt/taglimit.py
@@ -2,12 +2,14 @@
 # License: GNU AGPL, version 3 or later; http://www.gnu.org/copyleft/agpl.html
 
 import aqt
+from anki.hooks import HookOnInit
 from aqt.qt import *
 from aqt.utils import restoreGeom, saveGeom
 
 
-class TagLimit(QDialog):
+class TagLimit(QDialog, HookOnInit):
     def __init__(self, mw, parent):
+        # pylint: disable=W0231
         QDialog.__init__(self, parent, Qt.Window)
         self.mw = mw
         self.parent = parent

--- a/qt/aqt/theme.py
+++ b/qt/aqt/theme.py
@@ -6,13 +6,14 @@ import platform
 import sys
 from typing import Dict
 
+from anki.hooks import HookOnInit
 from anki.utils import isMac
 from aqt import QApplication, gui_hooks, isWin
 from aqt.colors import colors
 from aqt.qt import QColor, QIcon, QPalette, QPixmap, QStyleFactory, Qt
 
 
-class ThemeManager:
+class ThemeManager(HookOnInit):
     _night_mode_preference = False
     _icon_cache_light: Dict[str, QIcon] = {}
     _icon_cache_dark: Dict[str, QIcon] = {}

--- a/qt/aqt/toolbar.py
+++ b/qt/aqt/toolbar.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 from typing import Any, Dict, Optional
 
 import aqt
+from anki.hooks import HookOnInit
 from anki.lang import _
 from aqt import gui_hooks
 from aqt.qt import *
@@ -25,8 +26,9 @@ class BottomToolbar:
         self.toolbar = toolbar
 
 
-class Toolbar:
+class Toolbar(HookOnInit):
     def __init__(self, mw: aqt.AnkiQt, web: AnkiWebView) -> None:
+        # pylint: disable=W0231
         self.mw = mw
         self.web = web
         self.link_handlers: Dict[str, Callable] = {

--- a/qt/aqt/utils.py
+++ b/qt/aqt/utils.py
@@ -11,6 +11,7 @@ import sys
 from typing import Any, Optional, Union
 
 import aqt
+from anki.hooks import HookOnInit
 from anki.lang import _
 from anki.rsbackend import StringsGroup
 from anki.utils import invalidFilename, isMac, isWin, noBundledLibs, versionWithBuild
@@ -188,8 +189,9 @@ def askUser(text, parent=None, help="", defaultno=False, msgfunc=None, title="An
     return r == QMessageBox.Yes
 
 
-class ButtonedDialog(QMessageBox):
+class ButtonedDialog(QMessageBox, HookOnInit):
     def __init__(self, text, buttons, parent=None, help="", title="Anki"):
+        # pylint: disable=W0231
         QMessageBox.__init__(self, parent)
         self.buttons = []
         self.setWindowTitle(title)

--- a/qt/aqt/webview.py
+++ b/qt/aqt/webview.py
@@ -7,6 +7,7 @@ import math
 import sys
 from typing import Any, List, Optional, Tuple
 
+from anki.hooks import HookOnInit
 from anki.lang import _
 from anki.utils import isLin, isMac, isWin
 from aqt import gui_hooks
@@ -18,8 +19,9 @@ from aqt.utils import openLink
 ##########################################################################
 
 
-class AnkiWebPage(QWebEnginePage):  # type: ignore
+class AnkiWebPage(QWebEnginePage, HookOnInit):  # type: ignore
     def __init__(self, onBridgeCmd):
+        # pylint: disable=W0231
         QWebEnginePage.__init__(self)
         self._onBridgeCmd = onBridgeCmd
         self._setupBridge()
@@ -161,10 +163,11 @@ class WebContent:
 ##########################################################################
 
 
-class AnkiWebView(QWebEngineView):  # type: ignore
+class AnkiWebView(QWebEngineView, HookOnInit):  # type: ignore
     def __init__(
         self, parent: Optional[QWidget] = None, title: str = "default"
     ) -> None:
+        # pylint: disable=W0231
         QWebEngineView.__init__(self, parent=parent)  # type: ignore
         self.title = title
         self._page = AnkiWebPage(self._onBridgeCmd)

--- a/qt/tools/genhooks_gui.py
+++ b/qt/tools/genhooks_gui.py
@@ -72,13 +72,13 @@ hooks = [
     ),
     Hook(
         name="reviewer_did_show_question",
-        args=["card: Card"],
+        args=["card: anki.cards.Card"],
         legacy_hook="showQuestion",
         legacy_no_args=True,
     ),
     Hook(
         name="reviewer_did_show_answer",
-        args=["card: Card"],
+        args=["card: anki.cards.Card"],
         legacy_hook="showAnswer",
         legacy_no_args=True,
     ),
@@ -87,7 +87,7 @@ hooks = [
         args=[
             "ease_tuple: Tuple[bool, int]",
             "reviewer: aqt.reviewer.Reviewer",
-            "card: Card",
+            "card: anki.cards.Card",
         ],
         return_type="Tuple[bool, int]",
         doc="""Used to modify the ease at which a card is rated or to bypass
@@ -102,7 +102,7 @@ hooks = [
     ),
     Hook(
         name="reviewer_did_answer_card",
-        args=["reviewer: aqt.reviewer.Reviewer", "card: Card", "ease: int"],
+        args=["reviewer: aqt.reviewer.Reviewer", "card: anki.cards.Card", "ease: int"],
     ),
     Hook(
         name="reviewer_will_show_context_menu",
@@ -116,7 +116,7 @@ hooks = [
     ),
     Hook(
         name="card_will_show",
-        args=["text: str", "card: Card", "kind: str"],
+        args=["text: str", "card: anki.cards.Card", "kind: str"],
         return_type="str",
         legacy_hook="prepareQA",
         doc="Can modify card text before review/preview.",


### PR DESCRIPTION
It often occurs that add-on must redefine the `__init__` method in order to do one last action when class is loaded. This PR create a hook `class_name_did_init` which is called when a method init is called on the class class_name.

I decided to create a simple class which redefine `__init__`, in order to avoid code repetition. Actually, it allows to create a new line in each `__init__` AND adding one hook by class in pylib/tools/genhooks.py. The biggest downside is that any add-on dev' which looks for this hook won't directly see it in the class. So this need to be properly documented in the add-on creation manual

Creating a real meta class for HookOnInit would have been nice too. The unexpected problem here wath that each PyQt class have already their meta class. Which led to a meta class conflict when I added HookOnInit to any class which was a child of a QTClass. This is the reason why I simply used __init_subclass__, which lead to pylint saying W0231. I know that meta class can be merged, but I didn't want to venture in such complex python programming.

For example
```python
from anki import hooks
def init_card(card):
    print(card.id)
hooks.Card_did_init.append(init_card)
```
would print the id of each card created.
