### PR TITLE
Add deck options hooks

### DIFF
--- a/qt/aqt/deckconf.py
+++ b/qt/aqt/deckconf.py
@@ -221,7 +221,7 @@ class DeckConf(QDialog):
         f.replayQuestion.setChecked(c.get("replayq", True))
         # description
         f.desc.setPlainText(self.deck["desc"])
-        gui_hooks.deck_conf_did_load_config(self, self.conf)
+        gui_hooks.deck_conf_did_load_config(self, self.deck, self.conf)
 
     def onRestore(self):
         self.mw.progress.start()

--- a/qt/aqt/deckconf.py
+++ b/qt/aqt/deckconf.py
@@ -29,6 +29,7 @@ class DeckConf(QDialog):
         self._origNewOrder = None
         self.form = aqt.forms.dconf.Ui_Dialog()
         self.form.setupUi(self)
+        gui_hooks.deck_conf_did_setup_ui_form(self)
         self.mw.checkpoint(_("Options"))
         self.setupCombos()
         self.setupConfs()

--- a/qt/aqt/deckconf.py
+++ b/qt/aqt/deckconf.py
@@ -6,6 +6,7 @@ from operator import itemgetter
 import aqt
 from anki.consts import NEW_CARDS_RANDOM
 from anki.lang import _, ngettext
+from aqt import gui_hooks
 from aqt.qt import *
 from aqt.utils import (
     askUser,
@@ -40,6 +41,7 @@ class DeckConf(QDialog):
         self.setWindowTitle(_("Options for %s") % self.deck["name"])
         # qt doesn't size properly with altered fonts otherwise
         restoreGeom(self, "deckconf", adjustSize=True)
+        gui_hooks.deck_conf_will_show(self)
         self.show()
         self.exec_()
         saveGeom(self, "deckconf")
@@ -218,6 +220,7 @@ class DeckConf(QDialog):
         f.replayQuestion.setChecked(c.get("replayq", True))
         # description
         f.desc.setPlainText(self.deck["desc"])
+        gui_hooks.deck_conf_did_load_config(self, self.conf)
 
     def onRestore(self):
         self.mw.progress.start()
@@ -301,6 +304,7 @@ class DeckConf(QDialog):
         c["replayq"] = f.replayQuestion.isChecked()
         # description
         self.deck["desc"] = f.desc.toPlainText()
+        gui_hooks.deck_conf_will_save_config(self, self.deck, self.conf)
         self.mw.col.decks.save(self.deck)
         self.mw.col.decks.save(self.conf)
 

--- a/qt/aqt/gui_hooks.py
+++ b/qt/aqt/gui_hooks.py
@@ -521,20 +521,22 @@ deck_browser_will_show_options_menu = _DeckBrowserWillShowOptionsMenuHook()
 class _DeckConfDidLoadConfigHook:
     """Called once widget state has been set from deck config"""
 
-    _hooks: List[Callable[["aqt.deckconf.DeckConf", Any], None]] = []
+    _hooks: List[Callable[["aqt.deckconf.DeckConf", Any, Any], None]] = []
 
-    def append(self, cb: Callable[["aqt.deckconf.DeckConf", Any], None]) -> None:
-        """(deck_conf: aqt.deckconf.DeckConf, config: Any)"""
+    def append(self, cb: Callable[["aqt.deckconf.DeckConf", Any, Any], None]) -> None:
+        """(deck_conf: aqt.deckconf.DeckConf, deck: Any, config: Any)"""
         self._hooks.append(cb)
 
-    def remove(self, cb: Callable[["aqt.deckconf.DeckConf", Any], None]) -> None:
+    def remove(self, cb: Callable[["aqt.deckconf.DeckConf", Any, Any], None]) -> None:
         if cb in self._hooks:
             self._hooks.remove(cb)
 
-    def __call__(self, deck_conf: aqt.deckconf.DeckConf, config: Any) -> None:
+    def __call__(
+        self, deck_conf: aqt.deckconf.DeckConf, deck: Any, config: Any
+    ) -> None:
         for hook in self._hooks:
             try:
-                hook(deck_conf, config)
+                hook(deck_conf, deck, config)
             except:
                 # if the hook fails, remove it
                 self._hooks.remove(hook)
@@ -576,7 +578,7 @@ class _DeckConfWillSaveConfigHook:
     _hooks: List[Callable[["aqt.deckconf.DeckConf", Any, Any], None]] = []
 
     def append(self, cb: Callable[["aqt.deckconf.DeckConf", Any, Any], None]) -> None:
-        """(deck_conf: aqt.deckconf.DeckConf, config: Any, deck: Any)"""
+        """(deck_conf: aqt.deckconf.DeckConf, deck: Any, config: Any)"""
         self._hooks.append(cb)
 
     def remove(self, cb: Callable[["aqt.deckconf.DeckConf", Any, Any], None]) -> None:
@@ -584,11 +586,11 @@ class _DeckConfWillSaveConfigHook:
             self._hooks.remove(cb)
 
     def __call__(
-        self, deck_conf: aqt.deckconf.DeckConf, config: Any, deck: Any
+        self, deck_conf: aqt.deckconf.DeckConf, deck: Any, config: Any
     ) -> None:
         for hook in self._hooks:
             try:
-                hook(deck_conf, config, deck)
+                hook(deck_conf, deck, config)
             except:
                 # if the hook fails, remove it
                 self._hooks.remove(hook)

--- a/qt/aqt/gui_hooks.py
+++ b/qt/aqt/gui_hooks.py
@@ -544,6 +544,32 @@ class _DeckConfDidLoadConfigHook:
 deck_conf_did_load_config = _DeckConfDidLoadConfigHook()
 
 
+class _DeckConfDidSetupUiFormHook:
+    """Allows modifying or adding widgets in the deck options UI form"""
+
+    _hooks: List[Callable[["aqt.deckconf.DeckConf"], None]] = []
+
+    def append(self, cb: Callable[["aqt.deckconf.DeckConf"], None]) -> None:
+        """(deck_conf: aqt.deckconf.DeckConf)"""
+        self._hooks.append(cb)
+
+    def remove(self, cb: Callable[["aqt.deckconf.DeckConf"], None]) -> None:
+        if cb in self._hooks:
+            self._hooks.remove(cb)
+
+    def __call__(self, deck_conf: aqt.deckconf.DeckConf) -> None:
+        for hook in self._hooks:
+            try:
+                hook(deck_conf)
+            except:
+                # if the hook fails, remove it
+                self._hooks.remove(hook)
+                raise
+
+
+deck_conf_did_setup_ui_form = _DeckConfDidSetupUiFormHook()
+
+
 class _DeckConfWillSaveConfigHook:
     """Called before widget state is saved to config"""
 

--- a/qt/aqt/gui_hooks.py
+++ b/qt/aqt/gui_hooks.py
@@ -518,6 +518,86 @@ class _DeckBrowserWillShowOptionsMenuHook:
 deck_browser_will_show_options_menu = _DeckBrowserWillShowOptionsMenuHook()
 
 
+class _DeckConfDidLoadConfigHook:
+    """Called once widget state has been set from deck config"""
+
+    _hooks: List[Callable[["aqt.deckconf.DeckConf", Any], None]] = []
+
+    def append(self, cb: Callable[["aqt.deckconf.DeckConf", Any], None]) -> None:
+        """(deck_conf: aqt.deckconf.DeckConf, config: Any)"""
+        self._hooks.append(cb)
+
+    def remove(self, cb: Callable[["aqt.deckconf.DeckConf", Any], None]) -> None:
+        if cb in self._hooks:
+            self._hooks.remove(cb)
+
+    def __call__(self, deck_conf: aqt.deckconf.DeckConf, config: Any) -> None:
+        for hook in self._hooks:
+            try:
+                hook(deck_conf, config)
+            except:
+                # if the hook fails, remove it
+                self._hooks.remove(hook)
+                raise
+
+
+deck_conf_did_load_config = _DeckConfDidLoadConfigHook()
+
+
+class _DeckConfWillSaveConfigHook:
+    """Called before widget state is saved to config"""
+
+    _hooks: List[Callable[["aqt.deckconf.DeckConf", Any, Any], None]] = []
+
+    def append(self, cb: Callable[["aqt.deckconf.DeckConf", Any, Any], None]) -> None:
+        """(deck_conf: aqt.deckconf.DeckConf, config: Any, deck: Any)"""
+        self._hooks.append(cb)
+
+    def remove(self, cb: Callable[["aqt.deckconf.DeckConf", Any, Any], None]) -> None:
+        if cb in self._hooks:
+            self._hooks.remove(cb)
+
+    def __call__(
+        self, deck_conf: aqt.deckconf.DeckConf, config: Any, deck: Any
+    ) -> None:
+        for hook in self._hooks:
+            try:
+                hook(deck_conf, config, deck)
+            except:
+                # if the hook fails, remove it
+                self._hooks.remove(hook)
+                raise
+
+
+deck_conf_will_save_config = _DeckConfWillSaveConfigHook()
+
+
+class _DeckConfWillShowHook:
+    """Allows modifying the deck options dialog before it is shown"""
+
+    _hooks: List[Callable[["aqt.deckconf.DeckConf"], None]] = []
+
+    def append(self, cb: Callable[["aqt.deckconf.DeckConf"], None]) -> None:
+        """(deck_conf: aqt.deckconf.DeckConf)"""
+        self._hooks.append(cb)
+
+    def remove(self, cb: Callable[["aqt.deckconf.DeckConf"], None]) -> None:
+        if cb in self._hooks:
+            self._hooks.remove(cb)
+
+    def __call__(self, deck_conf: aqt.deckconf.DeckConf) -> None:
+        for hook in self._hooks:
+            try:
+                hook(deck_conf)
+            except:
+                # if the hook fails, remove it
+                self._hooks.remove(hook)
+                raise
+
+
+deck_conf_will_show = _DeckConfWillShowHook()
+
+
 class _EditorDidFireTypingTimerHook:
     _hooks: List[Callable[["anki.notes.Note"], None]] = []
 

--- a/qt/tools/genhooks_gui.py
+++ b/qt/tools/genhooks_gui.py
@@ -124,6 +124,11 @@ hooks = [
     # Deck options
     ###################
     Hook(
+        name="deck_conf_did_setup_ui_form",
+        args=["deck_conf: aqt.deckconf.DeckConf"],
+        doc="Allows modifying or adding widgets in the deck options UI form",
+    ),
+    Hook(
         name="deck_conf_will_show",
         args=["deck_conf: aqt.deckconf.DeckConf"],
         doc="Allows modifying the deck options dialog before it is shown",

--- a/qt/tools/genhooks_gui.py
+++ b/qt/tools/genhooks_gui.py
@@ -135,12 +135,12 @@ hooks = [
     ),
     Hook(
         name="deck_conf_did_load_config",
-        args=["deck_conf: aqt.deckconf.DeckConf", "config: Any"],
+        args=["deck_conf: aqt.deckconf.DeckConf", "deck: Any", "config: Any"],
         doc="Called once widget state has been set from deck config",
     ),
     Hook(
         name="deck_conf_will_save_config",
-        args=["deck_conf: aqt.deckconf.DeckConf", "config: Any", "deck: Any"],
+        args=["deck_conf: aqt.deckconf.DeckConf", "deck: Any", "config: Any"],
         doc="Called before widget state is saved to config",
     ),
     # Browser

--- a/qt/tools/genhooks_gui.py
+++ b/qt/tools/genhooks_gui.py
@@ -121,6 +121,23 @@ hooks = [
         legacy_hook="prepareQA",
         doc="Can modify card text before review/preview.",
     ),
+    # Deck options
+    ###################
+    Hook(
+        name="deck_conf_will_show",
+        args=["deck_conf: aqt.deckconf.DeckConf"],
+        doc="Allows modifying the deck options dialog before it is shown",
+    ),
+    Hook(
+        name="deck_conf_did_load_config",
+        args=["deck_conf: aqt.deckconf.DeckConf", "config: Any"],
+        doc="Called once widget state has been set from deck config",
+    ),
+    Hook(
+        name="deck_conf_will_save_config",
+        args=["deck_conf: aqt.deckconf.DeckConf", "config: Any", "deck: Any"],
+        doc="Called before widget state is saved to config",
+    ),
     # Browser
     ###################
     Hook(


### PR DESCRIPTION
Adds a number of hooks for modifying the deck options dialog, which paves the way for add-ons like Speed Focus Mode to move away from patching `DeckConf` for their own deck-specific settings.


**A few notes**:

- Personally, `deck_conf_did_setup_ui_form` is sufficient for all my current use cases, but I could see `deck_conf_will_show` coming in handy for things like:
    - adjusting the combo menu entries
    - tweaking signal/slot assignments and window geometry

    More generally, I think it would make sense to keep `deck_conf_will_show` given that we are likely to see more hooks of this type to cover the use cases we discussed in #455
- I went with `Any` as the type for `config` and `deck` because the corresponding methods in `anki.decks` don't specify more specific types at the moment. I wasn't sure whether I should tweak that because a lot of code paths depend on `anki.decks` and I assume `Any` is used there for a reason

**Demo add-on**:

```python
from typing import Any

from PyQt5.QtWidgets import QLineEdit

from aqt import gui_hooks
from aqt.deckconf import DeckConf


def on_deck_conf_did_setup_ui_form(deck_conf: DeckConf):
    form = deck_conf.form
    form.myLineEdit = QLineEdit(form.tab_5)
    form.verticalLayout_6.addWidget(form.myLineEdit)


def on_deck_conf_did_load_config(deck_conf: DeckConf, deck: Any, config: Any):
    my_line_edit: QLineEdit = deck_conf.form.myLineEdit
    my_line_edit.setText(config.get("myLineEdit", ""))


def on_deck_conf_will_save_config(deck_conf: DeckConf, deck: Any, config: Any):
    my_line_edit: QLineEdit = deck_conf.form.myLineEdit
    config["myLineEdit"] = my_line_edit.text()


gui_hooks.deck_conf_did_setup_ui_form.append(on_deck_conf_did_setup_ui_form)
gui_hooks.deck_conf_did_load_config.append(on_deck_conf_did_load_config)
gui_hooks.deck_conf_will_save_config.append(on_deck_conf_will_save_config)
```
