### PR TITLE
Fixed build-mo-files not stopping on build errors

### DIFF
--- a/.github/scripts/contrib.sh
+++ b/.github/scripts/contrib.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -e
+set -eo pipefail
 
 antispam=", at the domain "
 

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ buildhash:
 
 .PHONY: develop
 develop: pyenv buildhash
-	@set -e && \
+	@set -eo pipefail && \
 	. pyenv/bin/activate && \
 	for dir in $(DEVEL); do \
 		$(SUBMAKE) -C $$dir develop BUILDFLAGS="$(BUILDFLAGS)"; \
@@ -42,7 +42,7 @@ develop: pyenv buildhash
 
 .PHONY: run
 run: develop
-	@set -e && \
+	@set -eo pipefail && \
 	. pyenv/bin/activate && \
 	echo "Starting Anki..."; \
 	qt/runanki $(RUNFLAGS)
@@ -69,7 +69,7 @@ build-qt:
 
 .PHONY: clean
 clean: clean-dist
-	@set -e && \
+	@set -eo pipefail && \
 	for dir in $(DEVEL); do \
 	  $(SUBMAKE) -C $$dir clean; \
 	done
@@ -80,7 +80,7 @@ clean-dist:
 
 .PHONY: check
 check: pyenv buildhash
-	@set -e && \
+	@set -eo pipefail && \
 	for dir in $(CHECKABLE_RS); do \
 	  $(SUBMAKE) -C $$dir check; \
 	done; \
@@ -95,7 +95,7 @@ check: pyenv buildhash
 
 .PHONY: fix
 fix:
-	@set -e && \
+	@set -eo pipefail && \
 	. pyenv/bin/activate && \
 	for dir in $(CHECKABLE_RS) $(CHECKABLE_PY); do \
 	  $(SUBMAKE) -C $$dir fix; \

--- a/README.contributing
+++ b/README.contributing
@@ -104,7 +104,7 @@ You can do this automatically by adding the following into
 .git/hooks/pre-commit or .git/hooks/pre-push and making it executable.
 
 #!/bin/bash
-set -e
+set -eo pipefail
 make check
 
 You may need to adjust the PATH variable so that things like a local install

--- a/qt/i18n/build-mo-files
+++ b/qt/i18n/build-mo-files
@@ -2,7 +2,7 @@
 #
 # build mo files
 #
-set -e
+set -eo pipefail
 
 targetDir="../aqt_data/locale/gettext"
 mkdir -p $targetDir
@@ -10,9 +10,9 @@ mkdir -p $targetDir
 echo "Compiling *.po..."
 for file in po/desktop/*/anki.po
 do
-    outdir=$(echo $file | \
+    outdir=$(echo "$file" | \
         perl -pe "s%po/desktop/(.*)/anki.po%$targetDir/\1/LC_MESSAGES%")
     outfile="$outdir/anki.mo"
     mkdir -p $outdir
-    msgmerge --for-msgfmt $file po/desktop/anki.pot | msgfmt - --output-file=$outfile
+    msgmerge --for-msgfmt "$file" po/desktop/anki.pot | msgfmt - --output-file=$outfile
 done

--- a/qt/i18n/build-mo-files
+++ b/qt/i18n/build-mo-files
@@ -14,5 +14,5 @@ do
         perl -pe "s%po/desktop/(.*)/anki.po%$targetDir/\1/LC_MESSAGES%")
     outfile="$outdir/anki.mo"
     mkdir -p $outdir
-    msgmerge --for-msgfmt "$file" po/desktop/anki.pot | msgfmt - --output-file=$outfile
+    msgmerge --for-msgfmt "$file" po/desktop/anki.pot | msgfmt - --output-file="$outfile"
 done

--- a/qt/i18n/build-mo-files
+++ b/qt/i18n/build-mo-files
@@ -2,6 +2,7 @@
 #
 # build mo files
 #
+set -e
 
 targetDir="../aqt_data/locale/gettext"
 mkdir -p $targetDir

--- a/qt/i18n/copy-qt-files
+++ b/qt/i18n/copy-qt-files
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -e
+set -eo pipefail
 
 out=../aqt_data/locale/qt
 mkdir -p $out

--- a/qt/i18n/sync-po-git
+++ b/qt/i18n/sync-po-git
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+set -eo pipefail
 
 # pull any pending changes from git repos
 ./pull-git

--- a/qt/i18n/sync-po-git
+++ b/qt/i18n/sync-po-git
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 # pull any pending changes from git repos
 ./pull-git

--- a/qt/i18n/update-po-template
+++ b/qt/i18n/update-po-template
@@ -2,7 +2,7 @@
 #
 # update template .pot file from source code strings
 #
-
+set -e
 
 topDir=$(dirname $0)/../..
 cd $topDir

--- a/qt/i18n/update-po-template
+++ b/qt/i18n/update-po-template
@@ -2,7 +2,7 @@
 #
 # update template .pot file from source code strings
 #
-set -e
+set -eo pipefail
 
 topDir=$(dirname $0)/../..
 cd $topDir

--- a/qt/tools/build_ui.sh
+++ b/qt/tools/build_ui.sh
@@ -4,7 +4,7 @@
 # should be on the path.
 #
 
-set -e
+set -eo pipefail
 
 if [ ! -d "designer" ]
 then


### PR DESCRIPTION
Complete the fix on https://github.com/ankitects/anki-desktop-i18n/pull/1 by making errors stop the build process, i.e., do not let the pass unnoticed.