### PR TITLE
Add new will_init_bottom and did_init_bottom hooks

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -26,6 +26,7 @@ Arthur Milchior <arthur@milchior.fr>
 Yngve Hoiseth <yngve@hoiseth.net>
 Ijgnd
 Yoonchae Lee
+Jorge Bucaran <https://jorgebucaran.com>
 
 ********************
 

--- a/qt/aqt/reviewer.py
+++ b/qt/aqt/reviewer.py
@@ -156,7 +156,7 @@ class Reviewer:
             context=self,
         )
 
-        if gui_hooks.will_init_bottom():
+        if not gui_hooks.toolbar_bottom_will_init(True):
             return
 
         # show answer / ease buttons
@@ -168,7 +168,7 @@ class Reviewer:
             context=ReviewerBottomBar(self),
         )
 
-        gui_hooks.did_init_bottom()
+        gui_hooks.toolbar_bottom_did_init()
 
     # Showing the question
     ##########################################################################

--- a/qt/aqt/reviewer.py
+++ b/qt/aqt/reviewer.py
@@ -155,6 +155,10 @@ class Reviewer:
             ],
             context=self,
         )
+
+        if gui_hooks.will_init_bottom():
+            return
+
         # show answer / ease buttons
         self.bottom.web.show()
         self.bottom.web.stdHtml(
@@ -163,6 +167,8 @@ class Reviewer:
             js=["jquery.js", "reviewer-bottom.js"],
             context=ReviewerBottomBar(self),
         )
+
+        gui_hooks.did_init_bottom()
 
     # Showing the question
     ##########################################################################

--- a/qt/tools/genhooks_gui.py
+++ b/qt/tools/genhooks_gui.py
@@ -392,15 +392,15 @@ hooks = [
         args=["player: aqt.sound.Player", "tag: anki.sound.AVTag"],
     ),
     Hook(name="av_player_did_end_playing", args=["player: aqt.sound.Player"]),
-    # Web
+    # Toolbar
     ###################
     Hook(
-        name="will_init_bottom", 
+        name="toolbar_bottom_will_init", 
         return_type="bool",
-        doc="Return True to not display the bottom web.",),
+        doc="Return True to not display the toolbar while reviewing.",),
     Hook(
-        name="did_init_bottom", 
-        doc="Used to extend the bottom web. E.g. add extra stats to the status bar",),
+        name="toolbar_bottom_did_init", 
+        doc="Used to extend the toolbar while reviewing E.g. add extra stats to the toolbar",),
     # Other
     ###################
     Hook(

--- a/qt/tools/genhooks_gui.py
+++ b/qt/tools/genhooks_gui.py
@@ -392,6 +392,15 @@ hooks = [
         args=["player: aqt.sound.Player", "tag: anki.sound.AVTag"],
     ),
     Hook(name="av_player_did_end_playing", args=["player: aqt.sound.Player"]),
+    # Web
+    ###################
+    Hook(
+        name="will_init_bottom", 
+        return_type="bool",
+        doc="Return True to not display the bottom web.",),
+    Hook(
+        name="did_init_bottom", 
+        doc="Used to extend the bottom web. E.g. add extra stats to the status bar",),
     # Other
     ###################
     Hook(

--- a/qt/tools/genhooks_gui.py
+++ b/qt/tools/genhooks_gui.py
@@ -397,7 +397,7 @@ hooks = [
     Hook(
         name="toolbar_bottom_will_init", 
         return_type="bool",
-        doc="Return True to not display the toolbar while reviewing.",),
+        doc="Return True to hide the toolbar while reviewing.",),
     Hook(
         name="toolbar_bottom_did_init", 
         doc="Used to extend the toolbar while reviewing E.g. add extra stats to the toolbar",),


### PR DESCRIPTION
This is my first attempt at adding two new hooks that might prove useful (and I would benefit from). Please let me know if I need to fix or change anything, etc. 👋 

- ~~`will_init_bottom`~~ `toolbar_bottom_will_init` allows you to hide the bottom web (status bar) by simply returning `False`.

- ~~`did_init_bottom`~~ `toolbar_bottom_did_init` is called after bottom web is created, allowing you to easily extend it, e.g. add more card stats, show how many times you have failed this card, and so on.

### Background

I'd like to hide the toolbar bottom while reviewing. 

I hope that these hooks allow me to do this as easily as:

```python
from aqt import mw
from aqt import gui_hooks as hooks

hooks.toolbar_bottom_will_init.append(lambda _: False)
```

Compare to my current solution monkey-patching `_initWeb`:

```python
Reviewer._initWeb = (
    lambda init:
    lambda self: init(self) or mw.reviewer.bottom.web.eval(
        "outer.style.display='none'"))(Reviewer._initWeb)
```