### PR TITLE
Announce which file it is building

### DIFF
--- a/qt/i18n/build-mo-files
+++ b/qt/i18n/build-mo-files
@@ -15,5 +15,10 @@ do
         perl -pe "s%po/desktop/(.*)/anki.po%$targetDir/\1/LC_MESSAGES%")
     outfile="$outdir/anki.mo"
     mkdir -p $outdir
-    msgmerge -q "$file" po/desktop/anki.pot | msgfmt - --output-file="$outfile"
+    mergedfile="$(msgmerge -q "$file" po/desktop/anki.pot)"
+    printf '%s' "$mergedfile" | msgfmt - --output-file="$outfile" \
+        || (error=$? \
+            && printf '%s' "$mergedfile" > "$file.error" \
+            && printf 'See the file "%s" to find the error line number just showed!\n' "$file.error" \
+            && exit $error)
 done

--- a/qt/i18n/build-mo-files
+++ b/qt/i18n/build-mo-files
@@ -10,6 +10,7 @@ mkdir -p $targetDir
 echo "Compiling *.po..."
 for file in po/desktop/*/anki.po
 do
+    echo "Building '$file'"
     outdir=$(echo "$file" | \
         perl -pe "s%po/desktop/(.*)/anki.po%$targetDir/\1/LC_MESSAGES%")
     outfile="$outdir/anki.mo"


### PR DESCRIPTION
Without this, I cannot tell on which file the installation failed:
```
Updating translations from git...
Already up to date.
Current branch master is up to date.
Compiling *.po...
<stdin>:728: 'msgid' and 'msgstr' entries do not both end with '\n'
<stdin>:810: 'msgid' and 'msgstr' entries do not both end with '\n'
F:\Cygwin\bin\msgfmt.exe: found 2 fatal errors
make[1]: *** [Makefile:31: .build/i18n] Error 1
```

With this pull request, now I know where it failed:
```
Updating translations from git...
Already up to date.
Current branch master is up to date.
Compiling *.po...
Building 'po/desktop/af/anki.po'
...
Building 'po/desktop/hu/anki.po'
<stdin>:728: 'msgid' and 'msgstr' entries do not both end with '\n'
<stdin>:810: 'msgid' and 'msgstr' entries do not both end with '\n'
F:\Cygwin\bin\msgfmt.exe: found 2 fatal errors
See the file "po/desktop/hu/anki.po.error" to find the error line number just showed!
make[1]: *** [Makefile:31: .build/i18n] Error 1
```