### PR TITLE
fix comment on setWebExports usage

### DIFF
--- a/qt/aqt/mediasrv.py
+++ b/qt/aqt/mediasrv.py
@@ -161,11 +161,10 @@ class RequestHandler(http.server.SimpleHTTPRequestHandler):
             if not pattern:
                 return path
 
-            if not re.fullmatch(pattern, subPath):
-                return path
-
-            newPath = os.path.join(addMgr.addonsFolder(), addonPath)
-            return newPath
+            subPath2 = subPath.replace(os.sep, "/")
+            if re.fullmatch(pattern, subPath) or re.fullmatch(pattern, subPath2):
+                newPath = os.path.join(addMgr.addonsFolder(), addonPath)
+                return newPath
 
         return path
 

--- a/qt/aqt/webview.py
+++ b/qt/aqt/webview.py
@@ -149,6 +149,8 @@ class WebContent:
                       f"/_addons/{addon_package}/web/my-addon.css")
                   web_content.js.append(
                       f"/_addons/{addon_package}/web/my-addon.js")
+          
+          Note that '/' will also match the os specific path separator.
     """
 
     body: str = ""


### PR DESCRIPTION
The comment regarding usage on setWebExports is very misleading as it would not work on an OS that does not use `/` but `\` as the directory seperator. 