### PR TITLE
Hook to do more actions during fix integrity

### DIFF
--- a/pylib/anki/collection.py
+++ b/pylib/anki/collection.py
@@ -970,6 +970,7 @@ and type=0""",
         self.optimize()
         newSize = os.stat(self.path)[stat.ST_SIZE]
         txt = _("Database rebuilt and optimized.")
+        problems = hooks.fix_integrity(problems, self)
         ok = not problems
         problems.append(txt)
         # if any problems were found, force a full sync

--- a/pylib/tools/genhooks.py
+++ b/pylib/tools/genhooks.py
@@ -95,6 +95,20 @@ hooks = [
         name="schedv2_did_answer_review_card",
         args=["card: anki.cards.Card", "ease: int", "early: bool"],
     ),
+    Hook(
+        name="fix_integrity",
+        args=["problems: List[str]", "col: anki.collection._Collection"],
+        return_type="List[str]",
+        doc="""Allow to add more actions to do when calling "Check Database". Any
+        error should be appended to the list and then returned.
+
+        For example:
+        * Checking for duplicate cards (same ord, same nid)
+        * Duplicate GUID
+        * calling automatically "Check Media"
+        * checking whether all deck/model parameters are set
+        """,
+    ),
 ]
 
 if __name__ == "__main__":


### PR DESCRIPTION
I did a change as minimal as possible.
Currently, I've an add-on which:
* does more fixes
* explain in more details what are the corrected problems

The way to do it was to monkey-patch fixIntigrety. Copying previous code and adding some tests/correction. Which means that: 
* if another add-on want to change fixIntegrity, they are incompatible
* if you add more fixe, my add-on would ensure they are not applied since it's not in my add-on code.

This hook would correct those two problems.

This still would lead the problem that the error messages does not have enough informations for my taste. Which is why the real change I would like to make is more profound (and I don't know whether you would accept it)

I want to break the extra long "fixIntegrity" methods in plenty of methods, and then add each of them to the hook.
If each fix was a separate method, I could replace it (monkey patch or hook) to show the exact corrected errors. And if you eventually add more fixes, then they'll still work even if they won't give a lot of informations.
Another solution could be to have an option (in preference, or through environment variable, or something else) to tell anki's code to switch between the simplified error message we currently have, and a detailed error message. I must state that it will be mostly useful for add-on devs, but not exclusively. It could also be useful for users when they want to make bug reports, this would lead to more details for us