### PR TITLE
Hook init clayout

### DIFF
--- a/qt/aqt/clayout.py
+++ b/qt/aqt/clayout.py
@@ -65,6 +65,7 @@ class CardLayout(QDialog):
         v1.addLayout(self.buttons)
         v1.setContentsMargins(12, 12, 12, 12)
         self.setLayout(v1)
+        gui_hooks.card_layout_will_show(self)
         self.redraw()
         restoreGeom(self, "CardLayout")
         self.setWindowModality(Qt.ApplicationModal)

--- a/qt/aqt/gui_hooks.py
+++ b/qt/aqt/gui_hooks.py
@@ -328,6 +328,33 @@ class _BrowserWillShowContextMenuHook:
 browser_will_show_context_menu = _BrowserWillShowContextMenuHook()
 
 
+class _CardLayoutWillShowHook:
+    """Allow to change the display of the card layout. After most values are
+         set and before the window is actually shown."""
+
+    _hooks: List[Callable[["aqt.clayout.CardLayout"], None]] = []
+
+    def append(self, cb: Callable[["aqt.clayout.CardLayout"], None]) -> None:
+        """(clayout: aqt.clayout.CardLayout)"""
+        self._hooks.append(cb)
+
+    def remove(self, cb: Callable[["aqt.clayout.CardLayout"], None]) -> None:
+        if cb in self._hooks:
+            self._hooks.remove(cb)
+
+    def __call__(self, clayout: aqt.clayout.CardLayout) -> None:
+        for hook in self._hooks:
+            try:
+                hook(clayout)
+            except:
+                # if the hook fails, remove it
+                self._hooks.remove(hook)
+                raise
+
+
+card_layout_will_show = _CardLayoutWillShowHook()
+
+
 class _CardWillShowFilter:
     """Can modify card text before review/preview."""
 

--- a/qt/tools/genhooks_gui.py
+++ b/qt/tools/genhooks_gui.py
@@ -114,6 +114,9 @@ hooks = [
         legacy_hook="reviewCleanup",
         doc="Called before Anki transitions from the review screen to another screen.",
     ),
+    # Multiple windows
+    ###################
+    # reviewer, clayout and browser
     Hook(
         name="card_will_show",
         args=["text: str", "card: Card", "kind: str"],

--- a/qt/tools/genhooks_gui.py
+++ b/qt/tools/genhooks_gui.py
@@ -114,6 +114,14 @@ hooks = [
         legacy_hook="reviewCleanup",
         doc="Called before Anki transitions from the review screen to another screen.",
     ),
+    # Card layout
+    ###################
+    Hook(
+        name="card_layout_will_show",
+        args=["clayout: aqt.clayout.CardLayout"],
+        doc="""Allow to change the display of the card layout. After most values are
+         set and before the window is actually shown.""",
+    ),
     # Multiple windows
     ###################
     # reviewer, clayout and browser


### PR DESCRIPTION
Those are two kind of related change. The first hook is only here to correct something which is unclear in the hook list.

I intend to use this hook for https://ankiweb.net/shared/info/915063177 . Even if it will still lead to some monkey-patching. I don't see any way to create hook for all changes I make. 

If you are interested, I think it may be nice to merge this add-on in anki. Being able to preview easily how cards in different cloze may be nice. Especially since you can test for a specific card number in the template.