### PR TITLE
hook addon_current_config_is_invalid

### DIFF
--- a/qt/aqt/addons.py
+++ b/qt/aqt/addons.py
@@ -26,6 +26,7 @@ import aqt
 import aqt.forms
 from anki.httpclient import HttpClient
 from anki.lang import _, ngettext
+from aqt import gui_hooks
 from aqt.qt import *
 from aqt.utils import (
     TR,
@@ -248,11 +249,13 @@ class AddonManager:
     # in new code, use self.addon_meta() instead
     def addonMeta(self, dir: str) -> Dict[str, Any]:
         path = self._addonMetaPath(dir)
+        t = None
         try:
             with open(path, encoding="utf8") as f:
-                return json.load(f)
-        except:
-            return dict()
+                t = f.read()
+            return json.loads(t)
+        except Exception as e:
+            return gui_hooks.addon_current_config_is_invalid(dict(), e, t)
 
     # in new code, use write_addon_meta() instead
     def writeAddonMeta(self, dir, meta):

--- a/qt/aqt/addons.py
+++ b/qt/aqt/addons.py
@@ -573,11 +573,13 @@ and have been disabled: %(found)s"
 
     def addonConfigDefaults(self, dir):
         path = os.path.join(self.addonsFolder(dir), "config.json")
+        t = None
         try:
             with open(path, encoding="utf8") as f:
-                return json.load(f)
-        except:
-            return None
+                t = f.read
+            return json.loads(t)
+        except Exception as e:
+            return gui_hooks.addon_default_config_is_invalid(None, e, t)
 
     def addonConfigHelp(self, dir):
         path = os.path.join(self.addonsFolder(dir), "config.md")

--- a/qt/tools/genhooks_gui.py
+++ b/qt/tools/genhooks_gui.py
@@ -438,6 +438,25 @@ def emptyNewCard():
         args=["player: aqt.sound.Player", "tag: anki.sound.AVTag"],
     ),
     Hook(name="av_player_did_end_playing", args=["player: aqt.sound.Player"]),
+    # Add-on manager
+    ###################
+    Hook(
+        name="addon_current_config_is_invalid",
+        args=[
+            "config: Dict[str, Any]",
+            "exc: Exception",
+            "file_content: Optional[str]",
+        ],
+        return_type="Dict[str, Any]",
+        doc="""Allow to react when a current configuration file (meta.json) is
+        broken. You can either use the file content to display it, or
+        try to correct it, or print the json error message so that the
+        user/dev can correct it manually.
+
+        This should never occur except if a user changed the file
+        without using anki add-on manager (or if an add-on wrote some
+        value without just dumping some json.""",
+    ),
     # Other
     ###################
     Hook(

--- a/qt/tools/genhooks_gui.py
+++ b/qt/tools/genhooks_gui.py
@@ -457,6 +457,23 @@ def emptyNewCard():
         without using anki add-on manager (or if an add-on wrote some
         value without just dumping some json.""",
     ),
+    Hook(
+        name="addon_default_config_is_invalid",
+        args=[
+            "config: Optional[Dict[str, Any]]",
+            "exc: Exception",
+            "file_content: Optional[str]",
+        ],
+        return_type="Dict[str, Any]",
+        doc="""Allow to react when a default configuration file (config.json) is
+        broken. You can either use the file content to display it, or
+        try to correct it, or print the json error message so that the
+        user/dev can correct it manually.
+
+        This should never occur except if an add-on as a default
+        config file, in which case the developper should probably be
+        told quickly.""",
+    ),
     # Other
     ###################
     Hook(


### PR DESCRIPTION
The main reason to use that is that, when I create add-on, I sometime make typo when I create/change the configuration. And then I want to be able to read the json error message in order to debug it.

By the way, would you accept a PR which check whether an edited config satisfies a json-schema before accepting it ?
I think json-schema for config would be useful, first to help user not to write anything wrong. And in a second time because it would help create automatic preference GUI, where the name of the fields are prefilled, and it's clear whether it's a boolean (check box), an integer (numeric box) or a float, or a string (text field), or another dict (which would be created by openining a new config window), a tuple or a list (probably created as in clayout, with a menu to choose which element of the list to check). However, this feature would only make sens if there is already some add-on with schemas