### PR TITLE
Hook browser init

### DIFF
--- a/qt/aqt/browser.py
+++ b/qt/aqt/browser.py
@@ -596,6 +596,7 @@ class Browser(QMainWindow):
         self.updateFont()
         self.onUndoState(self.mw.form.actionUndo.isEnabled())
         self.setupSearch()
+        gui_hooks.browser_will_show(self)
         self.show()
 
     def setupMenus(self) -> None:

--- a/qt/aqt/gui_hooks.py
+++ b/qt/aqt/gui_hooks.py
@@ -302,6 +302,30 @@ class _BrowserWillBuildTreeFilter:
 browser_will_build_tree = _BrowserWillBuildTreeFilter()
 
 
+class _BrowserWillShowHook:
+    _hooks: List[Callable[["aqt.browser.Browser"], None]] = []
+
+    def append(self, cb: Callable[["aqt.browser.Browser"], None]) -> None:
+        """(browser: aqt.browser.Browser)"""
+        self._hooks.append(cb)
+
+    def remove(self, cb: Callable[["aqt.browser.Browser"], None]) -> None:
+        if cb in self._hooks:
+            self._hooks.remove(cb)
+
+    def __call__(self, browser: aqt.browser.Browser) -> None:
+        for hook in self._hooks:
+            try:
+                hook(browser)
+            except:
+                # if the hook fails, remove it
+                self._hooks.remove(hook)
+                raise
+
+
+browser_will_show = _BrowserWillShowHook()
+
+
 class _BrowserWillShowContextMenuHook:
     _hooks: List[Callable[["aqt.browser.Browser", QMenu], None]] = []
 

--- a/qt/tools/genhooks_gui.py
+++ b/qt/tools/genhooks_gui.py
@@ -46,31 +46,6 @@ hooks = [
         """,
     ),
     Hook(
-        name="deck_browser_did_render",
-        args=["deck_browser: aqt.deckbrowser.DeckBrowser"],
-        doc="""Allow to update the deck browser window. E.g. change its title.""",
-    ),
-    Hook(
-        name="deck_browser_will_render_content",
-        args=[
-            "deck_browser: aqt.deckbrowser.DeckBrowser",
-            "content: aqt.deckbrowser.DeckBrowserContent",
-        ],
-        doc="""Used to modify HTML content sections in the deck browser body
-        
-        'content' contains the sections of HTML content the deck browser body
-        will be updated with.
-        
-        When modifying the content of a particular section, please make sure your
-        changes only perform the minimum required edits to make your add-on work.
-        You should avoid overwriting or interfering with existing data as much
-        as possible, instead opting to append your own changes, e.g.:
-        
-            def on_deck_browser_will_render_content(deck_browser, content):
-                content.stats += "\n<div>my html</div>"
-        """,
-    ),
-    Hook(
         name="reviewer_did_show_question",
         args=["card: Card"],
         legacy_hook="showQuestion",
@@ -120,6 +95,33 @@ hooks = [
         return_type="str",
         legacy_hook="prepareQA",
         doc="Can modify card text before review/preview.",
+    ),
+    # Deck browser
+    ###################
+    Hook(
+        name="deck_browser_did_render",
+        args=["deck_browser: aqt.deckbrowser.DeckBrowser"],
+        doc="""Allow to update the deck browser window. E.g. change its title.""",
+    ),
+    Hook(
+        name="deck_browser_will_render_content",
+        args=[
+            "deck_browser: aqt.deckbrowser.DeckBrowser",
+            "content: aqt.deckbrowser.DeckBrowserContent",
+        ],
+        doc="""Used to modify HTML content sections in the deck browser body
+        
+        'content' contains the sections of HTML content the deck browser body
+        will be updated with.
+        
+        When modifying the content of a particular section, please make sure your
+        changes only perform the minimum required edits to make your add-on work.
+        You should avoid overwriting or interfering with existing data as much
+        as possible, instead opting to append your own changes, e.g.:
+        
+            def on_deck_browser_will_render_content(deck_browser, content):
+                content.stats += "\n<div>my html</div>"
+        """,
     ),
     # Deck options
     ###################

--- a/qt/tools/genhooks_gui.py
+++ b/qt/tools/genhooks_gui.py
@@ -147,6 +147,7 @@ hooks = [
     ),
     # Browser
     ###################
+    Hook(name="browser_will_show", args=["browser: aqt.browser.Browser"]),
     Hook(
         name="browser_menus_did_init",
         args=["browser: aqt.browser.Browser"],


### PR DESCRIPTION
I moved the deck browser in a separate section of the gui_hooks.

It's the same idea than a recent commit. Being able to change the content of the window after it was initialized and before it is shown. 