### PR TITLE
Reset can be cancelled

### DIFF
--- a/qt/aqt/gui_hooks.py
+++ b/qt/aqt/gui_hooks.py
@@ -907,6 +907,31 @@ def emptyNewCard():
 empty_cards_will_be_deleted = _EmptyCardsWillBeDeletedFilter()
 
 
+class _MainWindowShouldResetFilter:
+    _hooks: List[Callable[[bool], bool]] = []
+
+    def append(self, cb: Callable[[bool], bool]) -> None:
+        """(should_reset: bool)"""
+        self._hooks.append(cb)
+
+    def remove(self, cb: Callable[[bool], bool]) -> None:
+        if cb in self._hooks:
+            self._hooks.remove(cb)
+
+    def __call__(self, should_reset: bool) -> bool:
+        for filter in self._hooks:
+            try:
+                should_reset = filter(should_reset)
+            except:
+                # if the hook fails, remove it
+                self._hooks.remove(filter)
+                raise
+        return should_reset
+
+
+main_window_should_reset = _MainWindowShouldResetFilter()
+
+
 class _MediaSyncDidProgressHook:
     _hooks: List[Callable[["aqt.mediasync.LogEntryWithTime"], None]] = []
 

--- a/qt/aqt/main.py
+++ b/qt/aqt/main.py
@@ -636,6 +636,8 @@ from the profile screen."
 
     def requireReset(self, modal=False):
         "Signal queue needs to be rebuilt when edits are finished or by user."
+        if not gui_hooks.main_window_should_reset(True):
+            return
         self.autosave()
         self.resetModal = modal
         if self.interactiveState():

--- a/qt/tools/genhooks_gui.py
+++ b/qt/tools/genhooks_gui.py
@@ -370,6 +370,9 @@ def emptyNewCard():
     gui_hooks.remove(filter)
 ```""",
     ),
+    Hook(
+        name="main_window_should_reset", args=["should_reset: bool"], return_type="bool"
+    ),
     # Adding cards
     ###################
     Hook(


### PR DESCRIPTION
I believe that reset is called far too often. When a card is not
modified, it can still be displayed. It's actually sometime useful
when the content of the current card made me know I need to change
another card.
I want to be able to cancel the reset. Even if it means that the
scheduler will not be rebuild and thus in some case this change which
card I see