### PR TITLE
Fixed shared decks link on qt/aqt/__init__.py

### DIFF
--- a/qt/aqt/__init__.py
+++ b/qt/aqt/__init__.py
@@ -27,7 +27,7 @@ appVersion = _version
 appWebsite = "https://apps.ankiweb.net/"
 appChanges = "https://apps.ankiweb.net/docs/changes.html"
 appDonate = "https://apps.ankiweb.net/support/"
-appShared = "https://ankiweb.net/shared/"
+appShared = "https://ankiweb.net/shared/decks/"
 appUpdate = "https://ankiweb.net/update/desktop"
 appHelpSite = HELP_SITE
 


### PR DESCRIPTION
The page https://ankiweb.net/shared/ does not exists:
![image](https://user-images.githubusercontent.com/5332158/75629314-aac2dd80-5bbf-11ea-899c-05322c7b984b.png)

But the page https://ankiweb.net/shared/decks/ does:
![image](https://user-images.githubusercontent.com/5332158/75629320-b7473600-5bbf-11ea-8f23-fb471cd9e875.png)

