### PR TITLE
Hook renaming

### DIFF
--- a/pylib/anki/decks.py
+++ b/pylib/anki/decks.py
@@ -284,11 +284,13 @@ class DeckManager:
         "Rename deck prefix to NAME if not exists. Updates children."
         # make sure target node doesn't already exist
         if self.byName(newName):
-            raise DeckRenameError(_("That deck already exists."))
+            raise DeckRenameError(_("That deck already exists."), g, newName)
         # make sure we're not nesting under a filtered deck
         for p in self.parentsByName(newName):
             if p["dyn"]:
-                raise DeckRenameError(_("A filtered deck cannot have subdecks."))
+                raise DeckRenameError(
+                    _("A filtered deck cannot have subdecks."), g, newName
+                )
         # ensure we have parents
         newName = self._ensureParents(newName)
         # rename children

--- a/pylib/anki/decks.py
+++ b/pylib/anki/decks.py
@@ -304,19 +304,27 @@ class DeckManager:
         # renaming may have altered active did order
         self.maybeAddToActive()
 
-    def renameForDragAndDrop(self, draggedDeckDid: int, ontoDeckDid: Any) -> None:
+    def renameForDragAndDrop(
+        self, draggedDeckDid: str, ontoDeckDid: Optional[str]
+    ) -> None:
         draggedDeck = self.get(draggedDeckDid)
+        new_name = self.new_name_for_drag_and_drop(draggedDeck, ontoDeckDid)
+        if new_name is not None:
+            self.rename(draggedDeck, new_name)
+
+    def new_name_for_drag_and_drop(
+        self, draggedDeck: Dict[str, Any], ontoDeckDid: Optional[str]
+    ) -> Optional[str]:
         draggedDeckName = draggedDeck["name"]
         ontoDeckName = self.get(ontoDeckDid)["name"]
 
         if ontoDeckDid is None or ontoDeckDid == "":
             if len(self._path(draggedDeckName)) > 1:
-                self.rename(draggedDeck, self._basename(draggedDeckName))
+                return self._basename(draggedDeckName)
         elif self._canDragAndDrop(draggedDeckName, ontoDeckName):
             assert ontoDeckName.strip()
-            self.rename(
-                draggedDeck, ontoDeckName + "::" + self._basename(draggedDeckName)
-            )
+            return ontoDeckName + "::" + self._basename(draggedDeckName)
+        return None
 
     def _canDragAndDrop(self, draggedDeckName: str, ontoDeckName: str) -> bool:
         if (

--- a/pylib/anki/decks.py
+++ b/pylib/anki/decks.py
@@ -313,9 +313,6 @@ class DeckManager:
             if len(self._path(draggedDeckName)) > 1:
                 self.rename(draggedDeck, self._basename(draggedDeckName))
         elif self._canDragAndDrop(draggedDeckName, ontoDeckName):
-            draggedDeck = self.get(draggedDeckDid)
-            draggedDeckName = draggedDeck["name"]
-            ontoDeckName = self.get(ontoDeckDid)["name"]
             assert ontoDeckName.strip()
             self.rename(
                 draggedDeck, ontoDeckName + "::" + self._basename(draggedDeckName)

--- a/pylib/anki/errors.py
+++ b/pylib/anki/errors.py
@@ -1,7 +1,7 @@
 # Copyright: Ankitects Pty Ltd and contributors
 # License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
-from typing import Any
+from typing import Any, Dict
 
 
 class AnkiError(Exception):
@@ -18,9 +18,11 @@ class AnkiError(Exception):
 
 
 class DeckRenameError(Exception):
-    def __init__(self, description: str) -> None:
+    def __init__(self, description: str, deck: Dict[str, Any], newName: str) -> None:
         super().__init__()
         self.description = description
+        self.deck = deck
+        self.newName = newName
 
     def __str__(self):
         return "Couldn't rename deck: " + self.description

--- a/qt/aqt/deckbrowser.py
+++ b/qt/aqt/deckbrowser.py
@@ -299,7 +299,10 @@ where id > ?""",
         try:
             self.mw.col.decks.rename(deck, newName)
         except DeckRenameError as e:
-            return showWarning(e.description)
+            if gui_hooks.deck_failed_to_rename(True, e, self):
+                return showWarning(e.description)
+            else:
+                return
         self.show()
 
     def _options(self, did):
@@ -312,12 +315,14 @@ where id > ?""",
         self.mw.col.decks.collapse(did)
         self._renderPage(reuse=True)
 
-    def _dragDeckOnto(self, draggedDeckDid, ontoDeckDid):
+    def _dragDeckOnto(self, draggedDeckDid: str, ontoDeckDid: str):
         try:
             self.mw.col.decks.renameForDragAndDrop(draggedDeckDid, ontoDeckDid)
         except DeckRenameError as e:
-            return showWarning(e.description)
-
+            if gui_hooks.deck_failed_to_rename(True, e, self):
+                return showWarning(e.description)
+            else:
+                return
         self.show()
 
     def _delete(self, did):

--- a/qt/tools/genhooks_gui.py
+++ b/qt/tools/genhooks_gui.py
@@ -134,6 +134,20 @@ hooks = [
                 content.stats += "\n<div>my html</div>"
         """,
     ),
+    Hook(
+        name="deck_failed_to_rename",
+        args=[
+            "should_warn: bool",
+            "exc: anki.decks.DeckRenameError",
+            "deck_browser: aqt.deckbrowser.DeckBrowser",
+        ],
+        return_type="bool",
+        doc="""This hook allows to change the behavior when renaming would fail
+        (name already existing or becoming descendant of filtered
+        deck). For example it would allow to merge decks. Return True
+        if an exception should still be raised; false if it should
+        just return silently.""",
+    ),
     # Deck options
     ###################
     Hook(


### PR DESCRIPTION
All of those changes are related to renaming.

First, there seems to have been some errors, I don't really understand how, with the typing of renameForDragAndDrop. Indeed, the parameters are given from a js command, and are a substring of a command. So they are string (potentially empty), and not int. So I corrected that.
It never created any typing problem, probably because the type inference is not good enough to detect it.

I created an add-on which allow to merge decks. Instead of rejecting because of duplicate name, it simply move all cards to the existing deck and destroy the moved deck. After asking user for confirmation. It uses monkey patch. To avoid monkey patch, I need a filter which will do the merge and tell the program that, instead of raising an exception/warning, it should just return.

My add-on also need to compute the new name. The method to do so is almost in anki, except that the ne
 name is not returned but is directly used. So I separated a method in two, so that I can access to the renaming part and no change is seen from the point of view of users and of other add-ons