### PR TITLE
Allow to define python bin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,21 @@
 SHELL := /bin/bash
 
 ifeq ($(OS),Windows_NT)
-	PYTHON_BIN := python
-	ACTIVATE_SCRIPT := pyenv/Scripts/activate
+	ifndef ACTIVATE_SCRIPT
+		ACTIVATE_SCRIPT := pyenv/Scripts/activate
+	endif
+
+	ifndef PYTHON_BIN
+		PYTHON_BIN := python
+	endif
 else
-	PYTHON_BIN := python3
-	ACTIVATE_SCRIPT := pyenv/bin/activate
+	ifndef ACTIVATE_SCRIPT
+		ACTIVATE_SCRIPT := pyenv/bin/activate
+	endif
+
+	ifndef PYTHON_BIN
+		PYTHON_BIN := python3
+	endif
 endif
 
 ifndef ANKI_EXTRA_PIP

--- a/rspy/Makefile
+++ b/rspy/Makefile
@@ -2,9 +2,13 @@ SHELL := /bin/bash
 FIND := $(if $(wildcard /bin/find),/bin/find,/usr/bin/find)
 
 ifeq ($(OS),Windows_NT)
-	PYTHON_BIN := python
+	ifndef PYTHON_BIN
+		PYTHON_BIN := python
+	endif
 else
-	PYTHON_BIN := python3
+	ifndef PYTHON_BIN
+		PYTHON_BIN := python3
+	endif
 endif
 
 .SHELLFLAGS := -eu -o pipefail -c

--- a/rspy/Makefile
+++ b/rspy/Makefile
@@ -1,6 +1,12 @@
 SHELL := /bin/bash
 FIND := $(if $(wildcard /bin/find),/bin/find,/usr/bin/find)
 
+ifeq ($(OS),Windows_NT)
+	PYTHON_BIN := python
+else
+	PYTHON_BIN := python3
+endif
+
 .SHELLFLAGS := -eu -o pipefail -c
 .DELETE_ON_ERROR:
 MAKEFLAGS += --warn-undefined-variables
@@ -37,7 +43,7 @@ build: $(DEPS)
 	rm -rf $(OUTDIR)/ankirspy*
 	touch ../proto/backend.proto
 	FTL_TEMPLATE_DIRS="$(QT_FTL_TEMPLATES)" FTL_LOCALE_DIRS="$(QT_FTL_LOCALES)" \
-		maturin build -i $(shell which python3) -o $(OUTDIR) $(BUILDFLAGS)
+		maturin build -i $(shell which ${PYTHON_BIN}) -o $(OUTDIR) $(BUILDFLAGS)
 
 check: .build/check
 


### PR DESCRIPTION
Merge this after: (Fixed rspy/Makefile trying to use python3 on Windows #481) because this depends on a commit from there. Or do not merge that and only merge this.

With this, the user can set the variables `PYTHON_BIN` and `ACTIVATE_SCRIPT` to change the default python and binary scripts.

I need this on my Debian 9 because there, the default Python is 3.5 (python3), but I have installed/compiled Python 3.7 (python3.7). Then, I used this to change the default Python3 interpreter before calling `sh run`:
```sh
export PYTHON_BIN=python3.7
sh run
```