### PR TITLE
Created a relative badge link README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,4 +8,4 @@ For more information on building, please see README.development
 
 If you'd like to contribute code, please see README.contributing
 
-![](https://github.com/ankitects/anki/workflows/Checks/badge.svg)
+[![](../../workflows/Checks/badge.svg)](../../actions)


### PR DESCRIPTION
Before, clicking on the README.md badge would only open a image of the badge.

Now, clicking on it shows the actions page of the actual repository, i.e., in my fork it will show the actions badge for my fork and it would open the actions page for my fork by clicking on the badge link.

I got the idea to build this link after researching and finding: 
1. https://stackoverflow.com/questions/7653483/github-relative-link-in-markdown-file