### PR TITLE
Added --enable-loadable-sqlite-extensions requirement 

### DIFF
--- a/README.development
+++ b/README.development
@@ -10,6 +10,9 @@ provide support for problems you encounter when running from source.
 To start, make sure you have the following installed:
 
  - Python 3.7+
+   If you build Python from its source, you will have to call the `./configure` command with 
+   `--enable-loadable-sqlite-extensions`, for example: 
+   ./configure --enable-optimizations --enable-loadable-sqlite-extensions && sudo make altinstall
  - portaudio
  - mpv
  - lame


### PR DESCRIPTION
To run Anki on Debian 9, I had to build Python from the source because its default Python interpreter `python3` is Python 3.5. Then, I build Python 3.7 from source, but it did not work with the following stacktrace for `_sqlite3`. Then, after researching, I found the solution/cause of the problem: https://stackoverflow.com/questions/20126475/importerror-no-module-named-sqlite3-in-python3-3

Then, I am adding a warning to README.development instructions that when building Python from source, it has to be called with `--enable-loadable-sqlite-extensions`. Otherwise anki will not start:
```
Starting Anki...
Traceback (most recent call last):
  File "qt/runanki", line 3, in <module>
    import aqt
  File "/home/linux/anki/qt/aqt/__init__.py", line 15, in <module>
    import anki.buildinfo
  File "/home/linux/anki/pylib/anki/__init__.py", line 7, in <module>
    from anki.storage import Collection
  File "/home/linux/anki/pylib/anki/storage.py", line 10, in <module>
    from anki.collection import _Collection
  File "/home/linux/anki/pylib/anki/collection.py", line 17, in <module>
    import anki.find
  File "/home/linux/anki/pylib/anki/find.py", line 10, in <module>
    from anki import hooks
  File "/home/linux/anki/pylib/anki/hooks.py", line 20, in <module>
    from anki.cards import Card
  File "/home/linux/anki/pylib/anki/cards.py", line 13, in <module>
    from anki.models import NoteType, Template
  File "/home/linux/anki/pylib/anki/models.py", line 16, in <module>
    from anki.utils import checksum, ids2str, intTime, joinFields, splitFields
  File "/home/linux/anki/pylib/anki/utils.py", line 25, in <module>
    from anki.db import DB
  File "/home/linux/anki/pylib/anki/db.py", line 6, in <module>
    from sqlite3 import Cursor
  File "/usr/local/lib/python3.7/sqlite3/__init__.py", line 23, in <module>
    from sqlite3.dbapi2 import *
  File "/usr/local/lib/python3.7/sqlite3/dbapi2.py", line 27, in <module>
    from _sqlite3 import *
ModuleNotFoundError: No module named '_sqlite3'
Makefile:70: recipe for target 'run' failed
```
