### PR TITLE
Fixed "Makefile:4: warning: undefined variable 'OS'"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,9 @@
 SHELL := /bin/bash
 
+ifndef OS
+	OS := unknown
+endif
+
 ifeq ($(OS),Windows_NT)
 	ifndef ACTIVATE_SCRIPT
 		ACTIVATE_SCRIPT := pyenv/Scripts/activate

--- a/rspy/Makefile
+++ b/rspy/Makefile
@@ -1,6 +1,10 @@
 SHELL := /bin/bash
 FIND := $(if $(wildcard /bin/find),/bin/find,/usr/bin/find)
 
+ifndef OS
+	OS := unknown
+endif
+
 ifeq ($(OS),Windows_NT)
 	ifndef PYTHON_BIN
 		PYTHON_BIN := python


### PR DESCRIPTION
All `Makefiles` on this project are using `MAKEFLAGS += --warn-undefined-variables` and the variable `OS` is only defined on Windows. So, to suppress that warning, define the variable `OS` if it is not defined.