### PR TITLE
print json decode error message

### DIFF
--- a/qt/aqt/addons.py
+++ b/qt/aqt/addons.py
@@ -251,7 +251,8 @@ class AddonManager:
         try:
             with open(path, encoding="utf8") as f:
                 return json.load(f)
-        except:
+        except json.JSONDecodeError as e:
+            print(f"json error in add-on {dir}:\n{e}")
             return dict()
 
     # in new code, use write_addon_meta() instead


### PR DESCRIPTION
As discussed in another thread. The main point is to allow add-on dev' to debug their own json.

Ideally, I'd have preferred to print to stderr, since it's an error. But it would prompt a warning window. So I stayed on standard output