### PR TITLE
add-on config check schema of user config

### DIFF
--- a/qt/aqt/addons.py
+++ b/qt/aqt/addons.py
@@ -594,6 +594,24 @@ and have been disabled: %(found)s"
     def configUpdatedAction(self, addon: str) -> Callable[[Any], None]:
         return self._configUpdatedActions.get(addon)
 
+    # Schema
+    ######################################################################
+
+    def _addonSchemaPath(self, dir):
+        return os.path.join(self.addonsFolder(dir), "config.schema.json")
+
+    def _addonSchema(self, dir):
+        path = self._addonSchemaPath(dir)
+        try:
+            if not os.path.exists(path):
+                # True is a schema accepting everything
+                return True
+            with open(path, encoding="utf-8") as f:
+                return json.load(f)
+        except json.decoder.JSONDecodeError as e:
+            print("The schema is not valid:")
+            print(e)
+
     # Add-on Config API
     ######################################################################
 
@@ -1304,6 +1322,12 @@ class ConfigEditor(QDialog):
         txt = gui_hooks.addon_config_editor_will_save_json(txt)
         try:
             new_conf = json.loads(txt)
+            jsonschema.validate(new_conf, self.parent().mgr._addonSchema(self.addon))
+        except ValidationError as e:
+            # The user did edit the configuration and entered a value
+            # which can not be interpreted.
+            showInfo(tr(TR.ADDONS_CONFIG_VALIDATION_ERROR, problem=e.message))
+            return
         except Exception as e:
             showInfo(_("Invalid configuration: ") + repr(e))
             return

--- a/qt/ftl/addons.ftl
+++ b/qt/ftl/addons.ftl
@@ -6,3 +6,4 @@ addons-failed-to-load =
     {$traceback}
 # Shown in the add-on configuration screen (Tools>Add-ons>Config), in the title bar
 addons-config-window-title = Configure '{$name}'
+addons-config-validation-error = There was a problem with the provided configuration: {$problem}


### PR DESCRIPTION
As discussed in another PR:
If there is a file "schema.json" then configs are validated against it before being accepted.

I suggest that you also validate config.json against schema.json when an add-on is uploaded. I can't write the code given that ankiweb is private. 
The reason being that if the default config is not valid, it's going to be pretty hard for users to do anything about it.
