### PR TITLE
Renamed BeautifulSoup import name for consistency with other usages of it

### DIFF
--- a/pylib/anki/importing/supermemo_xml.py
+++ b/pylib/anki/importing/supermemo_xml.py
@@ -143,18 +143,18 @@ class SupermemoXmlImporter(NoteImporter):
             ]
         )
 
-    def _decode_htmlescapes(self, s: str) -> str:
+    def _decode_htmlescapes(self, html: str) -> str:
         """Unescape HTML code."""
-        # In case of bad formated html you can import MinimalSoup etc.. see btflsoup source code
-        from bs4 import BeautifulSoup as btflsoup
+        # In case of bad formated html you can import MinimalSoup etc.. see BeautifulSoup source code
+        from bs4 import BeautifulSoup
 
         # my sm2004 also ecaped & char in escaped sequences.
-        s = re.sub("&amp;", "&", s)
+        html = re.sub("&amp;", "&", html)
         # unescaped solitary chars < or > that were ok for minidom confuse btfl soup
-        # s = re.sub(u'>',u'&gt;',s)
-        # s = re.sub(u'<',u'&lt;',s)
+        # html = re.sub(u'>',u'&gt;',html)
+        # html = re.sub(u'<',u'&lt;',html)
 
-        return str(btflsoup(s, "html.parser"))
+        return str(BeautifulSoup(html, "html.parser"))
 
     def _afactor2efactor(self, af: float) -> float:
         # Adapted from <http://www.supermemo.com/beta/xml/xml-core.htm>


### PR DESCRIPTION
This was initially a fix for https://anki.tenderapp.com/discussions/ankidesktop/39543-anki-is-replacing-the-character-by-when-i-exit-the-html-edit-mode-ctrlshiftx

But now, I am just renaming a variable to keep it consistent with the rest of the code which uses BeautifulSoup.