### PR TITLE
normalize name in _checkDeckTree

### DIFF
--- a/pylib/anki/decks.py
+++ b/pylib/anki/decks.py
@@ -491,26 +491,27 @@ class DeckManager:
 
         for deck in decks:
             # two decks with the same name?
-            if deck["name"] in names:
+            deck_name = self.normalizeName(deck["name"])
+            if deck_name in names:
                 self.col.log("fix duplicate deck name", deck["name"])
                 deck["name"] += "%d" % intTime(1000)
                 self.save(deck)
 
             # ensure no sections are blank
-            if not all(deck["name"].split("::")):
+            if not all(deck_name.split("::")):
                 self.col.log("fix deck with missing sections", deck["name"])
                 deck["name"] = "recovered%d" % intTime(1000)
                 self.save(deck)
 
             # immediate parent must exist
-            if "::" in deck["name"]:
-                immediateParent = "::".join(deck["name"].split("::")[:-1])
+            if "::" in deck_name:
+                immediateParent = "::".join(deck_name.split("::")[:-1])
                 if immediateParent not in names:
                     self.col.log("fix deck with missing parent", deck["name"])
                     self._ensureParents(deck["name"])
-                    names.add(immediateParent)
+                    names.add(self.normalizeName(immediateParent))
 
-            names.add(deck["name"])
+            names.add(deck_name)
 
     def checkIntegrity(self) -> None:
         self._recoverOrphans()


### PR DESCRIPTION
Currently, if there is two decks "A" and "a", they won't be considered
as duplicate. So they won't be corrected.
That's hard to test, because you're not supposed to be able to create
those two decks. However, it seems that it may still be possible on
AnkiDroid (correction is in master, and probabla alpha)

Thus, I suggest to compare normalized names instead of names
themselves.
Actually, I'm even surprised that I didn't do this PR while doing dae/anki@e44b0492781e8248318e87a47eb179561db94b7b