### PR TITLE
Give the 'typearrow' id to the type answer arrow

### DIFF
--- a/qt/aqt/reviewer.py
+++ b/qt/aqt/reviewer.py
@@ -517,7 +517,7 @@ Please run Tools>Empty Cards"""
                     res += good(txt)
                 else:
                     res += bad(txt)
-            res += "<br>&darr;<br>"
+            res += "<br><span id=typearrow>&darr;</span><br>"
             for ok, txt in correctElems:
                 txt = self._noLoneMarks(txt)
                 if ok:


### PR DESCRIPTION
So, it can be styled by the user with something like:
```css
#typearrow {
  color: #e56727;
  position: absolute;
  margin-top: -7px;
}
```

Making it centered and with a different color:

![image](https://user-images.githubusercontent.com/5332158/76714730-a17d5900-6707-11ea-9923-17cab76be4ba.png)

Instead of:

![image](https://user-images.githubusercontent.com/5332158/76714738-afcb7500-6707-11ea-88d5-3748ddfe9dd5.png)
