### PR TITLE
reminder: special fields when importing

### DIFF
--- a/pylib/anki/hooks.py
+++ b/pylib/anki/hooks.py
@@ -20,6 +20,12 @@ import anki
 from anki.cards import Card
 from anki.notes import Note
 
+if False:  # pylint: disable=W0125
+    import anki.importing.anki2
+
+    # this import is required for mypy to know how to import the type
+    # Anki2Importer.
+
 # New hook/filter handling
 ##############################################################################
 # The code in this section is automatically generated - any edits you make
@@ -279,6 +285,38 @@ class _FieldFilterFilter:
 
 
 field_filter = _FieldFilterFilter()
+
+
+class _ImporterChangeUpdateHook:
+    """Change the notes before updating them."""
+
+    _hooks: List[Callable[[List[Any], "anki.importing.anki2.Anki2Importer"], None]] = []
+
+    def append(
+        self, cb: Callable[[List[Any], "anki.importing.anki2.Anki2Importer"], None]
+    ) -> None:
+        """(update: List[Any], importer: anki.importing.anki2.Anki2Importer)"""
+        self._hooks.append(cb)
+
+    def remove(
+        self, cb: Callable[[List[Any], "anki.importing.anki2.Anki2Importer"], None]
+    ) -> None:
+        if cb in self._hooks:
+            self._hooks.remove(cb)
+
+    def __call__(
+        self, update: List[Any], importer: anki.importing.anki2.Anki2Importer
+    ) -> None:
+        for hook in self._hooks:
+            try:
+                hook(update, importer)
+            except:
+                # if the hook fails, remove it
+                self._hooks.remove(hook)
+                raise
+
+
+importer_change_update = _ImporterChangeUpdateHook()
 
 
 class _ImporterDoesItUpdateNoteFilter:

--- a/pylib/anki/hooks.py
+++ b/pylib/anki/hooks.py
@@ -403,6 +403,33 @@ class _ImporterDoesItUpdateNoteTypeFilter:
 importer_does_it_update_note_type = _ImporterDoesItUpdateNoteTypeFilter()
 
 
+class _ImportingChangeDeckDescriptionFilter:
+    """Whether to update the description of a deck."""
+
+    _hooks: List[Callable[[bool, int, Dict[str, Any]], bool]] = []
+
+    def append(self, cb: Callable[[bool, int, Dict[str, Any]], bool]) -> None:
+        """(update: bool, newid: int, imported_deck: Dict[str, Any])"""
+        self._hooks.append(cb)
+
+    def remove(self, cb: Callable[[bool, int, Dict[str, Any]], bool]) -> None:
+        if cb in self._hooks:
+            self._hooks.remove(cb)
+
+    def __call__(self, update: bool, newid: int, imported_deck: Dict[str, Any]) -> bool:
+        for filter in self._hooks:
+            try:
+                update = filter(update, newid, imported_deck)
+            except:
+                # if the hook fails, remove it
+                self._hooks.remove(filter)
+                raise
+        return update
+
+
+importing_change_deck_description = _ImportingChangeDeckDescriptionFilter()
+
+
 class _MediaFilesDidExportHook:
     _hooks: List[Callable[[int], None]] = []
 

--- a/pylib/anki/importing/anki2.py
+++ b/pylib/anki/importing/anki2.py
@@ -139,6 +139,7 @@ class Anki2Importer(Importer):
                             self._ignoredGuids[note[GUID]] = True
                     else:
                         dupesIdentical.append(note)
+        hooks.importer_change_update(update, self)
 
         self.log.append(_("Notes found in file: %d") % total)
 

--- a/pylib/anki/importing/anki2.py
+++ b/pylib/anki/importing/anki2.py
@@ -5,6 +5,7 @@ import os
 import unicodedata
 from typing import Any, Dict, List, Optional, Tuple
 
+from anki import hooks
 from anki.collection import _Collection
 from anki.consts import *
 from anki.importing.base import Importer
@@ -122,7 +123,9 @@ class Anki2Importer(Importer):
                 if self.allowUpdate:
                     oldNid, oldMod, oldMid = self._notes[note[GUID]]
                     # will update if incoming note more recent
-                    if oldMod < note[MOD]:
+                    if hooks.importer_does_it_update_note(
+                        oldMod < note[MOD], note, self._notes[note[GUID]]
+                    ):
                         # safe if note types identical
                         if oldMid == note[MID]:
                             # incoming note should use existing id

--- a/pylib/anki/importing/anki2.py
+++ b/pylib/anki/importing/anki2.py
@@ -293,9 +293,10 @@ class Anki2Importer(Importer):
             g2["conf"] = g["conf"]
             self.dst.decks.save(g2)
         # save desc
-        deck = self.dst.decks.get(newid)
-        deck["desc"] = g["desc"]
-        self.dst.decks.save(deck)
+        if hooks.importing_change_deck_description(True, newid, g):
+            deck = self.dst.decks.get(newid)
+            deck["desc"] = g["desc"]
+            self.dst.decks.save(deck)
         # add to deck map and return
         self._decks[did] = newid
         return newid

--- a/pylib/anki/importing/anki2.py
+++ b/pylib/anki/importing/anki2.py
@@ -238,7 +238,9 @@ class Anki2Importer(Importer):
             dstScm = self.dst.models.scmhash(dstModel)
             if srcScm == dstScm:
                 # copy styling changes over if newer
-                if srcModel["mod"] > dstModel["mod"]:
+                if hooks.importer_does_it_update_note_type(
+                    srcModel["mod"] > dstModel["mod"], srcModel, dstModel
+                ):
                     model = srcModel.copy()
                     model["id"] = mid
                     model["usn"] = self.col.usn()

--- a/pylib/tools/genhooks.py
+++ b/pylib/tools/genhooks.py
@@ -145,6 +145,12 @@ hooks = [
         args=["update: List[Any]", "importer: anki.importing.anki2.Anki2Importer"],
         doc="""Change the notes before updating them.""",
     ),
+    Hook(
+        name="importing_change_deck_description",
+        args=["update: bool", "newid: int", "imported_deck: Dict[str, Any]"],
+        return_type="bool",
+        doc="""Whether to update the description of a deck.""",
+    ),
 ]
 
 if __name__ == "__main__":

--- a/pylib/tools/genhooks.py
+++ b/pylib/tools/genhooks.py
@@ -126,6 +126,20 @@ hooks = [
         The note is the list of values taken from the collection
         database.  The old_note is an in Anki2Importer._notes.  """,
     ),
+    Hook(
+        name="importer_does_it_update_note_type",
+        args=[
+            "importing: bool",
+            "srcModel: anki.models.NoteType",
+            "dstModel: anki.models.NoteType",
+        ],
+        return_type="bool",
+        doc="""Decides whether a note type should be replaced when importing a
+        collection. By default, a note type is replaced iff its last
+        modification date is more recent in the imported deck than in
+        the current collection. It is assumed that the schemas are the
+        same, otherwise update is technically impossible anyway.""",
+    ),
 ]
 
 if __name__ == "__main__":

--- a/pylib/tools/genhooks.py
+++ b/pylib/tools/genhooks.py
@@ -109,6 +109,23 @@ hooks = [
         doc="""Allows changing the number of rev card for this deck (without
         considering descendants).""",
     ),
+    # Importing
+    ###################
+    Hook(
+        name="importer_does_it_update_note",
+        args=["importing: bool", "note: List[Any]", "old_note: Tuple[int, int, int]"],
+        return_type="bool",
+        doc="""Decides whether a note from the collection should be updated to the
+        imported deck value. It assumes that the note is present in
+        both collection and imported deck.
+
+        By default, a note is updated iff its last modification date
+        is more recent in the imported deck than in the current
+        collection.
+
+        The note is the list of values taken from the collection
+        database.  The old_note is an in Anki2Importer._notes.  """,
+    ),
 ]
 
 if __name__ == "__main__":

--- a/pylib/tools/genhooks.py
+++ b/pylib/tools/genhooks.py
@@ -140,6 +140,11 @@ hooks = [
         the current collection. It is assumed that the schemas are the
         same, otherwise update is technically impossible anyway.""",
     ),
+    Hook(
+        name="importer_change_update",
+        args=["update: List[Any]", "importer: anki.importing.anki2.Anki2Importer"],
+        doc="""Change the notes before updating them.""",
+    ),
 ]
 
 if __name__ == "__main__":


### PR DESCRIPTION
I add three hooks which may be used for the add-on "Special fields". 
There is a real problem here, which has been hard to solve.
I want the hooks to have access to the type Anki2Importer. But if I don't import anki.importing.anki2 (or at least anki.importing ?) mypy tells 
mypy error: Name "anki.importing.anki2.Anki2Importer" is not defined [name-defined]
However, if I decide to import anki.importing.anki2, it executes anki/importing/__init__.py which creates a loops of import, since __init__.py imports anki2, which imports anki.collection, and so on...

So "if false" before the import seems to be required for mypy to accept. Which leads to pylint error 
anki/hooks.py:23:0: W0125: Using a conditional statement with a constant value (using-constant-test)
So I need to tell pylint to disable this warning