### PR TITLE
Allow to run individual unit tests 

### DIFF
--- a/pylib/Makefile
+++ b/pylib/Makefile
@@ -1,6 +1,11 @@
 SHELL := /bin/bash
 FIND := $(if $(wildcard /bin/find),/bin/find,/usr/bin/find)
 
+# For example, to run an individual test, use: export PYTEST_ARGS=tests/test_schedv2.py::test_suspend
+ifndef PYTEST_ARGS
+	PYTEST_ARGS :=
+endif
+
 .SHELLFLAGS := -eu -o pipefail -c
 .DELETE_ON_ERROR:
 MAKEFLAGS += --warn-undefined-variables
@@ -63,7 +68,7 @@ CHECKDEPS := $(shell ${FIND} anki tests -name '*.py' | grep -v buildinfo.py)
 	@touch $@
 
 .build/test: $(CHECKDEPS)
-	python -m pytest --durations=1 -s
+	python -m pytest --durations=1 -s ${PYTEST_ARGS}
 	@touch $@
 
 .build/lint: $(CHECKDEPS)

--- a/qt/Makefile
+++ b/qt/Makefile
@@ -1,6 +1,11 @@
 SHELL := /bin/bash
 FIND := $(if $(wildcard /bin/find),/bin/find,/usr/bin/find)
 
+# For example, to run an individual test, use: export PYTEST_ARGS=tests/test_addons.py::test_mustHaveName
+ifndef PYTEST_ARGS
+	PYTEST_ARGS :=
+endif
+
 .SHELLFLAGS := -eu -o pipefail -c
 .DELETE_ON_ERROR:
 MAKEFLAGS += --warn-undefined-variables
@@ -84,7 +89,7 @@ CHECKDEPS := $(shell ${FIND} aqt tests -name '*.py' | grep -v buildinfo.py)
 	@touch $@
 
 .build/test: $(CHECKDEPS)
-	python -m pytest -s
+	python -m pytest -s ${PYTEST_ARGS}
 	@touch $@
 
 .build/lint: $(CHECKDEPS)


### PR DESCRIPTION
This is useful when creating a new test and you do not want to wait for all the others to finish. By exporting the `PYTEST_ARGS` environment variable with `dir/file.py::test_name`, for example:
```
(pyenv) F:\anki\pylib>set PYTEST_ARGS=tests/test_schedv2.py::test_suspend

(pyenv) F:\anki\pylib>make .build/test -B
python -m pytest --durations=1 -s tests/test_schedv2.py::test_suspend
=========================================================================== test session starts ============================================================================
platform win32 -- Python 3.8.1, pytest-5.3.5, py-1.8.1, pluggy-0.13.1
rootdir: F:\anki\pylib
collected 1 item

tests\test_schedv2.py .

============================================================================= warnings summary =============================================================================
F:\anki\pyenv\lib\site-packages\win32\lib\pywintypes.py:2
  F:\anki\pyenv\lib\site-packages\win32\lib\pywintypes.py:2: DeprecationWarning: the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses
    import imp, sys, os

-- Docs: https://docs.pytest.org/en/latest/warnings.html
========================================================================= slowest 1 test durations =========================================================================
0.26s call     tests/test_schedv2.py::test_suspend
======================================================================= 1 passed, 1 warning in 0.64s =======================================================================

(pyenv) F:\anki\pylib>
```