### PR TITLE
Add pylib hook sync_chunk_will_be_applied

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -29,6 +29,7 @@ Yoonchae Lee
 Evandro Coan <github.com/evandrocoan>
 Alan Du <alanhdu@gmail.com>
 Yuchen Lei <lyc@xuming.studio>
+Henrik Giesel <hengiesel@gmail.com>
 
 ********************
 

--- a/pylib/anki/hooks.py
+++ b/pylib/anki/hooks.py
@@ -518,6 +518,30 @@ class _SearchTermsPreparedHook:
 search_terms_prepared = _SearchTermsPreparedHook()
 
 
+class _SyncChunkWillBeAppliedHook:
+    _hooks: List[Callable[[Any], None]] = []
+
+    def append(self, cb: Callable[[Any], None]) -> None:
+        """(chunk: Any)"""
+        self._hooks.append(cb)
+
+    def remove(self, cb: Callable[[Any], None]) -> None:
+        if cb in self._hooks:
+            self._hooks.remove(cb)
+
+    def __call__(self, chunk: Any) -> None:
+        for hook in self._hooks:
+            try:
+                hook(chunk)
+            except:
+                # if the hook fails, remove it
+                self._hooks.remove(hook)
+                raise
+
+
+sync_chunk_will_be_applied = _SyncChunkWillBeAppliedHook()
+
+
 class _SyncProgressDidChangeHook:
     _hooks: List[Callable[[str], None]] = []
 

--- a/pylib/anki/sync.py
+++ b/pylib/anki/sync.py
@@ -299,6 +299,8 @@ from notes where %s"""
         return buf
 
     def applyChunk(self, chunk) -> None:
+        hooks.sync_chunk_will_be_applied(chunk)
+
         if "revlog" in chunk:
             self.mergeRevlog(chunk["revlog"])
         if "cards" in chunk:

--- a/pylib/tools/genhooks.py
+++ b/pylib/tools/genhooks.py
@@ -50,6 +50,7 @@ hooks = [
     ),
     Hook(name="sync_stage_did_change", args=["stage: str"], legacy_hook="sync"),
     Hook(name="sync_progress_did_change", args=["msg: str"], legacy_hook="syncMsg"),
+    Hook(name="sync_chunk_will_be_applied", args=["chunk: Any"]),
     Hook(
         name="bg_thread_progress_callback",
         args=["proceed: bool", "progress: anki.rsbackend.Progress"],


### PR DESCRIPTION
This adds a new pylib hook for review chunks. 

This allows the user to inspect the chunks, before they are uploaded, however it does not allow them to alter it (as it shouldn't).

My use case is the add-on [Straight Reward](https://ankiweb.net/shared/info/957961234). It inspects the changes made to the revlog to update the ease of certain cards. This hook additionally let's you inspect all the other updates in the chunk. My thinking is, that one hook to inspect all three would be better than 3 to inspect each by itself, because it's easier to maintain and a little less overhead.