### PR TITLE
Pass the flag --autoplay-policy=no-user-gesture-required

### DIFF
--- a/qt/aqt/__init__.py
+++ b/qt/aqt/__init__.py
@@ -234,8 +234,6 @@ class AnkiApp(QApplication):
     TMOUT = 30000
 
     def __init__(self, argv):
-        # https://anki.tenderapp.com/discussions/beta-testing/1858-can-you-pass-autoplay-policyno-user-gesture-required-to-chrome-engine
-        argv.append("--autoplay-policy=no-user-gesture-required")
         QApplication.__init__(self, argv)
         self._argv = argv
 

--- a/qt/aqt/__init__.py
+++ b/qt/aqt/__init__.py
@@ -234,6 +234,8 @@ class AnkiApp(QApplication):
     TMOUT = 30000
 
     def __init__(self, argv):
+        # https://anki.tenderapp.com/discussions/beta-testing/1858-can-you-pass-autoplay-policyno-user-gesture-required-to-chrome-engine
+        argv.append("--autoplay-policy=no-user-gesture-required")
         QApplication.__init__(self, argv)
         self._argv = argv
 

--- a/qt/aqt/webview.py
+++ b/qt/aqt/webview.py
@@ -172,6 +172,9 @@ class AnkiWebView(QWebEngineView):  # type: ignore
         self._page = AnkiWebPage(self._onBridgeCmd)
         self._page.setBackgroundColor(self._getWindowColor())  # reduce flicker
 
+        # https://anki.tenderapp.com/discussions/beta-testing/1858-can-you-pass-autoplay-policyno-user-gesture-required-to-chrome-engine
+        self._page.settings().setAttribute(QWebEngineSettings.PlaybackRequiresUserGesture, False)  # type: ignore
+
         # in new code, use .set_bridge_command() instead of setting this directly
         self.onBridgeCmd: Callable[[str], Any] = self.defaultOnBridgeCmd
 


### PR DESCRIPTION
To the QtWebEngine:
1. https://anki.tenderapp.com/discussions/beta-testing/1858-can-you-pass-autoplay-policyno-user-gesture-required-to-chrome-engine