### PR TITLE
Added box-sizing: border-box; to typeans by default

### DIFF
--- a/qt/ts/scss/reviewer.scss
+++ b/qt/ts/scss/reviewer.scss
@@ -45,6 +45,8 @@ img {
 
 #typeans {
     width: 100%;
+    // https://anki.tenderapp.com/discussions/beta-testing/1854-using-margin-auto-causes-horizontal-scrollbar-on-typesomething
+    box-sizing: border-box;
 }
 
 .typeGood {


### PR DESCRIPTION
I do not see any trouble it can cause and by having this by default. And having this by default, should help when someone tries to limit the card width: https://anki.tenderapp.com/discussions/beta-testing/1854-using-margin-auto-causes-horizontal-scrollbar-on-typesomething