### PR TITLE
reminder: use card template names in empty cards screen

### DIFF
--- a/pylib/anki/collection.py
+++ b/pylib/anki/collection.py
@@ -583,19 +583,19 @@ select id from notes where id in %s and id not in (select nid from cards)"""
         return rem
 
     def emptyCardReport(self, cids) -> str:
-        rep = ""
+        rep = []
         for ords, cnt, flds in self.db.all(
             """
 select group_concat(ord+1), count(), flds from cards c, notes n
 where c.nid = n.id and c.id in %s group by nid"""
             % ids2str(cids)
         ):
-            rep += self.tr(
+            line = self.tr(
                 TR.EMPTY_CARDS_CARD_LINE,
                 **{"card-numbers": ords, "fields": flds.replace("\x1f", " / ")},
-            )
-            rep += "\n\n"
-        return rep
+            ) + "\n\n"
+            rep.append(line)
+        return "".join(rep)
 
     # Field checksums and sorting fields
     ##########################################################################

--- a/pylib/anki/collection.py
+++ b/pylib/anki/collection.py
@@ -584,16 +584,20 @@ select id from notes where id in %s and id not in (select nid from cards)"""
 
     def emptyCardReport(self, cids) -> str:
         rep = []
-        for ords, cnt, flds in self.db.all(
+        for ords, cnt, flds, nid in self.db.all(
             """
-select group_concat(ord+1), count(), flds from cards c, notes n
+select group_concat(ord+1), count(), flds, n.id from cards c, notes n
 where c.nid = n.id and c.id in %s group by nid"""
             % ids2str(cids)
         ):
-            line = self.tr(
-                TR.EMPTY_CARDS_CARD_LINE,
-                **{"card-numbers": ords, "fields": flds.replace("\x1f", " / ")},
-            ) + "\n\n"
+            line = (
+                self.tr(
+                    TR.EMPTY_CARDS_CARD_LINE,
+                    **{"card-numbers": ords, "fields": flds.replace("\x1f", " / ")},
+                )
+                + "\n\n"
+            )
+            line = hooks.empty_card_line(line, ords, flds, int(nid))
             rep.append(line)
         return "".join(rep)
 

--- a/pylib/anki/hooks.py
+++ b/pylib/anki/hooks.py
@@ -213,6 +213,34 @@ class _DeckAddedHook:
 deck_added = _DeckAddedHook()
 
 
+class _EmptyCardLineFilter:
+    """Allow to change the line warning about empty cards ords of note nid
+        with fields flds."""
+
+    _hooks: List[Callable[[str, str, str, int], str]] = []
+
+    def append(self, cb: Callable[[str, str, str, int], str]) -> None:
+        """(line: str, ords: str, flds: str, nid: int)"""
+        self._hooks.append(cb)
+
+    def remove(self, cb: Callable[[str, str, str, int], str]) -> None:
+        if cb in self._hooks:
+            self._hooks.remove(cb)
+
+    def __call__(self, line: str, ords: str, flds: str, nid: int) -> str:
+        for filter in self._hooks:
+            try:
+                line = filter(line, ords, flds, nid)
+            except:
+                # if the hook fails, remove it
+                self._hooks.remove(filter)
+                raise
+        return line
+
+
+empty_card_line = _EmptyCardLineFilter()
+
+
 class _ExportersListCreatedHook:
     _hooks: List[Callable[[List[Tuple[str, Any]]], None]] = []
 

--- a/pylib/tools/genhooks.py
+++ b/pylib/tools/genhooks.py
@@ -109,6 +109,13 @@ hooks = [
         doc="""Allows changing the number of rev card for this deck (without
         considering descendants).""",
     ),
+    Hook(
+        name="empty_card_line",
+        args=["line: str", "ords: str", "flds: str", "nid: int"],
+        return_type="str",
+        doc="""Allow to change the line warning about empty cards ords of note nid
+        with fields flds.""",
+    ),
 ]
 
 if __name__ == "__main__":


### PR DESCRIPTION
I expect to use this with my add-on 25425599. This add-on explain which are the name of the cards that are going to be deleted, instead of only their ord. I find it quite clearer when I just changed a card type and want to make sure that the correct cards will be removed/try to understand a bug.

I believe this add-on should be incorporated in anki by the way, it's simple and quite more helpful