### PR TITLE
Fill _lrnQueue with tuples, not lists

### DIFF
--- a/pylib/anki/schedv2.py
+++ b/pylib/anki/schedv2.py
@@ -549,6 +549,8 @@ limit %d"""
             % (self._deckLimit(), self.reportLimit),
             cutoff,
         )
+        for i in range(len(self._lrnQueue)):
+            self._lrnQueue[i] = (self._lrnQueue[i][0], self._lrnQueue[i][1])
         # as it arrives sorted by did first, we need to sort it
         self._lrnQueue.sort()
         return self._lrnQueue


### PR DESCRIPTION
Looks like [_fillLrn](https://github.com/ankitects/anki/blob/master/pylib/anki/schedv2.py#L538) returns a list of lists instead of a list of tuples.
This causes the following error when a card is supposed to be rescheduled into the learning queue (from due or new):
```
Error
An error occurred. Please use Tools > Check Database to see if that fixes the problem.
If problems persist, please report the problem on our support site. Please copy and paste the information below into your report.
Anki 2.1.24 (430f1ad6) Python 3.7.7 Qt 5.13.2 PyQt 5.13.2
Platform: Linux
Flags: frz=False ao=False sv=2
Add-ons, last update check: 2020-03-22 11:31:08

Caught exception:
Traceback (most recent call last):
  File "/home/zjosua/sw_dev/anki/qt/aqt/reviewer.py", line 299, in <lambda>
    ("2", lambda: self._answerCard(2)),
  File "/home/zjosua/sw_dev/anki/qt/aqt/reviewer.py", line 266, in _answerCard
    self.mw.col.sched.answerCard(self.card, ease)
  File "/home/zjosua/sw_dev/anki/pylib/anki/schedv2.py", line 79, in answerCard
    self._answerCard(card, ease)
  File "/home/zjosua/sw_dev/anki/pylib/anki/schedv2.py", line 103, in _answerCard
    self._answerLrnCard(card, ease)
  File "/home/zjosua/sw_dev/anki/pylib/anki/schedv2.py", line 630, in _answerLrnCard
    self._repeatStep(card, conf)
  File "/home/zjosua/sw_dev/anki/pylib/anki/schedv2.py", line 659, in _repeatStep
    self._rescheduleLrnCard(card, conf, delay=delay)
  File "/home/zjosua/sw_dev/anki/pylib/anki/schedv2.py", line 684, in _rescheduleLrnCard
    heappush(self._lrnQueue, (card.due, card.id))
TypeError: '<' not supported between instances of 'tuple' and 'list'
```