### PR TITLE
Remove new timezone handling checkbox from preferences

### DIFF
--- a/qt/aqt/preferences.py
+++ b/qt/aqt/preferences.py
@@ -95,10 +95,8 @@ class Preferences(QDialog):
         f.dayLearnFirst.setChecked(qc.get("dayLearnFirst", False))
         if self.mw.col.schedVer() != 2:
             f.dayLearnFirst.setVisible(False)
-            f.new_timezone.setVisible(False)
         else:
             f.newSched.setChecked(True)
-            f.new_timezone.setChecked(self.mw.col.sched._new_timezone_enabled())
 
     def updateCollection(self):
         f = self.form
@@ -123,14 +121,6 @@ class Preferences(QDialog):
         qc["addToCur"] = not f.useCurrent.currentIndex()
         qc["dayLearnFirst"] = f.dayLearnFirst.isChecked()
         self._updateDayCutoff()
-        if self.mw.col.schedVer() != 1:
-            was_enabled = self.mw.col.sched._new_timezone_enabled()
-            is_enabled = f.new_timezone.isChecked()
-            if was_enabled != is_enabled:
-                if is_enabled:
-                    self.mw.col.sched.set_creation_offset()
-                else:
-                    self.mw.col.sched.clear_creation_offset()
         self._updateSchedVer(f.newSched.isChecked())
         d.setMod()
 

--- a/qt/designer/preferences.ui
+++ b/qt/designer/preferences.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>422</width>
-    <height>636</height>
+    <height>611</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -133,13 +133,6 @@
         <widget class="QCheckBox" name="newSched">
          <property name="text">
           <string>Anki 2.1 scheduler (beta)</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QCheckBox" name="new_timezone">
-         <property name="text">
-          <string notr="true">New timezone handling (not yet supported by AnkiDroid)</string>
          </property>
         </widget>
        </item>
@@ -566,7 +559,6 @@
   <tabstop>nightMode</tabstop>
   <tabstop>dayLearnFirst</tabstop>
   <tabstop>newSched</tabstop>
-  <tabstop>new_timezone</tabstop>
   <tabstop>useCurrent</tabstop>
   <tabstop>newSpread</tabstop>
   <tabstop>uiScale</tabstop>


### PR DESCRIPTION
Reverting the changes from 131d37dca52c29033432e0149052093ab1c79461, because _new_timezone_enabled was removed from schedv2 in 69d8cdd9ed1e32683aabe1714ed6402a59fab4cd.

Caused this error on opening preferences:
```
Error
An error occurred. Please use Tools > Check Database to see if that fixes the problem.
If problems persist, please report the problem on our support site. Please copy and paste the information below into your report.
Anki 2.1.24 (ac36fba9) Python 3.7.6 Qt 5.12.5 PyQt 5.14.1
Platform: Linux
Flags: frz=False ao=False sv=2
Add-ons, last update check: 2020-03-22 06:46:42

Caught exception:
Traceback (most recent call last):
  File "/home/zjosua/sw_dev/anki/qt/aqt/main.py", line 1020, in onPrefs
    aqt.dialogs.open("Preferences", self)
  File "/home/zjosua/sw_dev/anki/qt/aqt/__init__.py", line 94, in open
    instance = creator(*args)
  File "/home/zjosua/sw_dev/anki/qt/aqt/preferences.py", line 29, in __init__
    self.setupCollection()
  File "/home/zjosua/sw_dev/anki/qt/aqt/preferences.py", line 101, in setupCollection
    f.new_timezone.setChecked(self.mw.col.sched._new_timezone_enabled())
AttributeError: 'Scheduler' object has no attribute '_new_timezone_enabled'
``` 