### PR TITLE
Hook editor_note_will_load

### DIFF
--- a/qt/aqt/editor.py
+++ b/qt/aqt/editor.py
@@ -456,6 +456,7 @@ class Editor:
             json.dumps(focusTo),
             json.dumps(self.note.id),
         )
+        js = gui_hooks.editor_will_load_note(js, self.note, self)
         self.web.evalWithCallback(js, oncallback)
 
     def fonts(self) -> List[Tuple[str, int, bool]]:

--- a/qt/tools/genhooks_gui.py
+++ b/qt/tools/genhooks_gui.py
@@ -498,6 +498,13 @@ def emptyNewCard():
         args=["editor_web_view: aqt.editor.EditorWebView"],
     ),
     Hook(name="editor_did_init", args=["editor: aqt.editor.Editor"],),
+    Hook(
+        name="editor_will_load_note",
+        args=["js: str", "note: anki.notes.Note", "editor: aqt.editor.Editor"],
+        return_type="str",
+        doc="""Allows changing the javascript commands to load note before
+        executing it and do change in the QT editor.""",
+    ),
     # Sound/video
     ###################
     Hook(name="av_player_will_play", args=["tag: anki.sound.AVTag"]),


### PR DESCRIPTION
A current problem I have is that there is nothing similar to hook inside of javascript. It seems that it would be easier to be able to add other methods in javascript and call them in loadNote. Currently I simply redefined loadNote, which is far from perfect

I am not sure at all that's the best way to achieve this feature. But I am sure that I want to execute some function when a note is loaded. In particular because add-ons changing the editor need to pass more informations to the code