### PR TITLE
strip to test whether field is empty

### DIFF
--- a/qt/aqt/editor.py
+++ b/qt/aqt/editor.py
@@ -496,9 +496,10 @@ class Editor:
             return True
         m = self.note.model()
         for c, f in enumerate(self.note.fields):
+            f = f.replace("<br>", "").strip()
             notChangedvalues = {"", "<br>"}
             if previousNote and m["flds"][c]["sticky"]:
-                notChangedvalues.add(previousNote.fields[c])
+                notChangedvalues.add(previousNote.fields[c].replace("<br>", "").strip())
             if f not in notChangedvalues:
                 return False
         return True

--- a/qt/ts/src/editor.ts
+++ b/qt/ts/src/editor.ts
@@ -352,9 +352,7 @@ function setFields(fields) {
                      oncut='onCutOrCopy(this);'
                      contentEditable=true
                      class=field
-                >
-${f}
-                </div>
+                >${f}</div>
             </td>
         </tr>`;
     }


### PR DESCRIPTION
There are two reason for this PR.
The first one is that a field with only spaces and new line should probably be considered as empty anyway.
The second is that my last PR created a bug. The field value contained far more spaces than it should have. I didn't realize that because of this, even if those spaces were not taken into account in the GUI, there were taken into account to decide that the field is not empty
https://github.com/ankitects/anki/pull/524

Of course, I could also correct the change done in the javascript file. But in this case, I believe that this correction is more appropriate