### PR TITLE
Ensuring "setNote" is called only once during changing of note type

### DIFF
--- a/qt/aqt/addcards.py
+++ b/qt/aqt/addcards.py
@@ -112,7 +112,6 @@ class AddCards(QDialog):
                     except IndexError:
                         pass
             self.removeTempNote(oldNote)
-        self.editor.setNote(note)
 
     def onReset(self, model: None = None, keep: bool = False) -> None:
         oldNote = self.editor.note


### PR DESCRIPTION
Initially, I wanted to solve the bug reported on
https://github.com/Arthur-Milchior/anki-html-src-in-field/issues/1

After some research, I finally discovered that the trouble was that,
when we change the note type in add card, the method
`aqt.editor.Editor.loadNote` is called twice. In itself, it would not
be a problem, but given the way callback works, its call back is
called twice on the last version of the webview. Which means that
`gui_hooks.editor_did_load_note` is called twice, which breaks this
add-on.

The reason why loadNote is called twice is because `setNote` is called
twice in `aqt.modelchooser.onModelChange`. The first time through
`gui_hooks.current_note_type_did_change` which calls
`addcards.AddCards.onModelChange` which calls `loadNote`, the second
time through `self.mw.reset()` which calls
`gui_hooks.state_did_reset()` which calls `addcards.AddCards.onReset`
which calls `setAndFocusNote` which calls `setNote`.

I should note furthermore that currently,
`gui_hooks.current_note_type_did_change` is called only when the model
chooser change a model. And `addCards.onModelChange` is never called,
only added to the hook `gui_hooks.current_note_type_did_change`. So
removing the line of code removed in this commit will have no side
effect in Anki itself. It will only affect the fact that this method
is called twice.

I do not know of any add-on calling `onModelChange` or
`gui_hooks.current_note_type_did_change`, but it means little, so of
course, it may always mean an add-on will break because of this
change. No way of being sure.