### PR TITLE
Set to checks.yml install and import anki wheels

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -97,14 +97,21 @@ jobs:
         uses: actions/cache@v1
         with:
           path: ${{ github.workspace }}${{ matrix.SEP }}pyenv
-          key: ${{ runner.os }}-pyenv-${{ hashFiles('**/requirements.*') }}-${{ hashFiles('**/setup.py') }}-${{ hashFiles('**/Makefile') }}-14-
+          key: |
+            ${{ runner.os }}-pyenv-
+            ${{ hashFiles('**/requirements.*') }}-
+            ${{ hashFiles('**/setup.py') }}-
+            ${{ hashFiles('**/Makefile') }}-14-
 
       - name: Cache pip wheels
         if: matrix.BUILD_TYPE == 'build'
         uses: actions/cache@v1
         with:
           path: ${{ matrix.PIP_WHEELS_DIR }}
-          key: ${{ runner.os }}-pip-wheels-${{ hashFiles('**/requirements.txt') }}-${{ hashFiles('**/setup.py') }}-14-
+          key: |
+            ${{ runner.os }}-pip-wheels-
+            ${{ hashFiles('**/requirements.txt') }}-
+            ${{ hashFiles('**/setup.py') }}-14-
 
       - name: Cache cargo index
         uses: actions/cache@v1

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -270,7 +270,7 @@ jobs:
           cd dist
           setlocal EnableDelayedExpansion
           cmd /C set "wheels=" && for /f "delims=" %%i in ('dir /b *.*') DO set "wheels="%%i" !wheels!"
-          python -m pip install %wheels%
+          python -m pip install pyqtwebengine %wheels%
           python -c "import aqt; # aqt.run()"
 
       - name: Check Linux/Mac OS wheels
@@ -278,7 +278,7 @@ jobs:
         run: |
           set -x
           cd dist
-          python -m pip install *.*
+          python -m pip install pyqtwebengine *.*
           python -c "import aqt; # aqt.run()"
 
       - run: make check

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -97,23 +97,14 @@ jobs:
         uses: actions/cache@v1
         with:
           path: ${{ github.workspace }}${{ matrix.SEP }}pyenv
-          key: |
-            ${{ runner.os }}-pyenv-
-            ${{ hashFiles('**/requirements.*') }}-
-            ${{ hashFiles('**/setup.py') }}-
-            ${{ hashFiles('**/Makefile') }}-14-
+          key: ${{ runner.os }}-pyenv-${{ hashFiles('**/requirements.txt') }}-${{ hashFiles('**/setup.py') }}-${{ hashFiles('**/Makefile') }}-14-
 
-      # Disabling these caches for now because they do not seem to be used/help
-      # https://github.com/ankitects/anki/pull/528
-      # - name: Cache pip wheels
-      #   if: matrix.BUILD_TYPE == 'build'
-      #   uses: actions/cache@v1
-      #   with:
-      #     path: ${{ matrix.PIP_WHEELS_DIR }}
-      #     key: |
-      #       ${{ runner.os }}-pip-wheels-
-      #       ${{ hashFiles('**/requirements.txt') }}-
-      #       ${{ hashFiles('**/setup.py') }}-14-
+      - name: Cache pip wheels
+        if: matrix.BUILD_TYPE == 'build'
+        uses: actions/cache@v1
+        with:
+          path: ${{ matrix.PIP_WHEELS_DIR }}
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}-${{ hashFiles('**/setup.py') }}-14-
 
       - name: Cache cargo index
         uses: actions/cache@v1
@@ -237,6 +228,7 @@ jobs:
       - name: Set up Ubuntu ripgrep, pyaudio, gettext, rename
         if: matrix.os == 'ubuntu-latest'
         run: |
+          set -x
           sudo apt update
           sudo apt install portaudio19-dev gettext rename
           sudo snap install ripgrep --classic
@@ -244,6 +236,7 @@ jobs:
       - name: Set up brew ripgrep, pyaudio, gettext, rename
         if: matrix.os == 'macos-latest'
         run: |
+          set -x
           brew install portaudio protobuf gettext rename ripgrep make
           brew link gettext --force
 
@@ -263,16 +256,35 @@ jobs:
           node-version: 12
 
       - run: make develop
-        if: matrix.BUILD_TYPE != 'check'
+        if: matrix.BUILD_TYPE == 'build'
 
       - run: make build
-        if: matrix.BUILD_TYPE != 'check'
+        if: matrix.BUILD_TYPE == 'build'
+
+      - name: Check Windows wheels
+        if: matrix.BUILD_TYPE == 'build' && matrix.os == 'windows-latest'
+        shell: cmd
+        run: |
+          echo on
+          copy %pyaudio% dist
+          python -m pip install %pyaudio%
+          cd dist
+          cmd /C for /R %%i in (*.whl) DO python -m pip install "%%i"
+          python -c "import aqt; # aqt.run()"
+
+      - name: Check Linux/Mac OS wheels
+        if: matrix.BUILD_TYPE == 'build' && ( matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest' )
+        run: |
+          set -x
+          cd dist
+          python -m pip install *
+          python -c "import aqt; # aqt.run()"
 
       - run: make check
         if: matrix.BUILD_TYPE == 'check'
 
       - name: Upload python wheels
-        if: matrix.BUILD_TYPE != 'check'
+        if: matrix.BUILD_TYPE == 'build'
         uses: actions/upload-artifact@v1
         with:
           name: ${{ matrix.ANKI_PYTHON_WHEELS }}

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -97,7 +97,7 @@ jobs:
         uses: actions/cache@v1
         with:
           path: ${{ github.workspace }}${{ matrix.SEP }}pyenv
-          key: ${{ runner.os }}-pyenv-${{ hashFiles('**/requirements.txt') }}-${{ hashFiles('**/setup.py') }}-${{ hashFiles('**/Makefile') }}-14-
+          key: ${{ runner.os }}-pyenv-${{ hashFiles('**/requirements.*') }}-${{ hashFiles('**/setup.py') }}-${{ hashFiles('**/Makefile') }}-14-
 
       - name: Cache pip wheels
         if: matrix.BUILD_TYPE == 'build'

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -104,7 +104,7 @@ jobs:
         uses: actions/cache@v1
         with:
           path: ${{ matrix.PIP_WHEELS_DIR }}
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}-${{ hashFiles('**/setup.py') }}-14-
+          key: ${{ runner.os }}-pip-wheels-${{ hashFiles('**/requirements.txt') }}-${{ hashFiles('**/setup.py') }}-14-
 
       - name: Cache cargo index
         uses: actions/cache@v1
@@ -267,9 +267,10 @@ jobs:
         run: |
           echo on
           copy %pyaudio% dist
-          python -m pip install %pyaudio%
           cd dist
-          cmd /C for /R %%i in (*.whl) DO python -m pip install "%%i"
+          setlocal EnableDelayedExpansion
+          cmd /C set "wheels=" && for /f "delims=" %%i in ('dir /b *.whl') DO set "wheels="%%i" !wheels!"
+          python -m pip install %wheels%
           python -c "import aqt; # aqt.run()"
 
       - name: Check Linux/Mac OS wheels
@@ -277,7 +278,7 @@ jobs:
         run: |
           set -x
           cd dist
-          python -m pip install *
+          python -m pip install *.whl
           python -c "import aqt; # aqt.run()"
 
       - run: make check

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -269,7 +269,7 @@ jobs:
           copy %pyaudio% dist
           cd dist
           setlocal EnableDelayedExpansion
-          cmd /C set "wheels=" && for /f "delims=" %%i in ('dir /b *.whl') DO set "wheels="%%i" !wheels!"
+          cmd /C set "wheels=" && for /f "delims=" %%i in ('dir /b *.*') DO set "wheels="%%i" !wheels!"
           python -m pip install %wheels%
           python -c "import aqt; # aqt.run()"
 
@@ -278,7 +278,7 @@ jobs:
         run: |
           set -x
           cd dist
-          python -m pip install *.whl
+          python -m pip install *.*
           python -c "import aqt; # aqt.run()"
 
       - run: make check

--- a/Makefile
+++ b/Makefile
@@ -181,7 +181,7 @@ add-buildhash:
 	fi; \
 	ver="$$(cat meta/version)"; \
 	hash="$$(cat meta/buildhash)"; \
-	${RENAME_BIN} "s/-$${ver}-/-$${ver}+$${hash}-/" dist/*-"$${ver}"-*
+	${RENAME_BIN} "s/-$${ver}(\.|-)/-$${ver}+$${hash}\$$1/" dist/*-"$${ver}"*
 
 
 .PHONY: pull-i18n

--- a/qt/Makefile
+++ b/qt/Makefile
@@ -129,8 +129,8 @@ CHECKDEPS := $(shell ${FIND} aqt tests -name '*.py' | grep -v buildinfo.py)
 .PHONY: build
 build: $(BUILD_STEPS)
 	rm -rf dist build
-	python setup.py -q sdist
-	rsync -a dist/*.tar.gz ../dist/
+	python setup.py -q bdist_wheel
+	rsync -a dist/*.whl ../dist/
 
 .PHONY: develop
 develop: $(BUILD_STEPS)

--- a/qt/Makefile
+++ b/qt/Makefile
@@ -64,7 +64,7 @@ TSDEPS := $(wildcard ts/src/*.ts) $(wildcard ts/scss/*.scss)
 	python -m black aqt/gui_hooks.py
 	@touch $@
 
-BUILD_STEPS := .build/run-deps .build/dev-deps .build/js .build/ui aqt/buildinfo.py .build/hooks .build/i18n
+BUILD_STEPS := .build/vernum .build/run-deps .build/dev-deps .build/js .build/ui aqt/buildinfo.py .build/hooks .build/i18n
 
 # Checking
 ######################
@@ -129,8 +129,8 @@ CHECKDEPS := $(shell ${FIND} aqt tests -name '*.py' | grep -v buildinfo.py)
 .PHONY: build
 build: $(BUILD_STEPS)
 	rm -rf dist build
-	python setup.py -q bdist_wheel
-	rsync -a dist/*.whl ../dist/
+	python setup.py -q sdist
+	rsync -a dist/*.tar.gz ../dist/
 
 .PHONY: develop
 develop: $(BUILD_STEPS)
@@ -138,3 +138,9 @@ develop: $(BUILD_STEPS)
 aqt/buildinfo.py: ../meta/version ../meta/buildhash
 	echo "buildhash='$$(cat ../meta/buildhash)'" > $@
 	echo "version='$$(cat ../meta/version)'" >> $@
+
+VER := $(shell cat ../meta/version)
+.build/vernum: ../meta/version
+	sed -i.bak 's/.*automatically updated.*/    version="$(VER)",  # automatically updated/' setup.py
+	rm setup.py.bak
+	@touch $@

--- a/qt/pyproject.toml
+++ b/qt/pyproject.toml
@@ -1,0 +1,4 @@
+[build-system]
+# Minimum requirements for the build system to execute.
+# https://stackoverflow.com/questions/48048745/setup-py-require-a-recent-version-of-setuptools-before-trying-to-install
+requires = ["setuptools", "wheel"]

--- a/qt/setup.py
+++ b/qt/setup.py
@@ -5,9 +5,6 @@ from distutils.version import LooseVersion
 
 import setuptools
 
-with open("../meta/version") as fh:
-    version = fh.read().strip()
-
 
 def package_files(directory):
     entries = []
@@ -59,7 +56,7 @@ if not IS_PYQT_INSTALLED or (
 
 setuptools.setup(
     name="aqt",
-    version=version,
+    version="2.1.24",  # automatically updated
     author="Ankitects Pty Ltd",
     description="Anki's Qt GUI code",
     long_description="Anki's QT GUI code",

--- a/qt/setup.py
+++ b/qt/setup.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 import os
-import sys
 
 import setuptools
 
@@ -15,7 +14,6 @@ def package_files(directory):
 
 # just the Python files for type hints?
 pyonly = os.getenv("PYFILESONLY")
-minimum_python_version = (3, 7)
 
 if pyonly:
     extra_files = []
@@ -34,12 +32,6 @@ install_requires = [
     'pywin32; sys.platform == "win32"',
     'darkdetect; sys.platform == "darwin"',
 ]
-
-if sys.version_info < minimum_python_version:
-    raise RuntimeError(
-        "The minimum Python interpreter version required for Anki is '%s' "
-        "and version '%s' was found!" % (minimum_python_version, sys.version_info)
-    )
 
 
 setuptools.setup(

--- a/qt/setup.py
+++ b/qt/setup.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 import os
 import sys
-from distutils.version import LooseVersion
 
 import setuptools
 
@@ -30,6 +29,7 @@ install_requires = [
     "pyaudio",
     "markdown",
     "jsonschema",
+    "pyqt5>=5.9",
     'psutil; sys.platform == "win32"',
     'pywin32; sys.platform == "win32"',
     'darkdetect; sys.platform == "darwin"',
@@ -40,25 +40,6 @@ if sys.version_info < minimum_python_version:
         "The minimum Python interpreter version required for Anki is '%s' "
         "and version '%s' was found!" % (minimum_python_version, sys.version_info)
     )
-
-try:
-    import PyQt5 as IS_PYQT_INSTALLED
-
-except (ImportError, ValueError):
-    IS_PYQT_INSTALLED = None
-
-try:
-    from PyQt5.Qt import PYQT_VERSION_STR
-
-except (ImportError, ValueError):
-    PYQT_VERSION_STR = None
-
-# https://github.com/ankitects/anki/pull/530
-if not IS_PYQT_INSTALLED or (
-    PYQT_VERSION_STR and LooseVersion(PYQT_VERSION_STR) >= LooseVersion("5.12")
-):
-    install_requires.append("pyqt5")
-    install_requires.append("pyqtwebengine")
 
 
 setuptools.setup(

--- a/qt/setup.py
+++ b/qt/setup.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 import os
+from distutils.version import LooseVersion
 
 import setuptools
 
@@ -23,6 +24,39 @@ if pyonly:
 else:
     extra_files = package_files("aqt_data")
 
+install_requires = [
+    "beautifulsoup4",
+    "requests",
+    "send2trash",
+    "pyaudio",
+    "markdown",
+    "jsonschema",
+    'psutil; sys.platform == "win32"',
+    'pywin32; sys.platform == "win32"',
+    'darkdetect; sys.platform == "darwin"',
+]
+
+
+try:
+    import PyQt5 as IS_PYQT_INSTALLED
+
+except (ImportError, ValueError):
+    IS_PYQT_INSTALLED = None
+
+try:
+    from PyQt5.Qt import PYQT_VERSION_STR
+
+except (ImportError, ValueError):
+    PYQT_VERSION_STR = None
+
+# https://github.com/ankitects/anki/pull/530
+if not IS_PYQT_INSTALLED or (
+    PYQT_VERSION_STR and LooseVersion(PYQT_VERSION_STR) >= LooseVersion("5.12")
+):
+    install_requires.append("pyqt5")
+    install_requires.append("pyqtwebengine")
+
+
 setuptools.setup(
     name="aqt",
     version=version,
@@ -37,17 +71,5 @@ setuptools.setup(
     classifiers=[],
     python_requires=">=3.7",
     package_data={"aqt": ["py.typed"]},
-    install_requires=[
-        "beautifulsoup4",
-        "requests",
-        "send2trash",
-        "pyaudio",
-        "markdown",
-        "jsonschema",
-        "pyqt5",
-        "pyqtwebengine",
-        'psutil; sys.platform == "win32"',
-        'pywin32; sys.platform == "win32"',
-        'darkdetect; sys.platform == "darwin"',
-    ],
+    install_requires=install_requires,
 )

--- a/qt/setup.py
+++ b/qt/setup.py
@@ -44,6 +44,8 @@ setuptools.setup(
         "pyaudio",
         "markdown",
         "jsonschema",
+        "pyqt5",
+        "pyqtwebengine",
         'psutil; sys.platform == "win32"',
         'pywin32; sys.platform == "win32"',
         'darkdetect; sys.platform == "darwin"',

--- a/qt/setup.py
+++ b/qt/setup.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 import os
+import sys
 from distutils.version import LooseVersion
 
 import setuptools
@@ -15,6 +16,7 @@ def package_files(directory):
 
 # just the Python files for type hints?
 pyonly = os.getenv("PYFILESONLY")
+minimum_python_version = (3, 7)
 
 if pyonly:
     extra_files = []
@@ -33,6 +35,11 @@ install_requires = [
     'darkdetect; sys.platform == "darwin"',
 ]
 
+if sys.version_info < minimum_python_version:
+    raise RuntimeError(
+        "The minimum Python interpreter version required for Anki is '%s' "
+        "and version '%s' was found!" % (minimum_python_version, sys.version_info)
+    )
 
 try:
     import PyQt5 as IS_PYQT_INSTALLED


### PR DESCRIPTION
Just some basic testing to assure they are installing properly. Right away, the Anki wheels were not installing because the `setup.py` did not have `Qt` as a dependency. The Qt dependency was inside e `requirements.qt`, which was installed by `make pyenv`. As there was no need to use a `requirements.qt`, the `Qt` dependencies were moved into the `setup.py`. Now the Python Wheels are working fine installing all required dependencies.

Related to: https://anki.tenderapp.com/discussions/ankidesktop/40029-how-to-generate-anki-build-packages-for-linuxmac-oswindows