### PR TITLE
Previewer

### DIFF
--- a/qt/aqt/browser.py
+++ b/qt/aqt/browser.py
@@ -28,7 +28,7 @@ from anki.utils import htmlToTextLine, ids2str, intTime, isMac, isWin
 from aqt import AnkiQt, gui_hooks
 from aqt.editor import Editor
 from aqt.exporting import ExportDialog
-from aqt.previewer import Previewer
+from aqt.previewer import BrowserPreviewer
 from aqt.qt import *
 from aqt.theme import theme_manager
 from aqt.utils import (
@@ -1568,7 +1568,7 @@ where id in %s"""
             self._previewer = None
         else:
 
-            self._previewer = Previewer(self, self.mw)
+            self._previewer = BrowserPreviewer(self, self.mw)
             self._previewer._openPreview()
 
     def _renderPreview(self, cardChanged=False):

--- a/qt/aqt/browser.py
+++ b/qt/aqt/browser.py
@@ -5,8 +5,6 @@
 from __future__ import annotations
 
 import html
-import json
-import re
 import sre_constants
 import time
 import unicodedata
@@ -16,6 +14,7 @@ from operator import itemgetter
 from typing import Callable, List, Optional, Sequence, Union
 
 import anki
+import aqt
 import aqt.forms
 from anki import hooks
 from anki.cards import Card
@@ -29,8 +28,8 @@ from anki.utils import htmlToTextLine, ids2str, intTime, isMac, isWin
 from aqt import AnkiQt, gui_hooks
 from aqt.editor import Editor
 from aqt.exporting import ExportDialog
+from aqt.previewer import Previewer
 from aqt.qt import *
-from aqt.sound import av_player, play_clicked_audio
 from aqt.theme import theme_manager
 from aqt.utils import (
     MenuList,
@@ -55,12 +54,6 @@ from aqt.utils import (
     tr,
 )
 from aqt.webview import AnkiWebView
-
-
-@dataclass
-class PreviewDialog:
-    dialog: QDialog
-    browser: Browser
 
 
 @dataclass
@@ -583,7 +576,7 @@ class Browser(QMainWindow):
         self.col = self.mw.col
         self.lastFilter = ""
         self.focusTo = None
-        self._previewWindow = None
+        self._previewer = None
         self._closeEventHasCleanedUp = False
         self.form = aqt.forms.browser.Ui_Dialog()
         self.form.setupUi(self)
@@ -1569,229 +1562,22 @@ where id in %s"""
     # Preview
     ######################################################################
 
-    _previewTimer = None
-    _lastPreviewRender: Union[int, float] = 0
-    _lastPreviewState = None
-    _previewCardChanged = False
-
     def onTogglePreview(self):
-        if self._previewWindow:
-            self._closePreview()
+        if self._previewer:
+            self._previewer._closePreview()
+            self._previewer = None
         else:
-            self._openPreview()
 
-    def _openPreview(self):
-        self._previewState = "question"
-        self._lastPreviewState = None
-        self._previewWindow = QDialog(None, Qt.Window)
-        self._previewWindow.setWindowTitle(_("Preview"))
-
-        self._previewWindow.finished.connect(self._onPreviewFinished)
-        self._previewWindow.silentlyClose = True
-        vbox = QVBoxLayout()
-        vbox.setContentsMargins(0, 0, 0, 0)
-        self._previewWeb = AnkiWebView(title="previewer")
-        vbox.addWidget(self._previewWeb)
-        bbox = QDialogButtonBox()
-
-        self._previewReplay = bbox.addButton(
-            _("Replay Audio"), QDialogButtonBox.ActionRole
-        )
-        self._previewReplay.setAutoDefault(False)
-        self._previewReplay.setShortcut(QKeySequence("R"))
-        self._previewReplay.setToolTip(_("Shortcut key: %s" % "R"))
-
-        self._previewPrev = bbox.addButton("<", QDialogButtonBox.ActionRole)
-        self._previewPrev.setAutoDefault(False)
-        self._previewPrev.setShortcut(QKeySequence("Left"))
-        self._previewPrev.setToolTip(_("Shortcut key: Left arrow"))
-
-        self._previewNext = bbox.addButton(">", QDialogButtonBox.ActionRole)
-        self._previewNext.setAutoDefault(True)
-        self._previewNext.setShortcut(QKeySequence("Right"))
-        self._previewNext.setToolTip(_("Shortcut key: Right arrow or Enter"))
-
-        self._previewPrev.clicked.connect(self._onPreviewPrev)
-        self._previewNext.clicked.connect(self._onPreviewNext)
-        self._previewReplay.clicked.connect(self._onReplayAudio)
-
-        self.previewShowBothSides = QCheckBox(_("Show Both Sides"))
-        self.previewShowBothSides.setShortcut(QKeySequence("B"))
-        self.previewShowBothSides.setToolTip(_("Shortcut key: %s" % "B"))
-        bbox.addButton(self.previewShowBothSides, QDialogButtonBox.ActionRole)
-        self._previewBothSides = self.col.conf.get("previewBothSides", False)
-        self.previewShowBothSides.setChecked(self._previewBothSides)
-        self.previewShowBothSides.toggled.connect(self._onPreviewShowBothSides)
-
-        self._setupPreviewWebview()
-
-        vbox.addWidget(bbox)
-        self._previewWindow.setLayout(vbox)
-        restoreGeom(self._previewWindow, "preview")
-        self._previewWindow.show()
-        self._renderPreview(True)
-
-    def _onPreviewFinished(self, ok):
-        saveGeom(self._previewWindow, "preview")
-        self.mw.progress.timer(100, self._onClosePreview, False)
-        self.form.previewButton.setChecked(False)
-
-    def _onPreviewPrev(self):
-        if self._previewState == "answer" and not self._previewBothSides:
-            self._previewState = "question"
-            self._renderPreview()
-        else:
-            self.editor.saveNow(lambda: self._moveCur(QAbstractItemView.MoveUp))
-
-    def _onPreviewNext(self):
-        if self._previewState == "question":
-            self._previewState = "answer"
-            self._renderPreview()
-        else:
-            self.editor.saveNow(lambda: self._moveCur(QAbstractItemView.MoveDown))
-
-    def _onReplayAudio(self):
-        self.mw.reviewer.replayAudio(self)
-
-    def _updatePreviewButtons(self):
-        if not self._previewWindow:
-            return
-        current = self.currentRow()
-        canBack = current > 0 or (
-            current == 0
-            and self._previewState == "answer"
-            and not self._previewBothSides
-        )
-        self._previewPrev.setEnabled(bool(self.singleCard and canBack))
-        canForward = (
-            self.currentRow() < self.model.rowCount(None) - 1
-            or self._previewState == "question"
-        )
-        self._previewNext.setEnabled(bool(self.singleCard and canForward))
-
-    def _closePreview(self):
-        if self._previewWindow:
-            self._previewWindow.close()
-            self._onClosePreview()
-
-    def _onClosePreview(self):
-        self._previewWindow = self._previewPrev = self._previewNext = None
-
-    def _setupPreviewWebview(self):
-        jsinc = [
-            "jquery.js",
-            "browsersel.js",
-            "mathjax/conf.js",
-            "mathjax/MathJax.js",
-            "reviewer.js",
-        ]
-        web_context = PreviewDialog(dialog=self._previewWindow, browser=self)
-        self._previewWeb.stdHtml(
-            self.mw.reviewer.revHtml(),
-            css=["reviewer.css"],
-            js=jsinc,
-            context=web_context,
-        )
-        self._previewWeb.set_bridge_command(
-            self._on_preview_bridge_cmd, web_context,
-        )
-
-    def _on_preview_bridge_cmd(self, cmd: str) -> Any:
-        if cmd.startswith("play:"):
-            play_clicked_audio(cmd, self.card)
+            self._previewer = Previewer(self, self.mw)
+            self._previewer._openPreview()
 
     def _renderPreview(self, cardChanged=False):
-        self._cancelPreviewTimer()
-        # Keep track of whether _renderPreview() has ever been called
-        # with cardChanged=True since the last successful render
-        self._previewCardChanged |= cardChanged
-        # avoid rendering in quick succession
-        elapMS = int((time.time() - self._lastPreviewRender) * 1000)
-        delay = 300
-        if elapMS < delay:
-            self._previewTimer = self.mw.progress.timer(
-                delay - elapMS, self._renderScheduledPreview, False
-            )
-        else:
-            self._renderScheduledPreview()
+        if self._previewer:
+            self._previewer._renderPreview(cardChanged)
 
     def _cancelPreviewTimer(self):
-        if self._previewTimer:
-            self._previewTimer.stop()
-            self._previewTimer = None
-
-    def _renderScheduledPreview(self) -> None:
-        self._cancelPreviewTimer()
-        self._lastPreviewRender = time.time()
-
-        if not self._previewWindow:
-            return
-        c = self.card
-        func = "_showQuestion"
-        if not c or not self.singleCard:
-            txt = _("(please select 1 card)")
-            bodyclass = ""
-            self._lastPreviewState = None
-        else:
-            if self._previewBothSides:
-                self._previewState = "answer"
-            elif self._previewCardChanged:
-                self._previewState = "question"
-
-            currentState = self._previewStateAndMod()
-            if currentState == self._lastPreviewState:
-                # nothing has changed, avoid refreshing
-                return
-
-            # need to force reload even if answer
-            txt = c.q(reload=True)
-
-            if self._previewState == "answer":
-                func = "_showAnswer"
-                txt = c.a()
-            txt = re.sub(r"\[\[type:[^]]+\]\]", "", txt)
-
-            bodyclass = theme_manager.body_classes_for_card_ord(c.ord)
-
-            if self.mw.reviewer.autoplay(c):
-                if self._previewBothSides:
-                    # if we're showing both sides at once, remove any audio
-                    # from the answer that's appeared on the question already
-                    question_audio = c.question_av_tags()
-                    only_on_answer_audio = [
-                        x for x in c.answer_av_tags() if x not in question_audio
-                    ]
-                    audio = question_audio + only_on_answer_audio
-                elif self._previewState == "question":
-                    audio = c.question_av_tags()
-                else:
-                    audio = c.answer_av_tags()
-                av_player.play_tags(audio)
-            else:
-                av_player.clear_queue_and_maybe_interrupt()
-
-            txt = self.mw.prepare_card_text_for_display(txt)
-            txt = gui_hooks.card_will_show(
-                txt, c, "preview" + self._previewState.capitalize()
-            )
-            self._lastPreviewState = self._previewStateAndMod()
-        self._updatePreviewButtons()
-        self._previewWeb.eval("{}({},'{}');".format(func, json.dumps(txt), bodyclass))
-        self._previewCardChanged = False
-
-    def _onPreviewShowBothSides(self, toggle):
-        self._previewBothSides = toggle
-        self.col.conf["previewBothSides"] = toggle
-        self.col.setMod()
-        if self._previewState == "answer" and not toggle:
-            self._previewState = "question"
-        self._renderPreview()
-
-    def _previewStateAndMod(self):
-        c = self.card
-        n = c.note()
-        n.load()
-        return (self._previewState, c.id, n.mod)
+        if self._previewer:
+            self._previewer._cancelPreviewTimer()
 
     # Card deletion
     ######################################################################

--- a/qt/aqt/browser.py
+++ b/qt/aqt/browser.py
@@ -1564,19 +1564,19 @@ where id in %s"""
 
     def onTogglePreview(self):
         if self._previewer:
-            self._previewer._close()
+            self._previewer.close()
             self._previewer = None
         else:
             self._previewer = BrowserPreviewer(self, self.mw)
-            self._previewer._open()
+            self._previewer.open()
 
     def _renderPreview(self, cardChanged=False):
         if self._previewer:
-            self._previewer._render(cardChanged)
+            self._previewer.render(cardChanged)
 
     def _cancelPreviewTimer(self):
         if self._previewer:
-            self._previewer._cancelTimer()
+            self._previewer.cancelTimer()
 
     # Card deletion
     ######################################################################

--- a/qt/aqt/browser.py
+++ b/qt/aqt/browser.py
@@ -1576,7 +1576,7 @@ where id in %s"""
 
     def _cancelPreviewTimer(self):
         if self._previewer:
-            self._previewer.cancelTimer()
+            self._previewer.cancel_timer()
 
     # Card deletion
     ######################################################################

--- a/qt/aqt/browser.py
+++ b/qt/aqt/browser.py
@@ -1564,20 +1564,19 @@ where id in %s"""
 
     def onTogglePreview(self):
         if self._previewer:
-            self._previewer._closePreview()
+            self._previewer._close()
             self._previewer = None
         else:
-
             self._previewer = BrowserPreviewer(self, self.mw)
-            self._previewer._openPreview()
+            self._previewer._open()
 
     def _renderPreview(self, cardChanged=False):
         if self._previewer:
-            self._previewer._renderPreview(cardChanged)
+            self._previewer._render(cardChanged)
 
     def _cancelPreviewTimer(self):
         if self._previewer:
-            self._previewer._cancelPreviewTimer()
+            self._previewer._cancelTimer()
 
     # Card deletion
     ######################################################################

--- a/qt/aqt/previewer.py
+++ b/qt/aqt/previewer.py
@@ -2,7 +2,7 @@ import json
 import re
 import time
 from dataclasses import dataclass
-from typing import Any, Optional, Union
+from typing import Any, List, Optional, Union
 
 from anki.cards import Card
 from anki.lang import _
@@ -308,6 +308,44 @@ class BrowserPreviewer(MultipleCardsPreviewer):
     def _renderScheduledPreview(self) -> None:
         super()._renderScheduledPreview()
         self._updatePreviewButtons()
+
+
+class ListCardsPreviewer(MultipleCardsPreviewer):
+    def __init__(self, cards: List[Card], *args, **kwargs):
+        self.index = 0
+        self.cards = cards
+        super().__init__(*args, **kwargs)
+
+    def card(self):
+        if not self.cards:
+            return None
+        return self.cards[0]
+
+    def _openPreview(self):
+        if not self.cards:
+            return
+        super()._openPreview()
+
+    def _onPreviewPrevCard(self):
+        self.index -= 1
+        self._renderPreview()
+
+    def _onPreviewNextCard(self):
+        self.index += 1
+        self._renderPreview()
+
+    def _should_enable_prev(self):
+        return super()._should_enable_prev() or self.index > 0
+
+    def _should_enable_next(self):
+        return super()._should_enable_next() or self.index < len(self.cards) - 1
+
+    def _on_other_side(self):
+        if self._previewState == "question":
+            self._previewState = "answer"
+        else:
+            self._previewState = "question"
+        self._renderPreview()
 
 
 class SingleCardPreviewer(Previewer):

--- a/qt/aqt/previewer.py
+++ b/qt/aqt/previewer.py
@@ -2,8 +2,9 @@ import json
 import re
 import time
 from dataclasses import dataclass
-from typing import Any, Union
+from typing import Any, Optional, Union
 
+from anki.cards import Card
 from anki.lang import _
 from aqt import AnkiQt, gui_hooks
 from aqt.qt import (
@@ -37,6 +38,9 @@ class Previewer:
     def __init__(self, parent: QWidget, mw: AnkiQt):
         self.parent = parent
         self.mw = mw
+
+    def card(self) -> Optional[Card]:
+        return self.parent.card
 
     def _openPreview(self):
         self._previewState = "question"
@@ -163,7 +167,7 @@ class Previewer:
 
     def _on_preview_bridge_cmd(self, cmd: str) -> Any:
         if cmd.startswith("play:"):
-            play_clicked_audio(cmd, self.parent.card)
+            play_clicked_audio(cmd, self.card())
 
     def _renderPreview(self, cardChanged=False):
         self._cancelPreviewTimer()
@@ -191,7 +195,7 @@ class Previewer:
 
         if not self._previewWindow:
             return
-        c = self.parent.card
+        c = self.card()
         func = "_showQuestion"
         if not c or not self.parent.singleCard:
             txt = _("(please select 1 card)")
@@ -253,7 +257,7 @@ class Previewer:
         self._renderPreview()
 
     def _previewStateAndMod(self):
-        c = self.parent.card
+        c = self.card()
         n = c.note()
         n.load()
         return (self._previewState, c.id, n.mod)

--- a/qt/aqt/previewer.py
+++ b/qt/aqt/previewer.py
@@ -1,7 +1,6 @@
 import json
 import re
 import time
-from dataclasses import dataclass
 from typing import Any, List, Optional, Union
 
 from anki.cards import Card
@@ -21,12 +20,6 @@ from aqt.sound import av_player, play_clicked_audio
 from aqt.theme import theme_manager
 from aqt.utils import restoreGeom, saveGeom
 from aqt.webview import AnkiWebView
-
-
-@dataclass
-class PreviewDialog:
-    dialog: QDialog
-    parent: QWidget
 
 
 class Previewer:
@@ -105,15 +98,11 @@ class Previewer:
             "mathjax/MathJax.js",
             "reviewer.js",
         ]
-        web_context = PreviewDialog(dialog=self._previewWindow, parent=self.parent)
         self._previewWeb.stdHtml(
-            self.mw.reviewer.revHtml(),
-            css=["reviewer.css"],
-            js=jsinc,
-            context=web_context,
+            self.mw.reviewer.revHtml(), css=["reviewer.css"], js=jsinc, context=self,
         )
         self._previewWeb.set_bridge_command(
-            self._on_preview_bridge_cmd, web_context,
+            self._on_preview_bridge_cmd, self,
         )
 
     def _on_preview_bridge_cmd(self, cmd: str) -> Any:

--- a/qt/aqt/previewer.py
+++ b/qt/aqt/previewer.py
@@ -144,7 +144,9 @@ class Previewer:
 
     def _onClosePreview(self):
         self.parent.previewer = None
-        self._previewWindow = self._previewPrev = self._previewNext = None
+        self._previewWindow = None
+        self._previewPrev = None
+        self._previewNext = None
 
     def _setupPreviewWebview(self):
         jsinc = [

--- a/qt/aqt/previewer.py
+++ b/qt/aqt/previewer.py
@@ -260,18 +260,24 @@ class BrowserPreviewer(Previewer):
     def _updatePreviewButtons(self):
         if not self._previewWindow:
             return
+        self._previewPrev.setEnabled(self._should_enable_prev())
+        self._previewNext.setEnabled(self._should_enable_next())
+
+    def _should_enable_prev(self):
         current = self.parent.currentRow()
         canBack = current > 0 or (
             current == 0
             and self._previewState == "answer"
             and not self._previewBothSides
         )
-        self._previewPrev.setEnabled(bool(self.parent.singleCard and canBack))
+        return bool(self.parent.singleCard and canBack)
+
+    def _should_enable_next(self):
         canForward = (
             self.parent.currentRow() < self.parent.model.rowCount(None) - 1
             or self._previewState == "question"
         )
-        self._previewNext.setEnabled(bool(self.parent.singleCard and canForward))
+        return bool(self.parent.singleCard and canForward)
 
     def _onClosePreview(self):
         super()._onClosePreview()

--- a/qt/aqt/previewer.py
+++ b/qt/aqt/previewer.py
@@ -282,3 +282,30 @@ class BrowserPreviewer(Previewer):
     def _renderScheduledPreview(self) -> None:
         super()._renderScheduledPreview()
         self._updatePreviewButtons()
+
+
+class SingleCardPreviewer(Previewer):
+    def __init__(self, card: Card, *args, **kwargs):
+        self._card = card
+        super().__init__(*args, **kwargs)
+
+    def card(self) -> Card:
+        return self._card
+
+    def _create_gui(self):
+        super()._create_gui()
+        self._other_side = self.bbox.addButton(
+            "Other side", QDialogButtonBox.ActionRole
+        )
+        self._other_side.setAutoDefault(False)
+        self._other_side.setShortcut(QKeySequence("Right"))
+        self._other_side.setShortcut(QKeySequence("Left"))
+        self._other_side.setToolTip(_("Shortcut key: Left or Right arrow"))
+        self._other_side.clicked.connect(self._on_other_side)
+
+    def _on_other_side(self):
+        if self._previewState == "question":
+            self._previewState = "answer"
+        else:
+            self._previewState = "question"
+        self._renderPreview()

--- a/qt/aqt/previewer.py
+++ b/qt/aqt/previewer.py
@@ -41,6 +41,12 @@ class Previewer:
     def _openPreview(self):
         self._previewState = "question"
         self._lastPreviewState = None
+        self._create_gui()
+        self._setupPreviewWebview()
+        self._renderPreview(True)
+        self._previewWindow.show()
+
+    def _create_gui(self):
         self._previewWindow = QDialog(None, Qt.Window)
         self._previewWindow.setWindowTitle(_("Preview"))
 
@@ -81,13 +87,9 @@ class Previewer:
         self.previewShowBothSides.setChecked(self._previewBothSides)
         self.previewShowBothSides.toggled.connect(self._onPreviewShowBothSides)
 
-        self._setupPreviewWebview()
-
         vbox.addWidget(bbox)
         self._previewWindow.setLayout(vbox)
         restoreGeom(self._previewWindow, "preview")
-        self._previewWindow.show()
-        self._renderPreview(True)
 
     def _onPreviewFinished(self, ok):
         saveGeom(self._previewWindow, "preview")

--- a/qt/aqt/previewer.py
+++ b/qt/aqt/previewer.py
@@ -35,12 +35,12 @@ class Previewer:
     def card(self) -> Optional[Card]:
         raise NotImplementedError
 
-    def _open(self):
+    def open(self):
         self._state = "question"
         self._lastState = None
         self._create_gui()
         self._setupWebview()
-        self._render(True)
+        self.render(True)
         self._window.show()
 
     def _create_gui(self):
@@ -82,7 +82,7 @@ class Previewer:
     def _onReplayAudio(self):
         self.mw.reviewer.replayAudio(self)
 
-    def _close(self):
+    def close(self):
         if self._window:
             self._window.close()
             self._onClose()
@@ -107,9 +107,9 @@ class Previewer:
         if cmd.startswith("play:"):
             play_clicked_audio(cmd, self.card())
 
-    def _render(self, cardChanged=False):
-        self._cancelTimer()
-        # Keep track of whether _render() has ever been called
+    def render(self, cardChanged=False):
+        self.cancelTimer()
+        # Keep track of whether render() has ever been called
         # with cardChanged=True since the last successful render
         self._cardChanged |= cardChanged
         # avoid rendering in quick succession
@@ -122,13 +122,13 @@ class Previewer:
         else:
             self._renderScheduled()
 
-    def _cancelTimer(self):
+    def cancelTimer(self):
         if self._timer:
             self._timer.stop()
             self._timer = None
 
     def _renderScheduled(self) -> None:
-        self._cancelTimer()
+        self.cancelTimer()
         self._lastRender = time.time()
 
         if not self._window:
@@ -189,7 +189,7 @@ class Previewer:
         self.mw.col.setMod()
         if self._state == "answer" and not toggle:
             self._state = "question"
-        self._render()
+        self.render()
 
     def _stateAndMod(self):
         c = self.card()
@@ -221,7 +221,7 @@ class MultipleCardsPreviewer(Previewer):
     def _onPrev(self):
         if self._state == "answer" and not self._bothSides:
             self._state = "question"
-            self._render()
+            self.render()
         else:
             self._onPrevCard()
 
@@ -231,7 +231,7 @@ class MultipleCardsPreviewer(Previewer):
     def _onNext(self):
         if self._state == "question":
             self._state = "answer"
-            self._render()
+            self.render()
         else:
             self._onNextCard()
 
@@ -316,18 +316,18 @@ class ListCardsPreviewer(MultipleCardsPreviewer):
             self.cards[self.index] = self.mw.col.getCard(self.cards[self.index])
         return self.cards[self.index]
 
-    def _open(self):
+    def open(self):
         if not self.cards:
             return
-        super()._open()
+        super().open()
 
     def _onPrevCard(self):
         self.index -= 1
-        self._render()
+        self.render()
 
     def _onNextCard(self):
         self.index += 1
-        self._render()
+        self.render()
 
     def _should_enable_prev(self):
         return super()._should_enable_prev() or self.index > 0
@@ -340,7 +340,7 @@ class ListCardsPreviewer(MultipleCardsPreviewer):
             self._state = "answer"
         else:
             self._state = "question"
-        self._render()
+        self.render()
 
 
 class SingleCardPreviewer(Previewer):
@@ -367,4 +367,4 @@ class SingleCardPreviewer(Previewer):
             self._state = "answer"
         else:
             self._state = "question"
-        self._render()
+        self.render()

--- a/qt/aqt/previewer.py
+++ b/qt/aqt/previewer.py
@@ -1,0 +1,257 @@
+import json
+import re
+import time
+from dataclasses import dataclass
+from typing import Any, Union
+
+from anki.lang import _
+from aqt import AnkiQt, gui_hooks
+from aqt.qt import (
+    QAbstractItemView,
+    QCheckBox,
+    QDialog,
+    QDialogButtonBox,
+    QKeySequence,
+    Qt,
+    QVBoxLayout,
+    QWidget,
+)
+from aqt.sound import av_player, play_clicked_audio
+from aqt.theme import theme_manager
+from aqt.utils import restoreGeom, saveGeom
+from aqt.webview import AnkiWebView
+
+
+@dataclass
+class PreviewDialog:
+    dialog: QDialog
+    parent: QWidget
+
+
+class Previewer:
+    _lastPreviewState = None
+    _previewCardChanged = False
+    _lastPreviewRender: Union[int, float] = 0
+    _previewTimer = None
+
+    def __init__(self, parent: QWidget, mw: AnkiQt):
+        self.parent = parent
+        self.mw = mw
+
+    def _openPreview(self):
+        self._previewState = "question"
+        self._lastPreviewState = None
+        self._previewWindow = QDialog(None, Qt.Window)
+        self._previewWindow.setWindowTitle(_("Preview"))
+
+        self._previewWindow.finished.connect(self._onPreviewFinished)
+        self._previewWindow.silentlyClose = True
+        vbox = QVBoxLayout()
+        vbox.setContentsMargins(0, 0, 0, 0)
+        self._previewWeb = AnkiWebView(title="previewer")
+        vbox.addWidget(self._previewWeb)
+        bbox = QDialogButtonBox()
+
+        self._previewReplay = bbox.addButton(
+            _("Replay Audio"), QDialogButtonBox.ActionRole
+        )
+        self._previewReplay.setAutoDefault(False)
+        self._previewReplay.setShortcut(QKeySequence("R"))
+        self._previewReplay.setToolTip(_("Shortcut key: %s" % "R"))
+
+        self._previewPrev = bbox.addButton("<", QDialogButtonBox.ActionRole)
+        self._previewPrev.setAutoDefault(False)
+        self._previewPrev.setShortcut(QKeySequence("Left"))
+        self._previewPrev.setToolTip(_("Shortcut key: Left arrow"))
+
+        self._previewNext = bbox.addButton(">", QDialogButtonBox.ActionRole)
+        self._previewNext.setAutoDefault(True)
+        self._previewNext.setShortcut(QKeySequence("Right"))
+        self._previewNext.setToolTip(_("Shortcut key: Right arrow or Enter"))
+
+        self._previewPrev.clicked.connect(self._onPreviewPrev)
+        self._previewNext.clicked.connect(self._onPreviewNext)
+        self._previewReplay.clicked.connect(self._onReplayAudio)
+
+        self.previewShowBothSides = QCheckBox(_("Show Both Sides"))
+        self.previewShowBothSides.setShortcut(QKeySequence("B"))
+        self.previewShowBothSides.setToolTip(_("Shortcut key: %s" % "B"))
+        bbox.addButton(self.previewShowBothSides, QDialogButtonBox.ActionRole)
+        self._previewBothSides = self.mw.col.conf.get("previewBothSides", False)
+        self.previewShowBothSides.setChecked(self._previewBothSides)
+        self.previewShowBothSides.toggled.connect(self._onPreviewShowBothSides)
+
+        self._setupPreviewWebview()
+
+        vbox.addWidget(bbox)
+        self._previewWindow.setLayout(vbox)
+        restoreGeom(self._previewWindow, "preview")
+        self._previewWindow.show()
+        self._renderPreview(True)
+
+    def _onPreviewFinished(self, ok):
+        saveGeom(self._previewWindow, "preview")
+        self.mw.progress.timer(100, self._onClosePreview, False)
+        self.parent.form.previewButton.setChecked(False)
+
+    def _onPreviewPrev(self):
+        if self._previewState == "answer" and not self._previewBothSides:
+            self._previewState = "question"
+            self._renderPreview()
+        else:
+            self.parent.editor.saveNow(
+                lambda: self.parent._moveCur(QAbstractItemView.MoveUp)
+            )
+
+    def _onPreviewNext(self):
+        if self._previewState == "question":
+            self._previewState = "answer"
+            self._renderPreview()
+        else:
+            self.parent.editor.saveNow(
+                lambda: self.parent._moveCur(QAbstractItemView.MoveDown)
+            )
+
+    def _onReplayAudio(self):
+        self.mw.reviewer.replayAudio(self)
+
+    def _updatePreviewButtons(self):
+        if not self._previewWindow:
+            return
+        current = self.parent.currentRow()
+        canBack = current > 0 or (
+            current == 0
+            and self._previewState == "answer"
+            and not self._previewBothSides
+        )
+        self._previewPrev.setEnabled(bool(self.parent.singleCard and canBack))
+        canForward = (
+            self.parent.currentRow() < self.parent.model.rowCount(None) - 1
+            or self._previewState == "question"
+        )
+        self._previewNext.setEnabled(bool(self.parent.singleCard and canForward))
+
+    def _closePreview(self):
+        if self._previewWindow:
+            self._previewWindow.close()
+            self._onClosePreview()
+
+    def _onClosePreview(self):
+        self.parent.previewer = None
+        self._previewWindow = self._previewPrev = self._previewNext = None
+
+    def _setupPreviewWebview(self):
+        jsinc = [
+            "jquery.js",
+            "browsersel.js",
+            "mathjax/conf.js",
+            "mathjax/MathJax.js",
+            "reviewer.js",
+        ]
+        web_context = PreviewDialog(dialog=self._previewWindow, parent=self.parent)
+        self._previewWeb.stdHtml(
+            self.mw.reviewer.revHtml(),
+            css=["reviewer.css"],
+            js=jsinc,
+            context=web_context,
+        )
+        self._previewWeb.set_bridge_command(
+            self._on_preview_bridge_cmd, web_context,
+        )
+
+    def _on_preview_bridge_cmd(self, cmd: str) -> Any:
+        if cmd.startswith("play:"):
+            play_clicked_audio(cmd, self.parent.card)
+
+    def _renderPreview(self, cardChanged=False):
+        self._cancelPreviewTimer()
+        # Keep track of whether _renderPreview() has ever been called
+        # with cardChanged=True since the last successful render
+        self._previewCardChanged |= cardChanged
+        # avoid rendering in quick succession
+        elapMS = int((time.time() - self._lastPreviewRender) * 1000)
+        delay = 300
+        if elapMS < delay:
+            self._previewTimer = self.mw.progress.timer(
+                delay - elapMS, self._renderScheduledPreview, False
+            )
+        else:
+            self._renderScheduledPreview()
+
+    def _cancelPreviewTimer(self):
+        if self._previewTimer:
+            self._previewTimer.stop()
+            self._previewTimer = None
+
+    def _renderScheduledPreview(self) -> None:
+        self._cancelPreviewTimer()
+        self._lastPreviewRender = time.time()
+
+        if not self._previewWindow:
+            return
+        c = self.parent.card
+        func = "_showQuestion"
+        if not c or not self.parent.singleCard:
+            txt = _("(please select 1 card)")
+            bodyclass = ""
+            self._lastPreviewState = None
+        else:
+            if self._previewBothSides:
+                self._previewState = "answer"
+            elif self._previewCardChanged:
+                self._previewState = "question"
+
+            currentState = self._previewStateAndMod()
+            if currentState == self._lastPreviewState:
+                # nothing has changed, avoid refreshing
+                return
+
+            # need to force reload even if answer
+            txt = c.q(reload=True)
+
+            if self._previewState == "answer":
+                func = "_showAnswer"
+                txt = c.a()
+            txt = re.sub(r"\[\[type:[^]]+\]\]", "", txt)
+
+            bodyclass = theme_manager.body_classes_for_card_ord(c.ord)
+
+            if self.mw.reviewer.autoplay(c):
+                if self._previewBothSides:
+                    # if we're showing both sides at once, remove any audio
+                    # from the answer that's appeared on the question already
+                    question_audio = c.question_av_tags()
+                    only_on_answer_audio = [
+                        x for x in c.answer_av_tags() if x not in question_audio
+                    ]
+                    audio = question_audio + only_on_answer_audio
+                elif self._previewState == "question":
+                    audio = c.question_av_tags()
+                else:
+                    audio = c.answer_av_tags()
+                av_player.play_tags(audio)
+            else:
+                av_player.clear_queue_and_maybe_interrupt()
+
+            txt = self.mw.prepare_card_text_for_display(txt)
+            txt = gui_hooks.card_will_show(
+                txt, c, "preview" + self._previewState.capitalize()
+            )
+            self._lastPreviewState = self._previewStateAndMod()
+        self._updatePreviewButtons()
+        self._previewWeb.eval("{}({},'{}');".format(func, json.dumps(txt), bodyclass))
+        self._previewCardChanged = False
+
+    def _onPreviewShowBothSides(self, toggle):
+        self._previewBothSides = toggle
+        self.mw.col.conf["previewBothSides"] = toggle
+        self.mw.col.setMod()
+        if self._previewState == "answer" and not toggle:
+            self._previewState = "question"
+        self._renderPreview()
+
+    def _previewStateAndMod(self):
+        c = self.parent.card
+        n = c.note()
+        n.load()
+        return (self._previewState, c.id, n.mod)

--- a/qt/aqt/previewer.py
+++ b/qt/aqt/previewer.py
@@ -244,18 +244,24 @@ class BrowserPreviewer(Previewer):
             self._previewState = "question"
             self._renderPreview()
         else:
-            self.parent.editor.saveNow(
-                lambda: self.parent._moveCur(QAbstractItemView.MoveUp)
-            )
+            self._onPreviewPrevCard()
+
+    def _onPreviewPrevCard(self):
+        self.parent.editor.saveNow(
+            lambda: self.parent._moveCur(QAbstractItemView.MoveUp)
+        )
 
     def _onPreviewNext(self):
         if self._previewState == "question":
             self._previewState = "answer"
             self._renderPreview()
         else:
-            self.parent.editor.saveNow(
-                lambda: self.parent._moveCur(QAbstractItemView.MoveDown)
-            )
+            self._onPreviewNextCard()
+
+    def _onPreviewNextCard(self):
+        self.parent.editor.saveNow(
+            lambda: self.parent._moveCur(QAbstractItemView.MoveDown)
+        )
 
     def _updatePreviewButtons(self):
         if not self._previewWindow:

--- a/qt/aqt/previewer.py
+++ b/qt/aqt/previewer.py
@@ -29,7 +29,7 @@ class Previewer:
     _timer = None
 
     def __init__(self, parent: QWidget, mw: AnkiQt):
-        self.parent = parent
+        self._parent = parent
         self.mw = mw
 
     def card(self) -> Optional[Card]:
@@ -258,37 +258,37 @@ class MultipleCardsPreviewer(Previewer):
 
 class BrowserPreviewer(MultipleCardsPreviewer):
     def card(self) -> Optional[Card]:
-        if self.parent.singleCard:
-            return self.parent.card
+        if self._parent.singleCard:
+            return self._parent.card
         else:
             return None
 
     def _onFinished(self, ok):
         super()._onFinished(ok)
-        self.parent.form.previewButton.setChecked(False)
+        self._parent.form.previewButton.setChecked(False)
 
     def _onPrevCard(self):
-        self.parent.editor.saveNow(
-            lambda: self.parent._moveCur(QAbstractItemView.MoveUp)
+        self._parent.editor.saveNow(
+            lambda: self._parent._moveCur(QAbstractItemView.MoveUp)
         )
 
     def _onNextCard(self):
-        self.parent.editor.saveNow(
-            lambda: self.parent._moveCur(QAbstractItemView.MoveDown)
+        self._parent.editor.saveNow(
+            lambda: self._parent._moveCur(QAbstractItemView.MoveDown)
         )
 
     def _should_enable_prev(self):
-        return super()._should_enable_prev() or self.parent.currentRow() > 0
+        return super()._should_enable_prev() or self._parent.currentRow() > 0
 
     def _should_enable_next(self):
         return (
             super()._should_enable_next()
-            or self.parent.currentRow() < self.parent.model.rowCount(None) - 1
+            or self._parent.currentRow() < self._parent.model.rowCount(None) - 1
         )
 
     def _onClose(self):
         super()._onClose()
-        self.parent.previewer = None
+        self._parent.previewer = None
 
     def _renderScheduled(self) -> None:
         super()._renderScheduled()

--- a/qt/aqt/previewer.py
+++ b/qt/aqt/previewer.py
@@ -56,25 +56,25 @@ class Previewer:
 
         self._previewWindow.finished.connect(self._onPreviewFinished)
         self._previewWindow.silentlyClose = True
-        vbox = QVBoxLayout()
-        vbox.setContentsMargins(0, 0, 0, 0)
+        self.vbox = QVBoxLayout()
+        self.vbox.setContentsMargins(0, 0, 0, 0)
         self._previewWeb = AnkiWebView(title="previewer")
-        vbox.addWidget(self._previewWeb)
-        bbox = QDialogButtonBox()
+        self.vbox.addWidget(self._previewWeb)
+        self.bbox = QDialogButtonBox()
 
-        self._previewReplay = bbox.addButton(
+        self._previewReplay = self.bbox.addButton(
             _("Replay Audio"), QDialogButtonBox.ActionRole
         )
         self._previewReplay.setAutoDefault(False)
         self._previewReplay.setShortcut(QKeySequence("R"))
         self._previewReplay.setToolTip(_("Shortcut key: %s" % "R"))
 
-        self._previewPrev = bbox.addButton("<", QDialogButtonBox.ActionRole)
+        self._previewPrev = self.bbox.addButton("<", QDialogButtonBox.ActionRole)
         self._previewPrev.setAutoDefault(False)
         self._previewPrev.setShortcut(QKeySequence("Left"))
         self._previewPrev.setToolTip(_("Shortcut key: Left arrow"))
 
-        self._previewNext = bbox.addButton(">", QDialogButtonBox.ActionRole)
+        self._previewNext = self.bbox.addButton(">", QDialogButtonBox.ActionRole)
         self._previewNext.setAutoDefault(True)
         self._previewNext.setShortcut(QKeySequence("Right"))
         self._previewNext.setToolTip(_("Shortcut key: Right arrow or Enter"))
@@ -86,13 +86,13 @@ class Previewer:
         self.previewShowBothSides = QCheckBox(_("Show Both Sides"))
         self.previewShowBothSides.setShortcut(QKeySequence("B"))
         self.previewShowBothSides.setToolTip(_("Shortcut key: %s" % "B"))
-        bbox.addButton(self.previewShowBothSides, QDialogButtonBox.ActionRole)
+        self.bbox.addButton(self.previewShowBothSides, QDialogButtonBox.ActionRole)
         self._previewBothSides = self.mw.col.conf.get("previewBothSides", False)
         self.previewShowBothSides.setChecked(self._previewBothSides)
         self.previewShowBothSides.toggled.connect(self._onPreviewShowBothSides)
 
-        vbox.addWidget(bbox)
-        self._previewWindow.setLayout(vbox)
+        self.vbox.addWidget(self.bbox)
+        self._previewWindow.setLayout(self.vbox)
         restoreGeom(self._previewWindow, "preview")
 
     def _onPreviewFinished(self, ok):

--- a/qt/aqt/previewer.py
+++ b/qt/aqt/previewer.py
@@ -311,7 +311,15 @@ class BrowserPreviewer(MultipleCardsPreviewer):
 
 
 class ListCardsPreviewer(MultipleCardsPreviewer):
-    def __init__(self, cards: List[Card], *args, **kwargs):
+    def __init__(self, cards: List[Union[Card, int]], *args, **kwargs):
+        """A previewer displaying a list of card.
+
+        List can be changed by setting self.cards to a new value.
+
+        self.cards contains both cid and card. So that card is loaded
+        only when required and is not loaded twice.
+
+        """
         self.index = 0
         self.cards = cards
         super().__init__(*args, **kwargs)
@@ -319,7 +327,9 @@ class ListCardsPreviewer(MultipleCardsPreviewer):
     def card(self):
         if not self.cards:
             return None
-        return self.cards[0]
+        if isinstance(self.cards[self.index], int):
+            self.cards[self.index] = self.mw.col.getCard(self.cards[self.index])
+        return self.cards[self.index]
 
     def _openPreview(self):
         if not self.cards:


### PR DESCRIPTION
The previewer is quite practical. However, it can hardly be used in add-ons right now. So add-ons such as https://ankiweb.net/shared/info/1423933177 by @ijgnd basically needs to extract the previewer code and recreate them in the add-on.
I feel it makes things uselessly complex and it would be far better to have access to the previewer directly from add-on.

I'm not stating that this should be THE way to implement this feature, if you accept it. But I prefer to show some code as a starting point, which can always be changed if anyone has improvements for it.

The first commit simply create a class for the previewer, and ensures the browser uses it. Since the previewer has a lot of features which are related specifically to the browser, I then split the class into two classes. The parent class is the previewer which can be used anywhere, and the subclass deals with the features which are related to the browser. Finally, I added a third class, which is a previewer specially created to display a single card; i.e. exactly what the above-mentioned add-on needs (and what an add-on I'm working on needs too)