### PR TITLE
Use double quotes in taglimit queries

### DIFF
--- a/qt/aqt/taglimit.py
+++ b/qt/aqt/taglimit.py
@@ -93,12 +93,12 @@ class TagLimit(QDialog):
         if yes:
             arr = []
             for req in yes:
-                arr.append("tag:'%s'" % req)
+                arr.append('tag:"%s"' % req)
             self.tags += "(" + " or ".join(arr) + ")"
         if no:
             arr = []
             for req in no:
-                arr.append("-tag:'%s'" % req)
+                arr.append('-tag:"%s"' % req)
             self.tags += " " + " ".join(arr)
         saveGeom(self, "tagLimit")
         QDialog.accept(self)


### PR DESCRIPTION
Is it even necessary to quote tags?
I think it's not possible to create tags containing spaces. Unless maybe through an add-on or the debug console.