### PR TITLE
Deprecated maturin alternative version fix as version 0.8.0 was

### DIFF
--- a/rspy/requirements.txt
+++ b/rspy/requirements.txt
@@ -1,3 +1,1 @@
-# fixme: when maturin fixes 32 bit support, switch back to pypi
-git+https://github.com/dae/maturin#egg=maturin; sys_platform == "linux" and platform_machine != "x86_64"
-maturin; sys_platform != "linux" or platform_machine == "x86_64"
+maturin


### PR DESCRIPTION
Version 0.8.0 was just released within it: 
1. https://github.com/pyo3/maturin/releases
1. https://github.com/PyO3/maturin/issues/289 - Stop passing author.email to python
1. https://github.com/PyO3/maturin/pull/250 - 32 bit Python modules use i386, not x86