### PR TITLE
Remove useless recursion in DeckManager.rem

### DIFF
--- a/pylib/anki/decks.py
+++ b/pylib/anki/decks.py
@@ -150,13 +150,13 @@ class DeckManager:
             self.col.sched.emptyDyn(did)
             if childrenToo:
                 for name, id in self.children(did):
-                    self.rem(id, cardsToo)
+                    self.rem(id, cardsToo, childrenToo=False)
         else:
             # delete children first
             if childrenToo:
                 # we don't want to delete children when syncing
                 for name, id in self.children(did):
-                    self.rem(id, cardsToo)
+                    self.rem(id, cardsToo, childrenToo=False)
             # delete cards too?
             if cardsToo:
                 # don't use cids(), as we want cards in cram decks too


### PR DESCRIPTION
For any deck the children of it's children are its children. So applying rem to children of children is useless and actually slightly costly for deck with deep subdecks. 



I should note also that "def count" counts the default deck even if it is not listed. This is not a problem actually since this method is never called.