### PR TITLE
Added arguments as [sound:filename|argument1 argument2...]

### DIFF
--- a/pylib/anki/media.py
+++ b/pylib/anki/media.py
@@ -36,7 +36,7 @@ CheckMediaResponse = media_pb2.CheckMediaResponse
 
 class MediaManager(DeprecatedNamesMixin):
 
-    sound_regexps = [r"(?i)(\[sound:(?P<fname>[^]]+)\])"]
+    sound_regexps = [r"(?i)(\[sound:(?P<fname>[^\]|]+)(?:\|(?P<args>[^\]]+))?\])"]
     html_media_regexps = [
         # src element quoted case
         r"(?i)(<[img|audio][^>]* src=(?P<str>[\"'])(?P<fname>[^>]+?)(?P=str)[^>]*>)",

--- a/qt/aqt/legacy.py
+++ b/qt/aqt/legacy.py
@@ -47,6 +47,6 @@ def fmtTimeSpan(
 def install_pylib_legacy() -> None:
     anki.utils.bodyClass = bodyClass  # type: ignore
     anki.utils.fmtTimeSpan = fmtTimeSpan  # type: ignore
-    anki.sound._soundReg = r"\[sound:(.+?)\]"  # type: ignore
+    anki.sound._soundReg = r"\[sound:(.+?)(?:\|(.*?))?\]"  # type: ignore
     anki.sound.allSounds = allSounds  # type: ignore
     anki.sound.stripSounds = stripSounds  # type: ignore

--- a/rslib/src/text.rs
+++ b/rslib/src/text.rs
@@ -99,11 +99,13 @@ lazy_static! {
     // videos are also in sound tags
     static ref AV_TAGS: Regex = Regex::new(
         r#"(?xs)
-            \[sound:(.+?)\]     # 1 - the filename in a sound tag
+            \[sound:(?P<soundname>[^\]|]*)
+                (?:\|(?P<soundargs>[^\]]*))?
+            \]
             |
             \[anki:tts\]
-                \[(.*?)\]       # 2 - arguments to tts call
-                (.*?)           # 3 - field text
+                \[(?P<ttsargs>.*?)\]
+                (?P<ttstext>.*?)
             \[/anki:tts\]
             "#).unwrap();
 
@@ -185,11 +187,11 @@ pub fn extract_av_tags(text: &str, question_side: bool) -> (Cow<str>, Vec<AvTag>
     let context = if question_side { 'q' } else { 'a' };
     let replaced_text = AV_TAGS.replace_all(text, |caps: &Captures| {
         // extract
-        let tag = if let Some(av_file) = caps.get(1) {
+        let tag = if let Some(av_file) = caps.name("soundname") {
             AvTag::SoundOrVideo(decode_entities(av_file.as_str()).into())
         } else {
-            let args = caps.get(2).unwrap();
-            let field_text = caps.get(3).unwrap();
+            let args = caps.name("ttsargs").unwrap();
+            let field_text = caps.name("ttstext").unwrap();
             tts_tag_from_string(field_text.as_str(), args.as_str())
         };
         tags.push(tag);
@@ -228,7 +230,7 @@ pub(crate) fn extract_media_refs(text: &str) -> Vec<MediaRef> {
     }
 
     for caps in AV_TAGS.captures_iter(text) {
-        if let Some(m) = caps.get(1) {
+        if let Some(m) = caps.name("soundname") {
             let fname = m.as_str();
             let fname_decoded = decode_entities(fname);
             out.push(MediaRef {

--- a/rslib/src/text.rs
+++ b/rslib/src/text.rs
@@ -194,10 +194,20 @@ pub fn extract_av_tags(text: &str, question_side: bool) -> (Cow<str>, Vec<AvTag>
             let field_text = caps.name("ttstext").unwrap();
             tts_tag_from_string(field_text.as_str(), args.as_str())
         };
-        tags.push(tag);
 
         // and replace with reference
-        format!("[anki:play:{}:{}]", context, tags.len() - 1)
+        if caps.name("soundargs").is_some()
+            && caps
+                .name("soundargs")
+                .unwrap()
+                .as_str()
+                .contains("fileonly")
+        {
+            caps.name("soundname").unwrap().as_str().to_string()
+        } else {
+            tags.push(tag);
+            format!("[anki:play:{}:{}]", context, tags.len() - 1)
+        }
     });
 
     (replaced_text, tags)


### PR DESCRIPTION
Replaces: https://github.com/ankitects/anki/pull/498 Fix media files being marked as unused

Now, we can use the `[sound:file.mp3]` passing arguments to it as `[sound:file.mp3|arg1 arg2]`. For example:
1. I could pass an argument as `[sound:file.mp3|skipautoplay]` to anki does not play it automatically.
1. I can call `mplayer -af scaletempo -speed 0.5 filename.mp3` to play a file with `0.5` speed. The `-af scaletempo` is to `mplayer` do not distort the [audio pitch](https://unix.stackexchange.com/questions/387803/programmatically-change-the-playback-speed-not-pitch-in-real-time), while playing it.

I just do not know how I could use/access the arguments and pass them to `mplayer`. Any suggestions?

Created the argument 'fileonly' to sound, stopping anki from inserting and interpreting the sound tags. If the argument `fileonly` is used as `[sound:file.mp3|fileonly]`, anki will skip processing that file while rendering the card and will replace the `[sound:file.mp3|fileonly]` directly by the sound name `file.mp3`. This allows to completely render the audio by JavaScript, while keeping anki Unused Files checking fully working.
```
// Front
<input type="button" value="♬" onclick="playsound('{{Audio}}', 1.5);" />

<script type="text/javascript">
    var audio;
    function playsound(filename, speed=1.5) {
        if( audio !== undefined) { audio.pause(); }
        audio = new Audio(filename);
        audio.playbackRate = speed;
        audio.play();
    }
    if( !document.getElementById("answer") ) {
         playsound('{{Audio}}', 1.5);
    }
</script>

// Back
<script type="text/javascript">
    playsound('{{Audio}}', 1.5);
</script>
```