### PR TITLE
Sort according to path

### DIFF
--- a/pylib/anki/decks.py
+++ b/pylib/anki/decks.py
@@ -126,7 +126,7 @@ class DeckManager:
             # child of an existing deck then it needs to be renamed
             deck = self.get(did)
             if "::" in deck["name"]:
-                base = deck["name"].split("::")[-1]
+                base = self._path(deck["name"])[-1]
                 suffix = ""
                 while True:
                     # find an unused name
@@ -469,14 +469,14 @@ class DeckManager:
                 self.save(deck)
 
             # ensure no sections are blank
-            if not all(deck["name"].split("::")):
+            if not all(self._path(deck["name"])):
                 self.col.log("fix deck with missing sections", deck["name"])
                 deck["name"] = "recovered%d" % intTime(1000)
                 self.save(deck)
 
             # immediate parent must exist
             if "::" in deck["name"]:
-                immediateParent = "::".join(deck["name"].split("::")[:-1])
+                immediateParent = "::".join(self._path(deck["name"])[:-1])
                 if immediateParent not in names:
                     self.col.log("fix deck with missing parent", deck["name"])
                     self._ensureParents(deck["name"])
@@ -579,7 +579,7 @@ class DeckManager:
             childMap[deck["id"]] = node
 
             # add note to immediate parent
-            parts = deck["name"].split("::")
+            parts = self._path(deck["name"])
             if len(parts) > 1:
                 immediateParent = "::".join(parts[:-1])
                 pid = nameMap[immediateParent]["id"]
@@ -591,7 +591,7 @@ class DeckManager:
         "All parents of did."
         # get parent and grandparent names
         parents: List[str] = []
-        for part in self.get(did)["name"].split("::")[:-1]:
+        for part in self._path(self.get(did)["name"])[:-1]:
             if not parents:
                 parents.append(part)
             else:
@@ -609,7 +609,7 @@ class DeckManager:
         "All existing parents of name"
         if "::" not in name:
             return []
-        names = name.split("::")[:-1]
+        names = self._path(name)[:-1]
         head = []
         parents = []
 

--- a/pylib/anki/decks.py
+++ b/pylib/anki/decks.py
@@ -126,7 +126,7 @@ class DeckManager:
             # child of an existing deck then it needs to be renamed
             deck = self.get(did)
             if "::" in deck["name"]:
-                base = self._basename(deck["name"])
+                base = self.basename(deck["name"])
                 suffix = ""
                 while True:
                     # find an unused name
@@ -261,14 +261,14 @@ class DeckManager:
 
         if ontoDeckDid is None or ontoDeckDid == "":
             if len(self.path(draggedDeckName)) > 1:
-                self.rename(draggedDeck, self._basename(draggedDeckName))
+                self.rename(draggedDeck, self.basename(draggedDeckName))
         elif self._canDragAndDrop(draggedDeckName, ontoDeckName):
             draggedDeck = self.get(draggedDeckDid)
             draggedDeckName = draggedDeck["name"]
             ontoDeckName = self.get(ontoDeckDid)["name"]
             assert ontoDeckName.strip()
             self.rename(
-                draggedDeck, ontoDeckName + "::" + self._basename(draggedDeckName)
+                draggedDeck, ontoDeckName + "::" + self.basename(draggedDeckName)
             )
 
     def _canDragAndDrop(self, draggedDeckName: str, ontoDeckName: str) -> bool:
@@ -283,7 +283,7 @@ class DeckManager:
 
     def _isParent(self, parentDeckName: str, childDeckName: str) -> Any:
         return self.path(childDeckName) == self.path(parentDeckName) + [
-            self._basename(childDeckName)
+            self.basename(childDeckName)
         ]
 
     def _isAncestor(self, ancestorDeckName: str, descendantDeckName: str) -> Any:
@@ -297,8 +297,10 @@ class DeckManager:
     _path = path
 
     @classmethod
-    def _basename(cls, name: str) -> Any:
+    def basename(cls, name: str) -> Any:
         return cls.path(name)[-1]
+
+    _basename = basename
 
     @classmethod
     def key(cls, deck: Dict[str, Any]) -> List[str]:

--- a/pylib/anki/decks.py
+++ b/pylib/anki/decks.py
@@ -126,7 +126,7 @@ class DeckManager:
             # child of an existing deck then it needs to be renamed
             deck = self.get(did)
             if "::" in deck["name"]:
-                base = self.path(deck["name"])[-1]
+                base = self._basename(deck["name"])
                 suffix = ""
                 while True:
                     # find an unused name
@@ -296,8 +296,9 @@ class DeckManager:
 
     _path = path
 
-    def _basename(self, name: str) -> Any:
-        return self.path(name)[-1]
+    @classmethod
+    def _basename(cls, name: str) -> Any:
+        return cls.path(name)[-1]
 
     @classmethod
     def key(cls, deck: Dict[str, Any]) -> List[str]:

--- a/pylib/anki/decks.py
+++ b/pylib/anki/decks.py
@@ -126,7 +126,7 @@ class DeckManager:
             # child of an existing deck then it needs to be renamed
             deck = self.get(did)
             if "::" in deck["name"]:
-                base = self._path(deck["name"])[-1]
+                base = self.path(deck["name"])[-1]
                 suffix = ""
                 while True:
                     # find an unused name
@@ -260,7 +260,7 @@ class DeckManager:
         ontoDeckName = self.get(ontoDeckDid)["name"]
 
         if ontoDeckDid is None or ontoDeckDid == "":
-            if len(self._path(draggedDeckName)) > 1:
+            if len(self.path(draggedDeckName)) > 1:
                 self.rename(draggedDeck, self._basename(draggedDeckName))
         elif self._canDragAndDrop(draggedDeckName, ontoDeckName):
             draggedDeck = self.get(draggedDeckDid)
@@ -282,29 +282,31 @@ class DeckManager:
             return True
 
     def _isParent(self, parentDeckName: str, childDeckName: str) -> Any:
-        return self._path(childDeckName) == self._path(parentDeckName) + [
+        return self.path(childDeckName) == self.path(parentDeckName) + [
             self._basename(childDeckName)
         ]
 
     def _isAncestor(self, ancestorDeckName: str, descendantDeckName: str) -> Any:
-        ancestorPath = self._path(ancestorDeckName)
-        return ancestorPath == self._path(descendantDeckName)[0 : len(ancestorPath)]
+        ancestorPath = self.path(ancestorDeckName)
+        return ancestorPath == self.path(descendantDeckName)[0 : len(ancestorPath)]
 
     @staticmethod
-    def _path(name: str) -> Any:
+    def path(name: str) -> Any:
         return name.split("::")
 
+    _path = path
+
     def _basename(self, name: str) -> Any:
-        return self._path(name)[-1]
+        return self.path(name)[-1]
 
     @classmethod
     def key(cls, deck: Dict[str, Any]) -> List[str]:
-        return cls._path(deck["name"])
+        return cls.path(deck["name"])
 
     def _ensureParents(self, name: str) -> Any:
         "Ensure parents exist, and return name with case matching parents."
         s = ""
-        path = self._path(name)
+        path = self.path(name)
         if len(path) < 2:
             return name
         for p in path[:-1]:
@@ -469,14 +471,14 @@ class DeckManager:
                 self.save(deck)
 
             # ensure no sections are blank
-            if not all(self._path(deck["name"])):
+            if not all(self.path(deck["name"])):
                 self.col.log("fix deck with missing sections", deck["name"])
                 deck["name"] = "recovered%d" % intTime(1000)
                 self.save(deck)
 
             # immediate parent must exist
             if "::" in deck["name"]:
-                immediateParent = "::".join(self._path(deck["name"])[:-1])
+                immediateParent = "::".join(self.path(deck["name"])[:-1])
                 if immediateParent not in names:
                     self.col.log("fix deck with missing parent", deck["name"])
                     self._ensureParents(deck["name"])
@@ -579,7 +581,7 @@ class DeckManager:
             childMap[deck["id"]] = node
 
             # add note to immediate parent
-            parts = self._path(deck["name"])
+            parts = self.path(deck["name"])
             if len(parts) > 1:
                 immediateParent = "::".join(parts[:-1])
                 pid = nameMap[immediateParent]["id"]
@@ -591,7 +593,7 @@ class DeckManager:
         "All parents of did."
         # get parent and grandparent names
         parents: List[str] = []
-        for part in self._path(self.get(did)["name"])[:-1]:
+        for part in self.path(self.get(did)["name"])[:-1]:
             if not parents:
                 parents.append(part)
             else:
@@ -609,7 +611,7 @@ class DeckManager:
         "All existing parents of name"
         if "::" not in name:
             return []
-        names = self._path(name)[:-1]
+        names = self.path(name)[:-1]
         head = []
         parents = []
 

--- a/pylib/anki/decks.py
+++ b/pylib/anki/decks.py
@@ -303,6 +303,10 @@ class DeckManager:
     _basename = basename
 
     @classmethod
+    def immediate_parent_path(cls, name: str) -> Any:
+        return cls._path(name)[:-1]
+
+    @classmethod
     def key(cls, deck: Dict[str, Any]) -> List[str]:
         return cls.path(deck["name"])
 
@@ -481,7 +485,7 @@ class DeckManager:
 
             # immediate parent must exist
             if "::" in deck["name"]:
-                immediateParent = "::".join(self.path(deck["name"])[:-1])
+                immediateParent = "::".join(self.immediate_parent_path(deck["name"]))
                 if immediateParent not in names:
                     self.col.log("fix deck with missing parent", deck["name"])
                     self._ensureParents(deck["name"])
@@ -584,9 +588,9 @@ class DeckManager:
             childMap[deck["id"]] = node
 
             # add note to immediate parent
-            parts = self.path(deck["name"])
-            if len(parts) > 1:
-                immediateParent = "::".join(parts[:-1])
+            immediate_parent_path = self.immediate_parent_path(deck["name"])
+            if immediate_parent_path:
+                immediateParent = "::".join(immediate_parent_path)
                 pid = nameMap[immediateParent]["id"]
                 childMap[pid][deck["id"]] = node
 
@@ -596,7 +600,7 @@ class DeckManager:
         "All parents of did."
         # get parent and grandparent names
         parents: List[str] = []
-        for part in self.path(self.get(did)["name"])[:-1]:
+        for part in self.immediate_parent_path(self.get(did)["name"]):
             if not parents:
                 parents.append(part)
             else:
@@ -614,7 +618,7 @@ class DeckManager:
         "All existing parents of name"
         if "::" not in name:
             return []
-        names = self.path(name)[:-1]
+        names = self.immediate_parent_path(name)
         head = []
         parents = []
 

--- a/pylib/anki/decks.py
+++ b/pylib/anki/decks.py
@@ -307,6 +307,12 @@ class DeckManager:
         return cls._path(name)[:-1]
 
     @classmethod
+    def immediate_parent(cls, name: str) -> Any:
+        pp = cls.immediate_parent_path(name)
+        if pp:
+            return "::".join(pp)
+
+    @classmethod
     def key(cls, deck: Dict[str, Any]) -> List[str]:
         return cls.path(deck["name"])
 
@@ -485,7 +491,7 @@ class DeckManager:
 
             # immediate parent must exist
             if "::" in deck["name"]:
-                immediateParent = "::".join(self.immediate_parent_path(deck["name"]))
+                immediateParent = self.immediate_parent(deck["name"])
                 if immediateParent not in names:
                     self.col.log("fix deck with missing parent", deck["name"])
                     self._ensureParents(deck["name"])
@@ -588,9 +594,8 @@ class DeckManager:
             childMap[deck["id"]] = node
 
             # add note to immediate parent
-            immediate_parent_path = self.immediate_parent_path(deck["name"])
-            if immediate_parent_path:
-                immediateParent = "::".join(immediate_parent_path)
+            immediateParent = self.immediate_parent(deck["name"])
+            if immediateParent is not None:
                 pid = nameMap[immediateParent]["id"]
                 childMap[pid][deck["id"]] = node
 

--- a/pylib/anki/decks.py
+++ b/pylib/anki/decks.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 import copy
 import json
-import operator
 import unicodedata
 from typing import Any, Dict, List, Optional, Set, Tuple, Union
 
@@ -298,6 +297,10 @@ class DeckManager:
     def _basename(self, name: str) -> Any:
         return self._path(name)[-1]
 
+    @classmethod
+    def key(cls, deck: Dict[str, Any]) -> List[str]:
+        return cls._path(deck["name"])
+
     def _ensureParents(self, name: str) -> Any:
         "Ensure parents exist, and return name with case matching parents."
         s = ""
@@ -455,7 +458,7 @@ class DeckManager:
 
     def _checkDeckTree(self) -> None:
         decks = self.col.decks.all()
-        decks.sort(key=operator.itemgetter("name"))
+        decks.sort(key=self.key)
         names: Set[str] = set()
 
         for deck in decks:
@@ -571,7 +574,7 @@ class DeckManager:
         childMap = {}
 
         # go through all decks, sorted by name
-        for deck in sorted(self.all(), key=operator.itemgetter("name")):
+        for deck in sorted(self.all(), key=self.key):
             node: Dict[int, Any] = {}
             childMap[deck["id"]] = node
 

--- a/pylib/anki/decks.py
+++ b/pylib/anki/decks.py
@@ -291,7 +291,8 @@ class DeckManager:
         ancestorPath = self._path(ancestorDeckName)
         return ancestorPath == self._path(descendantDeckName)[0 : len(ancestorPath)]
 
-    def _path(self, name: str) -> Any:
+    @staticmethod
+    def _path(name: str) -> Any:
         return name.split("::")
 
     def _basename(self, name: str) -> Any:

--- a/pylib/anki/importing/anki2.py
+++ b/pylib/anki/importing/anki2.py
@@ -264,7 +264,7 @@ class Anki2Importer(Importer):
                 name += "::" + tmpname
         # manually create any parents so we can pull in descriptions
         head = ""
-        for parent in DeckManager.path(name)[:-1]:
+        for parent in DeckManager.immediate_parent_path(name):
             if head:
                 head += "::"
             head += parent

--- a/pylib/anki/importing/anki2.py
+++ b/pylib/anki/importing/anki2.py
@@ -7,6 +7,7 @@ from typing import Any, Dict, List, Optional, Tuple
 
 from anki.collection import _Collection
 from anki.consts import *
+from anki.decks import DeckManager
 from anki.importing.base import Importer
 from anki.lang import _
 from anki.storage import Collection
@@ -257,13 +258,13 @@ class Anki2Importer(Importer):
         name = g["name"]
         # if there's a prefix, replace the top level deck
         if self.deckPrefix:
-            tmpname = "::".join(name.split("::")[1:])
+            tmpname = "::".join(DeckManager._path(name)[1:])
             name = self.deckPrefix
             if tmpname:
                 name += "::" + tmpname
         # manually create any parents so we can pull in descriptions
         head = ""
-        for parent in name.split("::")[:-1]:
+        for parent in DeckManager._path(name)[:-1]:
             if head:
                 head += "::"
             head += parent

--- a/pylib/anki/importing/anki2.py
+++ b/pylib/anki/importing/anki2.py
@@ -258,13 +258,13 @@ class Anki2Importer(Importer):
         name = g["name"]
         # if there's a prefix, replace the top level deck
         if self.deckPrefix:
-            tmpname = "::".join(DeckManager._path(name)[1:])
+            tmpname = "::".join(DeckManager.path(name)[1:])
             name = self.deckPrefix
             if tmpname:
                 name += "::" + tmpname
         # manually create any parents so we can pull in descriptions
         head = ""
-        for parent in DeckManager._path(name)[:-1]:
+        for parent in DeckManager.path(name)[:-1]:
             if head:
                 head += "::"
             head += parent

--- a/pylib/anki/sched.py
+++ b/pylib/anki/sched.py
@@ -153,18 +153,11 @@ class Scheduler(V2):
         lims: Dict[str, List[int]] = {}
         data = []
 
-        def parent(name):
-            parts = DeckManager.path(name)
-            if len(parts) < 2:
-                return None
-            parts = parts[:-1]
-            return "::".join(parts)
-
         for deck in decks:
-            p = parent(deck["name"])
+            p = DeckManager.immediate_parent(deck["name"])
             # new
             nlim = self._deckNewLimitSingle(deck)
-            if p:
+            if p is not None:
                 nlim = min(nlim, lims[p][0])
             new = self._newForDeck(deck["id"], nlim)
             # learning

--- a/pylib/anki/sched.py
+++ b/pylib/anki/sched.py
@@ -14,6 +14,7 @@ import anki
 from anki import hooks
 from anki.cards import Card
 from anki.consts import *
+from anki.decks import DeckManager
 from anki.schedv2 import Scheduler as V2
 from anki.utils import ids2str, intTime
 
@@ -153,7 +154,7 @@ class Scheduler(V2):
         data = []
 
         def parent(name):
-            parts = name.split("::")
+            parts = DeckManager._path(name)
             if len(parts) < 2:
                 return None
             parts = parts[:-1]

--- a/pylib/anki/sched.py
+++ b/pylib/anki/sched.py
@@ -154,7 +154,7 @@ class Scheduler(V2):
         data = []
 
         def parent(name):
-            parts = DeckManager._path(name)
+            parts = DeckManager.path(name)
             if len(parts) < 2:
                 return None
             parts = parts[:-1]

--- a/pylib/anki/schedv2.py
+++ b/pylib/anki/schedv2.py
@@ -240,19 +240,12 @@ order by due"""
         lims: Dict[str, List[int]] = {}
         data = []
 
-        def parent(name):
-            parts = DeckManager.path(name)
-            if len(parts) < 2:
-                return None
-            parts = parts[:-1]
-            return "::".join(parts)
-
         childMap = self.col.decks.childMap()
         for deck in decks:
-            p = parent(deck["name"])
+            p = DeckManager.immediate_parent(deck["name"])
             # new
             nlim = self._deckNewLimitSingle(deck)
-            if p:
+            if p is not None:
                 nlim = min(nlim, lims[p][0])
             new = self._newForDeck(deck["id"], nlim)
             # learning

--- a/pylib/anki/schedv2.py
+++ b/pylib/anki/schedv2.py
@@ -241,7 +241,7 @@ order by due"""
         data = []
 
         def parent(name):
-            parts = DeckManager._path(name)
+            parts = DeckManager.path(name)
             if len(parts) < 2:
                 return None
             parts = parts[:-1]
@@ -280,7 +280,7 @@ order by due"""
     def _groupChildren(self, grps: List[List[Any]]) -> Any:
         # first, split the group names into components
         for g in grps:
-            g[0] = DeckManager._path(g[0])
+            g[0] = DeckManager.path(g[0])
         # and sort based on those components
         grps.sort(key=itemgetter(0))
         # then run main function

--- a/pylib/anki/schedv2.py
+++ b/pylib/anki/schedv2.py
@@ -16,6 +16,7 @@ import anki  # pylint: disable=unused-import
 from anki import hooks
 from anki.cards import Card
 from anki.consts import *
+from anki.decks import DeckManager
 from anki.lang import _
 from anki.rsbackend import FormatTimeSpanContext, SchedTimingToday
 from anki.utils import ids2str, intTime
@@ -240,7 +241,7 @@ order by due"""
         data = []
 
         def parent(name):
-            parts = name.split("::")
+            parts = DeckManager._path(name)
             if len(parts) < 2:
                 return None
             parts = parts[:-1]
@@ -279,7 +280,7 @@ order by due"""
     def _groupChildren(self, grps: List[List[Any]]) -> Any:
         # first, split the group names into components
         for g in grps:
-            g[0] = g[0].split("::")
+            g[0] = DeckManager._path(g[0])
         # and sort based on those components
         grps.sort(key=itemgetter(0))
         # then run main function

--- a/pylib/anki/template.py
+++ b/pylib/anki/template.py
@@ -154,7 +154,7 @@ def fields_for_rendering(
     fields["Tags"] = note.stringTags().strip()
     fields["Type"] = card.note_type()["name"]
     fields["Deck"] = col.decks.name(card.odid or card.did)
-    fields["Subdeck"] = DeckManager.path(fields["Deck"])[-1]
+    fields["Subdeck"] = DeckManager._basename(fields["Deck"])
     fields["Card"] = card.template()["name"]
     flag = card.userFlag()
     fields["CardFlag"] = flag and f"flag{flag}" or ""

--- a/pylib/anki/template.py
+++ b/pylib/anki/template.py
@@ -34,6 +34,7 @@ from typing import Any, Dict, List, Optional, Tuple
 import anki
 from anki import hooks
 from anki.cards import Card
+from anki.decks import DeckManager
 from anki.models import NoteType
 from anki.notes import Note
 from anki.rsbackend import TemplateReplacementList
@@ -153,7 +154,7 @@ def fields_for_rendering(
     fields["Tags"] = note.stringTags().strip()
     fields["Type"] = card.note_type()["name"]
     fields["Deck"] = col.decks.name(card.odid or card.did)
-    fields["Subdeck"] = fields["Deck"].split("::")[-1]
+    fields["Subdeck"] = DeckManager._path(fields["Deck"])[-1]
     fields["Card"] = card.template()["name"]
     flag = card.userFlag()
     fields["CardFlag"] = flag and f"flag{flag}" or ""

--- a/pylib/anki/template.py
+++ b/pylib/anki/template.py
@@ -154,7 +154,7 @@ def fields_for_rendering(
     fields["Tags"] = note.stringTags().strip()
     fields["Type"] = card.note_type()["name"]
     fields["Deck"] = col.decks.name(card.odid or card.did)
-    fields["Subdeck"] = DeckManager._path(fields["Deck"])[-1]
+    fields["Subdeck"] = DeckManager.path(fields["Deck"])[-1]
     fields["Card"] = card.template()["name"]
     flag = card.userFlag()
     fields["CardFlag"] = flag and f"flag{flag}" or ""

--- a/pylib/anki/template.py
+++ b/pylib/anki/template.py
@@ -154,7 +154,7 @@ def fields_for_rendering(
     fields["Tags"] = note.stringTags().strip()
     fields["Type"] = card.note_type()["name"]
     fields["Deck"] = col.decks.name(card.odid or card.did)
-    fields["Subdeck"] = DeckManager._basename(fields["Deck"])
+    fields["Subdeck"] = DeckManager.basename(fields["Deck"])
     fields["Card"] = card.template()["name"]
     flag = card.userFlag()
     fields["CardFlag"] = flag and f"flag{flag}" or ""

--- a/qt/aqt/browser.py
+++ b/qt/aqt/browser.py
@@ -1303,7 +1303,7 @@ QTableView {{ gridline-color: {grid} }}
         def addDecks(parent, decks):
             for head, did, rev, lrn, new, children in decks:
                 name = self.mw.col.decks.get(did)["name"]
-                shortname = DeckManager._path(name)[-1]
+                shortname = DeckManager.path(name)[-1]
                 if children:
                     subm = parent.addMenu(shortname)
                     subm.addItem(_("Filter"), self._filterFunc("deck", name))

--- a/qt/aqt/browser.py
+++ b/qt/aqt/browser.py
@@ -1303,7 +1303,7 @@ QTableView {{ gridline-color: {grid} }}
         def addDecks(parent, decks):
             for head, did, rev, lrn, new, children in decks:
                 name = self.mw.col.decks.get(did)["name"]
-                shortname = DeckManager.path(name)[-1]
+                shortname = DeckManager._basename(name)
                 if children:
                     subm = parent.addMenu(shortname)
                     subm.addItem(_("Filter"), self._filterFunc("deck", name))

--- a/qt/aqt/browser.py
+++ b/qt/aqt/browser.py
@@ -20,6 +20,7 @@ from anki import hooks
 from anki.cards import Card
 from anki.collection import _Collection
 from anki.consts import *
+from anki.decks import DeckManager
 from anki.lang import _, ngettext
 from anki.models import NoteType
 from anki.notes import Note
@@ -1302,7 +1303,7 @@ QTableView {{ gridline-color: {grid} }}
         def addDecks(parent, decks):
             for head, did, rev, lrn, new, children in decks:
                 name = self.mw.col.decks.get(did)["name"]
-                shortname = name.split("::")[-1]
+                shortname = DeckManager._path(name)[-1]
                 if children:
                     subm = parent.addMenu(shortname)
                     subm.addItem(_("Filter"), self._filterFunc("deck", name))

--- a/qt/aqt/browser.py
+++ b/qt/aqt/browser.py
@@ -1303,7 +1303,7 @@ QTableView {{ gridline-color: {grid} }}
         def addDecks(parent, decks):
             for head, did, rev, lrn, new, children in decks:
                 name = self.mw.col.decks.get(did)["name"]
-                shortname = DeckManager._basename(name)
+                shortname = DeckManager.basename(name)
                 if children:
                     subm = parent.addMenu(shortname)
                     subm.addItem(_("Filter"), self._filterFunc("deck", name))

--- a/qt/aqt/studydeck.py
+++ b/qt/aqt/studydeck.py
@@ -3,6 +3,7 @@
 # License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
 import aqt
+from anki.decks import DeckManager
 from anki.lang import _
 from aqt import gui_hooks
 from aqt.qt import *
@@ -51,7 +52,10 @@ class StudyDeck(QDialog):
         if title:
             self.setWindowTitle(title)
         if not names:
-            names = sorted(self.mw.col.decks.allNames(dyn=dyn, force_default=False))
+            names = sorted(
+                self.mw.col.decks.allNames(dyn=dyn, force_default=False),
+                key=DeckManager._path,
+            )
             self.nameFunc = None
             self.origNames = names
         else:


### PR DESCRIPTION
Here is a bug and it's correction.
![2020-04-06-231008_130x100_scrot](https://user-images.githubusercontent.com/357361/78605425-c9ba2c80-785b-11ea-9ab8-aea884a7fe81.png)
On the left, the deck browser. On the right, the list of deck (in wrong order)
![2020-04-06-224729_131x111_scrot](https://user-images.githubusercontent.com/357361/78603869-2536eb00-7859-11ea-8855-d08553d07bd8.png)
On the right, the list of deck in correct order.

The error was that the keys used for sorting was the string, and not the path. :: was sorted between 9 and A.

The first commit allows _path to easily be used outside of this class. The second uses the correct key everywhere. You may want to merge those two and ignore the remainings, if you prefer short commits.
The other ones simply uses methods everywhere where it is possible, in order to avoid code redundancy and to increase clarity. It makes methods static, so that they can be used easily outside of the deck manager.

One reason why it would help me to have the first two commits merged is that ankidroid is trying to be as close as possible to Anki. I'm trying to increase ankidroid speed and codebase and it would be so much simple for me if I just could ensure that a single sorting function were used everywhere (because, yes, currently, ankidroid has two sorting functions for decks and at first, I didn't understand why)