### PR TITLE
strip HTML when displaying deck names in non-web

### DIFF
--- a/pylib/anki/utils.py
+++ b/pylib/anki/utils.py
@@ -56,7 +56,7 @@ def fmtFloat(float_value, point=1) -> str:
 reComment = re.compile("(?s)<!--.*?-->")
 reStyle = re.compile("(?si)<style.*?>.*?</style>")
 reScript = re.compile("(?si)<script.*?>.*?</script>")
-reTag = re.compile("(?s)<.*?>")
+reTag = re.compile(r"(?s)<[^>\s].*?>")
 reEnts = re.compile(r"&#?\w+;")
 reMedia = re.compile("(?i)<img[^>]+src=[\"']?([^\"'>]+)[\"']?[^>]*>")
 

--- a/qt/aqt/browser.py
+++ b/qt/aqt/browser.py
@@ -24,7 +24,7 @@ from anki.lang import _, ngettext
 from anki.models import NoteType
 from anki.notes import Note
 from anki.rsbackend import TR
-from anki.utils import htmlToTextLine, ids2str, intTime, isMac, isWin
+from anki.utils import htmlToTextLine, ids2str, intTime, isMac, isWin, stripHTML
 from aqt import AnkiQt, gui_hooks
 from aqt.editor import Editor
 from aqt.exporting import ExportDialog
@@ -1154,7 +1154,7 @@ QTableView {{ gridline-color: {grid} }}
 
                         continue
                 item = SidebarItem(
-                    g[0],
+                    stripHTML(g[0]),
                     ":/icons/deck.svg",
                     lambda g=g: self.setFilter("deck", head + g[0]),
                     lambda expanded, g=g: self.mw.col.decks.collapseBrowser(g[1]),

--- a/qt/aqt/deckchooser.py
+++ b/qt/aqt/deckchooser.py
@@ -3,6 +3,7 @@
 # License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
 from anki.lang import _
+from anki.utils import stripHTML
 from aqt import gui_hooks
 from aqt.qt import *
 from aqt.utils import shortcut
@@ -92,7 +93,7 @@ class DeckChooser(QHBoxLayout):
             self.setDeckName(ret.name)
 
     def setDeckName(self, name):
-        self.deck.setText(name.replace("&", "&&"))
+        self.deck.setText(stripHTML(name).replace("&", "&&"))
         self._deckName = name
 
     def deckName(self):

--- a/qt/aqt/studydeck.py
+++ b/qt/aqt/studydeck.py
@@ -4,6 +4,7 @@
 
 import aqt
 from anki.lang import _
+from anki.utils import stripHTML
 from aqt import gui_hooks
 from aqt.qt import *
 from aqt.utils import getOnlyText, openHelp, restoreGeom, saveGeom, shortcut, showInfo
@@ -92,9 +93,10 @@ class StudyDeck(QDialog):
         self.filt = filt
         self.focus = focus
         self.names = [n for n in self.origNames if self._matches(n, filt)]
+        self.view_names = [stripHTML(n) for n in self.names]
         l = self.form.list
         l.clear()
-        l.addItems(self.names)
+        l.addItems(self.view_names)
         if focus in self.names:
             idx = self.names.index(focus)
         else:


### PR DESCRIPTION
This PR will let users have html tags in deck names, and not get those html tags to show up in deck chooser and in browser.

Potential use cases are to bold/italicize deck names in the overview, or to put a d-day countdown script.
