### PR TITLE
add clear actions to context menu in debug console

### DIFF
--- a/qt/aqt/main.py
+++ b/qt/aqt/main.py
@@ -1362,11 +1362,11 @@ will be lost. Continue?"""
             menu = frm.log.createStandardContextMenu(QCursor.pos())
             menu.addSeparator()
             if name == "log":
-                a = menu.addAction(_("Clear Log"))
+                a = menu.addAction("Clear Log")
                 a.setShortcuts(QKeySequence("ctrl+l"))
                 qconnect(a.triggered, frm.log.clear)
             elif name == "text":
-                a = menu.addAction(_("Clear Code"))
+                a = menu.addAction("Clear Code")
                 a.setShortcuts(QKeySequence("ctrl+shift+l"))
                 qconnect(a.triggered, frm.text.clear)
             menu.exec(QCursor.pos())

--- a/qt/aqt/main.py
+++ b/qt/aqt/main.py
@@ -1356,6 +1356,23 @@ will be lost. Continue?"""
         s.activated.connect(frm.log.clear)
         s = self.debugDiagShort = QShortcut(QKeySequence("ctrl+shift+l"), d)
         s.activated.connect(frm.text.clear)
+
+        def addContextMenu(ev: QCloseEvent, name: str) -> None:
+            ev.accept()
+            menu = frm.log.createStandardContextMenu(QCursor.pos())
+            menu.addSeparator()
+            if name == "log":
+                a = menu.addAction(_("Clear Log"))
+                a.setShortcuts(QKeySequence("ctrl+l"))
+                qconnect(a.triggered, frm.log.clear)
+            elif name == "text":
+                a = menu.addAction(_("Clear Code"))
+                a.setShortcuts(QKeySequence("ctrl+shift+l"))
+                qconnect(a.triggered, frm.text.clear)
+            menu.exec(QCursor.pos())
+
+        frm.log.contextMenuEvent = lambda ev: addContextMenu(ev, "log")
+        frm.text.contextMenuEvent = lambda ev: addContextMenu(ev, "text")
         gui_hooks.debug_console_will_show(d)
         d.show()
 


### PR DESCRIPTION
Adds "Clear Log" and "Clear Code" context menu to the debug console, because it's really not obvious that the hotkeys exist. 