### PR TITLE
Include self

### DIFF
--- a/pylib/anki/decks.py
+++ b/pylib/anki/decks.py
@@ -601,11 +601,18 @@ class DeckManager:
 
         return childMap
 
-    def parents(self, did: int, nameMap: Optional[Any] = None) -> List:
+    def parents(
+        self, did: int, nameMap: Optional[Any] = None, include_self: bool = False
+    ) -> List:
         "All parents of did."
         # get parent and grandparent names
+        name = self.get(did)["name"]
+        if include_self:
+            path = self.path(name)
+        else:
+            path = self.immediate_parent_path(name)
         parents: List[str] = []
-        for part in self.immediate_parent_path(self.get(did)["name"]):
+        for part in path:
             if not parents:
                 parents.append(part)
             else:

--- a/pylib/anki/decks.py
+++ b/pylib/anki/decks.py
@@ -559,7 +559,7 @@ class DeckManager:
         self.col.conf["curDeck"] = did
         # and active decks (current + all children)
         actv = self.children(did, include_self=True)
-        actv.sort()
+        actv.sort(key=lambda name_id: self.path(name_id[0]))
         self.col.conf["activeDecks"] = [id for name, id in actv]
         self.col.setMod()
 

--- a/pylib/anki/exporting.py
+++ b/pylib/anki/exporting.py
@@ -171,7 +171,7 @@ class AnkiExporter(Exporter):
         if self.cids:
             return self.col.decks.for_card_ids(self.cids)
         elif self.did:
-            return [self.did] + [x[1] for x in self.src.decks.children(self.did)]
+            return [x[1] for x in self.src.decks.children(self.did, include_self=True)]
         else:
             return []
 

--- a/pylib/anki/schedv2.py
+++ b/pylib/anki/schedv2.py
@@ -175,19 +175,19 @@ order by due"""
 
     def _updateStats(self, card: Card, type: str, cnt: int = 1) -> None:
         key = type + "Today"
-        for g in [self.col.decks.get(card.did)] + self.col.decks.parents(card.did):
+        for g in self.col.decks.parents(card.did, include_self=True):
             # add
             g[key][1] += cnt
             self.col.decks.save(g)
 
     def extendLimits(self, new: int, rev: int) -> None:
         cur = self.col.decks.current()
-        parents = self.col.decks.parents(cur["id"])
+        parents = self.col.decks.parents(cur["id"], include_self=True)
         children = [
             self.col.decks.get(did)
             for (name, did) in self.col.decks.children(cur["id"])
         ]
-        for g in [cur] + parents + children:
+        for g in parents + children:
             # add
             g["newToday"][1] -= new
             g["revToday"][1] -= rev
@@ -441,10 +441,9 @@ did = ? and queue = {QUEUE_TYPE_NEW} limit ?)""",
     ) -> int:
         if not fn:
             fn = self._deckNewLimitSingle
-        sel = self.col.decks.get(did)
         lim = -1
         # for the deck and each of its parents
-        for g in [sel] + self.col.decks.parents(did):
+        for g in self.col.decks.parents(did, include_self=True):
             rem = fn(g)
             if lim == -1:
                 lim = rem

--- a/pylib/anki/tags.py
+++ b/pylib/anki/tags.py
@@ -66,9 +66,7 @@ class TagManager:
             query = basequery + " AND c.did=?"
             res = self.col.db.list(query, did)
             return list(set(self.split(" ".join(res))))
-        dids = [did]
-        for name, id in self.col.decks.children(did):
-            dids.append(id)
+        dids = [id for name, id in self.col.decks.children(did, include_self=True)]
         query = basequery + " AND c.did IN " + ids2str(dids)
         res = self.col.db.list(query)
         return list(set(self.split(" ".join(res))))

--- a/qt/aqt/deckbrowser.py
+++ b/qt/aqt/deckbrowser.py
@@ -292,7 +292,7 @@ where id > ?""",
         self.mw.checkpoint(_("Delete Deck"))
         deck = self.mw.col.decks.get(did)
         if not deck["dyn"]:
-            dids = [did] + [r[1] for r in self.mw.col.decks.children(did)]
+            dids = [r[1] for r in self.mw.col.decks.children(did, include_self=True)]
             cnt = self.mw.col.db.scalar(
                 "select count() from cards where did in {0} or "
                 "odid in {0}".format(ids2str(dids))


### PR DESCRIPTION
The last commit is related to https://github.com/ankitects/anki/pull/543 ; there was one place where I missed that sorting should not use alphabetical order: when you select in which order you review cards of subdecks.

The other two commits does not change any feature. As an add-on dev', it's a simple change that would sometime be easier to use and leads to more readable code according to my taste. Often, when we compute the list of parents/children of a deck D, we add D to the result. This adds an option to automatically adds it in the returned result. 
As a mathematician, I would simply states that I am allowing replacing "less than" by "less than or equal to" in the "parent" order