### PR TITLE
Improve fill lrn

### DIFF
--- a/pylib/anki/sched.py
+++ b/pylib/anki/sched.py
@@ -281,14 +281,13 @@ and due <= ? limit %d"""
             f"""
 select due, id from cards where
 did in %s and queue = {QUEUE_TYPE_LRN} and due < ?
+order by due ASC, id ASC
 limit %d"""
             % (self._deckLimit(), self.reportLimit),
             self.dayCutoff,
         )
         for i in range(len(self._lrnQueue)):
             self._lrnQueue[i] = (self._lrnQueue[i][0], self._lrnQueue[i][1])
-        # as it arrives sorted by did first, we need to sort it
-        self._lrnQueue.sort()
         return self._lrnQueue
 
     def _getLrnCard(self, collapse: bool = False) -> Optional[Card]:

--- a/pylib/anki/sched.py
+++ b/pylib/anki/sched.py
@@ -282,9 +282,10 @@ and due <= ? limit %d"""
 select due, id from cards where
 did in %s and queue = {QUEUE_TYPE_LRN} and due < ?
 order by due ASC, id ASC
-limit %d"""
-            % (self._deckLimit(), self.reportLimit),
+limit ?"""
+            % self._deckLimit(),
             self.dayCutoff,
+            self.reportLimit,
         )
         for i in range(len(self._lrnQueue)):
             self._lrnQueue[i] = (self._lrnQueue[i][0], self._lrnQueue[i][1])

--- a/pylib/anki/schedv2.py
+++ b/pylib/anki/schedv2.py
@@ -544,9 +544,10 @@ select count() from cards where did in %s and queue = {QUEUE_TYPE_PREVIEW}
 select due, id from cards where
 did in %s and queue in ({QUEUE_TYPE_LRN},{QUEUE_TYPE_PREVIEW}) and due < ?
 order by due ASC, id ASC
-limit %d """
-            % (self._deckLimit(), self.reportLimit),
+limit ? """
+            % self._deckLimit(),
             cutoff,
+            self.reportLimit,
         )
         for i in range(len(self._lrnQueue)):
             self._lrnQueue[i] = (self._lrnQueue[i][0], self._lrnQueue[i][1])

--- a/pylib/anki/schedv2.py
+++ b/pylib/anki/schedv2.py
@@ -543,14 +543,13 @@ select count() from cards where did in %s and queue = {QUEUE_TYPE_PREVIEW}
             f"""
 select due, id from cards where
 did in %s and queue in ({QUEUE_TYPE_LRN},{QUEUE_TYPE_PREVIEW}) and due < ?
-limit %d"""
+order by due ASC, id ASC
+limit %d """
             % (self._deckLimit(), self.reportLimit),
             cutoff,
         )
         for i in range(len(self._lrnQueue)):
             self._lrnQueue[i] = (self._lrnQueue[i][0], self._lrnQueue[i][1])
-        # as it arrives sorted by did first, we need to sort it
-        self._lrnQueue.sort()
         return self._lrnQueue
 
     def _getLrnCard(self, collapse: bool = False) -> Optional[Card]:


### PR DESCRIPTION
Either I am missing something fundamental, or there is a really simple speed improvement to Anki. Sorting in queries instead of sorting in python.

I believe I may miss something, because I have no clue why the comment states that cards are sorted according to their did, which does not seems to be required at all by the current code.

To be clear, the reason why I care about this PR is that if you accept it, then I can do the same PR in AnkiDroid; and AnkiDroid loose a lot ot time sorting this list; so this would be a noticeable improvement for me. (It spends actually more than one second on my phone and collection just to sort the _lrnQueue)

Note that there is a difference when the query returns more than self.reportLimit cards (i.e. 1000 cards in learning mode in a deck), since the set of cards won't be the same. But it means that the in this case, my PR will gives back cards with the smallest due instead of random cards in learning mode and already due. In practice, I hope noone has 1000 cards in learning mode, so that it won't change anything for anyone