### PR TITLE
apply color to reviewer buttons

### DIFF
--- a/qt/aqt/reviewer.py
+++ b/qt/aqt/reviewer.py
@@ -621,14 +621,14 @@ time = %(time)d;
             return 2
 
     def _answerButtonList(self) -> Sequence[Tuple[int, str]]:
-        l = ((1, _("Again")),)
+        l = ((1, "Again"),)
         cnt = self.mw.col.sched.answerButtons(self.card)
         if cnt == 2:
-            return l + ((2, _("Good")),)
+            return l + ((2, "Good"),)
         elif cnt == 3:
-            return l + ((2, _("Good")), (3, _("Easy")))
+            return l + ((2, "Good"), (3, "Easy"))
         else:
-            return l + ((2, _("Hard")), (3, _("Good")), (4, _("Easy")))
+            return l + ((2, "Hard"), (3, "Good"), (4, "Easy"))
 
     def _answerButtons(self) -> str:
         default = self._defaultEase()
@@ -640,14 +640,15 @@ time = %(time)d;
                 extra = ""
             due = self._buttonTime(i)
             return """
-<td align=center>%s<button %s title="%s" data-ease="%s" onclick='pycmd("ease%d");'>\
+<td align=center>%s<button %s class="%s" title="%s" data-ease="%s" onclick='pycmd("ease%d");'>\
 %s</button></td>""" % (
                 due,
                 extra,
+                label.lower(),
                 _("Shortcut key: %s") % i,
                 i,
                 i,
-                label,
+                _(label),
             )
 
         buf = "<center><table cellpading=0 cellspacing=0><tr>"

--- a/qt/ts/scss/_buttons.scss
+++ b/qt/ts/scss/_buttons.scss
@@ -23,6 +23,40 @@
   }
 }
 
+button.again {
+  color:vars.$day-button-again;
+}
+
+button.hard{
+  color: vars.$day-button-hard;
+}
+
+button.good {
+  color:vars.$day-button-good;
+}
+
+button.easy{
+  color: vars.$day-button-easy;
+}
+
+.nightMode{
+  button.again {
+    color:vars.$night-button-again;
+  }
+
+  button.hard{
+    color: vars.$night-button-hard;
+  }
+
+  button.good {
+    color:vars.$night-button-good;
+  }
+
+  button.easy{
+    color: vars.$night-button-easy;
+  }
+}
+
 .nightMode {
   button {
     -webkit-appearance: none;

--- a/qt/ts/scss/_vars.scss
+++ b/qt/ts/scss/_vars.scss
@@ -18,6 +18,10 @@ $day-flag3-bg: #82E0AA;
 $day-flag4-bg: #85C1E9;
 $day-suspended-bg: #FFFFB2;
 $day-marked-bg: #cce;
+$day-button-again: #C35617;
+$day-button-hard: #333;
+$day-button-good: #0a0;
+$day-button-easy: #00a;
 
 $night-text-fg: white;
 $night-window-bg: #2f2f31;
@@ -39,6 +43,10 @@ $night-flag3-bg: #33a055;
 $night-flag4-bg: #3581a9;
 $night-suspended-bg: #aaaa33;
 $night-marked-bg: #77c;
+$night-button-again: #FF935B;
+$night-button-hard: #ccc;
+$night-button-good: #5CcC00;
+$night-button-easy: #77ccff;
 
 /* night-mode-specific colours */
 $fusion-button-gradient-start: #555555;


### PR DESCRIPTION
All other Anki clients have colorful review buttons, It's time desktop had them too. I reused the colors used for displaying due card count in deckbrowser.

Here is how it looks like:
![colorful-anki-night](https://user-images.githubusercontent.com/50060875/79084636-c6e59d00-7d6f-11ea-910e-8fdea480a38b.png)

![colorful-anki-day](https://user-images.githubusercontent.com/50060875/79084635-c51bd980-7d6f-11ea-868e-45ccf977c9f6.png)

As for addon compatibility, it works with atleast 4 of the more popular addons that modify answer buttons: 'The KING of Button Add-ons', '[Large and Colorful Buttons'](https://ankiweb.net/shared/info/1829090218), '[RememorizeButtons](https://github.com/lovac42/ReMemorizeButtons/releases)', '[Button Colours (Good, Again)](https://ankiweb.net/shared/info/2494384865)'. (Although for some addons the buttons gets class names such as `<font color='red'>again</font>`)