### PR TITLE
Render deck tree table more efficiently

### DIFF
--- a/qt/aqt/deckbrowser.py
+++ b/qt/aqt/deckbrowser.py
@@ -146,12 +146,10 @@ where id > ?""",
     def _render_deck_tree(self, nodes):
         if not nodes:
             return ""
-        buf = """
-<tr><th colspan=5 align=left>%s</th><th class=count>%s</th>
-<th class=count>%s</th><th class=optscol></th></tr>""" % (
-            _("Deck"),
-            tr(TR.STATISTICS_DUE_COUNT),
-            _("New"),
+        buf = """\
+<tr><th colspan=5 align=left>{}</th><th class=count>{}</th>
+<th class=count>{}</th><th class=optscol></th></tr>""".format(
+            _("Deck"), tr(TR.STATISTICS_DUE_COUNT), _("New"),
         )
         depth = 0
 
@@ -196,12 +194,11 @@ where id > ?""",
             klass = "deck current"
         else:
             klass = "deck"
-        buf = "<tr class='%s' id='%d'>" % (klass, did)
+        buf = "<tr class='{}' id='{}'>".format(klass, did)
         # deck link
         if children:
-            collapse = (
-                "<a class=collapse href=# onclick='return pycmd(\"collapse:%d\")'>%s</a>"
-                % (did, prefix)
+            collapse = "<a class=collapse href=# onclick='return pycmd(\"collapse:{}\")'>{}</a>".format(
+                did, prefix
             )
         else:
             collapse = "<span class=collapse></span>"
@@ -210,24 +207,20 @@ where id > ?""",
         else:
             extraclass = ""
         buf += """
-        <td class=decktd colspan=5>%s%s<a class="deck %s"
-        href=# onclick="return pycmd('open:%d')">%s</a></td>""" % (
-            indent(),
-            collapse,
-            extraclass,
-            did,
-            name,
+        <td class=decktd colspan=5>{}{}<a class="deck {}"
+        href=# onclick="return pycmd('open:{}')">{}</a></td>""".format(
+            indent(), collapse, extraclass, did, name,
         )
 
         due += lrn
-        buf += "<td align=right>%s</td><td align=right>%s</td>" % (
+        buf += "<td align=right>{}</td><td align=right>{}</td>".format(
             self._non_zero_colour(due, "review-count"),
             self._non_zero_colour(new, "new-count"),
         )
         # options
         buf += (
-            "<td align=center class=opts><a onclick='return pycmd(\"opts:%d\");'>"
-            "<img src='/_anki/imgs/gears.svg' class=gears></a></td></tr>" % did
+            "<td align=center class=opts><a onclick='return pycmd(\"opts:{}\");'>"
+            "<img src='/_anki/imgs/gears.svg' class=gears></a></td></tr>".format(did)
         )
         return buf
 

--- a/qt/aqt/deckbrowser.py
+++ b/qt/aqt/deckbrowser.py
@@ -153,9 +153,9 @@ where id > ?""",
         )
         depth = 0
 
-        buf += self._topLevelDragRow()
+        buf += self._top_level_drag_row()
         buf += self._render_deck_nodes(nodes, depth)
-        buf += self._topLevelDragRow()
+        buf += self._top_level_drag_row()
         return buf
 
     def _render_deck_nodes(self, nodes, depth):
@@ -232,7 +232,7 @@ where id > ?""",
             cnt = "1000+"
         return f'<span class="{klass}">{cnt}</span>'
 
-    def _topLevelDragRow(self):
+    def _top_level_drag_row(self):
         return "<tr class='top-level-drag-row'><td colspan='6'>&nbsp;</td></tr>"
 
     # Options

--- a/qt/aqt/deckbrowser.py
+++ b/qt/aqt/deckbrowser.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from copy import deepcopy
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Tuple
 
 import aqt
 from anki.errors import DeckRenameError
@@ -143,7 +143,7 @@ where id > ?""",
         buf = self.mw.col.backend.studied_today(cards, float(thetime))
         return buf
 
-    def _render_deck_tree(self, nodes):
+    def _render_deck_tree(self, nodes: Tuple[Any, ...]) -> str:
         if not nodes:
             return ""
         buf = """\
@@ -158,7 +158,7 @@ where id > ?""",
         buf += self._top_level_drag_row()
         return buf
 
-    def _render_deck_nodes(self, nodes, depth):
+    def _render_deck_nodes(self, nodes: Tuple[Any, ...], depth: int) -> str:
         """
             Return HTML of rows of decks with same parent.
         """
@@ -176,7 +176,9 @@ where id > ?""",
                 buf += self._render_deck_nodes(children, depth + 1)
         return buf
 
-    def _render_deck_row(self, node, depth):
+    def _render_deck_row(
+        self, node: Tuple[str, int, int, int, int, Tuple[Any, ...]], depth: int
+    ) -> str:
         """
             Return HTML of a single deck row.
         """
@@ -224,15 +226,17 @@ where id > ?""",
         )
         return buf
 
-    def _non_zero_colour(self, cnt, klass):
+    def _non_zero_colour(self, cnt: int, klass: str) -> str:
         # due counts
         if not cnt:
             klass = "zero-count"
         if cnt >= 1000:
-            cnt = "1000+"
-        return f'<span class="{klass}">{cnt}</span>'
+            cntstr = "1000+"
+        else:
+            cntstr = str(cnt)
+        return f'<span class="{klass}">{cntstr}</span>'
 
-    def _top_level_drag_row(self):
+    def _top_level_drag_row(self) -> str:
         return "<tr class='top-level-drag-row'><td colspan='6'>&nbsp;</td></tr>"
 
     # Options


### PR DESCRIPTION
Current implementation of _renderDeckTree is not optimal, and it's almost impossible for an addon modify a part of the deck browser without replacing the whole function.

The proposed change separates the method so addons can only modify parts they need to. Even if monkey patching is discouraged, I don't see a clean way to add in versatile hooks with current code. With this change it will make writing addons modifying deckbrowser easier. If this gets accepted, I'll be doing a follow up PR with a hook. 

The PR also improves speed quite a bit. Here's a result of a speed test done on my laptop with approximately 20\*10\*10 decks, averaged over 5 times. (* means subdecks, total 2000 decks)

```
expanded original: 0.314s
expanded new: 0.099s
collapsed original: 0.022s
collapsed new: 0.001s
```

The only drawback is that it's probably going to break most addons monkey patching _renderDeckTree or _deckRow method.