### PR TITLE
Fix editor buttons not highlighted

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -30,6 +30,7 @@ Evandro Coan <github.com/evandrocoan>
 Alan Du <alanhdu@gmail.com>
 Yuchen Lei <lyc@xuming.studio>
 Henry Tang <hktang@ualberta.ca>
+Simone Gaiarin <simgunz@gmail.com>
 
 ********************
 

--- a/qt/ts/scss/editor.scss
+++ b/qt/ts/scss/editor.scss
@@ -60,12 +60,12 @@ button.linkb {
     background: transparent;
 }
 
-.linkb:disabled {
+button.linkb:disabled {
     opacity: 0.3;
     cursor: not-allowed;
 }
 
-.highlighted {
+button.highlighted {
     border-bottom: 3px solid #000;
 }
 


### PR DESCRIPTION
As it was, the selector 'button.linkb' takes precedence on '.highlighted' because
it is more specific, so that '.highlighted' is never applied.