### PR TITLE
GetTextDialog accepts, when return is pressed

### DIFF
--- a/qt/aqt/utils.py
+++ b/qt/aqt/utils.py
@@ -247,6 +247,7 @@ class GetTextDialog(QDialog):
         if not edit:
             edit = QLineEdit()
         self.l = edit
+        self.l.returnPressed.connect(self.accept)
         if default:
             self.l.setText(default)
             self.l.selectAll()


### PR DESCRIPTION
Since, by default, the ok button in a GetTextDialog appears highlighted, it can be assumed, that pressing the return key would activate that button, causing the text to be accepted and the dialog to be closed. This change adds this behaviour.

--------------------------

I don't know if this was brought up before, but it constantly trips me up, that in Dialogs the ok button seems to be highlighted, but pressing Enter, when inside of an editable widget, does nothing.

This change at least fixes that for the simple GetTextDialogs, so that you can rename a Deck and confirm it by simply pressing Enter.

(I'm on Xubuntu Linux, in case this isn't a problem on other OS's).

I tested this, simply by adding that line in my installation.