### PR TITLE
Set to show the JavaScript exception message and stacktrace

### DIFF
--- a/qt/ts/src/reviewer.ts
+++ b/qt/ts/src/reviewer.ts
@@ -39,7 +39,11 @@ function _updateQA(html, fadeTime, onupdate, onshown) {
         try {
             qa.html(html);
         } catch (err) {
-            qa.text("Invalid HTML on card: " + err);
+            qa.html(
+                "Invalid HTML on card: " +
+                    err +
+                    ("\n" + err.stack).replace(/\n/g, "<br />")
+            );
         }
         _runHook(onUpdateHook);
 


### PR DESCRIPTION
Set to show the JavaScript exception message and stacktrace when an exception is thrown, showing the function and lines from where the exception/error is coming from. https://stackoverflow.com/questions/591857/how-can-i-get-a-javascript-stack-trace-when-i-throw-an-exception

Exception example:
```
Invalid HTML on card: Error: The media element is missing its 'src' attribute.
at http://127.0.0.1:50233/_anki/reviewer.js:246:23
at http://127.0.0.1:50233/_anki/reviewer.js:112:9
at Array.forEach ()
at setAnkiMedia (http://127.0.0.1:50233/_anki/reviewer.js:111:11)
at AnkiMediaQueue.setup (http://127.0.0.1:50233/_anki/reviewer.js:244:9)
at eval (eval at (http://127.0.0.1:50233/_anki/jquery.js:2:2651), :2:11)
at eval ()
at http://127.0.0.1:50233/_anki/jquery.js:2:2651
at Function.globalEval (http://127.0.0.1:50233/_anki/jquery.js:2:2662)
at Ha (http://127.0.0.1:50233/_anki/jquery.js:3:21262)
```