### PR TITLE
Fixed javaScriptConsoleMessage showing 'error on line'

### DIFF
--- a/qt/aqt/webview.py
+++ b/qt/aqt/webview.py
@@ -67,15 +67,24 @@ class AnkiWebPage(QWebEnginePage):  # type: ignore
         script.setRunsOnSubFrames(False)
         self.profile().scripts().insert(script)
 
-    def javaScriptConsoleMessage(self, lvl, msg, line, srcID):
+    def javaScriptConsoleMessage(self, level, msg, line, srcID):
         # not translated because console usually not visible,
         # and may only accept ascii text
-        buf = "JS error on line %(a)d: %(b)s" % dict(a=line, b=msg + "\n")
-        # ensure we don't try to write characters the terminal can't handle
-        buf = buf.encode(sys.stdout.encoding, "backslashreplace").decode(
-            sys.stdout.encoding
+        srcID = srcID.replace(AnkiWebView.webBundlePath("/"), "")
+        if level == QWebEnginePage.InfoMessageLevel:
+            level = "info"
+        elif level == QWebEnginePage.WarningMessageLevel:
+            level = "warning"
+        elif level == QWebEnginePage.ErrorMessageLevel:
+            level = "error"
+        buf = "JS %(t)s /%(f)s:%(a)d %(b)s" % dict(
+            t=level, a=line, f=srcID, b=msg + "\n"
         )
-        sys.stdout.write(buf)
+        # ensure we don't try to write characters the terminal can't handle
+        buf = buf.encode(sys.stderr.encoding, "backslashreplace").decode(
+            sys.stderr.encoding
+        )
+        sys.stderr.write(buf)
 
     def acceptNavigationRequest(self, url, navType, isMainFrame):
         if not isMainFrame:
@@ -412,7 +421,8 @@ body {{ zoom: {}; background: {}; {} }}
         # print(html)
         self.setHtml(html)
 
-    def webBundlePath(self, path: str) -> str:
+    @classmethod
+    def webBundlePath(cls, path: str) -> str:
         from aqt import mw
 
         if path.startswith("/"):

--- a/qt/aqt/webview.py
+++ b/qt/aqt/webview.py
@@ -4,6 +4,7 @@
 import dataclasses
 import json
 import math
+import re
 import sys
 from typing import Any, Callable, List, Optional, Sequence, Tuple
 
@@ -70,14 +71,14 @@ class AnkiWebPage(QWebEnginePage):  # type: ignore
     def javaScriptConsoleMessage(self, level, msg, line, srcID):
         # not translated because console usually not visible,
         # and may only accept ascii text
-        srcID = srcID.replace(AnkiWebView.webBundlePath("/"), "")
+        srcID = re.sub(r"(?mi).+://[^/]+", "", srcID)
         if level == QWebEnginePage.InfoMessageLevel:
             level = "info"
         elif level == QWebEnginePage.WarningMessageLevel:
             level = "warning"
         elif level == QWebEnginePage.ErrorMessageLevel:
             level = "error"
-        buf = "JS %(t)s /%(f)s:%(a)d %(b)s" % dict(
+        buf = "JS %(t)s %(f)s:%(a)d %(b)s" % dict(
             t=level, a=line, f=srcID, b=msg + "\n"
         )
         # ensure we don't try to write characters the terminal can't handle

--- a/qt/aqt/webview.py
+++ b/qt/aqt/webview.py
@@ -81,10 +81,12 @@ class AnkiWebPage(QWebEnginePage):  # type: ignore
             t=level, a=line, f=srcID, b=msg + "\n"
         )
         # ensure we don't try to write characters the terminal can't handle
-        buf = buf.encode(sys.stderr.encoding, "backslashreplace").decode(
-            sys.stderr.encoding
+        buf = buf.encode(sys.stdout.encoding, "backslashreplace").decode(
+            sys.stdout.encoding
         )
-        sys.stderr.write(buf)
+        # output to stdout because it may raise error messages on the anki GUI
+        # https://github.com/ankitects/anki/pull/560
+        sys.stdout.write(buf)
 
     def acceptNavigationRequest(self, url, navType, isMainFrame):
         if not isMainFrame:


### PR DESCRIPTION
Fixed javaScriptConsoleMessage showing 'error on line' for all messages. 

The new output format is:
```
JS info /_anki/reviewer.js:166 autoadd
JS error /_anki/reviewer.js:240 Uncaught (in promise) NotAllowedError: play() can only be initiated by a user gesture.
...
```