### PR TITLE
Also limit the size of the error message

### DIFF
--- a/qt/ts/src/reviewer.ts
+++ b/qt/ts/src/reviewer.ts
@@ -40,11 +40,12 @@ function _updateQA(html, fadeTime, onupdate, onshown) {
             qa.html(html);
         } catch (err) {
             qa.html(
-                "Invalid HTML on card: " +
-                    err +
-                    ("\n" + err.stack)
-                        .substring(0, 2000)
-                        .replace(/\n/g, "<br />")
+                (
+                    `Invalid HTML on card: ${String(err).substring(
+                        0,
+                        2000
+                    )}\n` + String(err.stack).substring(0, 2000)
+                ).replace(/\n/g, "<br />")
             );
         }
         _runHook(onUpdateHook);


### PR DESCRIPTION
Also limit the size of the error message in just case it is built by a concatenation of stack traces, i.e.,
```js
throw new Error(err + err.stack)
```
