### PR TITLE
Question loading gets faster

### DIFF
--- a/pylib/anki/sched.py
+++ b/pylib/anki/sched.py
@@ -43,6 +43,7 @@ class Scheduler(V2):
         self.today: Optional[int] = None
         self._haveQueues = False
         self._updateCutoff()
+        self._next_card = None
 
     def answerCard(self, card: Card, ease: int) -> None:
         self.col.log()
@@ -996,6 +997,8 @@ and (queue={QUEUE_TYPE_NEW} or (queue={QUEUE_TYPE_REV} and due<=?))""",
                     self._revQueue.remove(cid)
                 except ValueError:
                     pass
+                if self._next_card and self._next_card.id = cid:
+                    self._next_card = None
             else:
                 # if bury disabled, we still discard to give same-day spacing
                 if buryNew:
@@ -1004,6 +1007,8 @@ and (queue={QUEUE_TYPE_NEW} or (queue={QUEUE_TYPE_REV} and due<=?))""",
                     self._newQueue.remove(cid)
                 except ValueError:
                     pass
+                if self._next_card and self._next_card.id = cid:
+                    self._next_card = None
         # then bury
         if toBury:
             self.col.db.execute(

--- a/pylib/anki/sched.py
+++ b/pylib/anki/sched.py
@@ -978,7 +978,7 @@ update cards set queue={QUEUE_TYPE_SIBLING_BURIED},mod=?,usn=? where id in """
     ##########################################################################
 
     def _burySiblings(self, card: Card) -> None:
-        toBury = []
+        toBury: List[int] = []
         nconf = self._newConf(card)
         buryNew = nconf.get("bury", True)
         rconf = self._revConf(card)
@@ -993,25 +993,9 @@ and (queue={QUEUE_TYPE_NEW} or (queue={QUEUE_TYPE_REV} and due<=?))""",
             self.today,
         ):
             if queue == QUEUE_TYPE_REV:
-                if buryRev:
-                    toBury.append(cid)
-                # if bury disabled, we still discard to give same-day spacing
-                try:
-                    self._revQueue.remove(cid)
-                except ValueError:
-                    pass
-                if self._next_card and self._next_card.id = cid:
-                    self._next_card = None
+                self._actual_bury_siblings(buryRev, toBury, cid, self._revQueue)
             else:
-                # if bury disabled, we still discard to give same-day spacing
-                if buryNew:
-                    toBury.append(cid)
-                try:
-                    self._newQueue.remove(cid)
-                except ValueError:
-                    pass
-                if self._next_card and self._next_card.id = cid:
-                    self._next_card = None
+                self._actual_bury_siblings(buryNew, toBury, cid, self._newQueue)
         # then bury
         if toBury:
             self.col.db.execute(

--- a/qt/aqt/reviewer.py
+++ b/qt/aqt/reviewer.py
@@ -116,6 +116,7 @@ class Reviewer:
             # we recycle the webview periodically so webkit can free memory
             self._initWeb()
         self._showQuestion()
+        self.mw.col.sched.load_next_card(True)
 
     # Audio
     ##########################################################################

--- a/qt/aqt/reviewer.py
+++ b/qt/aqt/reviewer.py
@@ -110,12 +110,14 @@ class Reviewer:
             c = self.mw.col.sched.getCard()
         self.card = c
         if not c:
+            self.mw.col.sched.set_current_card(None)
             self.mw.moveToState("overview")
             return
         if self._reps is None or self._reps % 100 == 0:
             # we recycle the webview periodically so webkit can free memory
             self._initWeb()
         self._showQuestion()
+        self.mw.col.sched.set_current_card(self.card)
         self.mw.col.sched.load_next_card(True)
 
     # Audio


### PR DESCRIPTION
Showing the next question is an important part of using anki. On my computer, it may sometime takes a fraction of second; enough to be noticeable even if it does not stop me from using anki.

I did realize that there was one pretty easy thing to do to make it faster; pre loading the next card. So I added a variable which store the result of "_getCard". The only trouble being that during reset, the next card may well be the card displayed in the reviewer. That is not a problem when the computation is done after the review is done; since the card will be marked as reviewed/in learning. Since I want to precompute the result, the reviewer should warns the scheduler so that it does not put the current card nor its siblings in the queue.

If it's not merged, I'll make an add-on out of it. I would understand if the complexity added was not worth the small speed increase it offers. However, it feels more pleasant to me. 
Note that @agentydragon told, which is probably true, that to be even more efficient, the HTML should be pre loaded in the reviewer. I may try do to it later. I've no experience with web preloading, but it would make a lot of sens. Given than a complaint about 2.1 is that it became slower, I guess that it would actually be a nice improvement.
(And if it's done in Anki, it'll be done in AnkiDroid too, and there, it will be an important improvement, because AnkiDroid is slow)
