### PR TITLE
Set .prettierrc printWidth to 88 because the default is too short

### DIFF
--- a/qt/ts/.prettierrc
+++ b/qt/ts/.prettierrc
@@ -1,5 +1,6 @@
 {
   "trailingComma": "es5",
+  "printWidth": 88,
   "tabWidth": 4,
   "semi": true
 }

--- a/qt/ts/src/editor.ts
+++ b/qt/ts/src/editor.ts
@@ -274,10 +274,7 @@ function enableButtons() {
 
 // disable the buttons if a field is not currently focused
 function maybeDisableButtons() {
-    if (
-        !document.activeElement ||
-        document.activeElement.className !== "field"
-    ) {
+    if (!document.activeElement || document.activeElement.className !== "field") {
         disableButtons();
     } else {
         enableButtons();

--- a/qt/ts/src/reviewer.ts
+++ b/qt/ts/src/reviewer.ts
@@ -41,10 +41,8 @@ function _updateQA(html, fadeTime, onupdate, onshown) {
         } catch (err) {
             qa.html(
                 (
-                    `Invalid HTML on card: ${String(err).substring(
-                        0,
-                        2000
-                    )}\n` + String(err.stack).substring(0, 2000)
+                    `Invalid HTML on card: ${String(err).substring(0, 2000)}\n` +
+                    String(err.stack).substring(0, 2000)
                 ).replace(/\n/g, "<br />")
             );
         }


### PR DESCRIPTION
Some codes were getting too much vertical, for example:
```js
pycmd(
    type +  
        ":" +   
        currentFieldOrdinal() + 
        ":" +   
        currentNoteId + 
        ":" +   
        currentField.innerHTML  
);
// Instead of  
pycmd(type + ":" + currentFieldOrdinal() + ":" + currentNoteId + ":" + currentField.innerHTML);
```
