### PR TITLE
Fixed ripgrep not installing on ubuntu anymore

### DIFF
--- a/.github/scripts/trailing-newlines.sh
+++ b/.github/scripts/trailing-newlines.sh
@@ -4,7 +4,7 @@ set -eu -o pipefail ${SHELLFLAGS}
 
 # Checking version to force it fail the build if rg is not installed.
 # Because `set -e` does not work inside the subshell $()
-rg --version > /dev/null 2>&1
+rg --version > /dev/null 2>&1 || echo "Error: ripgrep is not installed!"
 
 files=$(rg -l '[^\n]\z' -g '!*.{png,svg,scss,json,sql}' || true)
 

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -203,7 +203,10 @@ jobs:
           set -x
           sudo apt update
           sudo apt install portaudio19-dev gettext
-          sudo snap install ripgrep --classic
+          # https://github.com/BurntSushi/ripgrep/issues/1232
+          # sudo apt-get install ripgrep
+          curl -LO https://github.com/BurntSushi/ripgrep/releases/download/11.0.2/ripgrep_11.0.2_amd64.deb
+          sudo dpkg -i ripgrep_11.0.2_amd64.deb
 
       - name: Set up brew ripgrep, pyaudio, gettext
         if: matrix.os == 'macos-latest'


### PR DESCRIPTION
https://github.com/BurntSushi/ripgrep#installation
https://github.com/BurntSushi/ripgrep/issues/1232

N.B. Various snaps for ripgrep on Ubuntu are also available, but none of them seem to work right and generate a number of very strange bug reports that I don't know how to fix and don't have the time to fix. Therefore, it is no longer a recommended installation option.)