### PR TITLE
Keep window open during normal sync

### DIFF
--- a/qt/aqt/sync.py
+++ b/qt/aqt/sync.py
@@ -344,6 +344,7 @@ Check Database, then sync again."""
 
 class SyncThread(QThread):
 
+    fullSyncChoice: Optional[str]
     _event = pyqtSignal(str, str)
     progress_event = pyqtSignal(int, int)
 


### PR DESCRIPTION
In case it is of interest to you, here is a modification that ensure that during normal sync, windows stay open. If a full sync is needed, it'll ask whether windows should be closed and still allow to cancel syncing if the user reject.

Otherwise, if you would accept to tell me why the database is closed each time, I'd be interested in learning it, seeing what I ovrelooked

I of course tested full upload/download (sorry for your server) and failing sync by cutting internet access during syncs.