### PR TITLE
Add gcc-multilib to README.development

### DIFF
--- a/README.development
+++ b/README.development
@@ -24,6 +24,7 @@ To start, make sure you have the following installed:
  - ripgrep (cargo install ripgrep)
  - git
  - curl
+ - gcc-multilib (sudo apt install gcc-multilib)
 
 The build scripts assume a UNIX-like environment, so on Windows you will
 need to use WSL or Cygwin to use them.


### PR DESCRIPTION
The rust compilation was failing due to this error:
1. https://stackoverflow.com/questions/6329887/compiling-problems-cannot-find-crt1-o
1. https://reposcope.com/package/gcc-multilib