### PR TITLE
Fixed Makefile comments showing up on the console

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ ifndef OS
 endif
 
 ifeq (${OS},Windows_NT)
-	# Windows terminal is confusing it with its `cmd` builtin `rename` command
+# 	Windows terminal is confusing it with its `cmd` builtin `rename` command
 	ifndef RENAME_BIN
 		RENAME_BIN := perl scripts/rename
 	endif
@@ -60,8 +60,8 @@ all: run
 # - modern pip required for wheel
 # - add qt if missing
 pyenv:
-	# https://github.com/PyO3/maturin/issues/283
-	# Expected `python` to be a python interpreter inside a virtualenv
+# 	https://github.com/PyO3/maturin/issues/283
+# 	Expected `python` to be a python interpreter inside a virtualenv
 	set -eu -o pipefail ${SHELLFLAGS}; \
 	"${PYTHON_BIN}" -m pip install virtualenv; \
 	"${PYTHON_BIN}" -m venv pyenv; \


### PR DESCRIPTION
Makefile comments inside rules have to be put in the beginning
of the line, otherwise they are passed to shell when running the
recipe.