### PR TITLE
Fix msgmerge not failing on error

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -64,6 +64,9 @@ jobs:
           # https://stackoverflow.com/questions/43175529/updating-make-version-4-1-on-mac
           echo "::set-env name=PATH::/usr/local/opt/make/libexec/gnubin:$PATH"
 
+          # https://stackoverflow.com/questions/59644349/msgmerge-on-macos-catalina
+          echo "::set-env name=PATH::/usr/local/opt/gettext/bin:$PATH"
+
       - name: Configure Windows environment variables
         if: matrix.os == 'windows-latest'
         run: |
@@ -213,7 +216,6 @@ jobs:
         run: |
           set -x
           brew install portaudio protobuf gettext ripgrep make
-          brew link gettext --force
 
       - name: Set up python
         uses: actions/setup-python@v1

--- a/qt/po/scripts/build-mo-files
+++ b/qt/po/scripts/build-mo-files
@@ -15,7 +15,8 @@ do
         perl -pe "s%repo/desktop/(.*)/anki.po%$targetDir/\1/LC_MESSAGES%")
     outfile="$outdir/anki.mo"
     mkdir -p $outdir
-    (msgmerge -q "$file" repo/desktop/anki.pot | msgfmt - --output-file="$outfile") || (
-      echo "error building $file"
-    )
+    if ! msgmerge -q "$file" repo/desktop/anki.pot | msgfmt - --output-file="$outfile"; then
+        echo "error building $file";
+        exit 1;
+    fi;
 done


### PR DESCRIPTION
The `msgmerge` commands were not working on Mac OS: https://github.com/ankitects/anki/runs/617116053?check_suite_focus=true#step:27:1244
```
Compiling *.po...
./scripts/build-mo-files: line 18: msgfmt: command not found
./scripts/build-mo-files: line 18: msgmerge: command not found
error building repo/desktop/af/anki.po
./scripts/build-mo-files: line 18: msgmerge: command not found
./scripts/build-mo-files: line 18: msgfmt: command not found
error building repo/desktop/ar/anki.po
...
```

The build was not falling because when you do `(commands)` in a shell script, the `set -e` directive is not inherited. Then, either do not start a new shell or just use an if to test the error condition.