### PR TITLE
mw.debug_diag is the dialog and not the window

### DIFF
--- a/qt/aqt/main.py
+++ b/qt/aqt/main.py
@@ -1369,7 +1369,7 @@ will be lost. Continue?"""
     def onDebug(self):
         d = self.debugDiag = QDialog()
         d.silentlyClose = True
-        frm = aqt.forms.debug.Ui_Dialog()
+        frm = self.debug_diag_form = aqt.forms.debug.Ui_Dialog()
         frm.setupUi(d)
         font = QFontDatabase.systemFont(QFontDatabase.FixedFont)
         font.setPointSize(frm.text.font().pointSize() + 1)


### PR DESCRIPTION
This will allow, for example, for add-ons to do self.debugDiag.text
and access the debugger text. I see very little reason to have a
direct access to the dialog window.

I should note that self.debugDiag is never used anywhere in the code,
so I think it should be deleted; unless you've heard of some add-on
using it.

This PR is based on a discussion with @ijgnd , which stated that he had trouble accessing the debugger text; and I realized there were good reason for it