### PR TITLE
On modelchange used

### DIFF
--- a/qt/aqt/addcards.py
+++ b/qt/aqt/addcards.py
@@ -100,17 +100,15 @@ class AddCards(QDialog):
             newFields = list(note.keys())
             for n, f in enumerate(note.model()["flds"]):
                 fieldName = f["name"]
-                try:
-                    oldFieldName = oldNote.model()["flds"][n]["name"]
-                except IndexError:
-                    oldFieldName = None
                 # copy identical fields
                 if fieldName in oldFields:
                     note[fieldName] = oldNote[fieldName]
-                # set non-identical fields by field index
-                elif oldFieldName and oldFieldName not in newFields:
+                else:
+                    # set non-identical fields by field index
                     try:
-                        note.fields[n] = oldNote.fields[n]
+                        oldFieldName = oldNote.model()["flds"][n]["name"]
+                        if oldFieldName not in newFields:
+                            note.fields[n] = oldNote.fields[n]
                     except IndexError:
                         pass
             self.removeTempNote(oldNote)

--- a/qt/aqt/addcards.py
+++ b/qt/aqt/addcards.py
@@ -103,14 +103,11 @@ class AddCards(QDialog):
                 # copy identical fields
                 if fieldName in oldFields:
                     note[fieldName] = oldNote[fieldName]
-                else:
+                elif n < len(oldNote.model()["flds"]):
                     # set non-identical fields by field index
-                    try:
-                        oldFieldName = oldNote.model()["flds"][n]["name"]
-                        if oldFieldName not in newFields:
-                            note.fields[n] = oldNote.fields[n]
-                    except IndexError:
-                        pass
+                    oldFieldName = oldNote.model()["flds"][n]["name"]
+                    if oldFieldName not in newFields:
+                        note.fields[n] = oldNote.fields[n]
             self.removeTempNote(oldNote)
         self.editor.note = note
         # When on model change is called, reset is necessarily called.

--- a/qt/aqt/addcards.py
+++ b/qt/aqt/addcards.py
@@ -114,6 +114,9 @@ class AddCards(QDialog):
                     except IndexError:
                         pass
             self.removeTempNote(oldNote)
+        self.editor.note = note
+        # When on model change is called, reset is necessarily called.
+        # Reset load note, so it is not required to load it here.
 
     def onReset(self, model: None = None, keep: bool = False) -> None:
         oldNote = self.editor.note


### PR DESCRIPTION
in editor, the method onModelChange compute the new note... and that's all. It was forgotten to save it and put it as the new note of the editor.

My first commit solve this problem.

The other two commits simply clean up the code. In this case, I believe that a single try is better than two. And a if is even better than a try, since the only exception could be really easily detected in advance