### PR TITLE
addButton always save function

### DIFF
--- a/qt/aqt/editor.py
+++ b/qt/aqt/editor.py
@@ -221,7 +221,7 @@ class Editor:
         disables: bool = True,
     ):
         """Assign func to bridge cmd, register shortcut, return button"""
-        if cmd not in self._links:
+        if func:
             self._links[cmd] = func
         if keys:
             QShortcut(  # type: ignore


### PR DESCRIPTION
I had a strange problem while trying to make an add-on. I then realized that the trouble is that each time I called addButton I was using a slightly different method. I was expecting the button to call the function I passed. Instead, it called the function which was passed in the first call to addButton and it ignores next function. 

This change does just that: it always register the function if it is given.
I should note that addButton is never called in anki codebase. This change won't break any add-on which give multiple time the same method to addButton. 