### PR TITLE
Add rename method to ModelManager

### DIFF
--- a/pylib/anki/errors.py
+++ b/pylib/anki/errors.py
@@ -24,3 +24,12 @@ class DeckRenameError(Exception):
 
     def __str__(self):
         return "Couldn't rename deck: " + self.description
+
+
+class ModelRenameError(Exception):
+    def __init__(self, description: str) -> None:
+        super().__init__()
+        self.description = description
+
+    def __str__(self):
+        return "Couldn't rename note type: " + self.description

--- a/pylib/tests/test_models.py
+++ b/pylib/tests/test_models.py
@@ -2,8 +2,9 @@
 import time
 
 from anki.consts import MODEL_CLOZE
+from anki.errors import ModelRenameError
 from anki.utils import isWin, joinFields, stripHTML
-from tests.shared import getEmptyCol
+from tests.shared import assertException, getEmptyCol
 
 
 def test_modelDelete():
@@ -29,6 +30,22 @@ def test_modelCopy():
     assert len(m["tmpls"]) == 1
     assert len(m2["tmpls"]) == 1
     assert deck.models.scmhash(m) == deck.models.scmhash(m2)
+
+
+def test_modelRename():
+    deck = getEmptyCol()
+    m = deck.models.current()
+    new_name = "New Name"
+    deck.models.rename(m, new_name)
+    assert m["name"] == new_name
+    # make sure you can't have two models with same name
+    m2 = deck.models.copy(m)
+    assertException(ModelRenameError, lambda: deck.models.rename(m2, new_name))
+    # check if model is given unique name when renaming it to existing name
+    m2 = deck.models.copy(m)
+    deck.models.rename(m2, new_name, make_unique=True)
+    assert m2["name"].startswith(new_name)
+    assert m2["name"] != new_name
 
 
 def test_fields():

--- a/qt/aqt/models.py
+++ b/qt/aqt/models.py
@@ -6,6 +6,7 @@ from operator import itemgetter
 
 import aqt.clayout
 from anki import stdmodels
+from anki.errors import ModelRenameError
 from anki.lang import _, ngettext
 from aqt import AnkiQt, gui_hooks
 from aqt.qt import *
@@ -17,6 +18,7 @@ from aqt.utils import (
     restoreGeom,
     saveGeom,
     showInfo,
+    showWarning,
 )
 
 
@@ -67,8 +69,10 @@ class Models(QDialog):
     def onRename(self):
         txt = getText(_("New name:"), default=self.model["name"])
         if txt[1] and txt[0]:
-            self.model["name"] = txt[0]
-            self.mm.save(self.model, updateReqs=False)
+            try:
+                self.mm.rename(self.model, txt[0])
+            except ModelRenameError as e:
+                return showWarning(e.description)
         self.updateModelsList()
 
     def updateModelsList(self):


### PR DESCRIPTION
Currently, note types can only be renamed in note type manager. But I'd like to add a context menu to the browser sidebar treeview to allow renaming note types. It will be easier to maintain a single rename function in ModelManager.