### PR TITLE
Add rename method to TagManager

### DIFF
--- a/pylib/anki/tags.py
+++ b/pylib/anki/tags.py
@@ -119,6 +119,9 @@ class TagManager:
 
     def rename(self, old_tag: str, new_tag: str) -> None:
         "old_tag, new_tag must not contain whitespace. old_tag may contain wildcard *."
+        if " " in old_tag or " " in new_tag:
+            # Ideally, should be checked before calling this method
+            raise ValueError("Tag must not contain whitespace.")
         res = self.col.db.all(
             "select id, tags from notes where tags like ?",
             "%% %s %%" % old_tag.replace("*", "%"),

--- a/pylib/tests/test_collection.py
+++ b/pylib/tests/test_collection.py
@@ -109,17 +109,39 @@ def test_addDelTags():
     f2 = deck.newNote()
     f2["Front"] = "2"
     deck.addNote(f2)
+    f3 = deck.newNote()
+    f3["Front"] = "3"
+    deck.addNote(f3)
     # adding for a given id
-    deck.tags.bulkAdd([f.id], "foo")
+    deck.tags.bulkAdd([f.id, f2.id], "foo")
     f.load()
     f2.load()
-    assert "foo" in f.tags
-    assert "foo" not in f2.tags
+    f3.load()
+    assert f.tags == ["foo"]
+    assert f2.tags == ["foo"]
+    assert f3.tags == []
     # should be canonified
     deck.tags.bulkAdd([f.id], "foo aaa")
     f.load()
-    assert f.tags[0] == "aaa"
-    assert len(f.tags) == 2
+    f2.load()
+    assert f.tags == ["aaa", "foo"]
+    assert f2.tags == ["foo"]
+    # rename a tag
+    deck.tags.rename("foo", "bar")
+    f.load()
+    f2.load()
+    f3.load()
+    assert f.tags == ["aaa", "bar"]
+    assert f2.tags == ["bar"]
+    assert f3.tags == []
+    deck.tags.bulkAdd([f.id, f3.id], "bor")
+    deck.tags.rename("b*r", "baz")
+    f.load()
+    f2.load()
+    f3.load()
+    assert f.tags == ["aaa", "baz"]
+    assert f2.tags == ["baz"]
+    assert f3.tags == ["baz"]
 
 
 def test_timestamps():

--- a/pylib/tests/test_find.py
+++ b/pylib/tests/test_find.py
@@ -63,6 +63,9 @@ def test_findCards():
     deck.tags.bulkRem(deck.db.list("select id from notes"), "foo")
     assert len(deck.findCards("tag:foo")) == 0
     assert len(deck.findCards("tag:bar")) == 5
+    deck.tags.rename("bar", "baz")
+    assert len(deck.findCards("tag:bar")) == 0
+    assert len(deck.findCards("tag:baz")) == 5
     # text searches
     assert len(deck.findCards("cat")) == 2
     assert len(deck.findCards("cat -dog")) == 1


### PR DESCRIPTION
As noted in #586, I'm planning to add a context menu to the deck browser sidebar tree view. It'd be great if tags could be renamed, instead of having to bulk add, then bulk delete the tags.

If you plan to accept my PR, please scrutinize over my changes more than usual. I have close to zero knowledge in db, and pretty much just copied over the code from bulkAdd.