### PR TITLE
Sidebar context menu

### DIFF
--- a/qt/aqt/browser.py
+++ b/qt/aqt/browser.py
@@ -589,6 +589,10 @@ class SidebarTreeView(QTreeView):
         self.expanded.connect(self.onExpansion)
         self.collapsed.connect(self.onCollapse)
 
+        self.setContextMenuPolicy(Qt.CustomContextMenu)
+        self.customContextMenuRequested.connect(self.onContextMenu)
+        self.context_menus = {SidebarItemType.DECK: ()}
+
     def onClickCurrent(self) -> None:
         idx = self.currentIndex()
         if idx.isValid():
@@ -618,6 +622,19 @@ class SidebarTreeView(QTreeView):
             item.expanded = expanded
             if item.onExpanded:
                 item.onExpanded(expanded)
+
+    def onContextMenu(self, point: QPoint) -> None:
+        idx: QModelIndex = self.indexAt(point)
+        item: SidebarItem = idx.internalPointer()
+        item_type: SidebarItemType = item.item_type
+        if item_type not in self.context_menus:
+            return
+
+        m = QMenu()
+        for action in self.context_menus[item_type]:
+            a = m.addAction(action[0])
+            a.triggered.connect(action[1])
+        m.exec_(QCursor.pos())
 
 
 # Browser window
@@ -1204,6 +1221,7 @@ QTableView {{ gridline-color: {grid} }}
                 m["name"],
                 ":/icons/notetype.svg",
                 lambda m=m: self.setFilter("note", m["name"]),  # type: ignore
+                item_type=SidebarItemType.NOTETYPE,
             )
             root.addChild(item)
 

--- a/qt/aqt/browser.py
+++ b/qt/aqt/browser.py
@@ -581,8 +581,11 @@ class SidebarModel(QAbstractItemModel):
 
 
 class SidebarTreeView(QTreeView):
-    def __init__(self):
+    def __init__(self, browser: "Browser"):
         super().__init__()
+        self.browser = browser
+        self.mw = browser.mw
+        self.col = self.mw.col
         self.expanded.connect(self.onExpansion)
         self.collapsed.connect(self.onCollapse)
 
@@ -1067,7 +1070,7 @@ QTableView {{ gridline-color: {grid} }}
         dw.setFeatures(QDockWidget.DockWidgetClosable)
         dw.setObjectName("Sidebar")
         dw.setAllowedAreas(Qt.LeftDockWidgetArea)
-        self.sidebarTree = SidebarTreeView()
+        self.sidebarTree = SidebarTreeView(self)
         self.sidebarTree.mw = self.mw
         self.sidebarTree.setUniformRowHeights(True)
         self.sidebarTree.setHeaderHidden(True)

--- a/qt/aqt/browser.py
+++ b/qt/aqt/browser.py
@@ -582,16 +582,16 @@ class SidebarModel(QAbstractItemModel):
 
 
 class SidebarTreeView(QTreeView):
-    def __init__(self, browser: "Browser"):
+    def __init__(self, browser: "Browser") -> None:
         super().__init__()
         self.browser = browser
         self.mw = browser.mw
         self.col = self.mw.col
-        self.expanded.connect(self.onExpansion)
-        self.collapsed.connect(self.onCollapse)
+        self.expanded.connect(self.onExpansion)  # type: ignore
+        self.collapsed.connect(self.onCollapse)  # type: ignore
 
         self.setContextMenuPolicy(Qt.CustomContextMenu)
-        self.customContextMenuRequested.connect(self.onContextMenu)
+        self.customContextMenuRequested.connect(self.onContextMenu)  # type: ignore
         self.context_menus = {SidebarItemType.DECK: ((_("Rename"), self.rename_deck),)}
 
     def onClickCurrent(self) -> None:
@@ -636,7 +636,7 @@ class SidebarTreeView(QTreeView):
             act_name = action[0]
             act_func = action[1]
             a = m.addAction(act_name)
-            a.triggered.connect(lambda _, func=act_func: func(item))
+            a.triggered.connect(lambda _, func=act_func: func(item))  # type: ignore
         m.exec_(QCursor.pos())
 
     def rename_deck(self, item: SidebarItem) -> None:


### PR DESCRIPTION
This PR adds a custom context menu to the browser sidebar.

The context menu will likely have different actions per SidebarItem type. For example, a filter should have an action that can edit the filter. And according to its type, an action that looks the same ("Rename" for example) will likely need different function. So when calling SidebarItem, I passed its type to the constructor, which can later be accessed by SidebarTreeView when context menu is triggered.

I thought I should get a green light beforehand, so I only added one action for renaming deck as an example.