### PR TITLE
Add missing aqt and anki modules dependency requirements

### DIFF
--- a/pylib/Makefile
+++ b/pylib/Makefile
@@ -117,6 +117,7 @@ anki/buildinfo.py: ../meta/version ../meta/buildhash
 
 VER := $(shell cat ../meta/version)
 .build/vernum: ../meta/version
-	sed -i.bak 's/.*automatically updated.*/    version="$(VER)",  # automatically updated/' setup.py
+	sed -i.bak 's/.*automatically updated 1.*/    "ankirspy==$(VER)",  # automatically updated 1/' setup.py
+	sed -i.bak 's/.*automatically updated 2.*/    version="$(VER)",  # automatically updated 2/' setup.py
 	rm setup.py.bak
 	@touch $@

--- a/pylib/Makefile
+++ b/pylib/Makefile
@@ -32,7 +32,7 @@ PHONY: all
 all: check
 
 .build/run-deps: setup.py
-	python -m pip install -e .
+	SKIP_ANKI_RSPY=true python -m pip install -e .
 	@touch $@
 
 .build/dev-deps: requirements.dev
@@ -117,7 +117,7 @@ anki/buildinfo.py: ../meta/version ../meta/buildhash
 
 VER := $(shell cat ../meta/version)
 .build/vernum: ../meta/version
-	sed -i.bak 's/.*automatically updated 1.*/    "ankirspy==$(VER)",  # automatically updated 1/' setup.py
+	sed -i.bak 's/.*automatically updated 1.*/    install_requires.append("ankirspy==$(VER)")  # automatically updated 1/' setup.py
 	sed -i.bak 's/.*automatically updated 2.*/    version="$(VER)",  # automatically updated 2/' setup.py
 	rm setup.py.bak
 	@touch $@

--- a/pylib/setup.py
+++ b/pylib/setup.py
@@ -7,6 +7,7 @@ install_requires = [
     "requests",
     "decorator",
     "protobuf",
+    "ankirspy==2.1.25",  # automatically updated 1
     'orjson; platform_machine == "x86_64"',
     'psutil; sys_platform == "win32"',
     'distro; sys_platform != "darwin" and sys_platform != "win32"',
@@ -15,7 +16,7 @@ install_requires = [
 
 setuptools.setup(
     name="anki",
-    version="2.1.25",  # automatically updated
+    version="2.1.25",  # automatically updated 2
     author="Ankitects Pty Ltd",
     description="Anki's library code",
     long_description="Anki's library code",

--- a/pylib/setup.py
+++ b/pylib/setup.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+import os
+
 import setuptools
 
 install_requires = [
@@ -7,12 +9,14 @@ install_requires = [
     "requests",
     "decorator",
     "protobuf",
-    "ankirspy==2.1.25",  # automatically updated 1
     'orjson; platform_machine == "x86_64"',
     'psutil; sys_platform == "win32"',
     'distro; sys_platform != "darwin" and sys_platform != "win32"',
 ]
 
+# maturin develop hides the package from pip - https://github.com/ankitects/anki/pull/600
+if not os.environ.get("SKIP_ANKI_RSPY", False):
+    install_requires.append("ankirspy==2.1.25")  # automatically updated 1
 
 setuptools.setup(
     name="anki",

--- a/qt/Makefile
+++ b/qt/Makefile
@@ -144,6 +144,7 @@ aqt/buildinfo.py: ../meta/version ../meta/buildhash
 
 VER := $(shell cat ../meta/version)
 .build/vernum: ../meta/version
-	sed -i.bak 's/.*automatically updated.*/    version="$(VER)",  # automatically updated/' setup.py
+	sed -i.bak 's/.*automatically updated 1.*/    "anki==$(VER)",  # automatically updated 1/' setup.py
+	sed -i.bak 's/.*automatically updated 2.*/    version="$(VER)",  # automatically updated 2/' setup.py
 	rm setup.py.bak
 	@touch $@

--- a/qt/setup.py
+++ b/qt/setup.py
@@ -30,12 +30,13 @@ install_requires = [
     "pyqt5>=5.9",
     'psutil; sys.platform == "win32"',
     'pywin32; sys.platform == "win32"',
+    "anki==2.1.25",  # automatically updated 1
 ]
 
 
 setuptools.setup(
     name="aqt",
-    version="2.1.25",  # automatically updated
+    version="2.1.25",  # automatically updated 2
     author="Ankitects Pty Ltd",
     description="Anki's Qt GUI code",
     long_description="Anki's QT GUI code",

--- a/rspy/Makefile
+++ b/rspy/Makefile
@@ -41,6 +41,10 @@ RSPY_TARGET_DIR ?= target
 QT_FTL_TEMPLATES := ../qt/ftl
 QT_FTL_LOCALES := ../qt/ftl/repo/desktop
 
+BUILD_VARIABLES = FTL_TEMPLATE_DIRS="$(QT_FTL_TEMPLATES)" \
+	FTL_LOCALE_DIRS="$(QT_FTL_LOCALES)" \
+	CARGO_TARGET_DIR="$(RSPY_TARGET_DIR)"
+
 .PHONY: all develop build check fix clean
 
 all: develop
@@ -56,16 +60,16 @@ DEPS := .build/tools .build/vernum ../meta/buildhash \
 
 .build/develop: $(DEPS)
 	touch ../proto/backend.proto
-	FTL_TEMPLATE_DIRS="$(QT_FTL_TEMPLATES)" FTL_LOCALE_DIRS="$(QT_FTL_LOCALES)" \
-		CARGO_TARGET_DIR="$(RSPY_TARGET_DIR)" maturin develop $(DEVFLAGS)
+	${BUILD_VARIABLES} \
+		maturin develop $(DEVFLAGS)
 	touch $@
 
 build: .build/build
 
 .build/build: $(DEPS)
 	touch ../proto/backend.proto
-	FTL_TEMPLATE_DIRS="$(QT_FTL_TEMPLATES)" FTL_LOCALE_DIRS="$(QT_FTL_LOCALES)" \
-		CARGO_TARGET_DIR="$(RSPY_TARGET_DIR)" maturin build -i "${PYTHON_FILE}" -o "$(OUTDIR)" $(BUILDFLAGS)
+	${BUILD_VARIABLES} \
+		maturin build -i "${PYTHON_FILE}" -o "$(OUTDIR)" $(BUILDFLAGS)
 	touch $@
 
 check: .build/check


### PR DESCRIPTION
1. https://github.com/ankitects/anki/pull/535#issuecomment-620268597 - Created the GitHub Actions step Upload to PyPi
1. https://github.com/PyO3/maturin/issues/304 - `maturin develop` hides the package from pip