### PR TITLE
Also run rspy clippy on macos

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ BUILDFLAGS := --release --strip
 DEVFLAGS := $(BUILDFLAGS)
 RUNFLAGS :=
 CHECKABLE_PY := pylib qt
-CHECKABLE_RS := rslib
+CHECKABLE_RS := rslib rspy
 DEVEL := rslib rspy pylib qt
 
 .PHONY: all
@@ -155,14 +155,8 @@ clean-dist: buildhash
 check: pyenv buildhash prepare
 	@set -eu -o pipefail ${SHELLFLAGS}; \
 	.github/scripts/trailing-newlines.sh; \
-	$(SUBMAKE) -C rslib develop; \
-	for dir in $(CHECKABLE_RS); do \
-		$(SUBMAKE) -C $$dir check; \
-	done; \
 	. "${ACTIVATE_SCRIPT}"; \
-	$(SUBMAKE) -C rspy develop; \
-	$(SUBMAKE) -C pylib develop; \
-	for dir in $(CHECKABLE_PY); do \
+	for dir in $(CHECKABLE_RS) $(CHECKABLE_PY); do \
 		$(SUBMAKE) -C $$dir check; \
 	done;
 	@echo

--- a/rslib/Makefile
+++ b/rslib/Makefile
@@ -17,7 +17,7 @@ $(shell mkdir -p .build)
 
 all: check
 
-check: ftl/repo .build/check
+check: .build/check
 
 fix:
 	cargo fmt
@@ -41,7 +41,7 @@ RUST_TOOLCHAIN := $(shell cat rust-toolchain)
 	rustup component add clippy-preview --toolchain $(RUST_TOOLCHAIN)
 	@touch $@
 
-.build/check: .build/rs-tools $(ALL_SOURCE)
+.build/check: ftl/repo .build/rs-tools $(ALL_SOURCE)
 	cargo test --lib -- --nocapture
 	cargo fmt -- --check
 	cargo clippy -- -D warnings

--- a/rspy/.gitignore
+++ b/rspy/.gitignore
@@ -1,3 +1,4 @@
 .build
 target
+targetclippy
 Cargo.lock

--- a/rspy/Makefile
+++ b/rspy/Makefile
@@ -74,6 +74,9 @@ build: .build/build
 
 check: .build/check
 
+# cargo clippy also run build.rs, thus it must be called before calling .build/develop
+clippy: .build/clippy .build/develop
+
 fix:
 	cargo fmt
 
@@ -90,8 +93,8 @@ RUST_TOOLCHAIN := $(shell cat rust-toolchain)
 	rustup component add clippy-preview --toolchain $(RUST_TOOLCHAIN)
 	@touch $@
 
-# cargo clippy also run build.rs, thus it must be called before calling .build/develop
-.build/check: .build/clippy .build/develop
+# we should not call clippy on Mac OS when running make check - https://github.com/ankitects/anki/pull/597
+.build/check: .build/develop
 	cargo fmt -- --check
 	@touch $@
 

--- a/rspy/Makefile
+++ b/rspy/Makefile
@@ -45,6 +45,13 @@ BUILD_VARIABLES = FTL_TEMPLATE_DIRS="$(QT_FTL_TEMPLATES)" \
 	FTL_LOCALE_DIRS="$(QT_FTL_LOCALES)" \
 	CARGO_TARGET_DIR="$(RSPY_TARGET_DIR)"
 
+# change target dir for clippy on Mac OS - https://github.com/ankitects/anki/pull/597
+ifeq ($(UNAME),Darwin)
+	CLIPPY_TARGET_DIR = ${RSPY_TARGET_DIR}clippy
+else
+	CLIPPY_TARGET_DIR = ${RSPY_TARGET_DIR}
+endif
+
 .PHONY: all develop build check fix clean
 
 all: develop
@@ -74,9 +81,6 @@ build: .build/build
 
 check: .build/check
 
-# cargo clippy also run build.rs, thus it must be called before calling .build/develop
-clippy: .build/clippy .build/develop
-
 fix:
 	cargo fmt
 
@@ -93,13 +97,13 @@ RUST_TOOLCHAIN := $(shell cat rust-toolchain)
 	rustup component add clippy-preview --toolchain $(RUST_TOOLCHAIN)
 	@touch $@
 
-# we should not call clippy on Mac OS when running make check - https://github.com/ankitects/anki/pull/597
-.build/check: .build/develop
+# cargo clippy also run build.rs, thus it must be called before calling .build/develop
+.build/check: .build/clippy .build/develop
 	cargo fmt -- --check
 	@touch $@
 
 .build/clippy: $(DEPS)
-	cargo clippy -- -D warnings
+	CARGO_TARGET_DIR="${CLIPPY_TARGET_DIR}" cargo clippy -- -D warnings
 	@touch $@
 
 VER := $(shell cat ../meta/version)

--- a/rspy/Makefile
+++ b/rspy/Makefile
@@ -90,8 +90,12 @@ RUST_TOOLCHAIN := $(shell cat rust-toolchain)
 	rustup component add clippy-preview --toolchain $(RUST_TOOLCHAIN)
 	@touch $@
 
-.build/check: build
+# cargo clippy also run build.rs, thus it must be called before calling .build/develop
+.build/check: .build/clippy .build/develop
 	cargo fmt -- --check
+	@touch $@
+
+.build/clippy: $(DEPS)
 	cargo clippy -- -D warnings
 	@touch $@
 


### PR DESCRIPTION
Almost the same thing as https://github.com/ankitects/anki/pull/597 (Fixed rspy check not being called), but also runs `clippy` on Mac OS by changing/using a different `CARGO_TARGET_DIR` just for `clippy`.

Detect we are on Mac OS and pass different locations for `clippy` and `maturin`. It would just use more disk/file system space for Mac OS, but keep the compilation times short.