### PR TITLE
Created the --benchmark command line option

### DIFF
--- a/qt/aqt/__init__.py
+++ b/qt/aqt/__init__.py
@@ -354,19 +354,17 @@ def setupGL(pm):
         os.environ["QT_OPENGL"] = mode
 
 
-def printBenchmark(argumentsNamespace, profiller):
-    if argumentsNamespace.benchmark and profiller:
+def printBenchmark(argumentsNamespace, profiler):
+    if argumentsNamespace.benchmark and profiler:
         import io
         import pstats
 
-        profiller.disable()
+        profiler.disable()
         outputstream = io.StringIO()
-        profiller_status = pstats.Stats(profiller, stream=outputstream)
-        profiller_status.sort_stats("time")
-        profiller_status.print_stats()
-        sys.stderr.write(
-            f"\n{outputstream.getvalue()[:argumentsNamespace.benchmark]}\n"
-        )
+        profiler_status = pstats.Stats(profiler, stream=outputstream)
+        profiler_status.sort_stats("time")
+        profiler_status.print_stats()
+        sys.stderr.write(f"\n{outputstream.getvalue()}\n")
 
 
 def run():
@@ -392,7 +390,7 @@ def _run(argv=None, exec=True):
     If no 'argv' is supplied then 'sys.argv' will be used.
     """
     global mw
-    profiller = None
+    profiler = None
 
     if argv is None:
         argv = sys.argv
@@ -403,8 +401,8 @@ def _run(argv=None, exec=True):
     if opts.benchmark:
         import cProfile
 
-        profiller = cProfile.Profile()
-        profiller.enable()
+        profiler = cProfile.Profile()
+        profiler.enable()
 
     # profile manager
     pm = None
@@ -438,7 +436,7 @@ def _run(argv=None, exec=True):
     app = AnkiApp(argv)
     if app.secondInstance():
         # we've signaled the primary instance, so we should close
-        printBenchmark(opts, profiller)
+        printBenchmark(opts, profiler)
         return
 
     if not pm:
@@ -449,7 +447,7 @@ def _run(argv=None, exec=True):
 Anki could not create its data folder. Please see the File Locations \
 section of the manual, and ensure that location is not read-only.""",
         )
-        printBenchmark(opts, profiller)
+        printBenchmark(opts, profiler)
         return
 
     # disable icons on mac; this must be done before window created
@@ -483,7 +481,7 @@ section of the manual, and ensure that location is not read-only.""",
 No usable temporary folder found. Make sure C:\\temp exists or TEMP in your \
 environment points to a valid, writable folder.""",
         )
-        printBenchmark(opts, profiller)
+        printBenchmark(opts, profiler)
         return
 
     if pmLoadResult.firstTime:
@@ -522,7 +520,7 @@ environment points to a valid, writable folder.""",
     if exec:
         app.exec()
     else:
-        printBenchmark(opts, profiller)
+        printBenchmark(opts, profiler)
         return app
 
-    printBenchmark(opts, profiller)
+    printBenchmark(opts, profiler)


### PR DESCRIPTION
https://anki.tenderapp.com/discussions/ankidesktop/41106-card-audio-playback-changes-bug-in-212x

Based on the snippet: https://gist.github.com/evandrocoan/961d46e10424e53ba8946fac66e0efac

Usage example:
```java
F:\anki>sh run --benchmark 2000
Starting Anki...
reverting to stock json

         117722 function calls (116503 primitive calls) in 7.586 seconds

   Ordered by: internal time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    6.188    6.188    6.673    6.673 {built-in method exec}
        3    0.417    0.139    0.418    0.139 F:\anki\qt\aqt\webview.py:25(__init__)
        1    0.300    0.300    0.300    0.300 F:\anki\qt\aqt\__init__.py:239(__init__)
        2    0.164    0.082    0.165    0.082 {built-in method show}
       10    0.142    0.014    0.142    0.014 {built-in method nt.listdir}
        2    0.068    0.034    0.068    0.034 {built-in method nt.unlink}
        1    0.031    0.031    0.031    0.031 {built-in method gc.collect}
       72    0.022    0.000    0.022    0.000 {method 'db_command' of 'Backend' objects}
       67    0.017    0.000    0.017    0.000 {built-in method io.open_code}
      262    0.016    0.000    0.016    0.000 {built-in method nt.stat}
    58902    0.014    0.000    0.014    0.000 {method 'startswith' of 'str' objects}
       45    0.009    0.000    0.009    0.000 {method 'command' of 'Backend' objects}
        1    0.009    0.009    0.011    0.011 F:\anki\qt\aqt\forms\main.py:15(setupUi)
        4    0.009    0.002    0.009    0.002 {built-in method setHtml}
       67    0.008    0.000    0.008    0.000 {built-in method marshal.loads}
        1    0.008    0.008    0.008    0.008 {built-in method pythoncom.CoCreateInstance}
        2    0.005    0.003    0.006    0.003 {built-in method hide}
   101/39    0.005    0.000    0.013    0.000 F:\Python\lib\sre_parse.py:493(_parse)
        2    0.005    0.002    0.005    0.002 {built-in method setContent}
  121/117    0.004    0.000    0.022    0.000 {built-in method builtins.__build_class__}
       68    0.004    0.000    0.004    0.000 {method 'read' of '_io.BufferedReader' objects}

make: Leaving directory '/cygdrive/f/anki'

F:\anki>
```