### PR TITLE
Fix missing pyaudio blocking Anki from running

### DIFF
--- a/qt/aqt/sound.py
+++ b/qt/aqt/sound.py
@@ -13,8 +13,6 @@ from concurrent.futures import Future
 from operator import itemgetter
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
-import pyaudio
-
 import aqt
 from anki.cards import Card
 from anki.lang import _
@@ -25,6 +23,14 @@ from aqt.mpv import MPV, MPVBase
 from aqt.qt import *
 from aqt.taskman import TaskManager
 from aqt.utils import restoreGeom, saveGeom, showWarning, startup_info
+
+try:
+    import pyaudio
+except:
+    print(
+        "Warning: pyaudio is not installed and audio recording will not work! Install it with: python3 -m pip install pyaudio"
+    )
+
 
 # AV player protocol
 ##########################################################################
@@ -408,7 +414,6 @@ class SimpleMplayerSlaveModePlayer(SimpleMplayerPlayer):
 ##########################################################################
 
 
-PYAU_FORMAT = pyaudio.paInt16
 PYAU_CHANNELS = 1
 PYAU_INPUT_INDEX: Optional[int] = None
 
@@ -457,6 +462,7 @@ class PyAudioThreadedRecorder(threading.Thread):
 
         rate = int(p.get_default_input_device_info()["defaultSampleRate"])
         wait = int(rate * self.startupDelay)
+        PYAU_FORMAT = pyaudio.paInt16
 
         stream = p.open(
             format=PYAU_FORMAT,

--- a/qt/aqt/sound.py
+++ b/qt/aqt/sound.py
@@ -27,9 +27,7 @@ from aqt.utils import restoreGeom, saveGeom, showWarning, startup_info
 try:
     import pyaudio
 except:
-    print(
-        "Warning: pyaudio is not installed and audio recording will not work! Install it with: python3 -m pip install pyaudio"
-    )
+    pyaudio = None
 
 
 # AV player protocol
@@ -526,6 +524,11 @@ Recorder = PyAudioRecorder
 
 def getAudio(parent: QWidget, encode: bool = True) -> Optional[str]:
     "Record and return filename"
+    if not pyaudio:
+        showWarning(
+            "The Python pip `pyaudio` dependency is not installed and audio recording will not work!"
+        )
+        return None
     # record first
     r = Recorder()
     mb = QMessageBox(parent)


### PR DESCRIPTION
Continuing from https://github.com/ankitects/anki/pull/606 - Remove pyaudio as mandatory dependency