### PR TITLE
Automatically install pyaudio when running make check

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -123,9 +123,6 @@ jobs:
           echo "::set-env name=RSPY_TARGET_DIR::${GITHUB_WORKSPACE}/target"
           echo "::set-env name=CARGO_TARGET_DIR::${GITHUB_WORKSPACE}/target"
 
-          # https://anki.tenderapp.com/discussions/add-ons/44009-problems-with-code-completion
-          echo "::set-env name=ANKI_EXTRA_PIP::python -m pip install pyaudio"
-
       - name: Configure Mac OS environment variables
         if: matrix.os == 'macos-latest'
         run: |
@@ -143,9 +140,6 @@ jobs:
 
           # https://stackoverflow.com/questions/59644349/msgmerge-on-macos-catalina
           echo "::set-env name=PATH::/usr/local/opt/gettext/bin:$PATH"
-
-          # https://anki.tenderapp.com/discussions/add-ons/44009-problems-with-code-completion
-          echo "::set-env name=ANKI_EXTRA_PIP::python -m pip install pyaudio"
 
       - name: Configure Windows environment variables
         if: matrix.os == 'windows-latest'

--- a/Makefile
+++ b/Makefile
@@ -61,8 +61,7 @@ all: run
 # - modern pip required for wheel
 # - add qt if missing
 pyenv:
-# 	https://github.com/PyO3/maturin/issues/283
-# 	Expected `python` to be a python interpreter inside a virtualenv
+# 	https://github.com/PyO3/maturin/issues/283 - Expected `python` to be a python interpreter inside a virtualenv
 	set -eu -o pipefail ${SHELLFLAGS}; \
 	"${PYTHON_BIN}" -m pip install virtualenv; \
 	"${PYTHON_BIN}" -m venv pyenv; \

--- a/qt/Makefile
+++ b/qt/Makefile
@@ -70,7 +70,11 @@ BUILD_STEPS := .build/vernum .build/run-deps .build/dev-deps .build/js .build/ui
 ######################
 
 .PHONY: check
-check: $(BUILD_STEPS) .build/mypy .build/test .build/fmt .build/imports .build/lint .build/ts-fmt
+check: pyaudio $(BUILD_STEPS) .build/mypy .build/test .build/fmt .build/imports .build/lint .build/ts-fmt
+
+# https://github.com/ankitects/anki/pull/611 - Automatically install pyaudio when running make check
+pyaudio:
+	python -m pip install pyaudio
 
 .PHONY: fix
 fix: $(BUILD_STEPS)


### PR DESCRIPTION
Continuing from https://github.com/ankitects/anki/pull/606 - Remove pyaudio as mandatory dependency

As the Linux/Mac OS instructions on `README.development` do not require to set `ANKI_EXTRA_PIP`, they should be updated asking it to be set to `ANKI_EXTRA_PIP="python -m pip install pyaudio`, but once `portaudio` is installed on Linux Mac OS (as asked on `README.development`), it is better to automatically install `pyaudio` on `make check` instead of asking Linux/Mac OS users to redundantly set `ANKI_EXTRA_PIP="python -m pip install pyaudio"`.