### PR TITLE
avoid playing entire media collection with mpv when audio path is empty

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -189,7 +189,7 @@ jobs:
         uses: actions/cache@v1
         with:
           path: ${{ github.workspace }}${{ matrix.SEP }}pyenv
-          key: ${{ runner.os }}-pyenv-${{ hashFiles('**/requirements.*') }}-${{ hashFiles('**/setup.py') }}-${{ hashFiles('**/Makefile') }}-15-
+          key: ${{ runner.os }}-pyenv-${{ hashFiles('**/requirements.*') }}-${{ hashFiles('**/setup.py') }}-${{ hashFiles('**/Makefile') }}-16-
 
       # # Disable it in attempt to reduce the overall cache size (https://github.com/ankitects/anki/pull/528)
       # - name: Cache pip wheels
@@ -197,42 +197,42 @@ jobs:
       #   uses: actions/cache@v1
       #   with:
       #     path: ${{ matrix.PIP_WHEELS_DIR }}
-      #     key: ${{ runner.os }}-pip-wheels-${{ hashFiles('**/requirements.txt') }}-${{ hashFiles('**/setup.py') }}-15-
+      #     key: ${{ runner.os }}-pip-wheels-${{ hashFiles('**/requirements.txt') }}-${{ hashFiles('**/setup.py') }}-16-
 
       - name: Cache cargo index
         if: matrix.python == '3.7'
         uses: actions/cache@v1
         with:
           path: ${{ matrix.CARGO_INDEX_DIR }}
-          key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/requirements.*') }}-${{ hashFiles('**/setup.py') }}-${{ hashFiles('**/Makefile') }}-${{ hashFiles('**/Cargo.toml') }}-15-
+          key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/requirements.*') }}-${{ hashFiles('**/setup.py') }}-${{ hashFiles('**/Makefile') }}-${{ hashFiles('**/Cargo.toml') }}-16-
 
       - name: Cache cargo registry
         if: matrix.python == '3.7'
         uses: actions/cache@v1
         with:
           path: ${{ matrix.CARGO_REGISTRY_DIR }}
-          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/requirements.*') }}-${{ hashFiles('**/setup.py') }}-${{ hashFiles('**/Makefile') }}-${{ hashFiles('**/Cargo.toml') }}-15-
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/requirements.*') }}-${{ hashFiles('**/setup.py') }}-${{ hashFiles('**/Makefile') }}-${{ hashFiles('**/Cargo.toml') }}-16-
 
       - name: Cache cargo target
         if: matrix.python == '3.7'
         uses: actions/cache@v1
         with:
           path: ${{ github.workspace }}${{ matrix.SEP }}target
-          key: ${{ runner.os }}-cargo-target-${{ hashFiles('**/requirements.*') }}-${{ hashFiles('**/setup.py') }}-${{ hashFiles('**/Makefile') }}-${{ hashFiles('**/Cargo.toml') }}-${{ matrix.BUILD_TYPE }}-15-
+          key: ${{ runner.os }}-cargo-target-${{ hashFiles('**/requirements.*') }}-${{ hashFiles('**/setup.py') }}-${{ hashFiles('**/Makefile') }}-${{ hashFiles('**/Cargo.toml') }}-${{ matrix.BUILD_TYPE }}-16-
 
       - name: Cache cargo rslib
         if: matrix.python == '3.7'
         uses: actions/cache@v1
         with:
           path: ${{ github.workspace }}${{ matrix.SEP }}rslib${{ matrix.SEP }}target
-          key: ${{ runner.os }}-cargo-rslib-${{ hashFiles('**/requirements.*') }}-${{ hashFiles('**/setup.py') }}-${{ hashFiles('**/Makefile') }}-${{ hashFiles('**/Cargo.toml') }}-${{ matrix.BUILD_TYPE }}-15-
+          key: ${{ runner.os }}-cargo-rslib-${{ hashFiles('**/requirements.*') }}-${{ hashFiles('**/setup.py') }}-${{ hashFiles('**/Makefile') }}-${{ hashFiles('**/Cargo.toml') }}-${{ matrix.BUILD_TYPE }}-16-
 
       - name: Cache cargo rspy
         if: matrix.python == '3.7'
         uses: actions/cache@v1
         with:
           path: ${{ github.workspace }}${{ matrix.SEP }}rspy${{ matrix.SEP }}target
-          key: ${{ runner.os }}-cargo-rspy-${{ hashFiles('**/requirements.*') }}-${{ hashFiles('**/setup.py') }}-${{ hashFiles('**/Makefile') }}-${{ hashFiles('**/Cargo.toml') }}-${{ matrix.BUILD_TYPE }}-15-
+          key: ${{ runner.os }}-cargo-rspy-${{ hashFiles('**/requirements.*') }}-${{ hashFiles('**/setup.py') }}-${{ hashFiles('**/Makefile') }}-${{ hashFiles('**/Cargo.toml') }}-${{ matrix.BUILD_TYPE }}-16-
 
       - name: Cache pacman
         if: matrix.os == 'windows-latest'
@@ -240,7 +240,7 @@ jobs:
         id: cache-pacman
         with:
           path: C:\Program Files\Git
-          key: ${{ runner.os }}-pacman-${{ hashFiles('**/checks.yml') }}-15-
+          key: ${{ runner.os }}-pacman-${{ hashFiles('**/checks.yml') }}-16-
 
       - name: Set up pacman, rsync
         if: matrix.os == 'windows-latest' && steps.cache-pacman.outputs.cache-hit != 'true'

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -33,6 +33,7 @@ Henry Tang <hktang@ualberta.ca>
 Simone Gaiarin <simgunz@gmail.com>
 Rai (Michal Pokorny) <agentydragon@gmail.com>
 Zeno Gantner <zeno.gantner@gmail.com>
+siikamiika
 
 ********************
 

--- a/qt/aqt/sound.py
+++ b/qt/aqt/sound.py
@@ -338,9 +338,10 @@ class MpvManager(MPV, SoundOrVideoPlayer):
     def play(self, tag: AVTag, on_done: OnDoneCallback) -> None:
         assert isinstance(tag, SoundOrVideoTag)
         self._on_done = on_done
-        path = os.path.join(os.getcwd(), tag.filename)
+        cwd = os.getcwd()
+        path = os.path.join(cwd, tag.filename)
         # avoid playing the entire directory
-        if os.path.isfile(path):
+        if os.path.normpath(path) != cwd:
             self.command("loadfile", path, "append-play")
         gui_hooks.av_player_did_begin_playing(self, tag)
 

--- a/qt/aqt/sound.py
+++ b/qt/aqt/sound.py
@@ -339,7 +339,9 @@ class MpvManager(MPV, SoundOrVideoPlayer):
         assert isinstance(tag, SoundOrVideoTag)
         self._on_done = on_done
         path = os.path.join(os.getcwd(), tag.filename)
-        self.command("loadfile", path, "append-play")
+        # avoid playing the entire directory
+        if os.path.isfile(path):
+            self.command("loadfile", path, "append-play")
         gui_hooks.av_player_did_begin_playing(self, tag)
 
     def stop(self) -> None:


### PR DESCRIPTION
There's a bug on platforms that use mpv to play sound that if the `[sound:]` is empty, Anki will play every single file in the media directory. We noticed that when fixing another bug in https://github.com/FooSoft/yomichan/pull/524. It didn't reproduce on Windows, so I decided to investigate mpv related code in Anki and found the issue.

In this case it's caused by mpv's `loadfile` playing directory contents by default, but other players used by Anki could have similar issues as well, so I'm not sure if this is the correct place to fix it.

Also, I wasn't sure if `gui_hooks.av_player_did_begin_playing(self, tag)` is meant to be triggered even when the player doesn't start playing anything, so I didn't make the code return on invalid paths. It could also be done this way:
```python
# avoid playing the entire directory
if not os.path.isfile(path):
    return
self.command("loadfile", path, "append-play")
```