### PR TITLE
Also fix legacy.py::anki.sound._soundReg accepting empty tags

### DIFF
--- a/qt/aqt/legacy.py
+++ b/qt/aqt/legacy.py
@@ -41,6 +41,6 @@ def fmtTimeSpan(time, pad=0, point=0, short=False, inTime=False, unit=99):
 def install_pylib_legacy() -> None:
     anki.utils.bodyClass = bodyClass  # type: ignore
     anki.utils.fmtTimeSpan = fmtTimeSpan  # type: ignore
-    anki.sound._soundReg = r"\[sound:(.*?)\]"  # type: ignore
+    anki.sound._soundReg = r"\[sound:(.+?)\]"  # type: ignore
     anki.sound.allSounds = allSounds  # type: ignore
     anki.sound.stripSounds = stripSounds  # type: ignore


### PR DESCRIPTION
Completes the fix for:
1. https://github.com/ankitects/anki/pull/612 - avoid playing entire media collection with mpv when audio path is empty
1. https://github.com/ankitects/anki/commit/66809dd8a3386b5968ca4ca0b17301dbd155a9a3 - ignore empty sound tags