### PR TITLE
Use mpv on Windows if available

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -33,6 +33,7 @@ Henry Tang <hktang@ualberta.ca>
 Simone Gaiarin <simgunz@gmail.com>
 Rai (Michal Pokorny) <agentydragon@gmail.com>
 Zeno Gantner <zeno.gantner@gmail.com>
+ANH <github.com/ANH25>
 
 ********************
 

--- a/qt/aqt/sound.py
+++ b/qt/aqt/sound.py
@@ -630,13 +630,12 @@ def setup_audio(taskman: TaskManager, base_folder: str) -> None:
     # legacy global var
     global mpvManager
 
-    if not isWin:
-        try:
-            mpvManager = MpvManager(base_folder)
-        except FileNotFoundError:
-            print("mpv not found, reverting to mplayer")
-        except aqt.mpv.MPVProcessError:
-            print("mpv too old, reverting to mplayer")
+    try:
+        mpvManager = MpvManager(base_folder)
+    except FileNotFoundError:
+        print("mpv not found, reverting to mplayer")
+    except aqt.mpv.MPVProcessError:
+        print("mpv too old, reverting to mplayer")
 
     if mpvManager is not None:
         av_player.players.append(mpvManager)


### PR DESCRIPTION
Starting from version 2.1.20, Anki starts a new copy of mplayer for each audio file on Windows. This can cause noticeable slowness when playing audio.

Using mpv if available could solve that problem (unless there are caveats I'm not aware of).