### PR TITLE
Fixed previewer button not resetting the state when the preview

### DIFF
--- a/qt/aqt/browser.py
+++ b/qt/aqt/browser.py
@@ -1566,7 +1566,7 @@ where id in %s"""
     def onTogglePreview(self):
         if self._previewer:
             self._previewer.close()
-            self._previewer = None
+            self._on_preview_closed()
         else:
             self._previewer = PreviewDialog(self, self.mw, self._on_preview_closed)
             self._previewer.open()

--- a/qt/aqt/previewer.py
+++ b/qt/aqt/previewer.py
@@ -97,10 +97,10 @@ class Previewer(QDialog):
     def close(self):
         self._on_close()
         super().close()
-        self._close_callback()
 
     def _on_close(self):
         self._open = False
+        self._close_callback()
 
     def _setup_web_view(self):
         jsinc = [
@@ -300,10 +300,6 @@ class BrowserPreviewer(MultiCardPreviewer):
             super()._should_enable_next()
             or self._parent.currentRow() < self._parent.model.rowCount(None) - 1
         )
-
-    def _on_close(self):
-        super()._on_close()
-        self._parent.previewer = None
 
     def _render_scheduled(self) -> None:
         super()._render_scheduled()


### PR DESCRIPTION
Fixed previewer button not resetting the state when the preview window is closed by its X button.