### PR TITLE
It should close the HttpClient (which holds the session object)

### DIFF
--- a/qt/aqt/editor.py
+++ b/qt/aqt/editor.py
@@ -803,6 +803,7 @@ to a cloze type first, via Edit>Change Note Type."""
             local = False
         # fetch it into a temporary folder
         self.mw.progress.start(immediate=not local, parent=self.parentWindow)
+        client = None
         response = None
         content_type = None
         error_msg: Optional[str] = None
@@ -826,6 +827,8 @@ to a cloze type first, via Edit>Change Note Type."""
             error_msg = _("An error occurred while opening %s") % e
             return
         finally:
+            if client:
+                client.close()
             if response:
                 response.close()
             self.mw.progress.finish()


### PR DESCRIPTION
I confused the name of the objects on my old pull request (https://github.com/ankitects/anki/pull/630).

But after looking, both objects have a close method.