### PR TITLE
Add three deck config hooks

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -33,6 +33,7 @@ Henry Tang <hktang@ualberta.ca>
 Simone Gaiarin <simgunz@gmail.com>
 Rai (Michal Pokorny) <agentydragon@gmail.com>
 Zeno Gantner <zeno.gantner@gmail.com>
+Henrik Giesel <hengiesel@gmail.com>
 
 ********************
 

--- a/qt/aqt/deckconf.py
+++ b/qt/aqt/deckconf.py
@@ -119,10 +119,12 @@ class DeckConf(QDialog):
         name = getOnlyText(_("New options group name:"))
         if not name:
             return
+
         # first, save currently entered data to current conf
         self.saveConf()
         # then clone the conf
         id = self.mw.col.decks.add_config_returning_id(name, clone_from=self.conf)
+        gui_hooks.deck_conf_did_add_config(self, self.deck, self.conf, name, id)
         # set the deck to the new conf
         self.deck["conf"] = id
         # then reload the conf list
@@ -132,6 +134,7 @@ class DeckConf(QDialog):
         if int(self.conf["id"]) == 1:
             showInfo(_("The default configuration can't be removed."), self)
         else:
+            gui_hooks.deck_conf_will_remove_config(self, self.deck, self.conf)
             self.mw.col.modSchema(check=True)
             self.mw.col.decks.remove_config(self.conf["id"])
             self.conf = None
@@ -143,6 +146,8 @@ class DeckConf(QDialog):
         name = getOnlyText(_("New name:"), default=old)
         if not name or name == old:
             return
+
+        gui_hooks.deck_conf_will_rename_config(self, self.deck, self.conf, name)
         self.conf["name"] = name
         self.saveConf()
         self.loadConfs()

--- a/qt/aqt/gui_hooks.py
+++ b/qt/aqt/gui_hooks.py
@@ -918,14 +918,23 @@ deck_browser_will_show_options_menu = _DeckBrowserWillShowOptionsMenuHook()
 
 
 class _DeckConfDidAddConfigHook:
-    """Called after a new config group was added as a clone of the current one, but before initializing the widget state"""
+    """Allows modification of a newly created config group
+
+        This hook is called after the config group was created, but
+        before initializing the widget state.
+
+        `deck_conf` will point to the old config group, `new_conf_id` will
+        point to the newly created config group.
+
+        Config groups are created as clones of the current one.
+        """
 
     _hooks: List[Callable[["aqt.deckconf.DeckConf", Any, Any, str, int], None]] = []
 
     def append(
         self, cb: Callable[["aqt.deckconf.DeckConf", Any, Any, str, int], None]
     ) -> None:
-        """(deck_conf: aqt.deckconf.DeckConf, deck: Any, config: Any, new_name: str, new_confg_id: int)"""
+        """(deck_conf: aqt.deckconf.DeckConf, deck: Any, config: Any, new_name: str, new_conf_id: int)"""
         self._hooks.append(cb)
 
     def remove(
@@ -940,11 +949,11 @@ class _DeckConfDidAddConfigHook:
         deck: Any,
         config: Any,
         new_name: str,
-        new_confg_id: int,
+        new_conf_id: int,
     ) -> None:
         for hook in self._hooks:
             try:
-                hook(deck_conf, deck, config, new_name, new_confg_id)
+                hook(deck_conf, deck, config, new_name, new_conf_id)
             except:
                 # if the hook fails, remove it
                 self._hooks.remove(hook)

--- a/qt/aqt/gui_hooks.py
+++ b/qt/aqt/gui_hooks.py
@@ -917,6 +917,43 @@ class _DeckBrowserWillShowOptionsMenuHook:
 deck_browser_will_show_options_menu = _DeckBrowserWillShowOptionsMenuHook()
 
 
+class _DeckConfDidAddConfigHook:
+    """Called after a new config group was added as a clone of the current one, but before initializing the widget state"""
+
+    _hooks: List[Callable[["aqt.deckconf.DeckConf", Any, Any, str, int], None]] = []
+
+    def append(
+        self, cb: Callable[["aqt.deckconf.DeckConf", Any, Any, str, int], None]
+    ) -> None:
+        """(deck_conf: aqt.deckconf.DeckConf, deck: Any, config: Any, new_name: str, new_confg_id: int)"""
+        self._hooks.append(cb)
+
+    def remove(
+        self, cb: Callable[["aqt.deckconf.DeckConf", Any, Any, str, int], None]
+    ) -> None:
+        if cb in self._hooks:
+            self._hooks.remove(cb)
+
+    def __call__(
+        self,
+        deck_conf: aqt.deckconf.DeckConf,
+        deck: Any,
+        config: Any,
+        new_name: str,
+        new_confg_id: int,
+    ) -> None:
+        for hook in self._hooks:
+            try:
+                hook(deck_conf, deck, config, new_name, new_confg_id)
+            except:
+                # if the hook fails, remove it
+                self._hooks.remove(hook)
+                raise
+
+
+deck_conf_did_add_config = _DeckConfDidAddConfigHook()
+
+
 class _DeckConfDidLoadConfigHook:
     """Called once widget state has been set from deck config"""
 
@@ -969,6 +1006,66 @@ class _DeckConfDidSetupUiFormHook:
 
 
 deck_conf_did_setup_ui_form = _DeckConfDidSetupUiFormHook()
+
+
+class _DeckConfWillRemoveConfigHook:
+    """Called before current config group is removed"""
+
+    _hooks: List[Callable[["aqt.deckconf.DeckConf", Any, Any], None]] = []
+
+    def append(self, cb: Callable[["aqt.deckconf.DeckConf", Any, Any], None]) -> None:
+        """(deck_conf: aqt.deckconf.DeckConf, deck: Any, config: Any)"""
+        self._hooks.append(cb)
+
+    def remove(self, cb: Callable[["aqt.deckconf.DeckConf", Any, Any], None]) -> None:
+        if cb in self._hooks:
+            self._hooks.remove(cb)
+
+    def __call__(
+        self, deck_conf: aqt.deckconf.DeckConf, deck: Any, config: Any
+    ) -> None:
+        for hook in self._hooks:
+            try:
+                hook(deck_conf, deck, config)
+            except:
+                # if the hook fails, remove it
+                self._hooks.remove(hook)
+                raise
+
+
+deck_conf_will_remove_config = _DeckConfWillRemoveConfigHook()
+
+
+class _DeckConfWillRenameConfigHook:
+    """Called before config group is renamed"""
+
+    _hooks: List[Callable[["aqt.deckconf.DeckConf", Any, Any, str], None]] = []
+
+    def append(
+        self, cb: Callable[["aqt.deckconf.DeckConf", Any, Any, str], None]
+    ) -> None:
+        """(deck_conf: aqt.deckconf.DeckConf, deck: Any, config: Any, new_name: str)"""
+        self._hooks.append(cb)
+
+    def remove(
+        self, cb: Callable[["aqt.deckconf.DeckConf", Any, Any, str], None]
+    ) -> None:
+        if cb in self._hooks:
+            self._hooks.remove(cb)
+
+    def __call__(
+        self, deck_conf: aqt.deckconf.DeckConf, deck: Any, config: Any, new_name: str
+    ) -> None:
+        for hook in self._hooks:
+            try:
+                hook(deck_conf, deck, config, new_name)
+            except:
+                # if the hook fails, remove it
+                self._hooks.remove(hook)
+                raise
+
+
+deck_conf_will_rename_config = _DeckConfWillRenameConfigHook()
 
 
 class _DeckConfWillSaveConfigHook:

--- a/qt/tools/genhooks_gui.py
+++ b/qt/tools/genhooks_gui.py
@@ -172,6 +172,21 @@ hooks = [
         args=["deck_conf: aqt.deckconf.DeckConf", "deck: Any", "config: Any"],
         doc="Called before widget state is saved to config",
     ),
+    Hook(
+        name="deck_conf_did_add_config",
+        args=["deck_conf: aqt.deckconf.DeckConf", "deck: Any", "config: Any", "new_name: str", "new_confg_id: int"],
+        doc="Called after a new config group was added as a clone of the current one, but before initializing the widget state",
+    ),
+    Hook(
+        name="deck_conf_will_remove_config",
+        args=["deck_conf: aqt.deckconf.DeckConf", "deck: Any", "config: Any"],
+        doc="Called before current config group is removed",
+    ),
+    Hook(
+        name="deck_conf_will_rename_config",
+        args=["deck_conf: aqt.deckconf.DeckConf", "deck: Any", "config: Any", "new_name: str"],
+        doc="Called before config group is renamed",
+    ),
     # Browser
     ###################
     Hook(name="browser_will_show", args=["browser: aqt.browser.Browser"]),

--- a/qt/tools/genhooks_gui.py
+++ b/qt/tools/genhooks_gui.py
@@ -174,8 +174,23 @@ hooks = [
     ),
     Hook(
         name="deck_conf_did_add_config",
-        args=["deck_conf: aqt.deckconf.DeckConf", "deck: Any", "config: Any", "new_name: str", "new_confg_id: int"],
-        doc="Called after a new config group was added as a clone of the current one, but before initializing the widget state",
+        args=[
+            "deck_conf: aqt.deckconf.DeckConf",
+            "deck: Any",
+            "config: Any",
+            "new_name: str",
+            "new_conf_id: int",
+        ],
+        doc="""Allows modification of a newly created config group
+
+        This hook is called after the config group was created, but
+        before initializing the widget state.
+
+        `deck_conf` will point to the old config group, `new_conf_id` will
+        point to the newly created config group.
+
+        Config groups are created as clones of the current one.
+        """,
     ),
     Hook(
         name="deck_conf_will_remove_config",
@@ -184,7 +199,12 @@ hooks = [
     ),
     Hook(
         name="deck_conf_will_rename_config",
-        args=["deck_conf: aqt.deckconf.DeckConf", "deck: Any", "config: Any", "new_name: str"],
+        args=[
+            "deck_conf: aqt.deckconf.DeckConf",
+            "deck: Any",
+            "config: Any",
+            "new_name: str",
+        ],
         doc="Called before config group is renamed",
     ),
     # Browser


### PR DESCRIPTION
These PR will add three `gui_hooks` for working inside of the the deck config window. These are:

- `gui_hooks.deck_conf_did_add_config`
- `gui_hooks.deck_conf_will_remove_config`
- `gui_hooks.deck_conf_will_rename_config`

These are helpful, when you want to offer your add-on settings inside of the deck_conf window, and want them to behave correctly when the user utilizes these functionalities.

`did_add_config` is helpful because you have the new name and id, but you also have access to the previous settings. This allows for easily copying the previous settings to the new name or id (and thus behaving like Anki does when adding a new config group).

I specifically would use them in my addon [Straight Rewards](https://ankiweb.net/shared/info/957961234).