### PR TITLE
Fixed previewer.py::render_card() being called twice in row

### DIFF
--- a/qt/aqt/browser.py
+++ b/qt/aqt/browser.py
@@ -880,7 +880,6 @@ QTableView {{ gridline-color: {grid} }}
 
     def refreshCurrentCard(self, note: Note) -> None:
         self.model.refreshNote(note)
-        self._renderPreview(False)
 
     def onLoadNote(self, editor):
         self.refreshCurrentCard(editor.note)


### PR DESCRIPTION
Related to: 
1. https://github.com/ankitects/anki/pull/529 - Ensuring "setNote" is called only once during changing of note type
1. https://github.com/ankitects/anki/pull/625 - Fixed clayout.py rendering the contents twice when clicked

After debugging the code, every time the cards changes, there are two stacktraces generated and triggered when note cards change:

![image](https://user-images.githubusercontent.com/5332158/83054542-f18e6b00-a028-11ea-9cd4-1dbe51012fea.png)


```
calling 1590591251.4621403
   File "qt/runanki", line 4, in <module>
  File "F:\anki\qt\aqt\__init__.py", line 365, in run
    _run()
  File "F:\anki\qt\aqt\__init__.py", line 515, in _run
    app.exec()
  File "F:\anki\qt\aqt\webview.py", line 467, in handler
    cb(val)
  File "F:\anki\qt\aqt\editor.py", line 477, in <lambda>
    self.web.evalWithCallback("saveNow(%d)" % keepFocus, lambda res: callback())
  File "F:\anki\qt\aqt\browser.py", line 858, in <lambda>
    self.editor.saveNow(lambda: self._onRowChanged(current, previous))
  File "F:\anki\qt\aqt\browser.py", line 880, in _onRowChanged
    self._renderPreview(True)
  File "F:\anki\qt\aqt\browser.py", line 1576, in _renderPreview
    self._previewer.render_card(cardChanged)
  File "F:\anki\qt\aqt\previewer.py", line 136, in render_card
    print('calling', time.time(), "\n", "".join( traceback.format_stack() ) )

calling 1590591251.4766161
   File "qt/runanki", line 4, in <module>
  File "F:\anki\qt\aqt\__init__.py", line 365, in run
    _run()
  File "F:\anki\qt\aqt\__init__.py", line 515, in _run
    app.exec()
  File "F:\anki\qt\aqt\webview.py", line 467, in handler
    cb(val)
  File "F:\anki\qt\aqt\editor.py", line 453, in oncallback
    gui_hooks.editor_did_load_note(self)
  File "F:\anki\qt\aqt\gui_hooks.py", line 1168, in __call__
    hook(editor)
  File "F:\anki\qt\aqt\browser.py", line 887, in onLoadNote
    self.refreshCurrentCard(editor.note)
  File "F:\anki\qt\aqt\browser.py", line 884, in refreshCurrentCard
    self._renderPreview(False)
  File "F:\anki\qt\aqt\browser.py", line 1576, in _renderPreview
    self._previewer.render_card(cardChanged)
  File "F:\anki\qt\aqt\previewer.py", line 136, in render_card
    print('calling', time.time(), "\n", "".join( traceback.format_stack() ) )
```

Here, I am removing the second one which passes through `refreshCurrentCard` and has `cardChanged=False` set, while letting the first one (with `cardChanged=True`) passing through because the card had changed. That line I removed was added in 2013 in a refactoring: https://github.com/ankitects/anki/commit/5951ccb09ea82d80a06030eb6b156bb870265111#diff-19a1c68865eed945a2fe67d5502d8f0dR584