### PR TITLE
Added support to syntax highlighting on clayout.py text editor

### DIFF
--- a/qt/aqt/clayout.py
+++ b/qt/aqt/clayout.py
@@ -283,11 +283,15 @@ class CardLayout(QDialog):
 
         self.fill_fields_from_template()
 
-    def on_search_changed(self, text: str):
+    def on_search_changed(self, text: str, selectNext=False):
         editor = self.tform.edit_area
         from aqt import utils as aqtUtils
 
         if aqtUtils.Qsci and aqtUtils.QsciEnabled:
+            if not selectNext:
+                line_from, index_from, line_to, index_to = editor.getSelection()
+                editor.setSelection(line_from, index_from, line_from, index_from)
+
             if not editor.findFirst(text, True, False, False, True):
                 tooltip("No matches found.")
         else:
@@ -301,7 +305,7 @@ class CardLayout(QDialog):
 
     def on_search_next(self):
         text = self.tform.search_edit.text()
-        self.on_search_changed(text)
+        self.on_search_changed(text, selectNext=True)
 
     def setup_preview(self):
         pform = self.pform

--- a/qt/aqt/clayout.py
+++ b/qt/aqt/clayout.py
@@ -194,6 +194,10 @@ class CardLayout(QDialog):
         split.addWidget(left)
         split.setCollapsible(0, False)
 
+        from aqt.utils import setupSyntaxHighlighter
+
+        setupSyntaxHighlighter(tform, "edit_area", "verticalLayout")
+
         right = QWidget()
         self.pform = aqt.forms.preview.Ui_Form()
         pform = self.pform
@@ -258,31 +262,42 @@ class CardLayout(QDialog):
         self._renderPreview()
 
     def on_editor_toggled(self):
+        from aqt.utils import changeSyntaxName
+
         if self.tform.front_button.isChecked():
             self.current_editor_index = 0
             self.pform.preview_front.setChecked(True)
             self.on_preview_toggled()
             self.add_field_button.setHidden(False)
+            changeSyntaxName(self.tform.edit_area, "QsciLexerHTML")
         elif self.tform.back_button.isChecked():
             self.current_editor_index = 1
             self.pform.preview_back.setChecked(True)
             self.on_preview_toggled()
             self.add_field_button.setHidden(False)
+            changeSyntaxName(self.tform.edit_area, "QsciLexerHTML")
         else:
             self.current_editor_index = 2
             self.add_field_button.setHidden(True)
+            changeSyntaxName(self.tform.edit_area, "QsciLexerCSS")
 
         self.fill_fields_from_template()
 
     def on_search_changed(self, text: str):
         editor = self.tform.edit_area
-        if not editor.find(text):
-            # try again from top
-            cursor = editor.textCursor()
-            cursor.movePosition(QTextCursor.Start)
-            editor.setTextCursor(cursor)
-            if not editor.find(text):
+        from aqt import utils as aqtUtils
+
+        if aqtUtils.Qsci and aqtUtils.QsciEnabled:
+            if not editor.findFirst(text, True, False, False, True):
                 tooltip("No matches found.")
+        else:
+            if not editor.find(text):
+                # try again from top
+                cursor = editor.textCursor()
+                cursor.movePosition(QTextCursor.Start)
+                editor.setTextCursor(cursor)
+                if not editor.find(text):
+                    tooltip("No matches found.")
 
     def on_search_next(self):
         text = self.tform.search_edit.text()

--- a/qt/aqt/preferences.py
+++ b/qt/aqt/preferences.py
@@ -227,6 +227,7 @@ Not currently enabled; click the sync button in the main window to enable."""
         self.form.pasteInvert.setChecked(self.prof.get("pasteInvert", False))
         self.form.showPlayButtons.setChecked(self.prof.get("showPlayButtons", True))
         self.form.nightMode.setChecked(self.mw.pm.night_mode())
+        self.form.enableSyntaxHighlight.setChecked(self.mw.pm.syntax_highlight())
         self.form.interrupt_audio.setChecked(self.mw.pm.interrupt_audio())
 
     def updateOptions(self):
@@ -245,6 +246,7 @@ Not currently enabled; click the sync button in the main window to enable."""
             restart_required = True
 
         self.mw.pm.set_interrupt_audio(self.form.interrupt_audio.isChecked())
+        self.mw.pm.set_syntax_highlight(self.form.enableSyntaxHighlight.isChecked())
 
         if restart_required:
             showInfo(_("Changes will take effect when you restart Anki."))

--- a/qt/aqt/profiles.py
+++ b/qt/aqt/profiles.py
@@ -262,6 +262,10 @@ details have been forgotten."""
             print("resetting corrupt profile")
             self.profile = profileConf.copy()
             self.save()
+        finally:
+            from aqt import utils as aqtUtils
+
+            aqtUtils.QsciEnabled = self.syntax_highlight()
         return True
 
     def save(self) -> None:
@@ -611,6 +615,15 @@ create table if not exists profiles
 
     def interrupt_audio(self) -> bool:
         return self.profile.get("interrupt_audio", True)
+
+    def syntax_highlight(self) -> bool:
+        return self.profile.get("syntax_highlight", True)
+
+    def set_syntax_highlight(self, val: bool) -> None:
+        from aqt import utils as aqtUtils
+
+        aqtUtils.QsciEnabled = val
+        self.profile["syntax_highlight"] = val
 
     def set_interrupt_audio(self, val: bool) -> None:
         self.profile["interrupt_audio"] = val

--- a/qt/aqt/qt.py
+++ b/qt/aqt/qt.py
@@ -30,6 +30,19 @@ except ImportError:
     import sip  # type: ignore
 
 
+try:
+    # pylint: disable=no-name-in-module
+    from PyQt5 import Qsci  # type: ignore
+except Exception as error:
+    from anki.utils import devMode
+
+    Qsci = None
+    if devMode:
+        sys.stderr.write(
+            f"Could not create the syntax highlighter: {error}\n{traceback.format_exc()}\n"
+        )
+
+
 def debug():
     from pdb import set_trace
 

--- a/qt/aqt/qt.py
+++ b/qt/aqt/qt.py
@@ -32,7 +32,7 @@ except ImportError:
 
 try:
     # pylint: disable=no-name-in-module
-    from PyQt5 import Qsci  # type: ignore
+    from PyQt5 import Qsci
 except Exception as error:
     from anki.utils import devMode
 

--- a/qt/aqt/utils.py
+++ b/qt/aqt/utils.py
@@ -362,7 +362,7 @@ def setupSyntaxHighlighter(parent, name, layout_name):
             layout.replaceWidget(old_editor, editor)
             old_editor.setParent(None)
             setattr(parent, name, editor)
-        except:
+        except Exception as error:
             QsciEnabled = False
             import traceback
 

--- a/qt/aqt/utils.py
+++ b/qt/aqt/utils.py
@@ -275,6 +275,119 @@ class GetTextDialog(QDialog):
         openHelp(self.help)
 
 
+try:
+    QsciEnabled = True
+    Qsci_font = QFont()
+    Qsci_font.setFamily("Courier")
+    Qsci_font.setFixedPitch(True)
+    Qsci_font.setPointSize(10)
+
+    from aqt.qt import Qsci
+
+    class SimplePythonEditor(Qsci.QsciScintilla):
+        def __init__(self, parent=None):
+            super().__init__(parent)
+            self.setFont(Qsci_font)
+            self.setMarginsFont(Qsci_font)
+
+            fontmetrics = QFontMetrics(Qsci_font)
+            self.setMarginsFont(Qsci_font)
+
+            # Margin 0 is used for line numbers
+            self.setMarginWidth(0, fontmetrics.width("0000"))
+            self.setMarginLineNumbers(0, True)
+            self.setMarginsBackgroundColor(QColor("#cccccc"))
+
+            # Margin 1 used for markers (not used by us)
+            self.setMarginWidth(1, 0)
+
+            # Clickable margin 1 for showing markers
+            self.setMarginSensitivity(1, True)
+
+            # Brace matching: enable for a brace immediately before or after
+            # the current position
+            self.setBraceMatching(Qsci.QsciScintilla.SloppyBraceMatch)
+
+            # Current line visible with special background color
+            self.setCaretLineVisible(True)
+            self.setCaretLineBackgroundColor(QColor("#dadaff"))
+
+            lexer = Qsci.QsciLexerHTML()
+            lexer.setDefaultFont(Qsci_font)
+            self.setLexer(lexer)
+
+            text = bytearray(str.encode("Courier"))
+            self.SendScintilla(Qsci.QsciScintilla.SCI_STYLESETFONT, 1, text)
+            self.setWrapMode(Qsci.QsciScintilla.WrapWord)
+            self.setEolMode(Qsci.QsciScintilla.EolUnix)
+            self.setWrapIndentMode(Qsci.QsciScintilla.WrapIndentSame)
+
+            self.setAutoCompletionCaseSensitivity(False)
+            self.setAutoCompletionReplaceWord(False)
+            self.setAutoCompletionSource(Qsci.QsciScintilla.AcsDocument)
+            self.setAutoCompletionThreshold(1)
+
+        def setAcceptRichText(self, *args, **kwargs):
+            pass
+
+        def setTabStopDistance(self, *args, **kwargs):
+            pass
+
+        def setPlainText(self, text):
+            self.setText(text)
+
+        def toPlainText(self):
+            return self.text()
+
+
+except Exception as error:
+    import traceback
+    from anki.utils import devMode
+
+    Qsci = None
+    if devMode:
+        sys.stderr.write(
+            f"Could not create the syntax highlighter: {error}\n{traceback.format_exc()}\n"
+        )
+
+
+def setupSyntaxHighlighter(parent, name, layout_name):
+    global QsciEnabled
+    if Qsci and QsciEnabled:
+        try:
+            editor = SimplePythonEditor()
+            editor.setObjectName(name)
+            old_editor = getattr(parent, name)
+            old_editor.setParent(None)
+            layout = getattr(parent, layout_name)
+            layout.removeWidget(old_editor)
+            layout.addWidget(editor)
+            setattr(parent, name, editor)
+        except:
+            QsciEnabled = False
+            import traceback
+
+            sys.stderr.write(
+                f"Could not create the syntax highlighter: {error}\n{traceback.format_exc()}\n"
+            )
+
+
+def changeSyntaxName(editor, syntax_name):
+    global QsciEnabled
+    if Qsci and QsciEnabled:
+        try:
+            lexer = getattr(Qsci, syntax_name)()
+            lexer.setDefaultFont(Qsci_font)
+            editor.setLexer(lexer)
+        except Exception as error:
+            QsciEnabled = False
+            import traceback
+
+            sys.stderr.write(
+                f"Could not change the syntax highlighting to '{syntax_name}': {error}\n{traceback.format_exc()}\n"
+            )
+
+
 def getText(
     prompt,
     parent=None,

--- a/qt/aqt/utils.py
+++ b/qt/aqt/utils.py
@@ -342,6 +342,7 @@ try:
 
 except Exception as error:
     import traceback
+
     from anki.utils import devMode
 
     Qsci = None

--- a/qt/aqt/utils.py
+++ b/qt/aqt/utils.py
@@ -358,10 +358,9 @@ def setupSyntaxHighlighter(parent, name, layout_name):
             editor = SimplePythonEditor()
             editor.setObjectName(name)
             old_editor = getattr(parent, name)
-            old_editor.setParent(None)
             layout = getattr(parent, layout_name)
-            layout.removeWidget(old_editor)
-            layout.addWidget(editor)
+            layout.replaceWidget(old_editor, editor)
+            old_editor.setParent(None)
             setattr(parent, name, editor)
         except:
             QsciEnabled = False

--- a/qt/designer/preferences.ui
+++ b/qt/designer/preferences.ui
@@ -98,6 +98,13 @@
         </widget>
        </item>
        <item>
+        <widget class="QCheckBox" name="enableSyntaxHighlight">
+         <property name="text">
+          <string>Enable syntax highlighting on text editors</string>
+         </property>
+        </widget>
+       </item>
+       <item>
         <widget class="QComboBox" name="useCurrent">
          <item>
           <property name="text">
@@ -595,6 +602,7 @@
   <tabstop>pastePNG</tabstop>
   <tabstop>pasteInvert</tabstop>
   <tabstop>nightMode</tabstop>
+  <tabstop>enableSyntaxHighlight</tabstop>
   <tabstop>useCurrent</tabstop>
   <tabstop>uiScale</tabstop>
   <tabstop>showEstimates</tabstop>

--- a/qt/setup.py
+++ b/qt/setup.py
@@ -21,6 +21,7 @@ else:
     extra_files = package_files("aqt_data")
 
 install_requires = [
+    "QScintilla",
     "beautifulsoup4",
     "requests",
     "send2trash",


### PR DESCRIPTION
There is some time I was thinking about adding this, then, after seeing the request on https://anki.tenderapp.com/discussions/ankidesktop/41711-resize-windows-in-template-editor-syntax-highlighting, I decided to implement it.

In case someone has problems with it, it can be disabled in settings. Also, if the code fails to import the dependency or there is an error somehow it disables itself, i.e., it just does nothing, and the original code is run instead.

1. ![image](https://user-images.githubusercontent.com/5332158/83216257-34dafd80-a13f-11ea-9ddf-3fd91c3cdbc0.png)
1. ![image](https://user-images.githubusercontent.com/5332158/83216198-107f2100-a13f-11ea-9647-df01defaed75.png)
1. ![image](https://user-images.githubusercontent.com/5332158/83216230-22f95a80-a13f-11ea-86a4-ed5a0553b2c5.png)

Example code used:
<details>
<p>

```python
import sys

# https://stackoverflow.com/questions/22411463/how-to-use-the-autocomplete-feature-with-qscintilla
# http://getfr.org/pub/dragonfly-release/usr-local-share/doc/qscintilla2/html/hierarchy.html
# https://www.scintilla.org/ScintillaDoc.html#Autocompletion
# https://stackoverflow.com/questions/42329818/how-to-use-autocomplete-using-qscintilla-and-c
# https://stackoverflow.com/questions/40002373/qscintilla-based-text-editor-in-pyqt5-with-clickable-functions-and-variables
from PyQt5.QtWidgets import *
from PyQt5.QtCore import *
from PyQt5.QtGui import *
try:
    from PyQt5 import Qsci
except:
    Qsci = None
class SimplePythonEditor(Qsci.QsciScintilla):

    def setAcceptRichText(self, *args, **kwargs):
        pass

    def setTabStopDistance(self, *args, **kwargs):
        pass

    def setPlainText(self, text):
        self.setText(text)

    def toPlainText(self):
        return self.text()

    def __init__(self, parent=None):
        super().__init__(parent)
        font = QFont()
        font.setFamily('Courier')
        font.setFixedPitch(True)
        font.setPointSize(10)
        self.setFont(font)
        self.setMarginsFont(font)

        fontmetrics = QFontMetrics(font)
        self.setMarginsFont(font)

        # Margin 0 is used for line numbers
        self.setMarginWidth(0, fontmetrics.width("0000"))
        self.setMarginWidth(1, 0)
        self.setMarginLineNumbers(0, True)
        self.setMarginsBackgroundColor(QColor("#cccccc"))

        # Clickable margin 1 for showing markers
        self.setMarginSensitivity(1, True)

        # Brace matching: enable for a brace immediately before or after
        # the current position
        self.setBraceMatching(Qsci.QsciScintilla.SloppyBraceMatch)

        # Current line visible with special background color
        self.setCaretLineVisible(True)
        self.setCaretLineBackgroundColor(QColor("#ffe4e4"))

        lexer = Qsci.QsciLexerHTML()
        lexer.setDefaultFont(font)
        self.setLexer(lexer)

        text = bytearray(str.encode("Courier"))
        self.SendScintilla(Qsci.QsciScintilla.SCI_STYLESETFONT, 1, text)
        self.setWrapMode(Qsci.QsciScintilla.WrapWord)
        self.setEolMode(Qsci.QsciScintilla.EolUnix)
        self.setWrapIndentMode(Qsci.QsciScintilla.WrapIndentSame)

        self.setAutoCompletionCaseSensitivity(False)
        self.setAutoCompletionReplaceWord(False)
        self.setAutoCompletionSource(Qsci.QsciScintilla.AcsDocument)
        self.setAutoCompletionThreshold(1)

if __name__ == "__main__":
    app = QApplication(sys.argv)
    editor = SimplePythonEditor()
    editor.show()
    # editor.setText(open(sys.argv[0]).read())
    editor.setText(
"""
<div class="fixBorders">
What is the <b>past simple</b> of the verb to <b>{{Verb}}</b>?</span><br>

<span style="display: flex; align-items: center;">
    <input type="button" value="x1.2" onclick="setAnkiMedia( media => { media.playbackRate = 1.2; } )" />
    <input type="button" value="x1.0" onclick="setAnkiMedia( media => { media.playbackRate = 1.0; } )" />
    <input type="button" value="x0.6" onclick="setAnkiMedia( media => { media.playbackRate = 0.6; } )" />
    <audio data-file="{{VerbAudio}}" controlsList="nodownload" controls></audio>
</span>

{{type:PastSimple}}
</div>

<script type="text/javascript">
ankimedia.setup();
ankimedia.add( 'front', '{{VerbAudio}}', 1.2 );
</script>
""" )
    app.exec_()
```
</p>
</details>