### PR TITLE
Print qt context if it exists

### DIFF
--- a/qt/aqt/__init__.py
+++ b/qt/aqt/__init__.py
@@ -325,7 +325,23 @@ def setupGL(pm):
         ctypes.CDLL("libGL.so.1", ctypes.RTLD_GLOBAL)
 
     # catch opengl errors
-    def msgHandler(type, ctx, msg):
+    def msgHandler(category, ctx, msg):
+        if category == QtDebugMsg:
+            category = "debug"
+        elif category == QtInfoMsg:
+            category = "info"
+        elif category == QtWarningMsg:
+            category = "warning"
+        elif category == QtCriticalMsg:
+            category = "critical"
+        elif category == QtDebugMsg:
+            category = "debug"
+        elif category == QtFatalMsg:
+            category = "fatal"
+        elif category == QtSystemMsg:
+            category = "system"
+        else:
+            category = "unknown"
         context = ""
         if ctx.file:
             context += f"{ctx.file}:"
@@ -344,7 +360,7 @@ def setupGL(pm):
             pm.nextGlMode()
             return
         else:
-            print(f"qt: {msg} {context}")
+            print(f"Qt {category}: {msg} {context}")
 
     qInstallMessageHandler(msgHandler)
 

--- a/qt/aqt/__init__.py
+++ b/qt/aqt/__init__.py
@@ -326,17 +326,25 @@ def setupGL(pm):
 
     # catch opengl errors
     def msgHandler(type, ctx, msg):
+        context = ""
+        if ctx.file:
+            context += f"{ctx.file}:"
+        if ctx.line:
+            context += f"{ctx.line},"
+        if ctx.function:
+            context += f"{ctx.function}"
+        if context:
+            context = f"'{context}'"
         if "Failed to create OpenGL context" in msg:
             QMessageBox.critical(
                 None,
                 "Error",
-                "Error loading '%s' graphics driver. Please start Anki again to try next driver."
-                % mode,
+                f"Error loading '{mode}' graphics driver. Please start Anki again to try next driver. {context}",
             )
             pm.nextGlMode()
             return
         else:
-            print("qt:", msg)
+            print(f"qt: {msg} {context}")
 
     qInstallMessageHandler(msgHandler)
 


### PR DESCRIPTION
Qt won't give us the context unless it was compiled with `QT_MESSAGELOGCONTEXT`, but in case we got a qt compiled with `QT_MESSAGELOGCONTEXT`, print the function context: 
1. https://anki.tenderapp.com/discussions/ankidesktop/42070-anki-closes-without-warning-when-importing-conflicting-shared-deck
1. [How to debug an installed Qt5 library with GDB?](https://unix.stackexchange.com/questions/202374/how-to-debug-an-installed-qt5-library-with-gdb)
1. https://stackoverflow.com/questions/35894171/redirect-qdebug-output-to-file-with-pyqt5
1. https://doc.qt.io/qt-5/qtglobal.html#qInstallMessageHandler
