### PR TITLE
Remove code duplication _toBury

### DIFF
--- a/pylib/anki/sched.py
+++ b/pylib/anki/sched.py
@@ -864,7 +864,7 @@ update cards set queue={QUEUE_TYPE_SIBLING_BURIED},mod=?,usn=? where id in """
     ##########################################################################
 
     def _burySiblings(self, card: Card) -> None:
-        toBury = []
+        toBury: List[int] = []
         nconf = self._newConf(card)
         buryNew = nconf.get("bury", True)
         rconf = self._revConf(card)
@@ -879,21 +879,9 @@ and (queue={QUEUE_TYPE_NEW} or (queue={QUEUE_TYPE_REV} and due<=?))""",
             self.today,
         ):
             if queue == QUEUE_TYPE_REV:
-                if buryRev:
-                    toBury.append(cid)
-                # if bury disabled, we still discard to give same-day spacing
-                try:
-                    self._revQueue.remove(cid)
-                except ValueError:
-                    pass
+                self._actualBury(buryRev, toBury, cid, self._revQueue)
             else:
-                # if bury disabled, we still discard to give same-day spacing
-                if buryNew:
-                    toBury.append(cid)
-                try:
-                    self._newQueue.remove(cid)
-                except ValueError:
-                    pass
+                self._actualBury(buryNew, toBury, cid, self._newQueue)
         # then bury
         if toBury:
             self.col.db.execute(


### PR DESCRIPTION
The methods _toBury have a lot of code duplicated. I would greatly appreciate if you'd accept to consider removing some of it. Not necessarily this exact way.

The reason behind this PR is that, for speed efficiency, I prefetch the next card that will be sent to the reviewer. This mean that I need to change the code that does the actual burying. This change is quite simpler if there is a single method than if the change need to be done four time. Furthermore, since ankidroid tries to stay very close to Anki, having the change accepted here would help keeping AnkiDroid close while avoiding having more code duplication.
