### PR TITLE
Fixed checks.yml Windows pyaudio download URL

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -231,7 +231,7 @@ jobs:
         shell: cmd
         run: |
           echo on
-          curl -LO https://download.lfd.uci.edu/pythonlibs/s2jqpv5t/%pyaudio%
+          curl -LO https://download.lfd.uci.edu/pythonlibs/w3jqiv8s/%pyaudio%
           curl -LO http://repo.msys2.org/msys/x86_64/%rsyncbin%
 
           :: https://stackoverflow.com/questions/1359793/programmatically-extract-tar-gz

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -231,8 +231,8 @@ jobs:
         shell: cmd
         run: |
           echo on
-          curl -LO https://download.lfd.uci.edu/pythonlibs/w3jqiv8s/%pyaudio%
-          curl -LO http://repo.msys2.org/msys/x86_64/%rsyncbin%
+          curl --fail -LO https://download.lfd.uci.edu/pythonlibs/w3jqiv8s/%pyaudio%
+          curl --fail -LO http://repo.msys2.org/msys/x86_64/%rsyncbin%
 
           :: https://stackoverflow.com/questions/1359793/programmatically-extract-tar-gz
           7z x "%rsyncbin%" -so | 7z x -aoa -si -ttar -o"%programfiles%\Git"
@@ -253,7 +253,7 @@ jobs:
           sudo apt install portaudio19-dev gettext
           # https://github.com/BurntSushi/ripgrep/issues/1232
           # sudo apt-get install ripgrep
-          curl -LO https://github.com/BurntSushi/ripgrep/releases/download/11.0.2/ripgrep_11.0.2_amd64.deb
+          curl --fail -LO https://github.com/BurntSushi/ripgrep/releases/download/11.0.2/ripgrep_11.0.2_amd64.deb
           sudo dpkg -i ripgrep_11.0.2_amd64.deb
 
       - name: Set up brew ripgrep, pyaudio, gettext


### PR DESCRIPTION
Fix: https://github.com/ankitects/anki/runs/740449860#step:25:73
```
Processing d:\a\anki\anki\pyaudio-0.2.11-cp37-cp37m-win_amd64.whl
ERROR: Exception:
Traceback (most recent call last):
  File "D:\a\anki\anki\pyenv\lib\site-packages\pip\_internal\cli\base_command.py", line 188, in _main
    status = self.run(options, args)
  File "D:\a\anki\anki\pyenv\lib\site-packages\pip\_internal\cli\req_command.py", line 185, in wrapper
    return func(self, options, args)
  File "D:\a\anki\anki\pyenv\lib\site-packages\pip\_internal\commands\install.py", line 333, in run
    reqs, check_supported_wheels=not options.target_dir
  File "D:\a\anki\anki\pyenv\lib\site-packages\pip\_internal\resolution\legacy\resolver.py", line 179, in resolve
    discovered_reqs.extend(self._resolve_one(requirement_set, req))
  File "D:\a\anki\anki\pyenv\lib\site-packages\pip\_internal\resolution\legacy\resolver.py", line 362, in _resolve_one
    abstract_dist = self._get_abstract_dist_for(req_to_install)
  File "D:\a\anki\anki\pyenv\lib\site-packages\pip\_internal\resolution\legacy\resolver.py", line 314, in _get_abstract_dist_for
    abstract_dist = self.preparer.prepare_linked_requirement(req)
  File "D:\a\anki\anki\pyenv\lib\site-packages\pip\_internal\operations\prepare.py", line 469, in prepare_linked_requirement
    hashes=hashes,
  File "D:\a\anki\anki\pyenv\lib\site-packages\pip\_internal\operations\prepare.py", line 264, in unpack_url
    unpack_file(file.path, location, file.content_type)
  File "D:\a\anki\anki\pyenv\lib\site-packages\pip\_internal\utils\unpacking.py", line 252, in unpack_file
    flatten=not filename.endswith('.whl')
  File "D:\a\anki\anki\pyenv\lib\site-packages\pip\_internal\utils\unpacking.py", line 114, in unzip_file
    zip = zipfile.ZipFile(zipfp, allowZip64=True)
  File "C:\hostedtoolcache\windows\Python\3.7.7\x64\lib\zipfile.py", line 1258, in __init__
    self._RealGetContents()
  File "C:\hostedtoolcache\windows\Python\3.7.7\x64\lib\zipfile.py", line 1325, in _RealGetContents
    raise BadZipFile("File is not a zip file")
zipfile.BadZipFile: File is not a zip file
```

They use this magic javascript to get an URL: https://www.lfd.uci.edu/~gohlke/pythonlibs/#pyaudio
`href="javascript:;" onclick="&nbsp;javascript:dl([101,47,56,52,54,106,111,80,55,48,119,100,51,95,49,121,117,45,110,104,109,65,115,50,99,105,108,113,46,118,112,97], &quot;9;4JHL1E06>D?:H5@8KFK==@GM;7@GM;7C@9HA<NC:32K9BI&quot;);&nbsp;&quot;javascript: dl(&quot;"
`

As I do not know what it is doing, I hardcoded the URL it gave me but it looks like from time to time the URL changes.
```js
function dl1(ml, mi) {
    var ot = "https://download.lfd.uci.edu/pythonlibs/";
    for (var j = 0; j < mi.length; j++)
        ot += String.fromCharCode(ml[mi.charCodeAt(j) - 47]);
    location.href = ot;
}
function dl(ml, mi) {
    mi = mi.replace('&lt;', '<');
    mi = mi.replace('&#62;', '>');
    mi = mi.replace('&#38;', '&');
    setTimeout(function(l) {
        dl1(ml, mi)
    }, 1500, 1);
}
```

As a more permanent fix, you could create a new repository under `Ankitects` and put the pyaudio 3.7 and 3.8 binaries on it, updating the URL here pointing to our fork.

I would recommend against putting those binaries directly on this repository because it would increase permanently the size of this repository: https://robinwinslow.uk/2013/06/11/dont-ever-commit-binary-files-to-git/

Then, the files could be downloaded by activating/serving the repository master branch as HTML website: https://help.github.com/en/github/working-with-github-pages/configuring-a-publishing-source-for-your-github-pages-site

Then, download URL would be `https://ankitecks.github.io/RepositoryName/file1.whl` etc.