### PR TITLE
Update tooltip() in utils.py

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -36,6 +36,7 @@ Zeno Gantner <zeno.gantner@gmail.com>
 Henrik Giesel <hengiesel@gmail.com>
 Michał Bartoszkiewicz <mbartoszkiewicz@gmail.com>
 Sander Santema <github.com/sandersantema/>
+Thomas Brownback <https://github.com/brownbat/>
 
 ********************
 

--- a/qt/aqt/utils.py
+++ b/qt/aqt/utils.py
@@ -540,7 +540,7 @@ _tooltipTimer: Optional[QTimer] = None
 _tooltipLabel: Optional[QLabel] = None
 
 
-def tooltip(msg, period=3000, parent=None):
+def tooltip(msg, period=3000, parent=None, x_offset=0, y_offset=100):
     global _tooltipTimer, _tooltipLabel
 
     class CustomLabel(QLabel):
@@ -570,7 +570,7 @@ def tooltip(msg, period=3000, parent=None):
         p.setColor(QPalette.Window, QColor("#feffc4"))
         p.setColor(QPalette.WindowText, QColor("#000000"))
         lab.setPalette(p)
-    lab.move(aw.mapToGlobal(QPoint(0, -100 + aw.height())))
+    lab.move(aw.mapToGlobal(QPoint(0 + x_offset, aw.height() - y_offset)))
     lab.show()
     _tooltipTimer = aqt.mw.progress.timer(
         period, closeTooltip, False, requiresCollection=False


### PR DESCRIPTION
Allow x,y offsets to be specified for tooltip(), useful for accomodating longer tooltips.