### PR TITLE
Fix fixme "ensure nulls and x1f not in field contents"

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -36,6 +36,7 @@ Zeno Gantner <zeno.gantner@gmail.com>
 Henrik Giesel <hengiesel@gmail.com>
 Michał Bartoszkiewicz <mbartoszkiewicz@gmail.com>
 Sander Santema <github.com/sandersantema/>
+bogglez <bogglez@protonmail.ch>
 
 ********************
 


### PR DESCRIPTION
Reused "invalid input" error, added unit tests for "field separator" and "null character" each.
Also added test case for invalid idx in set_field() while I was at it.