### PR TITLE
Handle None from QApplication.desktop().screen()

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -37,6 +37,7 @@ Henrik Giesel <hengiesel@gmail.com>
 Michał Bartoszkiewicz <mbartoszkiewicz@gmail.com>
 Sander Santema <github.com/sandersantema/>
 Thomas Brownback <https://github.com/brownbat/>
+Andrew Gaul <andrew@gaul.org>
 
 ********************
 

--- a/qt/aqt/webview.py
+++ b/qt/aqt/webview.py
@@ -302,6 +302,9 @@ class AnkiWebView(QWebEngineView):
         if isMac:
             return 1
         screen = QApplication.desktop().screen()
+        if screen is None:
+            return 1
+
         dpi = screen.logicalDpiX()
         factor = dpi / 96.0
         if isLin:


### PR DESCRIPTION
This prevents a crash when Anki is open for multiple days.  Reference:
https://anki.tenderapp.com/discussions/ankidesktop/41879-qt-cannot-create-window-no-screens-available