### PR TITLE
Update message to user to match gui

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -38,6 +38,7 @@ Michał Bartoszkiewicz <mbartoszkiewicz@gmail.com>
 Sander Santema <github.com/sandersantema/>
 Thomas Brownback <https://github.com/brownbat/>
 Andrew Gaul <andrew@gaul.org>
+kenden
 
 ********************
 

--- a/qt/aqt/editor.py
+++ b/qt/aqt/editor.py
@@ -635,7 +635,7 @@ class Editor:
                     _(
                         """\
 To make a cloze deletion on an existing note, you need to change it \
-to a cloze type first, via 'Notes>Change Note Type...'"""
+to a cloze type first, via 'Notes>Change Note Type'"""
                     )
                 )
                 return

--- a/qt/aqt/editor.py
+++ b/qt/aqt/editor.py
@@ -635,7 +635,7 @@ class Editor:
                     _(
                         """\
 To make a cloze deletion on an existing note, you need to change it \
-to a cloze type first, via Edit>Change Note Type."""
+to a cloze type first, via 'Notes>Change Note Type...'"""
                     )
                 )
                 return


### PR DESCRIPTION
The "Change Note Type"... command is actually called "Change Note Type..."
and is under the "Notes" menu, not the "Edit" menu.