### PR TITLE
Strip name of added deck

### DIFF
--- a/qt/aqt/studydeck.py
+++ b/qt/aqt/studydeck.py
@@ -145,6 +145,7 @@ class StudyDeck(QDialog):
         else:
             default = self.names[self.form.list.currentRow()]
         n = getOnlyText(_("New deck name:"), default=default)
+        n = n.strip()
         if n:
             did = self.mw.col.decks.id(n)
             # deck name may not be the same as user input. ex: ", ::


### PR DESCRIPTION
There is currently what I believe to be a bug: create a deck "   ". The creation is accepted and the name is renamed to "blank". Instead, I believe you'd want to strip the deck name before testing its emptiness.

The idea of this test was found by @david-allison-1 in https://github.com/ankidroid/Anki-Android/pull/6453#discussion_r441376019 when I was trying to port the new behavior on ankidroid. Except that I believe than instead of porting this exact behaviour, I should correct it first.