### PR TITLE
A few mpv changes

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -39,6 +39,7 @@ Sander Santema <github.com/sandersantema/>
 Thomas Brownback <https://github.com/brownbat/>
 Andrew Gaul <andrew@gaul.org>
 kenden
+Nickolay Yudin <kelciour@gmail.com>
 
 ********************
 

--- a/qt/aqt/mpv.py
+++ b/qt/aqt/mpv.py
@@ -84,6 +84,7 @@ class MPVBase:
         "--ontop",
         "--audio-display=no",
         "--keep-open=no",
+        "--reset-on-next-file=pause",
     ]
 
     def __init__(self, window_id=None, debug=False):

--- a/qt/aqt/sound.py
+++ b/qt/aqt/sound.py
@@ -346,6 +346,7 @@ class MpvManager(MPV, SoundOrVideoPlayer):
         assert isinstance(tag, SoundOrVideoTag)
         self._on_done = on_done
         path = os.path.join(os.getcwd(), tag.filename)
+        self.command("script-message", "osc-visibility", "never", "no-osd")
         self.command("loadfile", path, "append-play")
         gui_hooks.av_player_did_begin_playing(self, tag)
 
@@ -361,6 +362,9 @@ class MpvManager(MPV, SoundOrVideoPlayer):
     def on_idle(self) -> None:
         if self._on_done:
             self._on_done()
+
+    def on_start_file(self) -> None:
+        self.command("script-message", "osc-visibility", "auto", "no-osd")
 
     def shutdown(self) -> None:
         self.close()

--- a/qt/aqt/sound.py
+++ b/qt/aqt/sound.py
@@ -333,6 +333,14 @@ class MpvManager(MPV, SoundOrVideoPlayer):
         self._on_done: Optional[OnDoneCallback] = None
         self.default_argv += ["--config-dir=" + base_path]
         super().__init__(window_id=None, debug=False)
+        self.init()
+
+    def init(self) -> None:
+        self.command("keybind", "q", "stop")
+        self.command("keybind", "Q", "stop")
+        self.command("keybind", "CLOSE_WIN", "stop")
+        self.command("keybind", "ctrl+w", "stop")
+        self.command("keybind", "ctrl+c", "stop")
 
     def play(self, tag: AVTag, on_done: OnDoneCallback) -> None:
         assert isinstance(tag, SoundOrVideoTag)

--- a/qt/aqt/sound.py
+++ b/qt/aqt/sound.py
@@ -359,8 +359,8 @@ class MpvManager(MPV, SoundOrVideoPlayer):
     def seek_relative(self, secs: int) -> None:
         self.command("seek", secs, "relative")
 
-    def on_idle(self) -> None:
-        if self._on_done:
+    def on_property_idle_active(self, val) -> None:
+        if val and self._on_done:
             self._on_done()
 
     def on_start_file(self) -> None:


### PR DESCRIPTION
This is partially a follow-up to the issue reported by ANH25 on the support forum a while ago about mpv on Windows.

> Testing it further, I noticed that it gets stuck when interrupting video playback by closing mpv window manually before the video ends. this closes mpv process completely, so Anki spawns a new process which is completely unresponsive on the next playback.

> UPDATE: the issue is due to mpv sending the quit command when closing the window [by default](https://github.com/mpv-player/mpv/blob/master/etc/input.conf). we should send stop instead, which just stops playback and clears the playlist. See [mpv docs](https://github.com/mpv-player/mpv/blob/master/DOCS/man/input.rst)

https://anki.tenderapp.com/discussions/beta-testing/1964-anki-2128-alpha/page/1#comment_48382756

The issue can be reproduced on Ubuntu too.

As it turned out, once the video window is closed, `on_done` callback is never called and `self.current_player` is never set to `None`, i.e. Anki thinks that mpv is still playing the audio file, asks mpv to stop the playback and call `on_done` callback, but mpv was just restarted, it doesn't play anything and there's no `on_done` callback, and `self.current_player` is never set to `None`.

I tried to use `shutdown` event but it seems mpv doesn't send it via JSON IPC. As a possible workaround, I tried to use `end-file` event, if `reason` was set to `quit`, and manually call `on_done` callback, it worked for one sound file, but if there were more sound files to play, I got an exception with `pywintypes.error: (232, 'WriteFile', 'The pipe is being closed.')`, that I'm not sure how to handle.

Maybe, in addition to input.conf, as an alternative, replacing "quit" keybindings with "stop" at runtime to keep mpv idle will be enough as a temporary fix. It's been done in the first commit.

There're now also a different JSON IPC implementation for mpv with some limited functionality. It has `quit_callback` that will be called after pipe was closed or maybe if read wasn't successful.

python-mpv-jsonipc - https://github.com/iwalton3/python-mpv-jsonipc

---

Getting back to the pull request, the first commit is to override default `quit` shortcuts with `stop` to prevent mpv restarting every time the video window is being closed with hotkey.

Next commits aren't relevant to the issue.

The second commit is to disable OSC idle message, i.e. "Drop files or URLs to play here.", while the video file is being opened.

There's an old, similar, but closed, and opened, issue about it - https://github.com/mpv-player/mpv/issues/3565

<details><summary>A quick demo video</summary>

![aMUn7eE59p](https://user-images.githubusercontent.com/16260735/85185160-82104200-b29b-11ea-8d90-4fb2e15c6455.gif)
</details>

The third commit is to replace `idle` event with `idle-active` property, since `idle` event was marked as deprecated in mpv 0.33.

https://github.com/mpv-player/mpv/commit/26ac6ead911bedf01b20d52e0696f70459ff0be2

The fourth commit is to always autoplay the next file in the playlist, for example, if the previous video file was paused and closed.

> Normally, mpv will try to keep all settings when playing the next file on the playlist, even if they were changed by the user during playback. (This behavior is the opposite of MPlayer's, which tries to reset all settings when starting next file.)

> --reset-on-next-file=pause Reset pause mode when switching to the next file.

https://mpv.io/manual/master/#options-reset-on-next-file