### PR TITLE
A few mpv changes 2

### DIFF
--- a/qt/aqt/mpv.py
+++ b/qt/aqt/mpv.py
@@ -384,6 +384,11 @@ class MPVBase:
             else:
                 raise
 
+    def _register_callbacks(self):
+        """Will be called after mpv restart to reinitialize callbacks
+           defined in MPV subclass
+        """
+
     #
     # Public API
     #

--- a/qt/aqt/mpv.py
+++ b/qt/aqt/mpv.py
@@ -448,6 +448,10 @@ class MPV(MPVBase):
             if not inspect.ismethod(method):
                 continue
 
+            # Bypass MPVError: no such event 'init'
+            if method_name == "on_init":
+                continue
+
             if method_name.startswith("on_property_"):
                 name = method_name[12:]
                 name = name.replace("_", "-")

--- a/qt/aqt/sound.py
+++ b/qt/aqt/sound.py
@@ -360,8 +360,8 @@ class MpvManager(MPV, SoundOrVideoPlayer):
     def seek_relative(self, secs: int) -> None:
         self.command("seek", secs, "relative")
 
-    def on_property_idle_active(self, val) -> None:
-        if val and self._on_done:
+    def on_end_file(self) -> None:
+        if self._on_done:
             self._on_done()
 
     def shutdown(self) -> None:

--- a/qt/aqt/sound.py
+++ b/qt/aqt/sound.py
@@ -19,7 +19,7 @@ from anki.lang import _
 from anki.sound import AV_REF_RE, AVTag, SoundOrVideoTag
 from anki.utils import isLin, isMac, isWin
 from aqt import gui_hooks
-from aqt.mpv import MPV, MPVBase
+from aqt.mpv import MPV, MPVBase, MPVCommandError
 from aqt.qt import *
 from aqt.taskman import TaskManager
 from aqt.utils import restoreGeom, saveGeom, showWarning, startup_info
@@ -333,6 +333,16 @@ class MpvManager(MPV, SoundOrVideoPlayer):
         self._on_done: Optional[OnDoneCallback] = None
         self.default_argv += ["--config-dir=" + base_path]
         super().__init__(window_id=None, debug=False)
+
+    def on_init(self) -> None:
+        try:
+            self.command("keybind", "q", "stop")
+            self.command("keybind", "Q", "stop")
+            self.command("keybind", "CLOSE_WIN", "stop")
+            self.command("keybind", "ctrl+w", "stop")
+            self.command("keybind", "ctrl+c", "stop")
+        except MPVCommandError:
+            print("mpv too old")
 
     def play(self, tag: AVTag, on_done: OnDoneCallback) -> None:
         assert isinstance(tag, SoundOrVideoTag)


### PR DESCRIPTION
The first commit is a fixed commit from the previous pull request to replace default mpv "quit" keybindings if mpv version is >= 0.30.

The second commit replaces mpv "idle" property with "end-file" event and the third commit tries to fix no sound if the video window was closed manually and mpv version is less than 0.30. I'm not sure how to do it better and maybe it'd be okay since it'll be only used if mpv is less than 0.30 and the video window was closed manually. I need to register callbacks again and reused _event_thread instead of creating a new one in an attempt to fix RuntimeError("cannot join current thread") and used Exception to be able to catch pywintypes.error on Windows and BrokenPipeError on Linux.