### PR TITLE
Fixed pbjs not working on Windows because package.json runs by

### DIFF
--- a/ts/Makefile
+++ b/ts/Makefile
@@ -24,7 +24,8 @@ PROTODEPS := ../proto/backend.proto ../proto/fluent.proto
 BUILDDEPS := .build/npm webpack.config.js
 
 .build/proto: $(BUILDDEPS) $(PROTODEPS)
-	npm run proto
+	npx pbjs -t json-module -w es6 ../proto/backend.proto -o src/backend/proto.js
+	npx pbjs -t static-module ../proto/backend.proto | npx pbts -o src/backend/proto.d.ts -
 	@touch $@
 
 PHONY: dev

--- a/ts/package.json
+++ b/ts/package.json
@@ -42,7 +42,6 @@
         "webpack-dev-server": "^3.11.0"
     },
     "scripts": {
-        "proto": "pbjs -t json-module -w es6 ../proto/backend.proto -o src/backend/proto.js; pbjs -t static-module ../proto/backend.proto | pbts -o src/backend/proto.d.ts -",
         "fix": "prettier --write src/*/*.ts",
         "check": "prettier --check src/*/*.ts && eslint --max-warnings=0 --ext .ts src",
         "build": "cross-env NODE_ENV=production webpack",


### PR DESCRIPTION
cmd.exe which does not support pipe | and ; semicolons
https://github.com/ankitects/anki/commit/6fd444b9587918834bf5f641bd7a44cd064ff495#r40232987


If this message: https://github.com/ankitects/anki/runs/817774681#step:25:884
```
TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string. Received an instance of Array
```

Was correctly implemented by the **incompetent developer** of that module, it should show us the `"path"` string is invalid. In our case, it would show that the invalid path would be `src/backend/proto.js; pbjs -t static-module ../proto/backend.proto | pbts...` (as ; and | are not interpreted by the Windows cmd.exe shell)