### PR TITLE
Always use standard QT color dialog on Linux

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -41,6 +41,7 @@ Andrew Gaul <andrew@gaul.org>
 kenden
 Nickolay Yudin <kelciour@gmail.com>
 neitrinoweb <github.com/neitrinoweb/>
+Andreas Reis <github.com/rathsky>
 ********************
 
 The text of the 3 clause BSD license follows:

--- a/qt/aqt/editor.py
+++ b/qt/aqt/editor.py
@@ -23,7 +23,7 @@ from anki.hooks import runFilter
 from anki.httpclient import HttpClient
 from anki.lang import _
 from anki.notes import Note
-from anki.utils import checksum, isWin, namedtmp, stripHTMLMedia
+from anki.utils import checksum, isLin, isWin, namedtmp, stripHTMLMedia
 from aqt import AnkiQt, gui_hooks
 from aqt.qt import *
 from aqt.sound import av_player, getAudio
@@ -665,7 +665,12 @@ to a cloze type first, via 'Notes>Change Note Type'"""
 
     # choose new colour
     def onChangeCol(self):
-        new = QColorDialog.getColor(QColor(self.fcolour), None)
+        if isLin:
+            new = QColorDialog.getColor(
+                QColor(self.fcolour), None, None, QColorDialog.DontUseNativeDialog
+            )
+        else:
+            new = QColorDialog.getColor(QColor(self.fcolour), None)
         # native dialog doesn't refocus us for some reason
         self.parentWindow.activateWindow()
         if new.isValid():


### PR DESCRIPTION
On Linux only Gnome uses its own color dialog, and it's inferior to QT's own: See the same issue @ OpenShot/openshot-qt#2425

(This is/was visible only on some distributions' packaged versions of Anki, not via ./run.)

isLin check since QT on Windows already uses the default, whereas Mac's own picker seems superior (from what I can judge by screenshots).