### PR TITLE
Fix _addons/ URL prefix not being removed on Windows systems

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -181,7 +181,7 @@ jobs:
         uses: actions/cache@v1
         with:
           path: ${{ github.workspace }}${{ matrix.SEP }}pyenv
-          key: ${{ runner.os }}-pyenv-${{ hashFiles('**/requirements.*') }}-${{ hashFiles('**/setup.py') }}-${{ hashFiles('**/Makefile') }}-${{ hashFiles('**/Cargo.toml') }}-17-
+          key: ${{ runner.os }}-pyenv-${{ hashFiles('**/requirements.*') }}-${{ hashFiles('**/setup.py') }}-${{ hashFiles('**/Makefile') }}-${{ hashFiles('**/Cargo.toml') }}-18-
 
       # # Disable it in attempt to reduce the overall cache size (https://github.com/ankitects/anki/pull/528)
       # - name: Cache pip wheels
@@ -189,42 +189,42 @@ jobs:
       #   uses: actions/cache@v1
       #   with:
       #     path: ${{ matrix.PIP_WHEELS_DIR }}
-      #     key: ${{ runner.os }}-pip-wheels-${{ hashFiles('**/requirements.txt') }}-${{ hashFiles('**/setup.py') }}-16-
+      #     key: ${{ runner.os }}-pip-wheels-${{ hashFiles('**/requirements.txt') }}-${{ hashFiles('**/setup.py') }}-18-
 
       - name: Cache cargo index
         if: matrix.python == '3.7'
         uses: actions/cache@v1
         with:
           path: ${{ matrix.CARGO_INDEX_DIR }}
-          key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/requirements.*') }}-${{ hashFiles('**/setup.py') }}-${{ hashFiles('**/Makefile') }}-${{ hashFiles('**/Cargo.toml') }}-16-
+          key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/requirements.*') }}-${{ hashFiles('**/setup.py') }}-${{ hashFiles('**/Makefile') }}-${{ hashFiles('**/Cargo.toml') }}-18-
 
       - name: Cache cargo registry
         if: matrix.python == '3.7'
         uses: actions/cache@v1
         with:
           path: ${{ matrix.CARGO_REGISTRY_DIR }}
-          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/requirements.*') }}-${{ hashFiles('**/setup.py') }}-${{ hashFiles('**/Makefile') }}-${{ hashFiles('**/Cargo.toml') }}-16-
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/requirements.*') }}-${{ hashFiles('**/setup.py') }}-${{ hashFiles('**/Makefile') }}-${{ hashFiles('**/Cargo.toml') }}-18-
 
       - name: Cache cargo target
         if: matrix.python == '3.7'
         uses: actions/cache@v1
         with:
           path: ${{ github.workspace }}${{ matrix.SEP }}target
-          key: ${{ runner.os }}-cargo-target-${{ hashFiles('**/requirements.*') }}-${{ hashFiles('**/setup.py') }}-${{ hashFiles('**/Makefile') }}-${{ hashFiles('**/Cargo.toml') }}-${{ matrix.BUILD_TYPE }}-16-
+          key: ${{ runner.os }}-cargo-target-${{ hashFiles('**/requirements.*') }}-${{ hashFiles('**/setup.py') }}-${{ hashFiles('**/Makefile') }}-${{ hashFiles('**/Cargo.toml') }}-${{ matrix.BUILD_TYPE }}-18-
 
       - name: Cache cargo rslib
         if: matrix.python == '3.7'
         uses: actions/cache@v1
         with:
           path: ${{ github.workspace }}${{ matrix.SEP }}rslib${{ matrix.SEP }}target
-          key: ${{ runner.os }}-cargo-rslib-${{ hashFiles('**/requirements.*') }}-${{ hashFiles('**/setup.py') }}-${{ hashFiles('**/Makefile') }}-${{ hashFiles('**/Cargo.toml') }}-${{ matrix.BUILD_TYPE }}-16-
+          key: ${{ runner.os }}-cargo-rslib-${{ hashFiles('**/requirements.*') }}-${{ hashFiles('**/setup.py') }}-${{ hashFiles('**/Makefile') }}-${{ hashFiles('**/Cargo.toml') }}-${{ matrix.BUILD_TYPE }}-18-
 
       - name: Cache cargo rspy
         if: matrix.python == '3.7'
         uses: actions/cache@v1
         with:
           path: ${{ github.workspace }}${{ matrix.SEP }}rspy${{ matrix.SEP }}target
-          key: ${{ runner.os }}-cargo-rspy-${{ hashFiles('**/requirements.*') }}-${{ hashFiles('**/setup.py') }}-${{ hashFiles('**/Makefile') }}-${{ hashFiles('**/Cargo.toml') }}-${{ matrix.BUILD_TYPE }}-16-
+          key: ${{ runner.os }}-cargo-rspy-${{ hashFiles('**/requirements.*') }}-${{ hashFiles('**/setup.py') }}-${{ hashFiles('**/Makefile') }}-${{ hashFiles('**/Cargo.toml') }}-${{ matrix.BUILD_TYPE }}-18-
 
       - name: Set up curl pyaudio, rsync
         if: matrix.os == 'windows-latest'

--- a/qt/aqt/mediasrv.py
+++ b/qt/aqt/mediasrv.py
@@ -179,7 +179,7 @@ def _redirectWebExports(path):
             return _exportFolder, addonPath
 
         try:
-            addon, subPath = addonPath.split(os.path.sep, 1)
+            addon, subPath = addonPath.split("/", 1)
         except ValueError:
             return addMgr.addonsFolder(), path
         if not addon:


### PR DESCRIPTION
Anki 2.1.28 Beta
https://forums.ankiweb.net/t/anki-2-1-28-beta/629/26

> Did the requirements on how to expose resources on the internal server change? Because scripts, css files and the like, registered with setWebExports, do not work anymore with beta2.
> A look at the console shows the following for all resources:
> Failed to load resource: the server responded with a status of 500 (INTERNAL SERVER ERROR)

**\Anki2\addons21\someaddon\__init__.py**
```py
from aqt import mw
import aqt

# assuming add-on folder is named "test"
# and assuming a 'test.js' is in the same folder
addon_id = "someaddon"
port = mw.mediaServer.getPort()
mw.addonManager.setWebExports(addon_id, ".*\\.js$")

print("Hello")

aqt.editor._html += f"""
<script>
    var script = document.createElement('script');
    script.type = 'text/javascript';
    script.src = 'http://127.0.0.1:{port}/_addons/{addon_id}/test.js';
    document.body.appendChild(script);
</script>"""
```