### PR TITLE
Add {{type:nc:…}} – ignores combining characters when comparing

### DIFF
--- a/qt/aqt/reviewer.py
+++ b/qt/aqt/reviewer.py
@@ -455,9 +455,6 @@ Please run Tools>Empty Cards"""
     def tokenizeComparison(
         self, given: str, correct: str
     ) -> Tuple[List[Tuple[bool, str]], List[Tuple[bool, str]]]:
-        # compare in NFC form so accents appear correct
-        given = ucd.normalize("NFC", given)
-        correct = ucd.normalize("NFC", correct)
         s = difflib.SequenceMatcher(None, given, correct, autojunk=False)
         givenElems: List[Tuple[bool, str]] = []
         correctElems: List[Tuple[bool, str]] = []
@@ -499,6 +496,9 @@ Please run Tools>Empty Cards"""
             if given == correct:
                 typed_correct = True
             else:
+                # compare in NFC form so accents appear correct
+                given = ucd.normalize("NFC", given)
+                correct = ucd.normalize("NFC", correct)
                 givenElems, correctElems = self.tokenizeComparison(given, correct)
         else:
             given_stripped = "".join(

--- a/qt/aqt/reviewer.py
+++ b/qt/aqt/reviewer.py
@@ -415,7 +415,7 @@ Please run Tools>Empty Cards"""
         cor = cor.strip()
         given = self.typedAnswer
         # compare with typed answer
-        res = self.correct(given, cor, showBad=False)
+        res = self.correct(given, cor)
         # and update the type answer area
         def repl(match):
             # can't pass a string in directly, and can't use re.escape as it
@@ -487,7 +487,7 @@ Please run Tools>Empty Cards"""
             logGood(y, cnt, correct, correctElems)
         return givenElems, correctElems
 
-    def correct(self, given: str, correct: str, showBad: bool = True) -> str:
+    def correct(self, given: str, correct: str) -> str:
         "Diff-corrects the typed-in answer."
 
         if not given:

--- a/qt/aqt/reviewer.py
+++ b/qt/aqt/reviewer.py
@@ -490,6 +490,9 @@ Please run Tools>Empty Cards"""
     def correct(self, given: str, correct: str, showBad: bool = True) -> str:
         "Diff-corrects the typed-in answer."
 
+        if not given:
+            return "<div><code id=typeans>" + correct + "</code></div>"
+
         typed_correct = False
 
         if self.combining:

--- a/qt/aqt/reviewer.py
+++ b/qt/aqt/reviewer.py
@@ -536,7 +536,7 @@ Please run Tools>Empty Cards"""
             return "<span class=typeMissed>" + html.escape(s) + "</span>"
 
         if typed_correct:
-            res = good(given)
+            res = good(correct)
         else:
             res = ""
             for ok, txt in givenElems:

--- a/rslib/src/template_filters.rs
+++ b/rslib/src/template_filters.rs
@@ -27,6 +27,8 @@ pub(crate) fn apply_filters<'a>(
     // type:cloze is handled specially
     let filters = if filters == ["cloze", "type"] {
         &["type-cloze"]
+    } else if filters == ["nc", "type"] {
+        &["type-nc"]
     } else {
         filters
     };
@@ -71,6 +73,7 @@ fn apply_filter<'a>(
         "kana" => kana_filter(text),
         "type" => type_filter(field_name),
         "type-cloze" => type_cloze_filter(field_name),
+        "type-nc" => type_nc_filter(field_name),
         "hint" => hint_filter(text, field_name),
         "cloze" => cloze_filter(text, context),
         // an empty filter name (caused by using two colons) is ignored
@@ -161,6 +164,10 @@ fn type_cloze_filter<'a>(field_name: &str) -> Cow<'a, str> {
     format!("[[type:cloze:{}]]", field_name).into()
 }
 
+fn type_nc_filter<'a>(field_name: &str) -> Cow<'a, str> {
+    format!("[[type:nc:{}]]", field_name).into()
+}
+
 fn hint_filter<'a>(text: &'a str, field_name: &str) -> Cow<'a, str> {
     if text.trim().is_empty() {
         return text.into();
@@ -199,7 +206,7 @@ mod test {
     use crate::template::RenderContext;
     use crate::template_filters::{
         apply_filters, cloze_filter, furigana_filter, hint_filter, kana_filter, kanji_filter,
-        tts_filter, type_cloze_filter, type_filter,
+        tts_filter, type_cloze_filter, type_filter, type_nc_filter,
     };
     use crate::text::strip_html;
 
@@ -233,6 +240,7 @@ field</a>
     fn typing() {
         assert_eq!(type_filter("Front"), "[[type:Front]]");
         assert_eq!(type_cloze_filter("Front"), "[[type:cloze:Front]]");
+        assert_eq!(type_nc_filter("Front"), "[[type:nc:Front]]");
         let ctx = RenderContext {
             fields: &Default::default(),
             nonempty_fields: &Default::default(),
@@ -242,6 +250,10 @@ field</a>
         assert_eq!(
             apply_filters("ignored", &["cloze", "type"], "Text", &ctx),
             ("[[type:cloze:Text]]".into(), vec![])
+        );
+        assert_eq!(
+            apply_filters("ignored", &["nc", "type"], "Text", &ctx),
+            ("[[type:nc:Text]]".into(), vec![])
         );
     }
 


### PR DESCRIPTION
This allows to add :nc to type fields, causing Anki to ignore all combining characters so as to not fault their absence in the user input as errors.

It improves one's learning experience with languages such as Hebrew whose use of diacritics (nikud) is almost entirely limited to reading them (in class/references), with nobody writing them (very cumbersome anyway) in everyday use for ordinary words.

Example before / after:

![wo-nc](https://user-images.githubusercontent.com/887320/86829037-409dd600-c094-11ea-9c23-4d2cc27141c6.png)
![with-nc](https://user-images.githubusercontent.com/887320/86829053-43003000-c094-11ea-9141-1464804ded32.png)

The approach basically consists of:
* Strip _given_ & _correct_ of their combining characters
* Use that for tokenizeComparison
* "Map" the stripped _correct_ to its original
* Restore the combining characters in the correction line with that "mapping"

It's either-or, meaning any combining characters in the input/_given_ are discarded as well (so no partial comparison).

Notable otherwise: one functional change affecting the non-:nc path and two clean-ups
* If no user input (_given_) was entered, simply return the field/_correct_ straight away with minimal formatting.
* Removed an unused correct() parameter.
* Skip the redundant tokenizeComparison for the non-:nc path when _given_ already matches _correct_.