### PR TITLE
Disable pyenv cache for linux because maturin is bugged as hell

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -176,8 +176,9 @@ jobs:
           sudo chown -R $(whoami):$(id -ng) ~/.cargo/
 
       # Disable it for macos because it pyenv cache is bugged (https://github.com/ankitects/anki/pull/563)
+      # Disable pyenv cache for linux because maturin is bugged as hell (https://github.com/ankitects/anki/pull/581)
       - name: Cache pyenv
-        if: matrix.os != 'macos-latest' && matrix.python == '3.7'
+        if: matrix.os != 'macos-latest' && matrix.os != 'ubuntu-latest' && matrix.python == '3.7'
         uses: actions/cache@v1
         with:
           path: ${{ github.workspace }}${{ matrix.SEP }}pyenv


### PR DESCRIPTION
1. https://github.com/ankitects/anki/commit/df319c7c5892910713ec94195cc296a12a9e4504 - is:review should include relearning cards
1. https://github.com/ankitects/anki/commit/c50fa2c787e9d039562b00479c89fee9a3dbb7f9 - invalidate cache

https://github.com/ankitects/anki/runs/852260154#step:25:768
```
FTL_TEMPLATE_DIRS="../qt/ftl" FTL_LOCALE_DIRS="../qt/ftl/repo/desktop" 
CARGO_TARGET_DIR="/home/runner/work/anki/anki/target" \
	maturin develop 
🔗 Found pyo3 bindings
🐍 Found CPython 3.7m at python
💥 maturin failed
  Caused by: Expected `python` to be a python interpreter inside a virtualenv ಠ_ಠ
```
