### PR TITLE
Add top_toolbar_did_redraw hook

### DIFF
--- a/qt/aqt/gui_hooks.py
+++ b/qt/aqt/gui_hooks.py
@@ -2437,6 +2437,35 @@ class _TopToolbarDidInitLinksHook:
 top_toolbar_did_init_links = _TopToolbarDidInitLinksHook()
 
 
+class _TopToolbarDidRedrawHook:
+    """Executed when the top toolbar is redrawn"""
+
+    _hooks: List[Callable[["aqt.toolbar.Toolbar"], None]] = []
+
+    def append(self, cb: Callable[["aqt.toolbar.Toolbar"], None]) -> None:
+        """(top_toolbar: aqt.toolbar.Toolbar)"""
+        self._hooks.append(cb)
+
+    def remove(self, cb: Callable[["aqt.toolbar.Toolbar"], None]) -> None:
+        if cb in self._hooks:
+            self._hooks.remove(cb)
+
+    def count(self) -> int:
+        return len(self._hooks)
+
+    def __call__(self, top_toolbar: aqt.toolbar.Toolbar) -> None:
+        for hook in self._hooks:
+            try:
+                hook(top_toolbar)
+            except:
+                # if the hook fails, remove it
+                self._hooks.remove(hook)
+                raise
+
+
+top_toolbar_did_redraw = _TopToolbarDidRedrawHook()
+
+
 class _UndoStateDidChangeHook:
     _hooks: List[Callable[[bool], None]] = []
 

--- a/qt/aqt/toolbar.py
+++ b/qt/aqt/toolbar.py
@@ -57,6 +57,7 @@ class Toolbar:
     def redraw(self) -> None:
         self.set_sync_active(self.mw.media_syncer.is_syncing())
         self.update_sync_status()
+        gui_hooks.top_toolbar_did_redraw(self)
 
     # Available links
     ######################################################################

--- a/qt/tools/genhooks_gui.py
+++ b/qt/tools/genhooks_gui.py
@@ -452,6 +452,11 @@ hooks = [
         """,
     ),
     Hook(
+        name="top_toolbar_did_redraw",
+        args=["top_toolbar: aqt.toolbar.Toolbar"],
+        doc="""Executed when the top toolbar is redrawn""",
+    ),
+    Hook(
         name="media_sync_did_progress", args=["entry: aqt.mediasync.LogEntryWithTime"],
     ),
     Hook(name="media_sync_did_start_or_stop", args=["running: bool"]),


### PR DESCRIPTION
Just a minor hook that notifies add-ons of the top toolbar being redrawn. Can act as a substitute for add-ons which hooked into `gui_hooks.toolbar_did_init_links` in the past to subsequently update their content at runtime. (after the recent changes, `gui_hooks.toolbar_did_init_links` is only called once now at toolbar initialization time)

Example usage:

```python
from aqt import gui_hooks

def on_top_toolbar_did_redraw(toolbar):
    print("top toolbar redrawn")
    print(toolbar)

gui_hooks.top_toolbar_did_redraw.append(on_top_toolbar_did_redraw)
```