### PR TITLE
Allow to choose note type from list by pressing ctrl + row number

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -42,6 +42,7 @@ kenden
 Nickolay Yudin <kelciour@gmail.com>
 neitrinoweb <github.com/neitrinoweb/>
 Andreas Reis <github.com/rathsky>
+Alexander Presnyakov <flagist0@gmail.com>
 ********************
 
 The text of the 3 clause BSD license follows:

--- a/qt/aqt/studydeck.py
+++ b/qt/aqt/studydeck.py
@@ -77,20 +77,23 @@ class StudyDeck(QDialog):
 
     def eventFilter(self, obj: QObject, evt: QEvent) -> bool:
         if evt.type() == QEvent.KeyPress:
-            if evt.key() == Qt.Key_Up:
-                c = self.form.list.count()
-                row = self.form.list.currentRow() - 1
-                if row < 0:
-                    row = c - 1
-                self.form.list.setCurrentRow(row)
-                return True
-            elif evt.key() == Qt.Key_Down:
-                c = self.form.list.count()
-                row = self.form.list.currentRow() + 1
-                if row == c:
-                    row = 0
-                self.form.list.setCurrentRow(row)
-                return True
+            new_row = current_row = self.form.list.currentRow()
+            rows_count = self.form.list.count()
+            key = evt.key()
+
+            if key == Qt.Key_Up:
+                new_row = current_row - 1
+            elif key == Qt.Key_Down:
+                new_row = current_row + 1
+            elif evt.modifiers() & Qt.ControlModifier and Qt.Key_1 <= key <= Qt.Key_9:
+                row_index = key - Qt.Key_1
+                if row_index < rows_count:
+                    new_row = row_index
+
+            if rows_count:
+                new_row %= rows_count  # don't let row index overflow/underflow
+            self.form.list.setCurrentRow(new_row)
+            return new_row != current_row
         return False
 
     def redraw(self, filt, focus=None):


### PR DESCRIPTION
This PR adds the ability to choose note type without selecting it with arrow keys or typing in the type name -- it can be done by pressing ctrl + row number. 
As the number of most used note types is limited, it's easy to remember one digit per type. So with the shortcut this operation becomes automatical and very fast (like "ctrl-n ctrl-5 enter" for choosing cloze type).
Multi-digit row indices are not supported for simplicity.
