### PR TITLE
Added parameter/return types, fixed possible logic error and typo

### DIFF
--- a/qt/aqt/customstudy.py
+++ b/qt/aqt/customstudy.py
@@ -68,7 +68,7 @@ class CustomStudy(QDialog):
                 new, self.conf["new"]["perDay"] - self.deck["newToday"][1]
             )
             newExceeding = min(new, new - newUnderLearning)
-            tit = _("New cards in deck over today's limit: %s") % plus(newExceeding)
+            tit = _("New cards in deck over today limit: %s") % plus(newExceeding)
             pre = _("Increase today's new card limit by")
             sval = min(new, self.deck.get("extendNew", 10))
             smin = -DYN_MAX_SIZE

--- a/qt/aqt/customstudy.py
+++ b/qt/aqt/customstudy.py
@@ -22,7 +22,7 @@ TYPE_ALL = 3
 
 
 class CustomStudy(QDialog):
-    def __init__(self, mw) -> None:
+    def __init__(self, mw: aqt.AnkiQt) -> None:
         QDialog.__init__(self, mw)
         self.mw = mw
         self.deck = self.mw.col.decks.current()
@@ -35,7 +35,7 @@ class CustomStudy(QDialog):
         f.radioNew.click()
         self.exec_()
 
-    def setupSignals(self):
+    def setupSignals(self) -> None:
         f = self.form
         qconnect(f.radioNew.clicked, lambda: self.onRadioChange(RADIO_NEW))
         qconnect(f.radioRev.clicked, lambda: self.onRadioChange(RADIO_REV))
@@ -44,7 +44,7 @@ class CustomStudy(QDialog):
         qconnect(f.radioPreview.clicked, lambda: self.onRadioChange(RADIO_PREVIEW))
         qconnect(f.radioCram.clicked, lambda: self.onRadioChange(RADIO_CRAM))
 
-    def onRadioChange(self, idx):
+    def onRadioChange(self, idx: int) -> None:
         f = self.form
         sp = f.spin
         smin = 1
@@ -56,8 +56,8 @@ class CustomStudy(QDialog):
         typeShow = False
         ok = _("OK")
 
-        def plus(num):
-            if num == 1000:
+        def plus(num: int) -> str:
+            if num > 1000:
                 num = "1000+"
             return "<b>" + str(num) + "</b>"
 
@@ -68,7 +68,7 @@ class CustomStudy(QDialog):
                 new, self.conf["new"]["perDay"] - self.deck["newToday"][1]
             )
             newExceeding = min(new, new - newUnderLearning)
-            tit = _("New cards in deck over today limit: %s") % plus(newExceeding)
+            tit = _("New cards in deck over today's limit: %s") % plus(newExceeding)
             pre = _("Increase today's new card limit by")
             sval = min(new, self.deck.get("extendNew", 10))
             smin = -DYN_MAX_SIZE


### PR DESCRIPTION
I added some simple return and parameter types for a few functions in qt/aqt/customstudy.py. There was also a possible logic error in the "plus" function.
```python
def plus(num: int) -> str:
    if num == 1000:
        num = "1000+"
    return "<b>" + str(num) + "</b>"
```

The "==" should be a ">"