### PR TITLE
Fix premature JS evaluation in views that set content via URL

### DIFF
--- a/qt/aqt/webview.py
+++ b/qt/aqt/webview.py
@@ -300,6 +300,11 @@ class AnkiWebView(QWebEngineView):
         if oldFocus:
             oldFocus.setFocus()
 
+    def load(self, url: QUrl):
+        # allow queuing actions when loading url directly
+        self._domDone = False
+        super().load(url)
+
     def zoomFactor(self) -> float:
         # overridden scale factor?
         webscale = os.environ.get("ANKI_WEBSCALE")


### PR DESCRIPTION
When playing around with the new stats view and looking into how to append additional widgets via JS, I ran into an issue where my scripts would always be evaluated prematurely before the DOM had finished loading.

This small change should fix that by bringing `AnkiWebView.load()` in line with `AnkiWebView.setHtml()` in that `_domDone` is set to `False` before the content is loaded in.

If we could get this in before .28 I would really appreciate that, as it would give add-on authors a basic way to manipulate the new stats view for now.

---

In the future, I think it would be great if we could construct some kind of API that would allow add-on authors to easily add their own sections to the new stats view without having to do all the boilerplate groundwork in injecting their scripts and manipulating the DOM. Though I'm not sure about the best way to go about this.

Right now the new stats view is unique in that it bypasses the code paths that add-on authors would usually use to add their own content via string composition (`webview_will_set_content`, etc.). I assume that Anki will switch more views away from this pattern in the future, dropping setting content via string composition in favor of loading the HTML skeleton (and then dynamically rendering in the content with whatever frontend framework is used). So it might make sense to think of a generic solution right from the start, rather than having an API that's specific to the stats view. 