### PR TITLE
Add a couple of hooks to trigger add-on actions before showing stats

### DIFF
--- a/qt/aqt/gui_hooks.py
+++ b/qt/aqt/gui_hooks.py
@@ -2342,6 +2342,64 @@ class _StateWillChangeHook:
 state_will_change = _StateWillChangeHook()
 
 
+class _StatsDialogOldWillShowHook:
+    """Allows changing the old stats dialog before it is shown."""
+
+    _hooks: List[Callable[["aqt.stats.NewDeckStats"], None]] = []
+
+    def append(self, cb: Callable[["aqt.stats.NewDeckStats"], None]) -> None:
+        """(dialog: aqt.stats.NewDeckStats)"""
+        self._hooks.append(cb)
+
+    def remove(self, cb: Callable[["aqt.stats.NewDeckStats"], None]) -> None:
+        if cb in self._hooks:
+            self._hooks.remove(cb)
+
+    def count(self) -> int:
+        return len(self._hooks)
+
+    def __call__(self, dialog: aqt.stats.NewDeckStats) -> None:
+        for hook in self._hooks:
+            try:
+                hook(dialog)
+            except:
+                # if the hook fails, remove it
+                self._hooks.remove(hook)
+                raise
+
+
+stats_dialog_old_will_show = _StatsDialogOldWillShowHook()
+
+
+class _StatsDialogWillShowHook:
+    """Allows changing the stats dialog before it is shown."""
+
+    _hooks: List[Callable[["aqt.stats.NewDeckStats"], None]] = []
+
+    def append(self, cb: Callable[["aqt.stats.NewDeckStats"], None]) -> None:
+        """(dialog: aqt.stats.NewDeckStats)"""
+        self._hooks.append(cb)
+
+    def remove(self, cb: Callable[["aqt.stats.NewDeckStats"], None]) -> None:
+        if cb in self._hooks:
+            self._hooks.remove(cb)
+
+    def count(self) -> int:
+        return len(self._hooks)
+
+    def __call__(self, dialog: aqt.stats.NewDeckStats) -> None:
+        for hook in self._hooks:
+            try:
+                hook(dialog)
+            except:
+                # if the hook fails, remove it
+                self._hooks.remove(hook)
+                raise
+
+
+stats_dialog_will_show = _StatsDialogWillShowHook()
+
+
 class _StyleDidInitFilter:
     _hooks: List[Callable[[str], str]] = []
 

--- a/qt/aqt/gui_hooks.py
+++ b/qt/aqt/gui_hooks.py
@@ -2345,20 +2345,20 @@ state_will_change = _StateWillChangeHook()
 class _StatsDialogOldWillShowHook:
     """Allows changing the old stats dialog before it is shown."""
 
-    _hooks: List[Callable[["aqt.stats.NewDeckStats"], None]] = []
+    _hooks: List[Callable[["aqt.stats.DeckStats"], None]] = []
 
-    def append(self, cb: Callable[["aqt.stats.NewDeckStats"], None]) -> None:
-        """(dialog: aqt.stats.NewDeckStats)"""
+    def append(self, cb: Callable[["aqt.stats.DeckStats"], None]) -> None:
+        """(dialog: aqt.stats.DeckStats)"""
         self._hooks.append(cb)
 
-    def remove(self, cb: Callable[["aqt.stats.NewDeckStats"], None]) -> None:
+    def remove(self, cb: Callable[["aqt.stats.DeckStats"], None]) -> None:
         if cb in self._hooks:
             self._hooks.remove(cb)
 
     def count(self) -> int:
         return len(self._hooks)
 
-    def __call__(self, dialog: aqt.stats.NewDeckStats) -> None:
+    def __call__(self, dialog: aqt.stats.DeckStats) -> None:
         for hook in self._hooks:
             try:
                 hook(dialog)

--- a/qt/aqt/stats.py
+++ b/qt/aqt/stats.py
@@ -8,6 +8,7 @@ import time
 
 import aqt
 from anki.lang import _
+from aqt import gui_hooks
 from aqt.qt import *
 from aqt.theme import theme_manager
 from aqt.utils import (
@@ -43,6 +44,7 @@ class NewDeckStats(QDialog):
         b.setAutoDefault(False)
         maybeHideClose(self.form.buttonBox)
         addCloseShortcut(self)
+        gui_hooks.stats_dialog_will_show(self)
         self.show()
         self.refresh()
         self.activateWindow()
@@ -125,6 +127,7 @@ class DeckStats(QDialog):
         qconnect(f.life.clicked, lambda: self.changePeriod(2))
         maybeHideClose(self.form.buttonBox)
         addCloseShortcut(self)
+        gui_hooks.stats_dialog_old_will_show(self)
         self.show()
         self.refresh()
         self.activateWindow()

--- a/qt/tools/genhooks_gui.py
+++ b/qt/tools/genhooks_gui.py
@@ -601,6 +601,18 @@ hooks = [
     # Model
     ###################
     Hook(name="models_advanced_will_show", args=["advanced: QDialog"],),
+    # Stats
+    ###################
+    Hook(
+        name="stats_dialog_will_show",
+        args=["dialog: aqt.stats.NewDeckStats"],
+        doc="""Allows changing the stats dialog before it is shown.""",
+    ),
+    Hook(
+        name="stats_dialog_old_will_show",
+        args=["dialog: aqt.stats.NewDeckStats"],
+        doc="""Allows changing the old stats dialog before it is shown.""",
+    ),
     # Other
     ###################
     Hook(

--- a/qt/tools/genhooks_gui.py
+++ b/qt/tools/genhooks_gui.py
@@ -610,7 +610,7 @@ hooks = [
     ),
     Hook(
         name="stats_dialog_old_will_show",
-        args=["dialog: aqt.stats.NewDeckStats"],
+        args=["dialog: aqt.stats.DeckStats"],
         doc="""Allows changing the old stats dialog before it is shown.""",
     ),
     # Other


### PR DESCRIPTION
Makes it easier for add-ons to modify the stats window, in line with similar hooks in other dialogs.