### PR TITLE
Refresh deck stats on reopen

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -43,6 +43,7 @@ Nickolay Yudin <kelciour@gmail.com>
 neitrinoweb <github.com/neitrinoweb/>
 Andreas Reis <github.com/rathsky>
 Alexander Presnyakov <flagist0@gmail.com>
+Vorlent <vorlent@web.de>
 ********************
 
 The text of the 3 clause BSD license follows:

--- a/qt/aqt/stats.py
+++ b/qt/aqt/stats.py
@@ -85,6 +85,9 @@ class NewDeckStats(QDialog):
     def changeScope(self, type):
         pass
 
+    def reopen(self, mw):
+        self.refresh()
+
     def refresh(self):
         self.form.web.set_open_links_externally(False)
         if theme_manager.night_mode:
@@ -168,6 +171,9 @@ class DeckStats(QDialog):
 
     def changeScope(self, type):
         self.wholeCollection = type == "collection"
+        self.refresh()
+
+    def reopen(self, mw):
         self.refresh()
 
     def refresh(self):


### PR DESCRIPTION
When I review my cards I usually click on the Stats button in the toolbar. Once the "DeckStats" dialog is open it refuses to refresh itself when I click on the "Stats" button again. I have to manually close the dialog and then click on the button again.

This PR just refreshes the dialog every time it is reopened.