### PR TITLE
Update actions/upload-artifact@v1 to v2 as v1 is deprecated

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -309,7 +309,7 @@ jobs:
 
       - name: Upload python wheels
         if: matrix.BUILD_TYPE == 'build'
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v2
         with:
           name: ${{ matrix.ANKI_PYTHON_WHEELS }}${{ matrix.python }}
           path: dist


### PR DESCRIPTION
Random error on Mac OS: [error]Too Many Requests
https://github.com/actions/toolkit/issues/503