### PR TITLE
Add --no-autoload-files option to mpv

### DIFF
--- a/qt/aqt/mpv.py
+++ b/qt/aqt/mpv.py
@@ -85,6 +85,7 @@ class MPVBase:
         "--audio-display=no",
         "--keep-open=no",
         "--reset-on-next-file=pause",
+        "--autoload-files=no",
     ]
 
     def __init__(self, window_id=None, debug=False):


### PR DESCRIPTION
It's enabled by default to automatically find and load external audio or subtitle files, but in my case, and apparently for a few more users, after restarting Windows and opening Anki, it could take about a minute to hear the sound for the first time, probably due to having a lot of files in the collection.media folder, 5400 RPM hard drive and high disk usage by Windows 10 or external apps.

It's the same behaviour with the latest mpv build.

After creating `mpv.conf` in `%APPDATA%/Anki2` with

    log-file=C:\Users\Nickolay\Desktop\mpv.log.txt
    msg-level=all=debug

restarting Windows and running Anki again, `mpv.log.txt` is being paused for some time on

> [   6.645][v][find_files] Loading external files in C:\Users\Nickolay\AppData\Roaming\Anki2\User 1\collection.media\

https://mpv.io/manual/master/#options-autoload-files