### PR TITLE
Add type hints for apt.dyndeckconf

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -43,6 +43,7 @@ Nickolay Yudin <kelciour@gmail.com>
 neitrinoweb <github.com/neitrinoweb/>
 Andreas Reis <github.com/rathsky>
 Alexander Presnyakov <flagist0@gmail.com>
+Matt Krump <github.com/mkrump>
 ********************
 
 The text of the 3 clause BSD license follows:

--- a/qt/aqt/dyndeckconf.py
+++ b/qt/aqt/dyndeckconf.py
@@ -1,6 +1,7 @@
 # Copyright: Ankitects Pty Ltd and contributors
 # -*- coding: utf-8 -*-
 # License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
+from typing import List, Optional
 
 import aqt
 from anki.lang import _
@@ -139,14 +140,14 @@ it?"""
     def listToUser(self, l):
         return " ".join([str(x) for x in l])
 
-    def userToList(self, w, minSize=1):
+    def userToList(self, w, minSize=1) -> Optional[List[Union[float, int]]]:
         items = str(w.text()).split(" ")
         ret = []
-        for i in items:
-            if not i:
+        for item in items:
+            if not item:
                 continue
             try:
-                i = float(i)
+                i = float(item)
                 assert i > 0
                 if i == int(i):
                     i = int(i)
@@ -154,8 +155,8 @@ it?"""
             except:
                 # invalid, don't update
                 showWarning(_("Steps must be numbers."))
-                return
+                return None
         if len(ret) < minSize:
             showWarning(_("At least one step is required."))
-            return
+            return None
         return ret

--- a/qt/mypy.ini
+++ b/qt/mypy.ini
@@ -66,3 +66,5 @@ check_untyped_defs=true
 check_untyped_defs=true
 [mypy-aqt.deckchooser]
 check_untyped_defs=true
+[mypy-aqt.dyndeckconf]
+check_untyped_defs=true


### PR DESCRIPTION
Wanted start contributing to Anki and https://github.com/ankitects/help-wanted/issues/4 looked a like a good place to start. Was just planning on doing one file at a time, so this PR adds type hints for `dyndeckconf.py` Haven't been using Python as much recently, and not super familiar with `mypy`, so assume no prior knowledge when reviewing :). 

Saw the following errors after turning on `check_untyped_defs` for `dyndeckconf.py`. PR fixes errors, adds type signature to the function, and turns on type checking.

```
aqt/dyndeckconf.py:149: error: Incompatible types in assignment (expression has type "float", variable has type "str")  [assignment]
                    i = float(i)
                        ^
aqt/dyndeckconf.py:150: error: Unsupported operand types for > ("str" and "int")  [operator]
                    assert i > 0
                               ^
aqt/dyndeckconf.py:152: error: Incompatible types in assignment (expression has type "int", variable has type "str")  [assignment]
                        i = int(i)
                            ^
```