### PR TITLE
Add type hints for apt.deckconf

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -42,8 +42,8 @@ kenden
 Nickolay Yudin <kelciour@gmail.com>
 neitrinoweb <github.com/neitrinoweb/>
 Andreas Reis <github.com/rathsky>
-Alexander Presnyakov <flagist0@gmail.com>
 Matt Krump <github.com/mkrump>
+Alexander Presnyakov <flagist0@gmail.com>
 ********************
 
 The text of the 3 clause BSD license follows:

--- a/qt/aqt/deckconf.py
+++ b/qt/aqt/deckconf.py
@@ -3,7 +3,9 @@
 # License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
 from operator import itemgetter
-from typing import Dict, Union
+from typing import Any, Dict
+
+from PyQt5.QtWidgets import QLineEdit
 
 import aqt
 from anki.consts import NEW_CARDS_RANDOM
@@ -257,14 +259,14 @@ class DeckConf(QDialog):
     # Saving
     ##################################################
 
-    def updateList(self, conf, key, w, minSize=1):
+    def updateList(self, conf: Any, key: str, w: QLineEdit, minSize: int = 1) -> None:
         items = str(w.text()).split(" ")
         ret = []
-        for i in items:
-            if not i:
+        for item in items:
+            if not item:
                 continue
             try:
-                i = float(i)
+                i = float(item)
                 assert i > 0
                 if i == int(i):
                     i = int(i)

--- a/qt/mypy.ini
+++ b/qt/mypy.ini
@@ -68,3 +68,5 @@ check_untyped_defs=true
 check_untyped_defs=true
 [mypy-aqt.dyndeckconf]
 check_untyped_defs=true
+[mypy-aqt.deckconf]
+check_untyped_defs=true


### PR DESCRIPTION
For https://github.com/ankitects/help-wanted/issues/4 

Saw the following errors after turning on `check_untyped_defs` for `deckconf.py`. PR fixes errors, adds type signature to the function, and turns on type checking.

```
aqt/deckconf.py:267: error: Incompatible types in assignment (expression has type "float", variable has type "str")  [assignment]
                    i = float(i)
                        ^
aqt/deckconf.py:268: error: Unsupported operand types for > ("str" and "int")  [operator]
                    assert i > 0
                               ^
aqt/deckconf.py:270: error: Incompatible types in assignment (expression has type "int", variable has type "str")  [assignment]
                        i = int(i)
                            ^
```

Also, I had an issue where mypy was throwing random errors in unrelated files. I tried re-running `make check` after a `make clean`, but they were still there. I ended up deleting the `pyenv` and reinstalling again and it seemed to work after. Wasn't sure if I was missing something that I could have used in Makefile 