### PR TITLE
Add type hints for aqt.importing, aqt.errors and aqt.models

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -42,8 +42,8 @@ kenden
 Nickolay Yudin <kelciour@gmail.com>
 neitrinoweb <github.com/neitrinoweb/>
 Andreas Reis <github.com/rathsky>
-Alexander Presnyakov <flagist0@gmail.com>
 Matt Krump <github.com/mkrump>
+Alexander Presnyakov <flagist0@gmail.com>
 ********************
 
 The text of the 3 clause BSD license follows:

--- a/qt/aqt/errors.py
+++ b/qt/aqt/errors.py
@@ -54,7 +54,7 @@ class ErrorHandler(QObject):
     def setTimer(self):
         # we can't create a timer from a different thread, so we post a
         # message to the object on the main thread
-        self.errorTimer.emit()
+        self.errorTimer.emit()  # type: ignore
 
     def _setTimer(self):
         if not self.timer:

--- a/qt/aqt/importing.py
+++ b/qt/aqt/importing.py
@@ -10,6 +10,7 @@ import traceback
 import unicodedata
 import zipfile
 from concurrent.futures import Future
+from typing import Optional
 
 import anki.importing as importing
 import aqt.deckchooser
@@ -55,7 +56,7 @@ class ChangeMap(QDialog):
                 self.frm.fields.setCurrentRow(n)
             else:
                 self.frm.fields.setCurrentRow(n + 1)
-        self.field = None
+        self.field: Optional[str] = None
 
     def getField(self):
         self.exec_()
@@ -488,7 +489,9 @@ def _replaceWithApkg(mw, filename, backup):
             colname = "collection.anki2"
 
         with z.open(colname) as source, open(mw.pm.collectionPath(), "wb") as target:
-            shutil.copyfileobj(source, target)
+            # ignore appears related to https://github.com/python/typeshed/issues/4349
+            # see if can turn off once issue fix is merged in
+            shutil.copyfileobj(source, target)  # type: ignore
 
         d = os.path.join(mw.pm.profileFolder(), "collection.media")
         for n, (cStr, file) in enumerate(

--- a/qt/aqt/models.py
+++ b/qt/aqt/models.py
@@ -6,6 +6,7 @@ from typing import List, Optional
 
 import aqt.clayout
 from anki import stdmodels
+from anki.backend_pb2 import NoteTypeNameIDUseCount
 from anki.lang import _, ngettext
 from anki.models import NoteType
 from anki.notes import Note
@@ -88,7 +89,7 @@ class Models(QDialog):
 
         self.mw.taskman.with_progress(save, on_done, self)
 
-    def updateModelsList(self, notetypes):
+    def updateModelsList(self, notetypes: List[NoteTypeNameIDUseCount]) -> None:
         row = self.form.modelsList.currentRow()
         if row == -1:
             row = 0
@@ -96,8 +97,7 @@ class Models(QDialog):
 
         self.models = notetypes
         for m in self.models:
-            mUse = m.use_count
-            mUse = ngettext("%d note", "%d notes", mUse) % mUse
+            mUse = ngettext("%d note", "%d notes", m.use_count) % m.use_count
             item = QListWidgetItem("%s [%s]" % (m.name, mUse))
             self.form.modelsList.addItem(item)
         self.form.modelsList.setCurrentRow(row)

--- a/qt/mypy.ini
+++ b/qt/mypy.ini
@@ -68,3 +68,5 @@ check_untyped_defs=true
 check_untyped_defs=true
 [mypy-aqt.dyndeckconf]
 check_untyped_defs=true
+[mypy-aqt.models]
+check_untyped_defs=true

--- a/qt/mypy.ini
+++ b/qt/mypy.ini
@@ -72,3 +72,5 @@ check_untyped_defs=true
 check_untyped_defs=true
 [mypy-aqt.errors]
 check_untyped_defs=true
+[mypy-aqt.importing]
+check_untyped_defs=true

--- a/qt/mypy.ini
+++ b/qt/mypy.ini
@@ -70,3 +70,5 @@ check_untyped_defs=true
 check_untyped_defs=true
 [mypy-aqt.models]
 check_untyped_defs=true
+[mypy-aqt.errors]
+check_untyped_defs=true


### PR DESCRIPTION
For ankitects/help-wanted#4

Saw the following errors after turning on `check_untyped_defs` for `aqt.importing`, `aqt.errors ` and `aqt.models`. PR fixes errors, adds type signature to the function, and turns on type checking.

```
aqt/models.py:100: error: Argument 3 to "ngettext" has incompatible type "str"; expected "int"  [arg-type]
                mUse = ngettext("%d note", "%d notes", mUse) % mUse

aqt/errors.py:57: error: "pyqtSignal" has no attribute "emit"  [attr-defined]
            self.errorTimer.emit()
            ^

aqt/importing.py:69: error: Incompatible types in assignment (expression has type "str", variable has type "None")  [assignment]
                self.field = "_tags"
                             ^
aqt/importing.py:491: error: Cannot infer type argument 1 of "copyfileobj"  [misc]
                shutil.copyfileobj(source, target)
                ^
```