### PR TITLE
 Turn on check_untyped_defs for aqt.taglimit, aqt.update and aqt.browser

### DIFF
--- a/qt/aqt/browser.py
+++ b/qt/aqt/browser.py
@@ -26,7 +26,8 @@ from anki.utils import htmlToTextLine, ids2str, intTime, isMac, isWin
 from aqt import AnkiQt, gui_hooks
 from aqt.editor import Editor
 from aqt.exporting import ExportDialog
-from aqt.previewer import BrowserPreviewer as PreviewDialog, Previewer
+from aqt.previewer import BrowserPreviewer as PreviewDialog
+from aqt.previewer import Previewer
 from aqt.qt import *
 from aqt.theme import theme_manager
 from aqt.utils import (

--- a/qt/aqt/browser.py
+++ b/qt/aqt/browser.py
@@ -2017,7 +2017,7 @@ update cards set usn=?, mod=?, did=? where id in """
         nids = set()
         for s, nidlist in res:
             nids.update(nidlist)
-        self.col.tags.bulkAdd(nids, _("duplicate"))
+        self.col.tags.bulkAdd(list(nids), _("duplicate"))
         self.mw.progress.finish()
         self.model.endReset()
         self.mw.requireReset()

--- a/qt/aqt/taglimit.py
+++ b/qt/aqt/taglimit.py
@@ -1,5 +1,6 @@
 # Copyright: Ankitects Pty Ltd and contributors
 # License: GNU AGPL, version 3 or later; http://www.gnu.org/copyleft/agpl.html
+from typing import List, Optional
 
 import aqt
 from aqt.qt import *
@@ -9,8 +10,9 @@ from aqt.utils import restoreGeom, saveGeom
 class TagLimit(QDialog):
     def __init__(self, mw, parent):
         QDialog.__init__(self, parent, Qt.Window)
+        self.tags: Union[str, List] = ""
         self.mw = mw
-        self.parent = parent
+        self.parent: Optional[QWidget] = parent
         self.deck = self.parent.deck
         self.dialog = aqt.forms.taglimit.Ui_Dialog()
         self.dialog.setupUi(self)

--- a/qt/aqt/update.py
+++ b/qt/aqt/update.py
@@ -47,18 +47,18 @@ class LatestVersionFinder(QThread):
             print("update check failed")
             return
         if resp["msg"]:
-            self.newMsg.emit(resp)
+            self.newMsg.emit(resp)  # type: ignore
         if resp["ver"]:
-            self.newVerAvail.emit(resp["ver"])
+            self.newVerAvail.emit(resp["ver"])  # type: ignore
         diff = resp["time"] - time.time()
         if abs(diff) > 300:
-            self.clockIsOff.emit(diff)
+            self.clockIsOff.emit(diff)  # type: ignore
 
 
 def askAndUpdate(mw, ver):
     baseStr = _("""<h1>Anki Updated</h1>Anki %s has been released.<br><br>""") % ver
     msg = QMessageBox(mw)
-    msg.setStandardButtons(QMessageBox.Yes | QMessageBox.No)
+    msg.setStandardButtons(QMessageBox.Yes | QMessageBox.No)  # type: ignore
     msg.setIcon(QMessageBox.Information)
     msg.setText(baseStr + _("Would you like to download it now?"))
     button = QPushButton(_("Ignore this update"))

--- a/qt/mypy.ini
+++ b/qt/mypy.ini
@@ -78,3 +78,5 @@ check_untyped_defs=true
 check_untyped_defs=true
 [mypy-aqt.taglimit]
 check_untyped_defs=true
+[mypy-aqt.update]
+check_untyped_defs=true

--- a/qt/mypy.ini
+++ b/qt/mypy.ini
@@ -80,3 +80,5 @@ check_untyped_defs=true
 check_untyped_defs=true
 [mypy-aqt.update]
 check_untyped_defs=true
+[mypy-aqt.browser]
+check_untyped_defs=true

--- a/qt/mypy.ini
+++ b/qt/mypy.ini
@@ -76,3 +76,5 @@ check_untyped_defs=true
 check_untyped_defs=true
 [mypy-aqt.deckconf]
 check_untyped_defs=true
+[mypy-aqt.taglimit]
+check_untyped_defs=true


### PR DESCRIPTION
For ankitects/help-wanted#4

Saw the following errors after turning on check_untyped_defs for aqt.taglimit, aqt.update and aqt.browser. 

7356756
```
aqt/taglimit.py:13: error: Cannot assign to a method  [assignment]
            self.parent = parent
            ^
aqt/taglimit.py:14: error: "Callable[[], QObject]" has no attribute "deck"  [attr-defined]
            self.deck = self.parent.deck
                        ^
aqt/taglimit.py:66: error: Incompatible types in assignment (expression has type "str", variable has type "List[Any]")  [assignment]
            self.tags = ""
                        ^
aqt/taglimit.py:92: error: Incompatible types in assignment (expression has type "str", variable has type "List[Any]")  [assignment]
            self.tags = ""
                        ^
```
b2cbe10
```
aqt/update.py:50: error: "pyqtSignal" has no attribute "emit"  [attr-defined]
                self.newMsg.emit(resp)
                ^
aqt/update.py:52: error: "pyqtSignal" has no attribute "emit"  [attr-defined]
                self.newVerAvail.emit(resp["ver"])
                ^
aqt/update.py:55: error: "pyqtSignal" has no attribute "emit"  [attr-defined]
                self.clockIsOff.emit(diff)
                ^
aqt/update.py:61: error: Argument 1 to "setStandardButtons" of "QMessageBox" has incompatible type "int"; expected
"Union[StandardButtons, StandardButton]"  [arg-type]
        msg.setStandardButtons(QMessageBox.Yes | QMessageBox.No)
```
b5222f9
```
aqt/browser.py:106: error: "Callable[[Iterable[QPersistentModelIndex], LayoutChangeHint], None]" has no attribute "emit"  [attr-defined]
                self.layoutChanged.emit()
                ^
aqt/browser.py:133: error: Argument 1 to "setFamily" of "QFont" has incompatible type "Union[str, int]"; expected "str"  [arg-type]
                f.setFamily(t.get("bfont", "arial"))
                            ^
aqt/browser.py:134: error: Argument 1 to "setPixelSize" of "QFont" has incompatible type "Union[str, int]"; expected "int"  [arg-type]
                f.setPixelSize(t.get("bsize", 12))
                               ^
aqt/browser.py:148: error: Incompatible types in assignment (expression has type "int", variable has type "AlignmentFlag")  [assignment]
                    align |= Qt.AlignHCenter
                    ^
aqt/browser.py:302: error: Unsupported operand types for + ("int" and "str")  [operator]
                    t += " %d" % (c.ord + 1)
                         ^
aqt/browser.py:302: note: Left operand is of type "Union[str, int, None]"
aqt/browser.py:311: error: Unsupported operand types for + ("str" and "int")  [operator]
                    t = "(" + t + ")"
                        ^
aqt/browser.py:311: note: Right operand is of type "Union[str, int, None]"
aqt/browser.py:1513: error: Incompatible types in assignment (expression has type "Previewer", variable has type "None")  [assignment]
                self._previewer = PreviewDialog(self, self.mw, self._on_preview_closed)
                                  ^
aqt/browser.py:1514: error: "None" has no attribute "open"  [attr-defined]
                self._previewer.open()
                ^
aqt/browser.py:2020: error: Argument 1 to "bulkAdd" of "TagManager" has incompatible type "Set[Any]"; expected "List[int]"  [arg-type]
            self.col.tags.bulkAdd(nids, _("duplicate"))
                                  ^
aqt/browser.py:2050: error: Incompatible types in assignment (expression has type "Optional[int]", variable has type "None")  [assignment]
            self.focusTo = self.editor.currentField
                           ^
aqt/browser.py:2057: error: Incompatible types in assignment (expression has type "Optional[int]", variable has type "None")  [assignment]
            self.focusTo = self.editor.currentField
                           ^
aqt/browser.py:2228: error: Need type annotation for 'map' (hint: "map: Dict[<type>, <type>] = ...")  [var-annotated]
            map = {}
```