### PR TITLE
Add a filter to control sibling burying via add-ons

### DIFF
--- a/pylib/anki/schedv2.py
+++ b/pylib/anki/schedv2.py
@@ -1540,11 +1540,14 @@ update cards set queue=?,mod=?,usn=? where id in """
     ##########################################################################
 
     def _burySiblings(self, card: Card) -> None:
+        should_bury = hooks.scheduler_might_bury_siblings(None, self, card)
+        if should_bury is False:
+            return
         toBury: List[int] = []
         nconf = self._newConf(card)
-        buryNew = nconf.get("bury", True)
+        buryNew = nconf.get("bury", True) or bool(should_bury)
         rconf = self._revConf(card)
-        buryRev = rconf.get("bury", True)
+        buryRev = rconf.get("bury", True) or bool(should_bury)
         # loop through and remove from queues
         for cid, queue in self.col.db.execute(
             f"""

--- a/pylib/tools/genhooks.py
+++ b/pylib/tools/genhooks.py
@@ -83,6 +83,29 @@ hooks = [
         doc="""Allows changing the number of rev card for this deck (without
         considering descendants).""",
     ),
+    Hook(
+        name="scheduler_might_bury_siblings",
+        args=[
+            "should_bury: Optional[bool]",
+            "scheduler: Union[anki.sched.Scheduler, anki.schedv2.Scheduler]",
+            "card: anki.cards.Card",
+        ],
+        return_type="Optional[bool]",
+        doc="""Allows customizing the sibling burying behavior.
+        
+        `should_bury` is a bool or None governing the burying behavior:
+        
+            - Return None to let sibling burying proceed as it was, with the
+              scheduler and user-set deck options determining the outcome
+            - Return True to force sibling burying, regardless of user-set deck
+              options
+            - Return False to completely bypass sibling burying and sibling
+              spacing.
+        
+        If your add-on does not need to modify the sibling burying behavior, please
+        return `should_bury` unchanged to preserve behaviors set by other add-ons.
+        """,
+    ),
     # obsolete
     Hook(name="deck_added", args=["deck: Dict[str, Any]"], doc="Obsolete, do not use."),
     Hook(


### PR DESCRIPTION
I thought it would be neat for add-ons to have the ability to influence the scheduler's sibling burying behavior, allowing for uses like conditional burying depending on the note type and other properties.

The immediate use case me for me would be in Cloze Overlapper, which currently monkey-patches `Scheduler._burySiblings` to optionally exclude sequential siblings from burying. Outside of that, I could also see this hook being useful for the various add-ons out there that also modify sibling burying to some degree.