### PR TITLE
Attempt to fix TypeError: allroutes() got an unexpected keyword

### DIFF
--- a/qt/aqt/mediasrv.py
+++ b/qt/aqt/mediasrv.py
@@ -87,9 +87,9 @@ class MediaServer(threading.Thread):
         return int(self.server.effective_port)
 
 
-@app.route("/", defaults={"path": ""})
-@app.route("/<path:pathin>", methods=["GET", "POST"])
-def allroutes(pathin):
+@app.route("/<path:path>", methods=["GET", "POST"])
+def allroutes(path=""):
+    pathin = path
     try:
         directory, path = _redirectWebExports(pathin)
     except TypeError:


### PR DESCRIPTION
Attempt to fix TypeError: allroutes() got an unexpected keyword argument ‘path’
https://forums.ankiweb.net/t/anki-2-1-28-error-message-when-reviewing-cards/1439