### PR TITLE
Turn on check_untyped_defs for aqt.editor and aqt.exporting

### DIFF
--- a/pylib/anki/exporting.py
+++ b/pylib/anki/exporting.py
@@ -19,6 +19,11 @@ from anki.utils import ids2str, namedtmp, splitFields, stripHTML
 
 class Exporter:
     includeHTML: Union[bool, None] = None
+    ext: Optional[str] = None
+    key: Optional[str] = None
+    includeTags: Optional[bool] = None
+    includeSched: Optional[bool] = None
+    includeMedia: Optional[bool] = None
 
     def __init__(
         self,

--- a/qt/aqt/editor.py
+++ b/qt/aqt/editor.py
@@ -13,6 +13,7 @@ import urllib.request
 import warnings
 from typing import Callable, List, Optional, Tuple
 
+import bs4
 import requests
 from bs4 import BeautifulSoup
 
@@ -859,7 +860,7 @@ to a cloze type first, via 'Notes>Change Note Type'"""
 
     removeTags = ["script", "iframe", "object", "style"]
 
-    def _pastePreFilter(self, html, internal):
+    def _pastePreFilter(self, html: str, internal: bool) -> str:
         # https://anki.tenderapp.com/discussions/ankidesktop/39543-anki-is-replacing-the-character-by-when-i-exit-the-html-edit-mode-ctrlshiftx
         if html.find(">") < 0:
             return html
@@ -868,6 +869,7 @@ to a cloze type first, via 'Notes>Change Note Type'"""
             warnings.simplefilter("ignore", UserWarning)
             doc = BeautifulSoup(html, "html.parser")
 
+        tag: bs4.element.Tag
         if not internal:
             for tag in self.removeTags:
                 for node in doc(tag):

--- a/qt/mypy.ini
+++ b/qt/mypy.ini
@@ -84,3 +84,5 @@ check_untyped_defs=true
 check_untyped_defs=true
 [mypy-aqt.editor]
 check_untyped_defs=true
+[mypy-aqt.exporting]
+check_untyped_defs=true

--- a/qt/mypy.ini
+++ b/qt/mypy.ini
@@ -82,3 +82,5 @@ check_untyped_defs=true
 check_untyped_defs=true
 [mypy-aqt.browser]
 check_untyped_defs=true
+[mypy-aqt.editor]
+check_untyped_defs=true

--- a/ts/src/stats/CardCounts.svelte
+++ b/ts/src/stats/CardCounts.svelte
@@ -36,7 +36,7 @@
     <svg
         bind:this={svg}
         viewBox={`0 0 ${bounds.width} ${bounds.height}`}
-        style={{ opacity: graphData.totalCards ? 1 : 0 }}>
+        style="opacity: {graphData.totalCards ? 1 : 0};">
         <g class="days" />
     </svg>
 


### PR DESCRIPTION
For ankitects/help-wanted#4

Saw the following errors after turning on check_untyped_defs for `aqt.editor`, `aqt.exporting`.

24e7156
```
aqt/editor.py:883: error: Invalid index type "str" for "str"; expected type "Union[int, slice]"  [index]
                    src = tag["src"]
                              ^
aqt/editor.py:893: error: Unsupported target for indexed assignment ("str")  [index]
                        tag["src"] = m.group(1)
                        ^
aqt/editor.py:899: error: Unsupported target for indexed assignment ("str")  [index]
                            tag["src"] = fname
                            ^
aqt/editor.py:902: error: Unsupported target for indexed assignment ("str")  [index]
                        tag["src"] = self.inlinedImageToFilename(src)
                        ^
```

5e6f532
```
aqt/exporting.py:68: error: Item "Exporter" of "Optional[Exporter]" has no attribute "ext"  [union-attr]
            self.isApkg = self.exporter.ext == ".apkg"
                          ^
aqt/exporting.py:90: error: Item "Exporter" of "Optional[Exporter]" has no attribute "includeSched"  [union-attr]
            self.exporter.includeSched = self.frm.includeSched.isChecked()
            ^
aqt/exporting.py:91: error: Item "Exporter" of "Optional[Exporter]" has no attribute "includeMedia"  [union-attr]
            self.exporter.includeMedia = self.frm.includeMedia.isChecked()
            ^
aqt/exporting.py:92: error: Item "Exporter" of "Optional[Exporter]" has no attribute "includeTags"  [union-attr]
            self.exporter.includeTags = self.frm.includeTags.isChecked()
            ^
aqt/exporting.py:116: error: Item "Exporter" of "Optional[Exporter]" has no attribute "ext"  [union-attr]
            filename = "{0}{1}".format(deck_name, self.exporter.ext)
                                                  ^
aqt/exporting.py:122: error: Item "Exporter" of "Optional[Exporter]" has no attribute "key"  [union-attr]
                    self.exporter.key,
                    ^
aqt/exporting.py:123: error: Item "Exporter" of "Optional[Exporter]" has no attribute "ext"  [union-attr]
                    self.exporter.ext,
```

Also, I was seeing the following `svelte` related error when running `make check`. 

```
Fix error: Type '{ opacity: number; }' is not assignable to type 'string'. (ts)
```

I haven't used `svelte` before, but looking at [this](https://svelte.dev/repl/5d68597ce6854beba658aed433632f22?version=3.6.9) it looked like the inline style format just needed to be adjusted, but let know if that doesn't seem right.