### PR TITLE
Re-add previously supported file extensions for media

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -45,6 +45,8 @@ Andreas Reis <github.com/rathsky>
 Matt Krump <github.com/mkrump>
 Alexander Presnyakov <flagist0@gmail.com>
 abdo <github.com/ANH25>
+aplaice <plaice.adam+github@gmail.com>
+
 ********************
 
 The text of the 3 clause BSD license follows:

--- a/qt/aqt/editor.py
+++ b/qt/aqt/editor.py
@@ -58,6 +58,11 @@ audio = (
     "spx",
     "oga",
     "webm",
+    "mpg",
+    "ogx",
+    "avi",
+    "flv",
+    "ogv",
 )
 
 _html = """


### PR DESCRIPTION
I've re-added the audio/video file extensions accepted when adding media (e.g. in onAddMedia), that had been previously accepted, but were (accidentally?) removed in 2ae342592cfb863e6b1aad6a6233ea799d083042.

`.mpg` and `.ogx` files can certainly be audio-only, so IMO it definitely makes sense to re-add them.

I had doubts about the remainder, since they're mostly or solely video, not audio file extensions, so adding them to the `audio` tuple is a bit of a misnomer. However:

* I *think* that it is possible for `.flv` and `.avi` files to only contain an audio track.

* If a video file is added as "sound", `mpv`/`mplayer` will still happily play it, so there's little harm to erring on the side of laxness.

* `.mov` is also mostly a video extension, but is still listed in the `audio` tuple.

so I think it might still be useful to re-add all the extensions.

PS As always thank you very much for Anki!

<hr/>

(For background, I encountered the issue while trying to add an `.mpg` file — it was trivial to work around by renaming the file to `.mpeg`, but a general solution might be valuable.)

<hr/>

Edit: I don't think that the change crosses the threshold for copyrightability, but without my adding myself to the list of contributors, the authors test failed.