### PR TITLE
Turn on check_untyped_defs for aqt.webview, aqt.addons and aqt.emptycards.

### DIFF
--- a/qt/aqt/addons.py
+++ b/qt/aqt/addons.py
@@ -179,7 +179,7 @@ class AddonManager:
         sys.path.insert(0, self.addonsFolder())
 
     # in new code, you may want all_addon_meta() instead
-    def allAddons(self):
+    def allAddons(self) -> List[str]:
         l = []
         for d in os.listdir(self.addonsFolder()):
             path = self.addonsFolder(d)
@@ -188,7 +188,7 @@ class AddonManager:
             l.append(d)
         l.sort()
         if os.getenv("ANKIREVADDONS", ""):
-            l = reversed(l)
+            l = list(reversed(l))
         return l
 
     def all_addon_meta(self) -> Iterable[AddonMeta]:

--- a/qt/aqt/emptycards.py
+++ b/qt/aqt/emptycards.py
@@ -85,10 +85,10 @@ class EmptyCardsDialog(QDialog):
 
         self.mw.taskman.run_in_background(delete, on_done)
 
-    def _delete_cards(self, keep_notes):
+    def _delete_cards(self, keep_notes: bool) -> int:
         to_delete = []
+        note: NoteWithEmptyCards
         for note in self.report.notes:
-            note: NoteWithEmptyCards = note
             if keep_notes and note.will_delete_note:
                 # leave first card
                 to_delete.extend(note.card_ids[1:])

--- a/qt/aqt/qt.py
+++ b/qt/aqt/qt.py
@@ -13,6 +13,7 @@ from PyQt5.Qt import *  # type: ignore
 from PyQt5.QtCore import *
 from PyQt5.QtCore import pyqtRemoveInputHook  # pylint: disable=no-name-in-module
 from PyQt5.QtGui import *  # type: ignore
+from PyQt5.QtWebChannel import QWebChannel
 from PyQt5.QtWebEngineWidgets import *
 from PyQt5.QtWidgets import *
 

--- a/qt/aqt/webview.py
+++ b/qt/aqt/webview.py
@@ -30,9 +30,9 @@ class AnkiWebPage(QWebEnginePage):
         self._setupBridge()
         self.open_links_externally = True
 
-    def _setupBridge(self):
+    def _setupBridge(self) -> None:
         class Bridge(QObject):
-            @pyqtSlot(str, result=str)
+            @pyqtSlot(str, result=str)  # type: ignore
             def cmd(self, str):
                 return json.dumps(self.onCmd(str))
 

--- a/qt/mypy.ini
+++ b/qt/mypy.ini
@@ -90,3 +90,5 @@ check_untyped_defs=true
 check_untyped_defs=true
 [mypy-aqt.webview]
 check_untyped_defs=true
+[mypy-aqt.addons]
+check_untyped_defs=true

--- a/qt/mypy.ini
+++ b/qt/mypy.ini
@@ -88,3 +88,5 @@ check_untyped_defs=true
 check_untyped_defs=true
 [mypy-aqt.modelchooser]
 check_untyped_defs=true
+[mypy-aqt.webview]
+check_untyped_defs=true

--- a/qt/mypy.ini
+++ b/qt/mypy.ini
@@ -92,3 +92,5 @@ check_untyped_defs=true
 check_untyped_defs=true
 [mypy-aqt.addons]
 check_untyped_defs=true
+[mypy-aqt.emptycards]
+check_untyped_defs=true


### PR DESCRIPTION
For ankitects/help-wanted#4

Saw the following errors after turning on check_untyped_defs for aqt.webview, aqt.addons and aqt.emptycards:

10f2f9c
```
aqt/emptycards.py:91: error: Name 'note' already defined on line 90  [no-redef]
                note: NoteWithEmptyCards = note
                ^
```

7d8f856
```                
aqt/addons.py:191: error: Incompatible types in assignment (expression has type "Iterator[Any]", variable has type "List[Any]")  [assignment]
                l = reversed(l)
```

a56690b
* when i tried to use Optional[str] for `result` mypy would complain `"pyqtSlot" has incompatible type "object"; expected "Optional[str]"`, so ignored 

* Seemed unlikely `QWebChannel` wasn't actually being imported, but mypy was complaining that it couldn't find it, so i added import to \_\_init\_\_ with rest of `PyQt5` imports.
```
aqt/webview.py:35: error: Argument "result" to "pyqtSlot" has incompatible type "Type[str]"; expected "Optional[str]"  [arg-type]
                @pyqtSlot(str, result=str)
                                      ^
aqt/webview.py:42: error: Name 'QWebChannel' is not defined  [name-defined]
            self._channel = QWebChannel(self)
```