### PR TITLE
Turn on check_untyped_defs for aqt.main and aqt.progress

### DIFF
--- a/qt/aqt/main.py
+++ b/qt/aqt/main.py
@@ -14,7 +14,7 @@ import weakref
 import zipfile
 from argparse import Namespace
 from threading import Thread
-from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple
+from typing import Any, Callable, Dict, List, Optional, Sequence, TextIO, Tuple, cast
 
 import anki
 import aqt
@@ -185,9 +185,9 @@ class AnkiQt(QMainWindow):
         onClose = pyqtSignal()
         closeFires = True
 
-        def closeEvent(self, evt):
+        def closeEvent(self, evt: QCloseEvent) -> None:
             if self.closeFires:
-                self.onClose.emit()
+                self.onClose.emit()  # type: ignore
             evt.accept()
 
         def closeWithoutQuitting(self):
@@ -924,10 +924,10 @@ title="%s" %s>%s</button>""" % (
     # Tools
     ##########################################################################
 
-    def raiseMain(self):
+    def raiseMain(self) -> bool:
         if not self.app.activeWindow():
             # make sure window is shown
-            self.setWindowState(self.windowState() & ~Qt.WindowMinimized)
+            self.setWindowState(self.windowState() & ~Qt.WindowMinimized)  # type: ignore
         return True
 
     def setupStyle(self) -> None:
@@ -1412,7 +1412,7 @@ will be lost. Continue?"""
         gui_hooks.debug_console_will_show(d)
         d.show()
 
-    def _captureOutput(self, on):
+    def _captureOutput(self, on: bool) -> None:
         mw = self
 
         class Stream:
@@ -1423,7 +1423,7 @@ will be lost. Continue?"""
             self._output = ""
             self._oldStderr = sys.stderr
             self._oldStdout = sys.stdout
-            s = Stream()
+            s = cast(TextIO, Stream())
             sys.stderr = s
             sys.stdout = s
         else:
@@ -1547,8 +1547,8 @@ will be lost. Continue?"""
         for action in self.findChildren(QAction):
             action.setStatusTip("")
 
-    def onMacMinimize(self):
-        self.setWindowState(self.windowState() | Qt.WindowMinimized)
+    def onMacMinimize(self) -> None:
+        self.setWindowState(self.windowState() | Qt.WindowMinimized)  # type: ignore
 
     # Single instance support
     ##########################################################################

--- a/qt/aqt/progress.py
+++ b/qt/aqt/progress.py
@@ -73,7 +73,7 @@ class ProgressManager:
         self._win.setWindowModality(Qt.ApplicationModal)
         self._win.setMinimumWidth(300)
         self._setBusy()
-        self._shown = 0
+        self._shown: float = 0
         self._counter = min
         self._min = min
         self._max = max
@@ -116,7 +116,7 @@ class ProgressManager:
 
         if process and elapsed >= 0.2:
             self._updating = True
-            self.app.processEvents()
+            self.app.processEvents()  # type: ignore #possibly related to https://github.com/python/mypy/issues/6910
             self._updating = False
             self._lastUpdate = time.time()
 
@@ -146,7 +146,7 @@ class ProgressManager:
         if delta > 0.5:
             self._showWin()
 
-    def _showWin(self):
+    def _showWin(self) -> None:
         self._shown = time.time()
         self._win.show()
 
@@ -160,7 +160,7 @@ class ProgressManager:
                 elap = time.time() - self._shown
                 if elap >= 0.5:
                     break
-                self.app.processEvents(QEventLoop.ExcludeUserInputEvents)
+                self.app.processEvents(QEventLoop.ExcludeUserInputEvents)  # type: ignore #possibly related to https://github.com/python/mypy/issues/6910
         self._win.cancel()
         self._win = None
         self._shown = 0

--- a/qt/mypy.ini
+++ b/qt/mypy.ini
@@ -98,3 +98,5 @@ check_untyped_defs=true
 check_untyped_defs=true
 [mypy-aqt.main]
 check_untyped_defs=true
+[mypy-aqt.progress]
+check_untyped_defs=true

--- a/qt/mypy.ini
+++ b/qt/mypy.ini
@@ -96,3 +96,5 @@ check_untyped_defs=true
 check_untyped_defs=true
 [mypy-aqt.profiles]
 check_untyped_defs=true
+[mypy-aqt.main]
+check_untyped_defs=true


### PR DESCRIPTION
For ankitects/help-wanted#4

Saw the following errors after turning on check_untyped_defs for aqt.main and aqt.progress:

83449e3
```
aqt/main.py:190: error: "pyqtSignal" has no attribute "emit"  [attr-defined]
                    self.onClose.emit()
                    ^
aqt/main.py:930: error: Argument 1 to "setWindowState" of "QWidget" has incompatible type "int"; expected "Union[WindowStates, WindowState]"  [arg-type]
                self.setWindowState(self.windowState() & ~Qt.WindowMinimized)
                                    ^
aqt/main.py:1427: error: Incompatible types in assignment (expression has type "Stream", variable has type "TextIO")  [assignment]
                sys.stderr = s
                             ^
aqt/main.py:1428: error: Incompatible types in assignment (expression has type "Stream", variable has type "TextIO")  [assignment]
                sys.stdout = s
                             ^
aqt/main.py:1551: error: Argument 1 to "setWindowState" of "QWidget" has incompatible type "int"; expected "Union[WindowStates, WindowState]"  [arg-type]
            self.setWindowState(self.windowState() | Qt.WindowMinimized)
```

f9a4625
```
aqt/progress.py:119: error: Attribute function "processEvents" with type "Callable[[Union[ProcessEventsFlags, ProcessEventsFlag]], None]" does not accept
self argument  [misc]
                self.app.processEvents()
                ^
aqt/progress.py:150: error: Incompatible types in assignment (expression has type "float", variable has type "int")  [assignment]
            self._shown = time.time()
                          ^
aqt/progress.py:163: error: Attribute function "processEvents" with type "Callable[[Union[ProcessEventsFlags, ProcessEventsFlag]], None]" does not accept
```