### PR TITLE
Typehints for qt addons

### DIFF
--- a/qt/aqt/addons.py
+++ b/qt/aqt/addons.py
@@ -179,7 +179,7 @@ class AddonManager:
         sys.path.insert(0, self.addonsFolder())
 
     # in new code, you may want all_addon_meta() instead
-    def allAddons(self) -> Iterable[str]:
+    def allAddons(self) -> List[str]:
         l = []
         for d in os.listdir(self.addonsFolder()):
             path = self.addonsFolder(d)
@@ -188,8 +188,8 @@ class AddonManager:
             l.append(d)
         l.sort()
         if os.getenv("ANKIREVADDONS", ""):
-            it = reversed(l)
-        return it
+            l = list(reversed(l))
+        return l
 
     def all_addon_meta(self) -> Iterable[AddonMeta]:
         return map(self.addon_meta, self.allAddons())


### PR DESCRIPTION
For https://github.com/ankitects/help-wanted/issues/4

Update for bcc35c1822e5422c8aa50a50c18da51a2c4cbbcf with as many typehints as I could manage.

The only function missing a return type is `def _addon_schema(...)`, as I wasn't sure what the best practice for returning after throwing an expection is, and mypy isn't too happy about not having a return statement along all conditional branches.