### PR TITLE
NF: Factorize schedulers

### DIFF
--- a/pylib/anki/sched.py
+++ b/pylib/anki/sched.py
@@ -699,16 +699,6 @@ did = ?, queue = %s, due = ?, usn = ? where id = ?"""
         self.removeLrn(ids)
         super().suspendCards(ids)
 
-    def unsuspendCards(self, ids: List[int]) -> None:
-        "Unsuspend cards."
-        self.col.log(ids)
-        self.col.db.execute(
-            f"update cards set {self._restoreQueueSnippet},mod=?,usn=? "
-            f"where queue = {QUEUE_TYPE_SUSPENDED} and id in " + ids2str(ids),
-            intTime(),
-            self.col.usn(),
-        )
-
     def buryCards(self, cids: List[int], manual: bool = False) -> None:
         # v1 only supported automatic burying
         assert not manual

--- a/pylib/anki/sched.py
+++ b/pylib/anki/sched.py
@@ -647,17 +647,6 @@ did = ?, queue = %s, due = ?, usn = ? where id = ?"""
             return True
         return conf["resched"]
 
-    # Deck finished state
-    ##########################################################################
-
-    def haveBuried(self) -> bool:
-        sdids = self._deckLimit()
-        cnt = self.col.db.scalar(
-            f"select 1 from cards where {self._queueIsBuriedSnippet} and did in %s limit 1"
-            % sdids
-        )
-        return not not cnt
-
     # Next time reports
     ##########################################################################
 

--- a/pylib/anki/sched.py
+++ b/pylib/anki/sched.py
@@ -441,8 +441,8 @@ where queue in ({QUEUE_TYPE_LRN},{QUEUE_TYPE_DAY_LEARN_RELEARN}) and type = {CAR
             )
         )
 
-    def _lrnForDeck(self, did: int) -> int:
-        cnt = (
+    def _subDayLrnForDeck(self, did: int) -> int:
+        return (
             self.col.db.scalar(
                 f"""
 select sum(left/1000) from
@@ -453,6 +453,9 @@ select sum(left/1000) from
             )
             or 0
         )
+
+    def _lrnForDeck(self, did: int) -> int:
+        cnt = self._subDayLrnForDeck(did)
         return cnt + self.col.db.scalar(
             f"""
 select count() from

--- a/pylib/anki/sched.py
+++ b/pylib/anki/sched.py
@@ -220,6 +220,8 @@ and due <= ? limit %d"""
     def _cutoff(self):
         return self.dayCutoff
 
+    _queueInLearningSnippet = f"queue = {QUEUE_TYPE_LRN}"
+
     # sub-day learning
     def _fillLrn(self) -> Union[bool, List[Any]]:
         if not self.lrnCount:
@@ -229,7 +231,7 @@ and due <= ? limit %d"""
         self._lrnQueue = self.col.db.all(
             f"""
 select due, id from cards where
-did in %s and queue = {QUEUE_TYPE_LRN} and due < ?
+did in %s and {self._queueInLearningSnippet} and due < ?
 limit %d"""
             % (self._deckLimit(), self.reportLimit),
             self._cutoff(),

--- a/pylib/anki/sched.py
+++ b/pylib/anki/sched.py
@@ -242,6 +242,9 @@ limit %d"""
         self._lrnQueue.sort()
         return self._lrnQueue
 
+    def _lrnCountDecrease(self, card: Card):
+        self.lrnCount -= card.left // 1000
+
     def _getLrnCard(self, collapse: bool = False) -> Optional[Card]:
         if self._fillLrn():
             cutoff = time.time()
@@ -250,7 +253,7 @@ limit %d"""
             if self._lrnQueue[0][0] < cutoff:
                 id = heappop(self._lrnQueue)[1]
                 card = self.col.getCard(id)
-                self.lrnCount -= card.left // 1000
+                self._lrnCountDecrease(card)
                 return card
         return None
 

--- a/pylib/anki/sched.py
+++ b/pylib/anki/sched.py
@@ -860,9 +860,9 @@ did = ?, queue = %s, due = ?, usn = ? where id = ?"""
 
     def suspendCards(self, ids: List[int]) -> None:
         "Suspend cards."
-        self.col.log(ids)
         self.remFromDyn(ids)
         self.removeLrn(ids)
+        self.col.log(ids)
         self.col.db.execute(
             f"update cards set queue={QUEUE_TYPE_SUSPENDED},mod=?,usn=? where id in "
             + ids2str(ids),
@@ -883,9 +883,9 @@ did = ?, queue = %s, due = ?, usn = ? where id = ?"""
     def buryCards(self, cids: List[int], manual: bool = False) -> None:
         # v1 only supported automatic burying
         assert not manual
-        self.col.log(cids)
         self.remFromDyn(cids)
         self.removeLrn(cids)
+        self.col.log(cids)
         self.col.db.execute(
             f"""
 update cards set queue={QUEUE_TYPE_SIBLING_BURIED},mod=?,usn=? where id in """

--- a/pylib/anki/sched.py
+++ b/pylib/anki/sched.py
@@ -115,15 +115,6 @@ class Scheduler(V2):
         else:
             return 3
 
-    def unburyCards(self) -> None:
-        "Unbury cards."
-        self.col.log(
-            self.col.db.list(f"select id from cards where {self._queueIsBuriedSnippet}")
-        )
-        self.col.db.execute(
-            f"update cards set {self._restoreQueueSnippet} where {self._queueIsBuriedSnippet}"
-        )
-
     def unburyCardsForDeck(self) -> None:  # type: ignore[override]
         super().unburyCardsForDeck("all")
 

--- a/pylib/anki/sched.py
+++ b/pylib/anki/sched.py
@@ -724,6 +724,14 @@ did = ?, queue = %s, due = ?, usn = ? where id = ?"""
     # Leeches
     ##########################################################################
 
+    def _filteredLeech(self, card: Card):
+        # if it has an old due, remove it from cram/relearning
+        if card.odue:
+            card.due = card.odue
+        if card.odid:
+            card.did = card.odid
+            card.odue = card.odid = 0
+
     def _checkLeech(self, card: Card, conf: Dict[str, Any]) -> bool:
         "Leech handler. True if card was a leech."
         lf = conf["leechFails"]
@@ -738,12 +746,7 @@ did = ?, queue = %s, due = ?, usn = ? where id = ?"""
             # handle
             a = conf["leechAction"]
             if a == LEECH_SUSPEND:
-                # if it has an old due, remove it from cram/relearning
-                if card.odue:
-                    card.due = card.odue
-                if card.odid:
-                    card.did = card.odid
-                card.odue = card.odid = 0
+                self._filteredLeech(card)
                 card.queue = QUEUE_TYPE_SUSPENDED
             # notify UI
             hooks.card_did_leech(card)

--- a/pylib/anki/sched.py
+++ b/pylib/anki/sched.py
@@ -519,20 +519,6 @@ queue = (case when type = {CARD_TYPE_LRN} then {QUEUE_TYPE_NEW}
 else type end), type = (case when type = {CARD_TYPE_LRN} then {CARD_TYPE_NEW} else type end)
     """
 
-    def rebuildDyn(self, did: Optional[int] = None) -> Optional[Sequence[int]]:  # type: ignore[override]
-        "Rebuild a dynamic deck."
-        did = did or self.col.decks.selected()
-        deck = self.col.decks.get(did)
-        assert deck["dyn"]
-        # move any existing cards back first, then fill
-        self.emptyDyn(did)
-        cnt = self._fillDyn(deck)
-        if not cnt:
-            return None
-        # and change to our new deck
-        self.col.decks.select(did)
-        return cnt
-
     def _fillDyn(self, deck: Dict[str, Any]) -> Sequence[int]:  # type: ignore[override]
         search, limit, order = deck["terms"][0]
         orderlimit = self._dynOrder(order, limit)

--- a/pylib/anki/sched.py
+++ b/pylib/anki/sched.py
@@ -641,24 +641,6 @@ did = ?, queue = %s, due = ?, usn = ? where id = ?"""
         oconf = self.col.decks.confForDid(card.odid)
         return conf["delays"] or oconf["lapse"]["delays"]
 
-    def _lapseConf(self, card: Card) -> Dict[str, Any]:
-        conf = self._cardConf(card)
-        # normal deck
-        if not card.odid:
-            return conf["lapse"]
-        # dynamic deck; override some attributes, use original deck for others
-        oconf = self.col.decks.confForDid(card.odid)
-        return dict(
-            # original deck
-            minInt=oconf["lapse"]["minInt"],
-            leechFails=oconf["lapse"]["leechFails"],
-            leechAction=oconf["lapse"]["leechAction"],
-            mult=oconf["lapse"]["mult"],
-            # overrides
-            delays=self._lapseConfDelays(card),
-            resched=conf["resched"],
-        )
-
     def _resched(self, card: Card) -> bool:
         conf = self._cardConf(card)
         if not conf["dyn"]:

--- a/pylib/anki/sched.py
+++ b/pylib/anki/sched.py
@@ -190,6 +190,9 @@ class Scheduler(V2):
     # Learning queues
     ##########################################################################
 
+    def _maybeResetLrn(self, force: bool) -> None:
+        pass
+
     def _resetLrnCount(self) -> None:
         # sub-day
         self.lrnCount = (
@@ -246,6 +249,7 @@ limit %d"""
         self.lrnCount -= card.left // 1000
 
     def _getLrnCard(self, collapse: bool = False) -> Optional[Card]:
+        self._maybeResetLrn(force=collapse and self.lrnCount == 0)
         if self._fillLrn():
             cutoff = time.time()
             if collapse:

--- a/pylib/anki/sched.py
+++ b/pylib/anki/sched.py
@@ -380,6 +380,9 @@ limit %d"""
         card.due = self.today + card.ivl
         card.factor = conf["initialFactor"]
 
+    def _logLrnNotLeaving(self, card: Card, ease: int, conf: Dict[str, Any]):
+        return -(self._delayForGrade(conf, card.left))
+
     def _logLrn(
         self,
         card: Card,
@@ -393,7 +396,7 @@ limit %d"""
         if leaving:
             ivl = card.ivl
         else:
-            ivl = -(self._delayForGrade(conf, card.left))
+            ivl = self._logLrnNotLeaving(card, ease, conf)
 
         def log():
             self.col.db.execute(

--- a/pylib/anki/sched.py
+++ b/pylib/anki/sched.py
@@ -655,12 +655,12 @@ else type end), type = (case when type = {CARD_TYPE_LRN} then {CARD_TYPE_NEW} el
         assert deck["dyn"]
         # move any existing cards back first, then fill
         self.emptyDyn(did)
-        ids = self._fillDyn(deck)
-        if not ids:
+        cnt = self._fillDyn(deck)
+        if not cnt:
             return None
         # and change to our new deck
         self.col.decks.select(did)
-        return ids
+        return cnt
 
     def _fillDyn(self, deck: Dict[str, Any]) -> Sequence[int]:  # type: ignore[override]
         search, limit, order = deck["terms"][0]

--- a/pylib/anki/sched.py
+++ b/pylib/anki/sched.py
@@ -313,18 +313,6 @@ select sum(left/1000) from
             or 0
         )
 
-    def _lrnForDeck(self, did: int) -> int:
-        cnt = self._subDayLrnForDeck(did)
-        return cnt + self.col.db.scalar(
-            f"""
-select count() from
-(select 1 from cards where did = ? and queue = {QUEUE_TYPE_DAY_LEARN_RELEARN}
-and due <= ? limit ?)""",
-            did,
-            self.today,
-            self.reportLimit,
-        )
-
     # Reviews
     ##########################################################################
 

--- a/pylib/anki/sched.py
+++ b/pylib/anki/sched.py
@@ -606,28 +606,6 @@ did = ?, queue = %s, due = ?, usn = ? where id = ?"""
             card.did = card.odid
             card.odue = card.odid = 0
 
-    def _checkLeech(self, card: Card, conf: Dict[str, Any]) -> bool:
-        "Leech handler. True if card was a leech."
-        lf = conf["leechFails"]
-        if not lf:
-            return False
-        # if over threshold or every half threshold reps after that
-        if card.lapses >= lf and (card.lapses - lf) % (max(lf // 2, 1)) == 0:
-            # add a leech tag
-            n = card.note()
-            n.addTag("leech")
-            n.flush()
-            # handle
-            a = conf["leechAction"]
-            if a == LEECH_SUSPEND:
-                self._filteredLeech(card)
-                card.queue = QUEUE_TYPE_SUSPENDED
-            # notify UI
-            hooks.card_did_leech(card)
-            return True
-        else:
-            return False
-
     # Tools
     ##########################################################################
 

--- a/pylib/anki/sched.py
+++ b/pylib/anki/sched.py
@@ -101,11 +101,6 @@ class Scheduler(V2):
         new, lrn, rev = counts
         return (new, lrn, rev)
 
-    def countIdx(self, card: Card) -> int:
-        if card.queue == QUEUE_TYPE_DAY_LEARN_RELEARN:
-            return QUEUE_TYPE_LRN
-        return card.queue
-
     def answerButtons(self, card: Card) -> int:
         if card.odue:
             # normal review in dyn deck?

--- a/pylib/anki/sched.py
+++ b/pylib/anki/sched.py
@@ -133,43 +133,6 @@ class Scheduler(V2):
     def _dayLearnFirst(self):
         return False
 
-    def _getCard(self) -> Optional[Card]:
-        "Return the next due card id, or None."
-        # learning card due?
-        c = self._getLrnCard()
-        if c:
-            return c
-        # new first, or time for one?
-        if self._timeForNewCard():
-            c = self._getNewCard()
-            if c:
-                return c
-
-        # day learning first and card due?
-        dayLearnFirst = self._dayLearnFirst()
-        if dayLearnFirst:
-            c = self._getLrnDayCard()
-            if c:
-                return c
-
-        # card due for review?
-        c = self._getRevCard()
-        if c:
-            return c
-
-        if not dayLearnFirst:
-            # day learning card due?
-            c = self._getLrnDayCard()
-            if c:
-                return c
-
-        # new cards left?
-        c = self._getNewCard()
-        if c:
-            return c
-        # collapse or finish
-        return self._getLrnCard(collapse=True)
-
     # Learning queues
     ##########################################################################
 

--- a/pylib/anki/sched.py
+++ b/pylib/anki/sched.py
@@ -130,17 +130,7 @@ class Scheduler(V2):
         )
 
     def unburyCardsForDeck(self) -> None:  # type: ignore[override]
-        sids = self._deckLimit()
-        self.col.log(
-            self.col.db.list(
-                f"select id from cards where {self._queueIsBuriedSnippet} and did in {sids}"
-            )
-        )
-        self.col.db.execute(
-            f"update cards set mod=?,usn=?,{self._restoreQueueSnippet} where {self._queueIsBuriedSnippet} and did in {sids}",
-            intTime(),
-            self.col.usn(),
-        )
+        super().unburyCardsForDeck("all")
 
     # Getting the next card
     ##########################################################################

--- a/pylib/anki/sched.py
+++ b/pylib/anki/sched.py
@@ -374,12 +374,6 @@ limit %d"""
         else:
             return ideal
 
-    def _rescheduleNew(self, card: Card, conf: Dict[str, Any], early: bool) -> None:
-        "Reschedule a new card that's graduated for the first time."
-        card.ivl = self._graduatingIvl(card, conf, early)
-        card.due = self.today + card.ivl
-        card.factor = conf["initialFactor"]
-
     def _logLrnNotLeaving(self, card: Card, ease: int, conf: Dict[str, Any]):
         return -(self._delayForGrade(conf, card.left))
 

--- a/pylib/anki/sched.py
+++ b/pylib/anki/sched.py
@@ -217,6 +217,9 @@ and due <= ? limit %d"""
         self._lrnDayQueue: List[Any] = []
         self._lrnDids = self.col.decks.active()[:]
 
+    def _cutoff(self):
+        return self.dayCutoff
+
     # sub-day learning
     def _fillLrn(self) -> Union[bool, List[Any]]:
         if not self.lrnCount:
@@ -229,7 +232,7 @@ select due, id from cards where
 did in %s and queue = {QUEUE_TYPE_LRN} and due < ?
 limit %d"""
             % (self._deckLimit(), self.reportLimit),
-            self.dayCutoff,
+            self._cutoff(),
         )
         for i in range(len(self._lrnQueue)):
             self._lrnQueue[i] = (self._lrnQueue[i][0], self._lrnQueue[i][1])

--- a/pylib/anki/sched.py
+++ b/pylib/anki/sched.py
@@ -345,8 +345,10 @@ limit %d"""
                 card.queue = card.type = CARD_TYPE_NEW
                 card.due = self.col.nextID("pos")
 
+    _relearning_type = CARD_TYPE_REV
+
     def _startingLeft(self, card: Card) -> int:
-        if card.type == CARD_TYPE_REV:
+        if card.type == self._relearning_type:
             conf = self._lapseConf(card)
         else:
             conf = self._lrnConf(card)

--- a/pylib/anki/sched.py
+++ b/pylib/anki/sched.py
@@ -281,42 +281,6 @@ and due <= ? limit %d"""
     def _logLrnNotLeaving(self, card: Card, ease: int, conf: Dict[str, Any]):
         return -(self._delayForGrade(conf, card.left))
 
-    def _logLrn(
-        self,
-        card: Card,
-        ease: int,
-        conf: Dict[str, Any],
-        leaving: bool,
-        type: int,
-        lastLeft: int,
-    ) -> None:
-        lastIvl = -(self._delayForGrade(conf, lastLeft))
-        if leaving:
-            ivl = card.ivl
-        else:
-            ivl = self._logLrnNotLeaving(card, ease, conf)
-
-        def log():
-            self.col.db.execute(
-                "insert into revlog values (?,?,?,?,?,?,?,?,?)",
-                int(time.time() * 1000),
-                card.id,
-                self.col.usn(),
-                ease,
-                ivl,
-                lastIvl,
-                card.factor,
-                card.timeTaken(),
-                type,
-            )
-
-        try:
-            log()
-        except:
-            # duplicate pk; retry in 10ms
-            time.sleep(0.01)
-            log()
-
     def removeLrn(self, ids: Optional[List[int]] = None) -> None:
         "Remove cards from the learning queues."
         if ids:

--- a/pylib/anki/sched.py
+++ b/pylib/anki/sched.py
@@ -258,15 +258,6 @@ and due <= ? limit %d"""
 
     _relearning_type = CARD_TYPE_REV
 
-    def _startingLeft(self, card: Card) -> int:
-        if card.type == self._relearning_type:
-            conf = self._lapseConf(card)
-        else:
-            conf = self._lrnConf(card)
-        tot = len(conf["delays"])
-        tod = self._leftToday(conf["delays"], tot)
-        return tot + tod * 1000
-
     def _graduatingIvl(
         self, card: Card, conf: Dict[str, Any], early: bool, adj: bool = True
     ) -> int:

--- a/pylib/anki/sched.py
+++ b/pylib/anki/sched.py
@@ -390,7 +390,10 @@ limit %d"""
         lastLeft: int,
     ) -> None:
         lastIvl = -(self._delayForGrade(conf, lastLeft))
-        ivl = card.ivl if leaving else -(self._delayForGrade(conf, card.left))
+        if leaving:
+            ivl = card.ivl
+        else:
+            ivl = -(self._delayForGrade(conf, card.left))
 
         def log():
             self.col.db.execute(

--- a/pylib/anki/sched.py
+++ b/pylib/anki/sched.py
@@ -732,9 +732,9 @@ did = ?, queue = %s, due = ?, usn = ? where id = ?"""
         # if over threshold or every half threshold reps after that
         if card.lapses >= lf and (card.lapses - lf) % (max(lf // 2, 1)) == 0:
             # add a leech tag
-            f = card.note()
-            f.addTag("leech")
-            f.flush()
+            n = card.note()
+            n.addTag("leech")
+            n.flush()
             # handle
             a = conf["leechAction"]
             if a == LEECH_SUSPEND:

--- a/pylib/anki/sched.py
+++ b/pylib/anki/sched.py
@@ -149,6 +149,9 @@ class Scheduler(V2):
     # Getting the next card
     ##########################################################################
 
+    def _dayLearnFirst(self):
+        return False
+
     def _getCard(self) -> Optional[Card]:
         "Return the next due card id, or None."
         # learning card due?
@@ -160,14 +163,25 @@ class Scheduler(V2):
             c = self._getNewCard()
             if c:
                 return c
+
+        # day learning first and card due?
+        dayLearnFirst = self._dayLearnFirst()
+        if dayLearnFirst:
+            c = self._getLrnDayCard()
+            if c:
+                return c
+
         # card due for review?
         c = self._getRevCard()
         if c:
             return c
-        # day learning card due?
-        c = self._getLrnDayCard()
-        if c:
-            return c
+
+        if not dayLearnFirst:
+            # day learning card due?
+            c = self._getLrnDayCard()
+            if c:
+                return c
+
         # new cards left?
         c = self._getNewCard()
         if c:

--- a/pylib/anki/sched.py
+++ b/pylib/anki/sched.py
@@ -862,13 +862,7 @@ did = ?, queue = %s, due = ?, usn = ? where id = ?"""
         "Suspend cards."
         self.remFromDyn(ids)
         self.removeLrn(ids)
-        self.col.log(ids)
-        self.col.db.execute(
-            f"update cards set queue={QUEUE_TYPE_SUSPENDED},mod=?,usn=? where id in "
-            + ids2str(ids),
-            intTime(),
-            self.col.usn(),
-        )
+        super().suspendCards(ids)
 
     def unsuspendCards(self, ids: List[int]) -> None:
         "Unsuspend cards."
@@ -885,11 +879,4 @@ did = ?, queue = %s, due = ?, usn = ? where id = ?"""
         assert not manual
         self.remFromDyn(cids)
         self.removeLrn(cids)
-        self.col.log(cids)
-        self.col.db.execute(
-            f"""
-update cards set queue={QUEUE_TYPE_SIBLING_BURIED},mod=?,usn=? where id in """
-            + ids2str(cids),
-            intTime(),
-            self.col.usn(),
-        )
+        super().buryCards(cids, False)

--- a/pylib/anki/sched.py
+++ b/pylib/anki/sched.py
@@ -836,7 +836,7 @@ did = ?, queue = %s, due = ?, usn = ? where id = ?"""
 
     # this isn't easily extracted from the learn code
     def _nextLrnIvl(self, card: Card, ease: int) -> float:
-        if card.queue == 0:
+        if card.queue == QUEUE_TYPE_NEW:
             card.left = self._startingLeft(card)
         conf = self._lrnConf(card)
         if ease == BUTTON_ONE:

--- a/pylib/anki/sched.py
+++ b/pylib/anki/sched.py
@@ -316,12 +316,6 @@ limit %d"""
                 card.queue = QUEUE_TYPE_DAY_LEARN_RELEARN
         self._logLrn(card, ease, conf, leaving, type, lastLeft)
 
-    def _lrnConf(self, card: Card) -> Dict[str, Any]:
-        if card.type == CARD_TYPE_REV:
-            return self._lapseConf(card)
-        else:
-            return self._newConf(card)
-
     def _rescheduleAsRev(self, card: Card, conf: Dict[str, Any], early: bool) -> None:
         lapse = card.type == CARD_TYPE_REV
         if lapse:

--- a/pylib/anki/sched.py
+++ b/pylib/anki/sched.py
@@ -128,7 +128,7 @@ class Scheduler(V2):
             )
         )
         self.col.db.execute(
-            f"update cards set queue=type where queue = {QUEUE_TYPE_SIBLING_BURIED}"
+            f"update cards set {self._restoreQueueSnippet} where queue = {QUEUE_TYPE_SIBLING_BURIED}"
         )
 
     def unburyCardsForDeck(self) -> None:  # type: ignore[override]
@@ -140,7 +140,7 @@ class Scheduler(V2):
             )
         )
         self.col.db.execute(
-            f"update cards set mod=?,usn=?,queue=type where queue = {QUEUE_TYPE_SIBLING_BURIED} and did in %s"
+            f"update cards set mod=?,usn=?,{self._restoreQueueSnippet} where queue = {QUEUE_TYPE_SIBLING_BURIED} and did in %s"
             % sids,
             intTime(),
             self.col.usn(),
@@ -857,6 +857,8 @@ did = ?, queue = %s, due = ?, usn = ? where id = ?"""
     # Suspending
     ##########################################################################
 
+    _restoreQueueSnippet = "queue = type"
+
     def suspendCards(self, ids: List[int]) -> None:
         "Suspend cards."
         self.col.log(ids)
@@ -873,7 +875,7 @@ did = ?, queue = %s, due = ?, usn = ? where id = ?"""
         "Unsuspend cards."
         self.col.log(ids)
         self.col.db.execute(
-            "update cards set queue=type,mod=?,usn=? "
+            f"update cards set {self._restoreQueueSnippet},mod=?,usn=? "
             f"where queue = {QUEUE_TYPE_SUSPENDED} and id in " + ids2str(ids),
             intTime(),
             self.col.usn(),

--- a/pylib/anki/sched.py
+++ b/pylib/anki/sched.py
@@ -133,13 +133,11 @@ class Scheduler(V2):
         sids = self._deckLimit()
         self.col.log(
             self.col.db.list(
-                f"select id from cards where {self._queueIsBuriedSnippet} and did in %s"
-                % sids
+                f"select id from cards where {self._queueIsBuriedSnippet} and did in {sids}"
             )
         )
         self.col.db.execute(
-            f"update cards set mod=?,usn=?,{self._restoreQueueSnippet} where {self._queueIsBuriedSnippet} and did in %s"
-            % sids,
+            f"update cards set mod=?,usn=?,{self._restoreQueueSnippet} where {self._queueIsBuriedSnippet} and did in {sids}",
             intTime(),
             self.col.usn(),
         )

--- a/pylib/anki/sched.py
+++ b/pylib/anki/sched.py
@@ -636,24 +636,6 @@ did = ?, queue = %s, due = ?, usn = ? where id = ?"""
         oconf = self.col.decks.confForDid(card.odid)
         return conf["delays"] or oconf["new"]["delays"]
 
-    def _newConf(self, card: Card) -> Dict[str, Any]:
-        conf = self._cardConf(card)
-        # normal deck
-        if not card.odid:
-            return conf["new"]
-        # dynamic deck; override some attributes, use original deck for others
-        oconf = self.col.decks.confForDid(card.odid)
-        return dict(
-            # original deck
-            ints=oconf["new"]["ints"],
-            initialFactor=oconf["new"]["initialFactor"],
-            bury=oconf["new"].get("bury", True),
-            # overrides
-            delays=self._newConfDelays(card),
-            order=NEW_CARDS_DUE,
-            perDay=self.reportLimit,
-        )
-
     def _lapseConfDelays(self, card: Card) -> Dict[str, Any]:
         conf = self._cardConf(card)
         oconf = self.col.decks.confForDid(card.odid)

--- a/pylib/anki/sched.py
+++ b/pylib/anki/sched.py
@@ -214,7 +214,11 @@ and due <= ? limit %d"""
             self.today,
         )
 
+    def _updateLrnCutoff(self, force):
+        pass
+
     def _resetLrn(self) -> None:
+        self._updateLrnCutoff(force=True)
         self._resetLrnCount()
         self._lrnQueue: List[Any] = []
         self._lrnDayQueue: List[Any] = []

--- a/pylib/anki/schedv2.py
+++ b/pylib/anki/schedv2.py
@@ -1556,15 +1556,12 @@ update cards set queue=?,mod=?,usn=? where id in """
         else:
             raise Exception("unknown type")
 
+        sids = self._deckLimit()
         self.col.log(
-            self.col.db.list(
-                "select id from cards where %s and did in %s"
-                % (queue, self._deckLimit())
-            )
+            self.col.db.list(f"select id from cards where {queue} and did in {sids}")
         )
         self.col.db.execute(
-            f"update cards set mod=?,usn=?,{self._restoreQueueSnippet} where %s and did in %s"
-            % (queue, self._deckLimit()),
+            f"update cards set mod=?,usn=?,{self._restoreQueueSnippet} where {queue} and did in {sids}",
             intTime(),
             self.col.usn(),
         )

--- a/pylib/anki/schedv2.py
+++ b/pylib/anki/schedv2.py
@@ -1401,7 +1401,11 @@ To study outside of the normal schedule, click the Custom Study button below."""
         return not not cnt
 
     def haveBuried(self) -> bool:
-        return self.haveManuallyBuried() or self.haveBuriedSiblings()
+        cnt = self.col.db.scalar(
+            f"select 1 from cards where {self._queueIsBuriedSnippet} and did in %s limit 1"
+            % self._deckLimit()
+        )
+        return not not cnt
 
     # Next time reports
     ##########################################################################

--- a/pylib/anki/schedv2.py
+++ b/pylib/anki/schedv2.py
@@ -480,6 +480,9 @@ limit %d"""
         self._lrnQueue.sort()
         return self._lrnQueue
 
+    def _lrnCountDecrease(self, card: Card):
+        self.lrnCount -= 1
+
     def _getLrnCard(self, collapse: bool = False) -> Optional[Card]:
         self._maybeResetLrn(force=collapse and self.lrnCount == 0)
         if self._fillLrn():
@@ -489,7 +492,7 @@ limit %d"""
             if self._lrnQueue[0][0] < cutoff:
                 id = heappop(self._lrnQueue)[1]
                 card = self.col.getCard(id)
-                self.lrnCount -= 1
+                self._lrnCountDecrease(card)
                 return card
         return None
 

--- a/pylib/anki/schedv2.py
+++ b/pylib/anki/schedv2.py
@@ -1184,9 +1184,9 @@ where id = ?
         # if over threshold or every half threshold reps after that
         if card.lapses >= lf and (card.lapses - lf) % (max(lf // 2, 1)) == 0:
             # add a leech tag
-            f = card.note()
-            f.addTag("leech")
-            f.flush()
+            n = card.note()
+            n.addTag("leech")
+            n.flush()
             # handle
             a = conf["leechAction"]
             if a == LEECH_SUSPEND:

--- a/pylib/anki/schedv2.py
+++ b/pylib/anki/schedv2.py
@@ -750,8 +750,8 @@ did = ? and queue = {QUEUE_TYPE_DAY_LEARN_RELEARN} and due <= ? limit ?""",
             time.sleep(0.01)
             log()
 
-    def _lrnForDeck(self, did: int) -> int:
-        cnt = (
+    def _subDayLrnForDeck(self, did: int) -> int:
+        return (
             self.col.db.scalar(
                 f"""
 select count() from
@@ -762,6 +762,9 @@ select count() from
             )
             or 0
         )
+
+    def _lrnForDeck(self, did: int) -> int:
+        cnt = self._subDayLrnForDeck(did)
         return cnt + self.col.db.scalar(
             f"""
 select count() from

--- a/pylib/anki/schedv2.py
+++ b/pylib/anki/schedv2.py
@@ -1484,9 +1484,9 @@ end)
         self.col.log(ids)
         self.col.db.execute(
             (
-                f"update cards set %s,mod=?,usn=? where queue = {QUEUE_TYPE_SUSPENDED} and id in %s"
+                f"update cards set {self._restoreQueueSnippet},mod=?,usn=? where queue = {QUEUE_TYPE_SUSPENDED} and id in %s"
             )
-            % (self._restoreQueueSnippet, ids2str(ids)),
+            % (ids2str(ids)),
             intTime(),
             self.col.usn(),
         )
@@ -1518,8 +1518,7 @@ update cards set queue=?,mod=?,usn=? where id in """
             )
         )
         self.col.db.execute(
-            f"update cards set %s where queue in ({QUEUE_TYPE_SIBLING_BURIED}, {QUEUE_TYPE_MANUALLY_BURIED})"
-            % self._restoreQueueSnippet
+            f"update cards set {self._restoreQueueSnippet} where queue in ({QUEUE_TYPE_SIBLING_BURIED}, {QUEUE_TYPE_MANUALLY_BURIED})"
         )
 
     def unburyCardsForDeck(self, type: str = "all") -> None:
@@ -1541,8 +1540,8 @@ update cards set queue=?,mod=?,usn=? where id in """
             )
         )
         self.col.db.execute(
-            "update cards set mod=?,usn=?,%s where %s and did in %s"
-            % (self._restoreQueueSnippet, queue, self._deckLimit()),
+            f"update cards set mod=?,usn=?,{self._restoreQueueSnippet} where %s and did in %s"
+            % (queue, self._deckLimit()),
             intTime(),
             self.col.usn(),
         )

--- a/pylib/anki/schedv2.py
+++ b/pylib/anki/schedv2.py
@@ -453,20 +453,22 @@ select count() from cards where did in %s and queue = {QUEUE_TYPE_PREVIEW}
         self._lrnDayQueue: List[int] = []
         self._lrnDids = self.col.decks.active()[:]
 
+    def _cutoff(self):
+        return intTime() + self.col.conf["collapseTime"]
+
     # sub-day learning
     def _fillLrn(self) -> Union[bool, List[Any]]:
         if not self.lrnCount:
             return False
         if self._lrnQueue:
             return True
-        cutoff = intTime() + self.col.conf["collapseTime"]
         self._lrnQueue = self.col.db.all(  # type: ignore
             f"""
 select due, id from cards where
 did in %s and queue in ({QUEUE_TYPE_LRN},{QUEUE_TYPE_PREVIEW}) and due < ?
 limit %d"""
             % (self._deckLimit(), self.reportLimit),
-            cutoff,
+            self._cutoff(),
         )
         for i in range(len(self._lrnQueue)):
             self._lrnQueue[i] = (self._lrnQueue[i][0], self._lrnQueue[i][1])

--- a/pylib/anki/schedv2.py
+++ b/pylib/anki/schedv2.py
@@ -456,6 +456,10 @@ select count() from cards where did in %s and queue = {QUEUE_TYPE_PREVIEW}
     def _cutoff(self):
         return intTime() + self.col.conf["collapseTime"]
 
+    _queueInLearningSnippet = (
+        f"queue in ({QUEUE_TYPE_LRN},{QUEUE_TYPE_DAY_LEARN_RELEARN})"
+    )
+
     # sub-day learning
     def _fillLrn(self) -> Union[bool, List[Any]]:
         if not self.lrnCount:
@@ -1742,7 +1746,7 @@ due = odue, odue = 0, odid = 0, usn = ? where odid != 0""",
                 f"""
     update cards set
     due = odue, queue = {QUEUE_TYPE_REV}, type = {CARD_TYPE_REV}, mod = %d, usn = %d, odue = 0
-    where queue in ({QUEUE_TYPE_LRN},{QUEUE_TYPE_DAY_LEARN_RELEARN}) and type in ({CARD_TYPE_REV}, {CARD_TYPE_RELEARNING})
+    where {self._queueInLearningSnippet} and type in ({CARD_TYPE_REV}, {CARD_TYPE_RELEARNING})
     """
                 % (intTime(), self.col.usn())
             )
@@ -1751,14 +1755,14 @@ due = odue, odue = 0, odid = 0, usn = ? where odid != 0""",
                 f"""
     update cards set
     due = %d+ivl, queue = {QUEUE_TYPE_REV}, type = {CARD_TYPE_REV}, mod = %d, usn = %d, odue = 0
-    where queue in ({QUEUE_TYPE_LRN},{QUEUE_TYPE_DAY_LEARN_RELEARN}) and type in ({CARD_TYPE_REV}, {CARD_TYPE_RELEARNING})
+    where {self._queueInLearningSnippet} and type in ({CARD_TYPE_REV}, {CARD_TYPE_RELEARNING})
     """
                 % (self.today, intTime(), self.col.usn())
             )
         # remove new cards from learning
         self.forgetCards(
             self.col.db.list(
-                f"select id from cards where queue in ({QUEUE_TYPE_LRN},{QUEUE_TYPE_DAY_LEARN_RELEARN})"
+                f"select id from cards where {self._queueInLearningSnippet}"
             )
         )
 

--- a/pylib/anki/schedv2.py
+++ b/pylib/anki/schedv2.py
@@ -1468,6 +1468,9 @@ else
   type
 end)
 """
+    _queueIsBuriedSnippet = (
+        f"queue in ({QUEUE_TYPE_SIBLING_BURIED}, {QUEUE_TYPE_MANUALLY_BURIED})"
+    )
 
     def suspendCards(self, ids: List[int]) -> None:
         "Suspend cards."
@@ -1513,19 +1516,15 @@ update cards set queue=?,mod=?,usn=? where id in """
     def unburyCards(self) -> None:
         "Unbury all buried cards in all decks."
         self.col.log(
-            self.col.db.list(
-                f"select id from cards where queue in ({QUEUE_TYPE_SIBLING_BURIED}, {QUEUE_TYPE_MANUALLY_BURIED})"
-            )
+            self.col.db.list(f"select id from cards where {self._queueIsBuriedSnippet}")
         )
         self.col.db.execute(
-            f"update cards set {self._restoreQueueSnippet} where queue in ({QUEUE_TYPE_SIBLING_BURIED}, {QUEUE_TYPE_MANUALLY_BURIED})"
+            f"update cards set {self._restoreQueueSnippet} where {self._queueIsBuriedSnippet}"
         )
 
     def unburyCardsForDeck(self, type: str = "all") -> None:
         if type == "all":
-            queue = (
-                f"queue in ({QUEUE_TYPE_SIBLING_BURIED}, {QUEUE_TYPE_MANUALLY_BURIED})"
-            )
+            queue = self._queueIsBuriedSnippet
         elif type == "manual":
             queue = f"queue = {QUEUE_TYPE_MANUALLY_BURIED}"
         elif type == "siblings":

--- a/pylib/anki/schedv2.py
+++ b/pylib/anki/schedv2.py
@@ -711,6 +711,12 @@ did = ? and queue = {QUEUE_TYPE_DAY_LEARN_RELEARN} and due <= ? limit ?""",
         card.factor = conf["initialFactor"]
         card.type = card.queue = QUEUE_TYPE_REV
 
+    def _logLrnNotLeaving(self, card: Card, ease: int, conf: Dict[str, Any]):
+        if ease == BUTTON_TWO:
+            return -self._delayForRepeatingGrade(conf, card.left)
+        else:
+            return -self._delayForGrade(conf, card.left)
+
     def _logLrn(
         self,
         card: Card,
@@ -724,10 +730,7 @@ did = ? and queue = {QUEUE_TYPE_DAY_LEARN_RELEARN} and due <= ? limit ?""",
         if leaving:
             ivl = card.ivl
         else:
-            if ease == BUTTON_TWO:
-                ivl = -self._delayForRepeatingGrade(conf, card.left)
-            else:
-                ivl = -self._delayForGrade(conf, card.left)
+            ivl = self._logLrnNotLeaving(card, ease, conf)
 
         def log() -> None:
             self.col.db.execute(

--- a/pylib/anki/schedv2.py
+++ b/pylib/anki/schedv2.py
@@ -1176,6 +1176,9 @@ where id = ?
     # Leeches
     ##########################################################################
 
+    def _filteredLeech(self, card: Card):
+        pass
+
     def _checkLeech(self, card: Card, conf: Dict[str, Any]) -> bool:
         "Leech handler. True if card was a leech."
         lf = conf["leechFails"]
@@ -1190,6 +1193,7 @@ where id = ?
             # handle
             a = conf["leechAction"]
             if a == LEECH_SUSPEND:
+                self._filteredLeech(card)
                 card.queue = QUEUE_TYPE_SUSPENDED
             # notify UI
             hooks.card_did_leech(card)

--- a/pylib/anki/schedv2.py
+++ b/pylib/anki/schedv2.py
@@ -1091,10 +1091,9 @@ end)
         self.col.log(self.col.db.list("select id from cards where %s" % lim))
 
         self.col.db.execute(
-            """
-update cards set did = odid, %s,
-due = (case when odue>0 then odue else due end), odue = 0, odid = 0, usn = ? where %s"""
-            % (self._restoreQueueWhenEmptyingSnippet, lim),
+            f"""
+update cards set did = odid, {self._restoreQueueWhenEmptyingSnippet},
+due = (case when odue>0 then odue else due end), odue = 0, odid = 0, usn = ? where {lim}""",
             self.col.usn(),
         )
 

--- a/pylib/anki/schedv2.py
+++ b/pylib/anki/schedv2.py
@@ -664,8 +664,10 @@ did = ? and queue = {QUEUE_TYPE_DAY_LEARN_RELEARN} and due <= ? limit ?""",
         card.queue = QUEUE_TYPE_REV
         card.type = CARD_TYPE_REV
 
+    _relearning_type = CARD_TYPE_RELEARNING
+
     def _startingLeft(self, card: Card) -> int:
-        if card.type == CARD_TYPE_RELEARNING:
+        if card.type == self._relearning_type:
             conf = self._lapseConf(card)
         else:
             conf = self._lrnConf(card)

--- a/pylib/anki/schedv2.py
+++ b/pylib/anki/schedv2.py
@@ -1196,6 +1196,10 @@ where id = ?
     def _cardConf(self, card: Card) -> Dict[str, Any]:
         return self.col.decks.confForDid(card.did)
 
+    def _newConfDelays(self, card: Card):
+        oconf = self.col.decks.confForDid(card.odid)
+        return oconf["new"]["delays"]
+
     def _newConf(self, card: Card) -> Any:
         conf = self._cardConf(card)
         # normal deck
@@ -1208,11 +1212,15 @@ where id = ?
             ints=oconf["new"]["ints"],
             initialFactor=oconf["new"]["initialFactor"],
             bury=oconf["new"].get("bury", True),
-            delays=oconf["new"]["delays"],
+            delays=self._newConfDelays(card),
             # overrides
             order=NEW_CARDS_DUE,
             perDay=self.reportLimit,
         )
+
+    def _lapseConfDelays(self, card: Card) -> Dict[str, Any]:
+        oconf = self.col.decks.confForDid(card.odid)
+        return oconf["lapse"]["delays"]
 
     def _lapseConf(self, card: Card) -> Any:
         conf = self._cardConf(card)
@@ -1227,7 +1235,7 @@ where id = ?
             leechFails=oconf["lapse"]["leechFails"],
             leechAction=oconf["lapse"]["leechAction"],
             mult=oconf["lapse"]["mult"],
-            delays=oconf["lapse"]["delays"],
+            delays=self._lapseConfDelays(card),
             # overrides
             resched=conf["resched"],
         )

--- a/pylib/anki/schedv2.py
+++ b/pylib/anki/schedv2.py
@@ -246,6 +246,9 @@ order by due"""
     # Getting the next card
     ##########################################################################
 
+    def _dayLearnFirst(self):
+        return self.col.conf.get("dayLearnFirst", False)
+
     def _getCard(self) -> Optional[Card]:
         """Return the next due card, or None."""
         # learning card due?
@@ -260,7 +263,7 @@ order by due"""
                 return c
 
         # day learning first and card due?
-        dayLearnFirst = self.col.conf.get("dayLearnFirst", False)
+        dayLearnFirst = self._dayLearnFirst()
         if dayLearnFirst:
             c = self._getLrnDayCard()
             if c:

--- a/pylib/anki/schedv2.py
+++ b/pylib/anki/schedv2.py
@@ -686,7 +686,7 @@ did = ? and queue = {QUEUE_TYPE_DAY_LEARN_RELEARN} and due <= ? limit ?""",
         self, card: Card, conf: Dict[str, Any], early: bool, fuzz: bool = True
     ) -> Any:
         if card.type in (CARD_TYPE_REV, CARD_TYPE_RELEARNING):
-            bonus = early and 1 or 0
+            bonus = 1 if early else 0
             return card.ivl + bonus
         if not early:
             # graduate
@@ -1495,7 +1495,7 @@ end)
         )
 
     def buryCards(self, cids: List[int], manual: bool = True) -> None:
-        queue = manual and QUEUE_TYPE_MANUALLY_BURIED or QUEUE_TYPE_SIBLING_BURIED
+        queue = QUEUE_TYPE_MANUALLY_BURIED if manual else QUEUE_TYPE_SIBLING_BURIED
         self.col.log(cids)
         self.col.db.execute(
             """


### PR DESCRIPTION
I must first state that I expect at least some of those change to be useless as they may be ported to rust. While this part of the scheduler is still in Python, I still have a preference for factorizing both schedulers if possible.

When I want to look at the schedulers, I like to know what is the difference between them. In some cases, the difference is very small and hard to find. Moving it to a member ensure that it can be found easily and that I know exactly what is the difference between them. Furthermore, in some cases, using snippes SQL also helps readability, since I can read a single word instead of reading a condition stating that queue is in a pair of elements.

 In an ideal world, I'd love a class, let's say `abstractSched`, which contains all the code in common, and then have sched.py and schedv2 containing only the code which differs, it would help a lot understanding the actual code. If you'd accept such a change I'd be happy to implement it. Right now I tried to limit myself to a bunch of small change trivial to check.


The real reason behind this change is that I expect to improve getCard in ankidroid. It may be quite slow when a deck has many subdecks. In order to do that as safely as possible, one of the step that I wish to take is to factorize the existing code as much as possible so that I don't have to do duplicate work and changes gets simpler to check.