### PR TITLE
add card layout save shortcut

### DIFF
--- a/qt/aqt/clayout.py
+++ b/qt/aqt/clayout.py
@@ -389,6 +389,7 @@ class CardLayout(QDialog):
         l.addStretch()
         save = QPushButton(_("Save"))
         save.setAutoDefault(False)
+        save.setShortcut(QKeySequence("Ctrl+Return"))
         l.addWidget(save)
         qconnect(save.clicked, self.accept)
 


### PR DESCRIPTION
This just sets `Ctrl+Return` as a shortcut to save modifications to card layout.