### PR TITLE
Add main_window_will_require_reset gui_hook

### DIFF
--- a/qt/aqt/addcards.py
+++ b/qt/aqt/addcards.py
@@ -177,8 +177,8 @@ class AddCards(QDialog):
         self.mw.col.add_note(note, self.deckChooser.selectedId())
         self.mw.col.clearUndo()
         self.addHistory(note)
-        self.mw.requireReset()
         self.previousNote = note
+        self.mw.requireReset('addCardsAddNote', self)
         gui_hooks.add_cards_did_add_note(note)
         return note
 

--- a/qt/aqt/addcards.py
+++ b/qt/aqt/addcards.py
@@ -178,7 +178,7 @@ class AddCards(QDialog):
         self.mw.col.clearUndo()
         self.addHistory(note)
         self.previousNote = note
-        self.mw.requireReset("addCardsAddNote", self)
+        self.mw.requireReset(reason="addCardsAddNote", context=self)
         gui_hooks.add_cards_did_add_note(note)
         return note
 

--- a/qt/aqt/addcards.py
+++ b/qt/aqt/addcards.py
@@ -178,7 +178,7 @@ class AddCards(QDialog):
         self.mw.col.clearUndo()
         self.addHistory(note)
         self.previousNote = note
-        self.mw.requireReset('addCardsAddNote', self)
+        self.mw.requireReset("addCardsAddNote", self)
         gui_hooks.add_cards_did_add_note(note)
         return note
 

--- a/qt/aqt/addcards.py
+++ b/qt/aqt/addcards.py
@@ -12,6 +12,7 @@ from anki.lang import _
 from anki.notes import Note
 from anki.utils import htmlToTextLine, isMac
 from aqt import AnkiQt, gui_hooks
+from aqt.main import ResetReason
 from aqt.qt import *
 from aqt.sound import av_player
 from aqt.utils import (
@@ -178,7 +179,7 @@ class AddCards(QDialog):
         self.mw.col.clearUndo()
         self.addHistory(note)
         self.previousNote = note
-        self.mw.requireReset(reason="addCardsAddNote", context=self)
+        self.mw.requireReset(reason=ResetReason.AddCardsAddNote, context=self)
         gui_hooks.add_cards_did_add_note(note)
         return note
 

--- a/qt/aqt/browser.py
+++ b/qt/aqt/browser.py
@@ -1564,7 +1564,7 @@ where id in %s"""
             newRow = max(newRow, 0)
             self.model.focusedCard = self.model.cards[newRow]
         self.model.endReset()
-        self.mw.requireReset("browserDeleteNote", self)
+        self.mw.requireReset(reason="browserDeleteNote", context=self)
         tooltip(
             ngettext("%d note deleted.", "%d notes deleted.", len(nids)) % len(nids)
         )
@@ -1616,7 +1616,7 @@ update cards set usn=?, mod=?, did=? where id in """
             did,
         )
         self.model.endReset()
-        self.mw.requireReset("browserSetDeck", self)
+        self.mw.requireReset(reason="browserSetDeck", context=self)
 
     # Tags
     ######################################################################
@@ -1642,7 +1642,7 @@ update cards set usn=?, mod=?, did=? where id in """
         self.model.beginReset()
         func(self.selectedNotes(), tags)
         self.model.endReset()
-        self.mw.requireReset("browserAddTags", self)
+        self.mw.requireReset(reason="browserAddTags", context=self)
 
     def deleteTags(self, tags=None, label=None):
         if label is None:
@@ -1675,7 +1675,7 @@ update cards set usn=?, mod=?, did=? where id in """
         else:
             self.col.sched.unsuspendCards(c)
         self.model.reset()
-        self.mw.requireReset("browserSuspend", self)
+        self.mw.requireReset(reason="browserSuspend", context=self)
 
     # Exporting
     ######################################################################
@@ -1763,7 +1763,7 @@ update cards set usn=?, mod=?, did=? where id in """
             shift=frm.shift.isChecked(),
         )
         self.search()
-        self.mw.requireReset("browserReposition", self)
+        self.mw.requireReset(reason="browserReposition", context=self)
         self.model.endReset()
 
     # Rescheduling
@@ -1789,7 +1789,7 @@ update cards set usn=?, mod=?, did=? where id in """
             fmax = max(fmin, fmax)
             self.col.sched.reschedCards(self.selectedCards(), fmin, fmax)
         self.search()
-        self.mw.requireReset("browserReschedule", self)
+        self.mw.requireReset(reason="browserReschedule", context=self)
         self.model.endReset()
 
     # Edit: selection
@@ -1923,7 +1923,7 @@ update cards set usn=?, mod=?, did=? where id in """
 
         def on_done(fut):
             self.search()
-            self.mw.requireReset("browserFindReplace", self)
+            self.mw.requireReset(reason="browserFindReplace", context=self)
             self.model.endReset()
 
             total = len(nids)
@@ -2025,7 +2025,7 @@ update cards set usn=?, mod=?, did=? where id in """
         self.col.tags.bulkAdd(list(nids), _("duplicate"))
         self.mw.progress.finish()
         self.model.endReset()
-        self.mw.requireReset("browserTagDupes", self)
+        self.mw.requireReset(reason="browserTagDupes", context=self)
         tooltip(_("Notes tagged."))
 
     def dupeLinkClicked(self, link):

--- a/qt/aqt/browser.py
+++ b/qt/aqt/browser.py
@@ -26,6 +26,7 @@ from anki.utils import htmlToTextLine, ids2str, intTime, isMac, isWin
 from aqt import AnkiQt, gui_hooks
 from aqt.editor import Editor
 from aqt.exporting import ExportDialog
+from aqt.main import ResetReason
 from aqt.previewer import BrowserPreviewer as PreviewDialog
 from aqt.previewer import Previewer
 from aqt.qt import *
@@ -1564,7 +1565,7 @@ where id in %s"""
             newRow = max(newRow, 0)
             self.model.focusedCard = self.model.cards[newRow]
         self.model.endReset()
-        self.mw.requireReset(reason="browserDeleteNote", context=self)
+        self.mw.requireReset(reason=ResetReason.BrowserDeleteNote, context=self)
         tooltip(
             ngettext("%d note deleted.", "%d notes deleted.", len(nids)) % len(nids)
         )
@@ -1616,7 +1617,7 @@ update cards set usn=?, mod=?, did=? where id in """
             did,
         )
         self.model.endReset()
-        self.mw.requireReset(reason="browserSetDeck", context=self)
+        self.mw.requireReset(reason=ResetReason.BrowserSetDeck, context=self)
 
     # Tags
     ######################################################################
@@ -1642,7 +1643,7 @@ update cards set usn=?, mod=?, did=? where id in """
         self.model.beginReset()
         func(self.selectedNotes(), tags)
         self.model.endReset()
-        self.mw.requireReset(reason="browserAddTags", context=self)
+        self.mw.requireReset(reason=ResetReason.BrowserAddTags, context=self)
 
     def deleteTags(self, tags=None, label=None):
         if label is None:
@@ -1675,7 +1676,7 @@ update cards set usn=?, mod=?, did=? where id in """
         else:
             self.col.sched.unsuspendCards(c)
         self.model.reset()
-        self.mw.requireReset(reason="browserSuspend", context=self)
+        self.mw.requireReset(reason=ResetReason.BrowserSuspend, context=self)
 
     # Exporting
     ######################################################################
@@ -1763,7 +1764,7 @@ update cards set usn=?, mod=?, did=? where id in """
             shift=frm.shift.isChecked(),
         )
         self.search()
-        self.mw.requireReset(reason="browserReposition", context=self)
+        self.mw.requireReset(reason=ResetReason.BrowserReposition, context=self)
         self.model.endReset()
 
     # Rescheduling
@@ -1789,7 +1790,7 @@ update cards set usn=?, mod=?, did=? where id in """
             fmax = max(fmin, fmax)
             self.col.sched.reschedCards(self.selectedCards(), fmin, fmax)
         self.search()
-        self.mw.requireReset(reason="browserReschedule", context=self)
+        self.mw.requireReset(reason=ResetReason.BrowserReschedule, context=self)
         self.model.endReset()
 
     # Edit: selection
@@ -1923,7 +1924,7 @@ update cards set usn=?, mod=?, did=? where id in """
 
         def on_done(fut):
             self.search()
-            self.mw.requireReset(reason="browserFindReplace", context=self)
+            self.mw.requireReset(reason=ResetReason.BrowserFindReplace, context=self)
             self.model.endReset()
 
             total = len(nids)
@@ -2025,7 +2026,7 @@ update cards set usn=?, mod=?, did=? where id in """
         self.col.tags.bulkAdd(list(nids), _("duplicate"))
         self.mw.progress.finish()
         self.model.endReset()
-        self.mw.requireReset(reason="browserTagDupes", context=self)
+        self.mw.requireReset(reason=ResetReason.BrowserTagDupes, context=self)
         tooltip(_("Notes tagged."))
 
     def dupeLinkClicked(self, link):

--- a/qt/aqt/browser.py
+++ b/qt/aqt/browser.py
@@ -1564,7 +1564,7 @@ where id in %s"""
             newRow = max(newRow, 0)
             self.model.focusedCard = self.model.cards[newRow]
         self.model.endReset()
-        self.mw.requireReset('browserDeleteNote', self)
+        self.mw.requireReset("browserDeleteNote", self)
         tooltip(
             ngettext("%d note deleted.", "%d notes deleted.", len(nids)) % len(nids)
         )
@@ -1616,7 +1616,7 @@ update cards set usn=?, mod=?, did=? where id in """
             did,
         )
         self.model.endReset()
-        self.mw.requireReset('browserSetDeck', self)
+        self.mw.requireReset("browserSetDeck", self)
 
     # Tags
     ######################################################################
@@ -1642,7 +1642,7 @@ update cards set usn=?, mod=?, did=? where id in """
         self.model.beginReset()
         func(self.selectedNotes(), tags)
         self.model.endReset()
-        self.mw.requireReset('browserAddTags', self)
+        self.mw.requireReset("browserAddTags", self)
 
     def deleteTags(self, tags=None, label=None):
         if label is None:
@@ -1675,7 +1675,7 @@ update cards set usn=?, mod=?, did=? where id in """
         else:
             self.col.sched.unsuspendCards(c)
         self.model.reset()
-        self.mw.requireReset('browserSuspend', self)
+        self.mw.requireReset("browserSuspend", self)
 
     # Exporting
     ######################################################################
@@ -1763,7 +1763,7 @@ update cards set usn=?, mod=?, did=? where id in """
             shift=frm.shift.isChecked(),
         )
         self.search()
-        self.mw.requireReset('browserReposition', self)
+        self.mw.requireReset("browserReposition", self)
         self.model.endReset()
 
     # Rescheduling
@@ -1789,7 +1789,7 @@ update cards set usn=?, mod=?, did=? where id in """
             fmax = max(fmin, fmax)
             self.col.sched.reschedCards(self.selectedCards(), fmin, fmax)
         self.search()
-        self.mw.requireReset('browserReschedule', self)
+        self.mw.requireReset("browserReschedule", self)
         self.model.endReset()
 
     # Edit: selection
@@ -1923,7 +1923,7 @@ update cards set usn=?, mod=?, did=? where id in """
 
         def on_done(fut):
             self.search()
-            self.mw.requireReset('browserFindReplace', self)
+            self.mw.requireReset("browserFindReplace", self)
             self.model.endReset()
 
             total = len(nids)
@@ -2025,7 +2025,7 @@ update cards set usn=?, mod=?, did=? where id in """
         self.col.tags.bulkAdd(list(nids), _("duplicate"))
         self.mw.progress.finish()
         self.model.endReset()
-        self.mw.requireReset('browserTagDupes', self)
+        self.mw.requireReset("browserTagDupes", self)
         tooltip(_("Notes tagged."))
 
     def dupeLinkClicked(self, link):

--- a/qt/aqt/browser.py
+++ b/qt/aqt/browser.py
@@ -1564,7 +1564,7 @@ where id in %s"""
             newRow = max(newRow, 0)
             self.model.focusedCard = self.model.cards[newRow]
         self.model.endReset()
-        self.mw.requireReset()
+        self.mw.requireReset('browserDeleteNote', self)
         tooltip(
             ngettext("%d note deleted.", "%d notes deleted.", len(nids)) % len(nids)
         )
@@ -1616,7 +1616,7 @@ update cards set usn=?, mod=?, did=? where id in """
             did,
         )
         self.model.endReset()
-        self.mw.requireReset()
+        self.mw.requireReset('browserSetDeck', self)
 
     # Tags
     ######################################################################
@@ -1642,7 +1642,7 @@ update cards set usn=?, mod=?, did=? where id in """
         self.model.beginReset()
         func(self.selectedNotes(), tags)
         self.model.endReset()
-        self.mw.requireReset()
+        self.mw.requireReset('browserAddTags', self)
 
     def deleteTags(self, tags=None, label=None):
         if label is None:
@@ -1675,7 +1675,7 @@ update cards set usn=?, mod=?, did=? where id in """
         else:
             self.col.sched.unsuspendCards(c)
         self.model.reset()
-        self.mw.requireReset()
+        self.mw.requireReset('browserSuspend', self)
 
     # Exporting
     ######################################################################
@@ -1763,7 +1763,7 @@ update cards set usn=?, mod=?, did=? where id in """
             shift=frm.shift.isChecked(),
         )
         self.search()
-        self.mw.requireReset()
+        self.mw.requireReset('browserReposition', self)
         self.model.endReset()
 
     # Rescheduling
@@ -1789,7 +1789,7 @@ update cards set usn=?, mod=?, did=? where id in """
             fmax = max(fmin, fmax)
             self.col.sched.reschedCards(self.selectedCards(), fmin, fmax)
         self.search()
-        self.mw.requireReset()
+        self.mw.requireReset('browserReschedule', self)
         self.model.endReset()
 
     # Edit: selection
@@ -1923,7 +1923,7 @@ update cards set usn=?, mod=?, did=? where id in """
 
         def on_done(fut):
             self.search()
-            self.mw.requireReset()
+            self.mw.requireReset('browserFindReplace', self)
             self.model.endReset()
 
             total = len(nids)
@@ -2025,7 +2025,7 @@ update cards set usn=?, mod=?, did=? where id in """
         self.col.tags.bulkAdd(list(nids), _("duplicate"))
         self.mw.progress.finish()
         self.model.endReset()
-        self.mw.requireReset()
+        self.mw.requireReset('browserTagDupes', self)
         tooltip(_("Notes tagged."))
 
     def dupeLinkClicked(self, link):

--- a/qt/aqt/editcurrent.py
+++ b/qt/aqt/editcurrent.py
@@ -27,7 +27,7 @@ class EditCurrent(QDialog):
         self.editor.setNote(self.mw.reviewer.card.note(), focusTo=0)
         restoreGeom(self, "editcurrent")
         gui_hooks.state_did_reset.append(self.onReset)
-        self.mw.requireReset('editCurrentInit', self)
+        self.mw.requireReset("editCurrentInit", self)
         self.show()
         # reset focus after open, taking care not to retain webview
         # pylint: disable=unnecessary-lambda

--- a/qt/aqt/editcurrent.py
+++ b/qt/aqt/editcurrent.py
@@ -27,7 +27,7 @@ class EditCurrent(QDialog):
         self.editor.setNote(self.mw.reviewer.card.note(), focusTo=0)
         restoreGeom(self, "editcurrent")
         gui_hooks.state_did_reset.append(self.onReset)
-        self.mw.requireReset()
+        self.mw.requireReset('editCurrentInit', self)
         self.show()
         # reset focus after open, taking care not to retain webview
         # pylint: disable=unnecessary-lambda

--- a/qt/aqt/editcurrent.py
+++ b/qt/aqt/editcurrent.py
@@ -5,6 +5,7 @@
 import aqt.editor
 from anki.lang import _
 from aqt import gui_hooks
+from aqt.main import ResetReason
 from aqt.qt import *
 from aqt.utils import restoreGeom, saveGeom, tooltip
 
@@ -27,7 +28,7 @@ class EditCurrent(QDialog):
         self.editor.setNote(self.mw.reviewer.card.note(), focusTo=0)
         restoreGeom(self, "editcurrent")
         gui_hooks.state_did_reset.append(self.onReset)
-        self.mw.requireReset(reason="editCurrentInit", context=self)
+        self.mw.requireReset(reason=ResetReason.EditCurrentInit, context=self)
         self.show()
         # reset focus after open, taking care not to retain webview
         # pylint: disable=unnecessary-lambda

--- a/qt/aqt/editcurrent.py
+++ b/qt/aqt/editcurrent.py
@@ -27,7 +27,7 @@ class EditCurrent(QDialog):
         self.editor.setNote(self.mw.reviewer.card.note(), focusTo=0)
         restoreGeom(self, "editcurrent")
         gui_hooks.state_did_reset.append(self.onReset)
-        self.mw.requireReset("editCurrentInit", self)
+        self.mw.requireReset(reason="editCurrentInit", context=self)
         self.show()
         # reset focus after open, taking care not to retain webview
         # pylint: disable=unnecessary-lambda

--- a/qt/aqt/editor.py
+++ b/qt/aqt/editor.py
@@ -393,7 +393,7 @@ class Editor:
 
             if not self.addMode:
                 self.note.flush()
-                self.mw.requireReset()
+                self.mw.requireReset('editorBridgeCmd', self)
             if type == "blur":
                 self.currentField = None
                 # run any filters

--- a/qt/aqt/editor.py
+++ b/qt/aqt/editor.py
@@ -393,7 +393,7 @@ class Editor:
 
             if not self.addMode:
                 self.note.flush()
-                self.mw.requireReset('editorBridgeCmd', self)
+                self.mw.requireReset("editorBridgeCmd", self)
             if type == "blur":
                 self.currentField = None
                 # run any filters

--- a/qt/aqt/editor.py
+++ b/qt/aqt/editor.py
@@ -393,7 +393,7 @@ class Editor:
 
             if not self.addMode:
                 self.note.flush()
-                self.mw.requireReset("editorBridgeCmd", self)
+                self.mw.requireReset(reason="editorBridgeCmd", context=self)
             if type == "blur":
                 self.currentField = None
                 # run any filters

--- a/qt/aqt/editor.py
+++ b/qt/aqt/editor.py
@@ -26,6 +26,7 @@ from anki.lang import _
 from anki.notes import Note
 from anki.utils import checksum, isLin, isWin, namedtmp, stripHTMLMedia
 from aqt import AnkiQt, gui_hooks
+from aqt.main import ResetReason
 from aqt.qt import *
 from aqt.sound import av_player, getAudio
 from aqt.theme import theme_manager
@@ -393,7 +394,7 @@ class Editor:
 
             if not self.addMode:
                 self.note.flush()
-                self.mw.requireReset(reason="editorBridgeCmd", context=self)
+                self.mw.requireReset(reason=ResetReason.EditorBridgeCmd, context=self)
             if type == "blur":
                 self.currentField = None
                 # run any filters

--- a/qt/aqt/gui_hooks.py
+++ b/qt/aqt/gui_hooks.py
@@ -7,7 +7,7 @@ See pylib/anki/hooks.py
 
 from __future__ import annotations
 
-from typing import Any, Callable, List, Optional, Union, Tuple
+from typing import Any, Callable, List, Optional, Tuple, Union
 
 import anki
 import aqt

--- a/qt/aqt/gui_hooks.py
+++ b/qt/aqt/gui_hooks.py
@@ -1737,6 +1737,41 @@ class _MainWindowDidInitHook:
 main_window_did_init = _MainWindowDidInitHook()
 
 
+class _MainWindowWillRequireResetFilter:
+    """Executed before the main window will require a reset
+        
+        This hook can be used to change the behavior of the main window,
+        when other dialogs, like the AddCards or Browser, require a reset
+        from the main window.
+        """
+
+    _hooks: List[Callable[[bool], bool]] = []
+
+    def append(self, cb: Callable[[bool], bool]) -> None:
+        """(will_reset: bool)"""
+        self._hooks.append(cb)
+
+    def remove(self, cb: Callable[[bool], bool]) -> None:
+        if cb in self._hooks:
+            self._hooks.remove(cb)
+
+    def count(self) -> int:
+        return len(self._hooks)
+
+    def __call__(self, will_reset: bool) -> bool:
+        for filter in self._hooks:
+            try:
+                will_reset = filter(will_reset)
+            except:
+                # if the hook fails, remove it
+                self._hooks.remove(filter)
+                raise
+        return will_reset
+
+
+main_window_will_require_reset = _MainWindowWillRequireResetFilter()
+
+
 class _MediaSyncDidProgressHook:
     _hooks: List[Callable[["aqt.mediasync.LogEntryWithTime"], None]] = []
 

--- a/qt/aqt/gui_hooks.py
+++ b/qt/aqt/gui_hooks.py
@@ -1745,23 +1745,23 @@ class _MainWindowWillRequireResetFilter:
         from the main window.
         """
 
-    _hooks: List[Callable[[bool], bool]] = []
+    _hooks: List[Callable[[bool, str, Optional[Any]], bool]] = []
 
-    def append(self, cb: Callable[[bool], bool]) -> None:
-        """(will_reset: bool)"""
+    def append(self, cb: Callable[[bool, str, Optional[Any]], bool]) -> None:
+        """(will_reset: bool, reason: str, context: Optional[Any])"""
         self._hooks.append(cb)
 
-    def remove(self, cb: Callable[[bool], bool]) -> None:
+    def remove(self, cb: Callable[[bool, str, Optional[Any]], bool]) -> None:
         if cb in self._hooks:
             self._hooks.remove(cb)
 
     def count(self) -> int:
         return len(self._hooks)
 
-    def __call__(self, will_reset: bool) -> bool:
+    def __call__(self, will_reset: bool, reason: str, context: Optional[Any]) -> bool:
         for filter in self._hooks:
             try:
-                will_reset = filter(will_reset)
+                will_reset = filter(will_reset, reason, context)
             except:
                 # if the hook fails, remove it
                 self._hooks.remove(filter)

--- a/qt/aqt/gui_hooks.py
+++ b/qt/aqt/gui_hooks.py
@@ -7,7 +7,7 @@ See pylib/anki/hooks.py
 
 from __future__ import annotations
 
-from typing import Any, Callable, List, Optional, Tuple
+from typing import Any, Callable, List, Optional, Union, Tuple
 
 import anki
 import aqt

--- a/qt/aqt/gui_hooks.py
+++ b/qt/aqt/gui_hooks.py
@@ -1737,28 +1737,44 @@ class _MainWindowDidInitHook:
 main_window_did_init = _MainWindowDidInitHook()
 
 
-class _MainWindowWillRequireResetFilter:
+class _MainWindowShouldRequireResetFilter:
     """Executed before the main window will require a reset
-        
+
         This hook can be used to change the behavior of the main window,
         when other dialogs, like the AddCards or Browser, require a reset
         from the main window.
+        If you decide to use this hook, make you sure you check the reason for the reset.
+        Some reasons require more attention than others, and skipping important ones might
+        put the main window into an invalid state (e.g. display a deleted note).
         """
 
-    _hooks: List[Callable[[bool, str, Optional[Any]], bool]] = []
+    _hooks: List[
+        Callable[[bool, "Union[aqt.main.ResetReason, str]", Optional[Any]], bool]
+    ] = []
 
-    def append(self, cb: Callable[[bool, str, Optional[Any]], bool]) -> None:
-        """(will_reset: bool, reason: str, context: Optional[Any])"""
+    def append(
+        self,
+        cb: Callable[[bool, "Union[aqt.main.ResetReason, str]", Optional[Any]], bool],
+    ) -> None:
+        """(will_reset: bool, reason: Union[aqt.main.ResetReason, str], context: Optional[Any])"""
         self._hooks.append(cb)
 
-    def remove(self, cb: Callable[[bool, str, Optional[Any]], bool]) -> None:
+    def remove(
+        self,
+        cb: Callable[[bool, "Union[aqt.main.ResetReason, str]", Optional[Any]], bool],
+    ) -> None:
         if cb in self._hooks:
             self._hooks.remove(cb)
 
     def count(self) -> int:
         return len(self._hooks)
 
-    def __call__(self, will_reset: bool, reason: str, context: Optional[Any]) -> bool:
+    def __call__(
+        self,
+        will_reset: bool,
+        reason: Union[aqt.main.ResetReason, str],
+        context: Optional[Any],
+    ) -> bool:
         for filter in self._hooks:
             try:
                 will_reset = filter(will_reset, reason, context)
@@ -1769,7 +1785,7 @@ class _MainWindowWillRequireResetFilter:
         return will_reset
 
 
-main_window_will_require_reset = _MainWindowWillRequireResetFilter()
+main_window_should_require_reset = _MainWindowShouldRequireResetFilter()
 
 
 class _MediaSyncDidProgressHook:

--- a/qt/aqt/main.py
+++ b/qt/aqt/main.py
@@ -688,7 +688,7 @@ from the profile screen."
         "Signal queue needs to be rebuilt when edits are finished or by user."
         self.autosave()
         self.resetModal = modal
-        if self.interactiveState():
+        if gui_hooks.main_window_will_require_reset(self.interactiveState()):
             self.moveToState("resetRequired")
 
     def interactiveState(self):

--- a/qt/aqt/main.py
+++ b/qt/aqt/main.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import enum
 import faulthandler
 import gc
 import os
@@ -66,6 +67,10 @@ from aqt.utils import (
 )
 
 install_pylib_legacy()
+
+
+class ResetReason(enum.Enum):
+    pass
 
 
 class ResetRequired:
@@ -688,7 +693,7 @@ from the profile screen."
         "Signal queue needs to be rebuilt when edits are finished or by user."
         self.autosave()
         self.resetModal = modal
-        if gui_hooks.main_window_will_require_reset(
+        if gui_hooks.main_window_should_require_reset(
             self.interactiveState(), reason, context
         ):
             self.moveToState("resetRequired")

--- a/qt/aqt/main.py
+++ b/qt/aqt/main.py
@@ -73,7 +73,6 @@ class ResetReason(enum.Enum):
     AddCardsAddNote = "addCardsAddNote"
     EditCurrentInit = "editCurrentInit"
     EditorBridgeCmd = "editorBridgeCmd"
-    BrowserDeleteNote = "browserDeleteNote"
     BrowserSetDeck = "browserSetDeck"
     BrowserAddTags = "browserAddTags"
     BrowserSuspend = "browserSuspend"

--- a/qt/aqt/main.py
+++ b/qt/aqt/main.py
@@ -684,11 +684,11 @@ from the profile screen."
             self.maybeEnableUndo()
             self.moveToState(self.state)
 
-    def requireReset(self, modal=False):
+    def requireReset(self, reason, context=None, modal=False):
         "Signal queue needs to be rebuilt when edits are finished or by user."
         self.autosave()
         self.resetModal = modal
-        if gui_hooks.main_window_will_require_reset(self.interactiveState()):
+        if gui_hooks.main_window_will_require_reset(self.interactiveState(), reason, context):
             self.moveToState("resetRequired")
 
     def interactiveState(self):

--- a/qt/aqt/main.py
+++ b/qt/aqt/main.py
@@ -70,7 +70,17 @@ install_pylib_legacy()
 
 
 class ResetReason(enum.Enum):
-    pass
+    AddCardsAddNote = "addCardsAddNote"
+    EditCurrentInit = "editCurrentInit"
+    EditorBridgeCmd = "editorBridgeCmd"
+    BrowserDeleteNote = "browserDeleteNote"
+    BrowserSetDeck = "browserSetDeck"
+    BrowserAddTags = "browserAddTags"
+    BrowserSuspend = "browserSuspend"
+    BrowserReposition = "browserReposition"
+    BrowserReschedule = "browserReschedule"
+    BrowserFindReplace = "browserFindReplace"
+    BrowserTagDupes = "browserTagDupes"
 
 
 class ResetRequired:

--- a/qt/aqt/main.py
+++ b/qt/aqt/main.py
@@ -684,7 +684,7 @@ from the profile screen."
             self.maybeEnableUndo()
             self.moveToState(self.state)
 
-    def requireReset(self, reason, context=None, modal=False):
+    def requireReset(self, modal=False, reason="unknown", context=None):
         "Signal queue needs to be rebuilt when edits are finished or by user."
         self.autosave()
         self.resetModal = modal

--- a/qt/aqt/main.py
+++ b/qt/aqt/main.py
@@ -688,7 +688,9 @@ from the profile screen."
         "Signal queue needs to be rebuilt when edits are finished or by user."
         self.autosave()
         self.resetModal = modal
-        if gui_hooks.main_window_will_require_reset(self.interactiveState(), reason, context):
+        if gui_hooks.main_window_will_require_reset(
+            self.interactiveState(), reason, context
+        ):
             self.moveToState("resetRequired")
 
     def interactiveState(self):

--- a/qt/tools/genhooks_gui.py
+++ b/qt/tools/genhooks_gui.py
@@ -442,7 +442,7 @@ hooks = [
     ),
     Hook(
         name="main_window_will_require_reset",
-        args=["will_reset: bool"],
+        args=["will_reset: bool", "reason: str", "context: Optional[Any]"],
         return_type="bool",
         doc="""Executed before the main window will require a reset
         

--- a/qt/tools/genhooks_gui.py
+++ b/qt/tools/genhooks_gui.py
@@ -441,14 +441,21 @@ hooks = [
         """,
     ),
     Hook(
-        name="main_window_will_require_reset",
-        args=["will_reset: bool", "reason: str", "context: Optional[Any]"],
+        name="main_window_should_require_reset",
+        args=[
+            "will_reset: bool",
+            "reason: Union[aqt.main.ResetReason, str]",
+            "context: Optional[Any]",
+        ],
         return_type="bool",
         doc="""Executed before the main window will require a reset
-        
+
         This hook can be used to change the behavior of the main window,
         when other dialogs, like the AddCards or Browser, require a reset
         from the main window.
+        If you decide to use this hook, make you sure you check the reason for the reset.
+        Some reasons require more attention than others, and skipping important ones might
+        put the main window into an invalid state (e.g. display a deleted note).
         """,
     ),
     Hook(name="backup_did_complete"),

--- a/qt/tools/genhooks_gui.py
+++ b/qt/tools/genhooks_gui.py
@@ -440,6 +440,17 @@ hooks = [
         is thus suitable for single-shot subscribers.
         """,
     ),
+    Hook(
+        name="main_window_will_require_reset",
+        args=["will_reset: bool"],
+        return_type="bool",
+        doc="""Executed before the main window will require a reset
+        
+        This hook can be used to change the behavior of the main window,
+        when other dialogs, like the AddCards or Browser, require a reset
+        from the main window.
+        """,
+    ),
     Hook(name="backup_did_complete"),
     Hook(
         name="profile_did_open",


### PR DESCRIPTION
This will add a gui_hook for when dialogs require the main window to require a reset and display an overlay.

The use case is my add-on [Persistent Editor](https://ankiweb.net/shared/info/1686259334), which allows the EditCurrent window to stay open during review and "move along" with the cards (or rather their notes).