### PR TITLE
Add editor_will_munge_html hook

### DIFF
--- a/qt/aqt/editor.py
+++ b/qt/aqt/editor.py
@@ -420,9 +420,7 @@ class Editor:
             print("uncaught cmd", cmd)
 
     def mungeHTML(self, txt):
-        if txt in ("<br>", "<div><br></div>"):
-            return ""
-        return txt
+        return gui_hooks.editor_will_munge_html(txt, self)
 
     # Setting/unsetting the current note
     ######################################################################
@@ -1201,4 +1199,9 @@ def fontMungeHack(font):
     return re.sub(" L$", " Light", font)
 
 
+def munge_html(txt, editor):
+    return "" if txt in ("<br>", "<div><br></div>") else txt
+
+
 gui_hooks.editor_will_use_font_for_field.append(fontMungeHack)
+gui_hooks.editor_will_munge_html.append(munge_html)

--- a/qt/aqt/gui_hooks.py
+++ b/qt/aqt/gui_hooks.py
@@ -1564,6 +1564,36 @@ class _EditorWillLoadNoteFilter:
 editor_will_load_note = _EditorWillLoadNoteFilter()
 
 
+class _EditorWillMungeHtmlFilter:
+    """Allows manipulating the text that will be saved by the editor"""
+
+    _hooks: List[Callable[[str, "aqt.editor.Editor"], str]] = []
+
+    def append(self, cb: Callable[[str, "aqt.editor.Editor"], str]) -> None:
+        """(txt: str, editor: aqt.editor.Editor)"""
+        self._hooks.append(cb)
+
+    def remove(self, cb: Callable[[str, "aqt.editor.Editor"], str]) -> None:
+        if cb in self._hooks:
+            self._hooks.remove(cb)
+
+    def count(self) -> int:
+        return len(self._hooks)
+
+    def __call__(self, txt: str, editor: aqt.editor.Editor) -> str:
+        for filter in self._hooks:
+            try:
+                txt = filter(txt, editor)
+            except:
+                # if the hook fails, remove it
+                self._hooks.remove(filter)
+                raise
+        return txt
+
+
+editor_will_munge_html = _EditorWillMungeHtmlFilter()
+
+
 class _EditorWillShowContextMenuHook:
     _hooks: List[Callable[["aqt.editor.EditorWebView", QMenu], None]] = []
 

--- a/qt/tools/genhooks_gui.py
+++ b/qt/tools/genhooks_gui.py
@@ -569,6 +569,12 @@ hooks = [
         legacy_hook="tagsUpdated",
     ),
     Hook(
+        name="editor_will_munge_html",
+        args=["txt: str", "editor: aqt.editor.Editor"],
+        return_type="str",
+        doc="""Allows manipulating the text that will be saved by the editor""",
+    ),
+    Hook(
         name="editor_will_use_font_for_field",
         args=["font: str"],
         return_type="str",


### PR DESCRIPTION
This hook generalizes the functionality of Editor.mungeHTML, so that you can easily extend by using the hook.

This used in my add-on [Persistent Editor](https://ankiweb.net/shared/info/1686259334). The add-on places a div inside of the text field, so that it can adopt the size of the field, but also obscure its content.