### PR TITLE
fix Ctrl+right/left handling in RTL fields

### DIFF
--- a/qt/ts/src/editor.ts
+++ b/qt/ts/src/editor.ts
@@ -47,6 +47,10 @@ function triggerKeyTimer() {
     }, 600);
 }
 
+interface Selection {
+    modify(s: string, t: string, u: string): void;
+}
+
 function onKey(evt: KeyboardEvent) {
     // esc clears focus, allowing dialog to close
     if (evt.which === 27) {

--- a/qt/ts/src/editor.ts
+++ b/qt/ts/src/editor.ts
@@ -59,6 +59,29 @@ function onKey(evt: KeyboardEvent) {
         focusPrevious();
         return;
     }
+
+    // fix Ctrl+right/left handling in RTL fields
+    if (currentField.dir === "rtl") {
+        const selection = window.getSelection();
+        let granularity = "character";
+        let alter = "move";
+        if (evt.ctrlKey) {
+            granularity = "word";
+        }
+        if (evt.shiftKey) {
+            alter = "extend";
+        }
+        if (evt.which === 39) {
+            selection.modify(alter, "right", granularity);
+            evt.preventDefault();
+            return;
+        } else if (evt.which === 37) {
+            selection.modify(alter, "left", granularity);
+            evt.preventDefault();
+            return;
+        }
+    }
+
     triggerKeyTimer();
 }
 


### PR DESCRIPTION
As I've reported in the [forum](https://forums.ankiweb.net/t/some-caret-navigation-shortcuts-in-the-editor-are-reversed-for-rtl-languages/1228), the Ctrl+right/left shortcuts are reversed for right-to-left fields.

This is the same workaround shown in the forum post, except limiting it to RTL fields.