### PR TITLE
Add hook for initializing answer buttons

### DIFF
--- a/qt/aqt/gui_hooks.py
+++ b/qt/aqt/gui_hooks.py
@@ -7,7 +7,7 @@ See pylib/anki/hooks.py
 
 from __future__ import annotations
 
-from typing import Any, Callable, List, Optional, Tuple
+from typing import Any, Callable, List, Optional, Tuple, Sequence
 
 import anki
 import aqt
@@ -2177,6 +2177,7 @@ class _ReviewerWillInitAnswerButtonsFilter:
     _hooks: List[
         Callable[
             ["Optional[Tuple[Tuple[int, str], ...]]", "aqt.reviewer.Reviewer", Card],
+            ["Tuple[Tuple[int, str], ...]", "aqt.reviewer.Reviewer", Card],
             Tuple[Tuple[int, str], ...],
         ]
     ] = []
@@ -2184,17 +2185,17 @@ class _ReviewerWillInitAnswerButtonsFilter:
     def append(
         self,
         cb: Callable[
-            ["Optional[Tuple[Tuple[int, str], ...]]", "aqt.reviewer.Reviewer", Card],
+            ["Tuple[Tuple[int, str], ...]", "aqt.reviewer.Reviewer", Card],
             Tuple[Tuple[int, str], ...],
         ],
     ) -> None:
-        """(buttons_tuple: Optional[Tuple[Tuple[int, str], ...]], reviewer: aqt.reviewer.Reviewer, card: Card)"""
+        """(buttons_tuple: Tuple[Tuple[int, str], ...], reviewer: aqt.reviewer.Reviewer, card: Card)"""
         self._hooks.append(cb)
 
     def remove(
         self,
         cb: Callable[
-            ["Optional[Tuple[Tuple[int, str], ...]]", "aqt.reviewer.Reviewer", Card],
+            ["Tuple[Tuple[int, str], ...]", "aqt.reviewer.Reviewer", Card],
             Tuple[Tuple[int, str], ...],
         ],
     ) -> None:
@@ -2206,7 +2207,7 @@ class _ReviewerWillInitAnswerButtonsFilter:
 
     def __call__(
         self,
-        buttons_tuple: Optional[Tuple[Tuple[int, str], ...]],
+        buttons_tuple: Tuple[Tuple[int, str], ...],
         reviewer: aqt.reviewer.Reviewer,
         card: Card,
     ) -> Tuple[Tuple[int, str], ...]:

--- a/qt/aqt/gui_hooks.py
+++ b/qt/aqt/gui_hooks.py
@@ -2079,6 +2079,52 @@ class _ReviewerDidShowQuestionHook:
 reviewer_did_show_question = _ReviewerDidShowQuestionHook()
 
 
+class _ReviewerWillInitAnswerButtonsFilter:
+    """Used to modify the answer buttons shown for a card.
+    """
+
+    _hooks: List[
+        Callable["aqt.reviewer.Reviewer", Card], Tuple[Tuple[int, str]]]
+    ] = []
+
+    def append(
+        self,
+        cb: Callable[
+            "aqt.reviewer.Reviewer", Card], Tuple[Tuple[int, str]]]
+        ],
+    ) -> None:
+        """(reviewer: aqt.reviewer.Reviewer, card: Card)"""
+        self._hooks.append(cb)
+
+    def remove(
+        self,
+        cb: Callable[
+            "aqt.reviewer.Reviewer", Card], Tuple[Tuple[int, str]]]
+        ],
+    ) -> None:
+        if cb in self._hooks:
+            self._hooks.remove(cb)
+
+    def count(self) -> int:
+        return len(self._hooks)
+
+    def __call__(
+        self, reviewer: aqt.reviewer.Reviewer, card: Card
+    ) -> Tuple[Tuple[int, str]]:
+        buttons_tuple = None
+        for filter in self._hooks:
+            try:
+                buttons_tuple = filter(reviewer, card)
+            except:
+                # if the hook fails, remove it
+                self._hooks.remove(filter)
+                raise
+        return buttons_tuple
+
+
+reviewer_will_init_answer_buttons = _ReviewerWillInitAnswerButtonsFilter()
+
+
 class _ReviewerWillAnswerCardFilter:
     """Used to modify the ease at which a card is rated or to bypass
         rating the card completely.

--- a/qt/aqt/gui_hooks.py
+++ b/qt/aqt/gui_hooks.py
@@ -7,7 +7,7 @@ See pylib/anki/hooks.py
 
 from __future__ import annotations
 
-from typing import Any, Callable, List, Optional, Tuple, Union, Sequence
+from typing import Any, Callable, List, Optional, Tuple, Union
 
 import anki
 import aqt

--- a/qt/aqt/gui_hooks.py
+++ b/qt/aqt/gui_hooks.py
@@ -2165,12 +2165,14 @@ reviewer_will_end = _ReviewerWillEndHook()
 class _ReviewerWillInitAnswerButtonsFilter:
     """Used to modify list of answer buttons
 
-        buttons_tuple is a tuple of buttons, with each button represented by a tuple
-        containing an int for the button's number and a string for the button's label.
+        buttons_tuple is a tuple of buttons, with each button represented by a 
+        tuple containing an int for the button's ease and a string for the 
+        button's label.
 
-        Return a tuple of the form ((1, "Label1"), (2, "Label2"), ...)
+        Return a tuple of the form ((int, str), ...), e.g.:
+            ((1, "Label1"), (2, "Label2"), ...)
 
-        Note: import _ from anki.lang to support automatic translation, using, e.g.,
+        Note: import _ from anki.lang to support translation, using, e.g.,
             ((1, _("Label1")), ...)
         """
 

--- a/qt/aqt/gui_hooks.py
+++ b/qt/aqt/gui_hooks.py
@@ -7,7 +7,7 @@ See pylib/anki/hooks.py
 
 from __future__ import annotations
 
-from typing import Any, Callable, List, Optional, Tuple, Sequence
+from typing import Any, Callable, List, Optional, Tuple, Union, Sequence
 
 import anki
 import aqt

--- a/qt/aqt/gui_hooks.py
+++ b/qt/aqt/gui_hooks.py
@@ -2079,8 +2079,6 @@ class _ReviewerDidShowQuestionHook:
 reviewer_did_show_question = _ReviewerDidShowQuestionHook()
 
 
-class _ReviewerWillInitAnswerButtonsFilter:
-    """Used to modify the answer buttons shown for a card.
 class _ReviewerWillAnswerCardFilter:
     """Used to modify the ease at which a card is rated or to bypass
         rating the card completely.

--- a/qt/aqt/gui_hooks.py
+++ b/qt/aqt/gui_hooks.py
@@ -2176,7 +2176,6 @@ class _ReviewerWillInitAnswerButtonsFilter:
 
     _hooks: List[
         Callable[
-            ["Optional[Tuple[Tuple[int, str], ...]]", "aqt.reviewer.Reviewer", Card],
             ["Tuple[Tuple[int, str], ...]", "aqt.reviewer.Reviewer", Card],
             Tuple[Tuple[int, str], ...],
         ]

--- a/qt/aqt/gui_hooks.py
+++ b/qt/aqt/gui_hooks.py
@@ -2081,50 +2081,6 @@ reviewer_did_show_question = _ReviewerDidShowQuestionHook()
 
 class _ReviewerWillInitAnswerButtonsFilter:
     """Used to modify the answer buttons shown for a card.
-    """
-
-    _hooks: List[
-        Callable["aqt.reviewer.Reviewer", Card], Tuple[Tuple[int, str]]]
-    ] = []
-
-    def append(
-        self,
-        cb: Callable[
-            "aqt.reviewer.Reviewer", Card], Tuple[Tuple[int, str]]]
-        ],
-    ) -> None:
-        """(reviewer: aqt.reviewer.Reviewer, card: Card)"""
-        self._hooks.append(cb)
-
-    def remove(
-        self,
-        cb: Callable[
-            "aqt.reviewer.Reviewer", Card], Tuple[Tuple[int, str]]]
-        ],
-    ) -> None:
-        if cb in self._hooks:
-            self._hooks.remove(cb)
-
-    def count(self) -> int:
-        return len(self._hooks)
-
-    def __call__(
-        self, reviewer: aqt.reviewer.Reviewer, card: Card
-    ) -> Tuple[Tuple[int, str]]:
-        buttons_tuple = None
-        for filter in self._hooks:
-            try:
-                buttons_tuple = filter(reviewer, card)
-            except:
-                # if the hook fails, remove it
-                self._hooks.remove(filter)
-                raise
-        return buttons_tuple
-
-
-reviewer_will_init_answer_buttons = _ReviewerWillInitAnswerButtonsFilter()
-
-
 class _ReviewerWillAnswerCardFilter:
     """Used to modify the ease at which a card is rated or to bypass
         rating the card completely.
@@ -2206,6 +2162,67 @@ class _ReviewerWillEndHook:
 
 
 reviewer_will_end = _ReviewerWillEndHook()
+
+
+class _ReviewerWillInitAnswerButtonsFilter:
+    """Used to modify list of answer buttons
+
+        buttons_tuple is a tuple of buttons, with each button represented by a tuple
+        containing an int for the button's number and a string for the button's label.
+
+        Return a tuple of the form ((1, "Label1"), (2, "Label2"), ...)
+
+        Note: import _ from anki.lang to support automatic translation, using, e.g.,
+            ((1, _("Label1")), ...)
+        """
+
+    _hooks: List[
+        Callable[
+            ["Optional[Tuple[Tuple[int, str], ...]]", "aqt.reviewer.Reviewer", Card],
+            Tuple[Tuple[int, str], ...],
+        ]
+    ] = []
+
+    def append(
+        self,
+        cb: Callable[
+            ["Optional[Tuple[Tuple[int, str], ...]]", "aqt.reviewer.Reviewer", Card],
+            Tuple[Tuple[int, str], ...],
+        ],
+    ) -> None:
+        """(buttons_tuple: Optional[Tuple[Tuple[int, str], ...]], reviewer: aqt.reviewer.Reviewer, card: Card)"""
+        self._hooks.append(cb)
+
+    def remove(
+        self,
+        cb: Callable[
+            ["Optional[Tuple[Tuple[int, str], ...]]", "aqt.reviewer.Reviewer", Card],
+            Tuple[Tuple[int, str], ...],
+        ],
+    ) -> None:
+        if cb in self._hooks:
+            self._hooks.remove(cb)
+
+    def count(self) -> int:
+        return len(self._hooks)
+
+    def __call__(
+        self,
+        buttons_tuple: Optional[Tuple[Tuple[int, str], ...]],
+        reviewer: aqt.reviewer.Reviewer,
+        card: Card,
+    ) -> Tuple[Tuple[int, str], ...]:
+        for filter in self._hooks:
+            try:
+                buttons_tuple = filter(buttons_tuple, reviewer, card)
+            except:
+                # if the hook fails, remove it
+                self._hooks.remove(filter)
+                raise
+        return buttons_tuple
+
+
+reviewer_will_init_answer_buttons = _ReviewerWillInitAnswerButtonsFilter()
 
 
 class _ReviewerWillPlayAnswerSoundsHook:

--- a/qt/aqt/reviewer.py
+++ b/qt/aqt/reviewer.py
@@ -621,10 +621,10 @@ time = %(time)d;
         else:
             return 2
 
-    def _answerButtonList(self) -> Sequence[Tuple[int, str], ...]:
+    def _answerButtonList(self) -> Tuple[Tuple[int, str], ...]:
         button_count = self.mw.col.sched.answerButtons(self.card)
         if button_count == 2:
-            buttons_tuple = ((1, _("Again")), (2, _("Good")),)
+            buttons_tuple: Tuple[Tuple[int, str], ...] = ((1, _("Again")), (2, _("Good")),)
         elif button_count == 3:
             buttons_tuple = ((1, _("Again")), (2, _("Good")), (3, _("Easy")))
         else:

--- a/qt/aqt/reviewer.py
+++ b/qt/aqt/reviewer.py
@@ -621,19 +621,16 @@ time = %(time)d;
         else:
             return 2
 
-    def _answerButtonList(self) -> Sequence[Tuple[int, str]]:
-        buttons_tuple = gui_hooks.reviewer_will_init_answer_buttons(self, self.card)
-        if buttons_tuple is not None:
-            return buttons_tuple
+    def _answerButtonList(self) -> Sequence[Tuple[int, str], ...]:
+        button_count = self.mw.col.sched.answerButtons(self.card)
+        if button_count == 2:
+            buttons_tuple = ((1, _("Again")), (2, _("Good")),)
+        elif button_count == 3:
+            buttons_tuple = ((1, _("Again")), (2, _("Good")), (3, _("Easy")))
         else:
-            l = ((1, _("Again")),)
-            cnt = self.mw.col.sched.answerButtons(self.card)
-            if cnt == 2:
-                return l + ((2, _("Good")),)
-            elif cnt == 3:
-                return l + ((2, _("Good")), (3, _("Easy")))
-            else:
-                return l + ((2, _("Hard")), (3, _("Good")), (4, _("Easy")))
+            buttons_tuple = ((1, _("Again")), (2, _("Hard")), (3, _("Good")), (4, _("Easy")))
+        buttons_tuple = gui_hooks.reviewer_will_init_answer_buttons(buttons_tuple, self, self.card)
+        return buttons_tuple
 
     def _answerButtons(self) -> str:
         default = self._defaultEase()

--- a/qt/aqt/reviewer.py
+++ b/qt/aqt/reviewer.py
@@ -622,14 +622,18 @@ time = %(time)d;
             return 2
 
     def _answerButtonList(self) -> Sequence[Tuple[int, str]]:
-        l = ((1, _("Again")),)
-        cnt = self.mw.col.sched.answerButtons(self.card)
-        if cnt == 2:
-            return l + ((2, _("Good")),)
-        elif cnt == 3:
-            return l + ((2, _("Good")), (3, _("Easy")))
+        buttons_tuple = gui_hooks.reviewer_will_init_answer_buttons(self, self.card)
+        if buttons_tuple is not None:
+            return buttons_tuple
         else:
-            return l + ((2, _("Hard")), (3, _("Good")), (4, _("Easy")))
+            l = ((1, _("Again")),)
+            cnt = self.mw.col.sched.answerButtons(self.card)
+            if cnt == 2:
+                return l + ((2, _("Good")),)
+            elif cnt == 3:
+                return l + ((2, _("Good")), (3, _("Easy")))
+            else:
+                return l + ((2, _("Hard")), (3, _("Good")), (4, _("Easy")))
 
     def _answerButtons(self) -> str:
         default = self._defaultEase()

--- a/qt/tools/genhooks_gui.py
+++ b/qt/tools/genhooks_gui.py
@@ -59,6 +59,17 @@ hooks = [
         legacy_no_args=True,
     ),
     Hook(
+        name="reviewer_will_init_answer_buttons",
+        args=["reviewer: aqt.reviewer.Reviewer", "card: Card"],
+        doc="""Used to modify list of answer buttons
+
+        Return a tuple of the form ((1, "Label1"), (2, "Label2"))
+
+        import _ from anki.lang to support translation, as
+           ((1, _("Label1)), ...)
+        """,
+    ),
+    Hook(
         name="reviewer_will_answer_card",
         args=[
             "ease_tuple: Tuple[bool, int]",

--- a/qt/tools/genhooks_gui.py
+++ b/qt/tools/genhooks_gui.py
@@ -68,14 +68,14 @@ hooks = [
         return_type="Tuple[Tuple[int, str], ...]",
         doc="""Used to modify list of answer buttons
 
-        buttons_tuple is a sequence of buttons, with each button represented
-        by a tuple containing an int for the button's number and a string for
-        the button's label.
+        buttons_tuple is a tuple of buttons, with each button represented by a 
+        tuple containing an int for the button's ease and a string for the 
+        button's label.
 
-        Return a tuple of the form ((1, "Label1"), (2, "Label2"), ...)
+        Return a tuple of the form ((int, str), ...), e.g.:
+            ((1, "Label1"), (2, "Label2"), ...)
 
-        Note: import _ from anki.lang to support automatic translation, using,
-        e.g.,
+        Note: import _ from anki.lang to support translation, using, e.g.,
             ((1, _("Label1")), ...)
         """,
     ),

--- a/qt/tools/genhooks_gui.py
+++ b/qt/tools/genhooks_gui.py
@@ -61,19 +61,21 @@ hooks = [
     Hook(
         name="reviewer_will_init_answer_buttons",
         args=[
-            "buttons_tuple: Optional[Tuple[Tuple[int, str], ...]]",
+            "buttons_tuple: Tuple[Tuple[int, str], ...]",
             "reviewer: aqt.reviewer.Reviewer",
             "card: Card",
         ],
         return_type="Tuple[Tuple[int, str], ...]",
         doc="""Used to modify list of answer buttons
 
-        buttons_tuple is a tuple of buttons, with each button represented by a tuple
-        containing an int for the button's number and a string for the button's label.
+        buttons_tuple is a sequence of buttons, with each button represented
+        by a tuple containing an int for the button's number and a string for
+        the button's label.
 
         Return a tuple of the form ((1, "Label1"), (2, "Label2"), ...)
 
-        Note: import _ from anki.lang to support automatic translation, using, e.g.,
+        Note: import _ from anki.lang to support automatic translation, using,
+        e.g.,
             ((1, _("Label1")), ...)
         """,
     ),

--- a/qt/tools/genhooks_gui.py
+++ b/qt/tools/genhooks_gui.py
@@ -60,13 +60,21 @@ hooks = [
     ),
     Hook(
         name="reviewer_will_init_answer_buttons",
-        args=["reviewer: aqt.reviewer.Reviewer", "card: Card"],
+        args=[
+            "buttons_tuple: Optional[Tuple[Tuple[int, str], ...]]",
+            "reviewer: aqt.reviewer.Reviewer",
+            "card: Card",
+        ],
+        return_type="Tuple[Tuple[int, str], ...]",
         doc="""Used to modify list of answer buttons
 
-        Return a tuple of the form ((1, "Label1"), (2, "Label2"))
+        buttons_tuple is a tuple of buttons, with each button represented by a tuple
+        containing an int for the button's number and a string for the button's label.
 
-        import _ from anki.lang to support translation, as
-           ((1, _("Label1)), ...)
+        Return a tuple of the form ((1, "Label1"), (2, "Label2"), ...)
+
+        Note: import _ from anki.lang to support automatic translation, using, e.g.,
+            ((1, _("Label1")), ...)
         """,
     ),
     Hook(


### PR DESCRIPTION
A few add ons (MIA's, my ease factor add-on, More Buttons) change the number of answer buttons either up or down. So far all the ones I've found just use monkey patching, so I think a filter would be useful.

Bad news -- My testing environment is still not up and running,[0] and this is my first shot at this, so it definitely needs another pass by somebody who has implemented a hook before before merge.

Sorry it's not ready to go out of the box. Hopefully this draft inspires somebody to carry it over the finish line. Shouldn't be too much more than this skeleton.

[0] Mentioned in the Discord. Anki fails to import QtWebEngineWidgets with ModuleNotFound, but if I copy and paste that import into the interpreter or any other file, the import works fine somehow. I'm guessing some sort of circular dependency or something with the bash run / make scripts that I don't understand.