### PR TITLE
Ignore buried cards which are on the scheduler in memory queues

### DIFF
--- a/pylib/anki/schedv2.py
+++ b/pylib/anki/schedv2.py
@@ -82,7 +82,13 @@ class Scheduler:
         self._checkDay()
         if not self._haveQueues:
             self.reset()
-        card = self._getCard()
+        while True:
+            card = self._getCard()
+            if not card:
+                break
+            # https://anki.tenderapp.com/discussions/beta-testing/1850-cards-marked-as-buried-are-being-scheduled
+            if card.queue > -1:
+                break
         if card:
             self.col.log(card)
             if not self._burySiblingsOnAnswer:


### PR DESCRIPTION
This is the solution I have been using for https://anki.tenderapp.com/discussions/beta-testing/1850-cards-marked-as-buried-are-being-scheduled

This is used in conjunction with the addons for https://github.com/ankitects/anki/pull/736 - (Create the hook scheduler_did_bury_notes).

When a card is buried, it may still in some Anki internal/in-memory queue. Then, either the addons have to manually/directly operate with the queues inside the `Scheduler` or the `Scheduler` can just ignore cards that are buried (which this pull request does).