### PR TITLE
Fix no sound after restarting mpv

### DIFF
--- a/qt/aqt/sound.py
+++ b/qt/aqt/sound.py
@@ -335,6 +335,7 @@ class MpvManager(MPV, SoundOrVideoPlayer):
         super().__init__(window_id=None, debug=False)
 
     def on_init(self) -> None:
+        self.on_end_file()
         try:
             self.command("keybind", "q", "stop")
             self.command("keybind", "Q", "stop")

--- a/qt/aqt/sound.py
+++ b/qt/aqt/sound.py
@@ -335,7 +335,10 @@ class MpvManager(MPV, SoundOrVideoPlayer):
         super().__init__(window_id=None, debug=False)
 
     def on_init(self) -> None:
+        # if mpv dies and is restarted, tell Anki the
+        # current file is done
         self.on_end_file()
+        
         try:
             self.command("keybind", "q", "stop")
             self.command("keybind", "Q", "stop")


### PR DESCRIPTION
Steps to reproduce:

1. Play some long audio file
2. Emulate crash by force closing mpv during the audio playback via the task manager
3. There's no sound anymore after clicking the audio play button