### PR TITLE
Make exporter correctly state "cards" instead of "notes"

### DIFF
--- a/qt/aqt/exporting.py
+++ b/qt/aqt/exporting.py
@@ -67,7 +67,7 @@ class ExportDialog(QDialog):
         self.exporter = self.exporters[idx][1](self.col)
         self.isApkg = self.exporter.ext == ".apkg"
         self.isVerbatim = getattr(self.exporter, "verbatim", False)
-        self.isTextNote = hasattr(self.exporter, "includeTags")
+        self.isTextNote = hasattr(self.exporter, "includeTags") and self.exporter.includeTags
         self.frm.includeSched.setVisible(
             getattr(self.exporter, "includeSched", None) is not None
         )


### PR DESCRIPTION
This fixes a small misnomer when exporting, where it states it exported "n" notes, when it actually exported "n" cards.
It was introduced, when introducing types in "pylib/anki/exporting.py".