### PR TITLE
Create a gui_hook for initializing buttons in Models

### DIFF
--- a/qt/aqt/gui_hooks.py
+++ b/qt/aqt/gui_hooks.py
@@ -17,7 +17,6 @@ from anki.hooks import runFilter, runHook
 from anki.models import NoteType
 from aqt.qt import QDialog, QEvent, QMenu
 from aqt.tagedit import TagEdit
-from aqt.models import Models
 
 # New hook/filter handling
 ##############################################################################
@@ -1875,26 +1874,35 @@ class _ModelsDidInitButtonsFilter:
 
     _hooks: List[
         Callable[
-            [List[Tuple[str, Callable[[Models], None]]], Models],
-            List[Tuple[str, Callable[[Models], None]]],
+            [
+                "List[Tuple[str, Callable[[aqt.models.Models], None]]]",
+                "aqt.models.Models",
+            ],
+            List[Tuple[str, Callable[[aqt.models.Models], None]]],
         ]
     ] = []
 
     def append(
         self,
         cb: Callable[
-            [List[Tuple[str, Callable[[Models], None]]], Models],
-            List[Tuple[str, Callable[[Models], None]]],
+            [
+                "List[Tuple[str, Callable[[aqt.models.Models], None]]]",
+                "aqt.models.Models",
+            ],
+            List[Tuple[str, Callable[[aqt.models.Models], None]]],
         ],
     ) -> None:
-        """(buttons: List[Tuple[str, Callable[[Models], None]]], models: Models)"""
+        """(buttons: List[Tuple[str, Callable[[aqt.models.Models], None]]], models: aqt.models.Models)"""
         self._hooks.append(cb)
 
     def remove(
         self,
         cb: Callable[
-            [List[Tuple[str, Callable[[Models], None]]], Models],
-            List[Tuple[str, Callable[[Models], None]]],
+            [
+                "List[Tuple[str, Callable[[aqt.models.Models], None]]]",
+                "aqt.models.Models",
+            ],
+            List[Tuple[str, Callable[[aqt.models.Models], None]]],
         ],
     ) -> None:
         if cb in self._hooks:
@@ -1904,8 +1912,10 @@ class _ModelsDidInitButtonsFilter:
         return len(self._hooks)
 
     def __call__(
-        self, buttons: List[Tuple[str, Callable[[Models], None]]], models: Models
-    ) -> List[Tuple[str, Callable[[Models], None]]]:
+        self,
+        buttons: List[Tuple[str, Callable[[aqt.models.Models], None]]],
+        models: aqt.models.Models,
+    ) -> List[Tuple[str, Callable[[aqt.models.Models], None]]]:
         for filter in self._hooks:
             try:
                 buttons = filter(buttons, models)

--- a/qt/aqt/gui_hooks.py
+++ b/qt/aqt/gui_hooks.py
@@ -1874,35 +1874,26 @@ class _ModelsDidInitButtonsFilter:
 
     _hooks: List[
         Callable[
-            [
-                "List[Tuple[str, Callable[[aqt.models.Models], None]]]",
-                "aqt.models.Models",
-            ],
-            List[Tuple[str, Callable[[aqt.models.Models], None]]],
+            [List[Tuple[str, Callable[[], None]]], "aqt.models.Models"],
+            List[Tuple[str, Callable[[], None]]],
         ]
     ] = []
 
     def append(
         self,
         cb: Callable[
-            [
-                "List[Tuple[str, Callable[[aqt.models.Models], None]]]",
-                "aqt.models.Models",
-            ],
-            List[Tuple[str, Callable[[aqt.models.Models], None]]],
+            [List[Tuple[str, Callable[[], None]]], "aqt.models.Models"],
+            List[Tuple[str, Callable[[], None]]],
         ],
     ) -> None:
-        """(buttons: List[Tuple[str, Callable[[aqt.models.Models], None]]], models: aqt.models.Models)"""
+        """(buttons: List[Tuple[str, Callable[[], None]]], models: aqt.models.Models)"""
         self._hooks.append(cb)
 
     def remove(
         self,
         cb: Callable[
-            [
-                "List[Tuple[str, Callable[[aqt.models.Models], None]]]",
-                "aqt.models.Models",
-            ],
-            List[Tuple[str, Callable[[aqt.models.Models], None]]],
+            [List[Tuple[str, Callable[[], None]]], "aqt.models.Models"],
+            List[Tuple[str, Callable[[], None]]],
         ],
     ) -> None:
         if cb in self._hooks:
@@ -1912,10 +1903,8 @@ class _ModelsDidInitButtonsFilter:
         return len(self._hooks)
 
     def __call__(
-        self,
-        buttons: List[Tuple[str, Callable[[aqt.models.Models], None]]],
-        models: aqt.models.Models,
-    ) -> List[Tuple[str, Callable[[aqt.models.Models], None]]]:
+        self, buttons: List[Tuple[str, Callable[[], None]]], models: aqt.models.Models
+    ) -> List[Tuple[str, Callable[[], None]]]:
         for filter in self._hooks:
             try:
                 buttons = filter(buttons, models)

--- a/qt/aqt/models.py
+++ b/qt/aqt/models.py
@@ -51,22 +51,21 @@ class Models(QDialog):
         box = f.buttonBox
 
         default_buttons = [
-            ("Add", self.onAdd),
-            ("Rename", self.onRename),
-            ("Delete", self.onDelete),
-            ("Options...", self.onAdvanced),
+            (_("Add"), self.onAdd),
+            (_("Rename"), self.onRename),
+            (_("Delete"), self.onDelete),
         ]
 
         if self.fromMain:
-            from_main_buttons = [
-                ("Fields...", self.onFields),
-                ("Cards...", self.onCards),
-            ]
+            default_buttons.extend([
+                (_("Fields..."), self.onFields),
+                (_("Cards..."), self.onCards),
+            ])
 
-            default_buttons[-1:-1] = from_main_buttons
+        default_buttons.append((_("Options..."), self.onAdvanced))
 
         for label, func in gui_hooks.models_did_init_buttons(default_buttons, self):
-            button = box.addButton(_(label), QDialogButtonBox.ActionRole)
+            button = box.addButton(label, QDialogButtonBox.ActionRole)
             qconnect(button.clicked, func)
 
         qconnect(f.modelsList.itemDoubleClicked, self.onRename)

--- a/qt/aqt/models.py
+++ b/qt/aqt/models.py
@@ -2,7 +2,7 @@
 # License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
 from operator import itemgetter
-from typing import Any, List, Tuple, Callable, Optional, Sequence
+from typing import Any, List, Optional, Sequence
 
 import aqt.clayout
 from anki import stdmodels

--- a/qt/aqt/models.py
+++ b/qt/aqt/models.py
@@ -54,15 +54,16 @@ class Models(QDialog):
             ("Add", self.onAdd),
             ("Rename", self.onRename),
             ("Delete", self.onDelete),
+            ("Options...", self.onAdvanced),
         ]
 
         if self.fromMain:
-            default_buttons.extend([
+            from_main_buttons = [
                 ("Fields...", self.onFields),
                 ("Cards...", self.onCards),
-            ])
+            ]
 
-        default_buttons.append(("Options...", self.onAdvanced))
+            default_buttons[-1:-1] = from_main_buttons
 
         for label, func in gui_hooks.models_did_init_buttons(default_buttons, self):
             button = box.addButton(_(label), QDialogButtonBox.ActionRole)

--- a/qt/aqt/models.py
+++ b/qt/aqt/models.py
@@ -72,6 +72,12 @@ class Models(QDialog):
         f.modelsList.setCurrentRow(0)
         maybeHideClose(box)
 
+    def add_button(self, label: str, func: Callable[Any, None]) -> None:
+        box = self.form.buttonBox
+
+        button = box.addButton(_(label), QDialogButtonBox.ActionRole)
+        qconnect(button.clicked, func)
+
     def onRename(self) -> None:
         nt = self.current_notetype()
         txt = getText(_("New name:"), default=nt["name"])

--- a/qt/aqt/models.py
+++ b/qt/aqt/models.py
@@ -57,10 +57,12 @@ class Models(QDialog):
         ]
 
         if self.fromMain:
-            default_buttons.extend([
-                (_("Fields..."), self.onFields),
-                (_("Cards..."), self.onCards),
-            ])
+            default_buttons.extend(
+                [
+                    (_("Fields..."), self.onFields),
+                    (_("Cards..."), self.onCards),
+                ]
+            )
 
         default_buttons.append((_("Options..."), self.onAdvanced))
 

--- a/qt/aqt/models.py
+++ b/qt/aqt/models.py
@@ -66,9 +66,8 @@ class Models(QDialog):
             ])
 
         default_buttons.append(("Options...", self.onAdvanced))
-        gui_hooks.models_did_init_buttons(default_buttons, self)
 
-        for label, func in buttons:
+        for label, func in gui_hooks.models_did_init_buttons(default_buttons, self):
             button = box.addButton(_(label), QDialogButtonBox.ActionRole)
             qconnect(button.clicked, func)
 

--- a/qt/aqt/models.py
+++ b/qt/aqt/models.py
@@ -54,13 +54,10 @@ class Models(QDialog):
             ("Add", self.onAdd),
             ("Rename", self.onRename),
             ("Delete", self.onDelete),
-            ("Fields...", self.onFields),
-            ("Cards...", self.onCards),
-            ("Options...", self.onAdvanced),
         ]
 
         if self.fromMain:
-            default_buttons.extends([
+            default_buttons.extend([
                 ("Fields...", self.onFields),
                 ("Cards...", self.onCards),
             ])

--- a/qt/tools/genhooks_gui.py
+++ b/qt/tools/genhooks_gui.py
@@ -685,7 +685,10 @@ hooks = [
     ),
     # Model
     ###################
-    Hook(name="models_advanced_will_show", args=["advanced: QDialog"],),
+    Hook(
+        name="models_advanced_will_show",
+        args=["advanced: QDialog"],
+    ),
     Hook(
         name="models_did_init_buttons",
         args=[

--- a/qt/tools/genhooks_gui.py
+++ b/qt/tools/genhooks_gui.py
@@ -685,9 +685,12 @@ hooks = [
     ),
     # Model
     ###################
+    Hook(name="models_advanced_will_show", args=["advanced: QDialog"],),
     Hook(
-        name="models_advanced_will_show",
-        args=["advanced: QDialog"],
+        name="models_did_init_buttons",
+        args=["buttons: List[Tuple[str, Callable[[Models], None]]]", "models: Models"],
+        return_type="buttons: List[Tuple[str, Callable[[Models], None]]]",
+        doc="""Allows adding buttons to the Model dialog""",
     ),
     # Stats
     ###################

--- a/qt/tools/genhooks_gui.py
+++ b/qt/tools/genhooks_gui.py
@@ -688,8 +688,11 @@ hooks = [
     Hook(name="models_advanced_will_show", args=["advanced: QDialog"],),
     Hook(
         name="models_did_init_buttons",
-        args=["buttons: List[Tuple[str, Callable[[aqt.models.Models], None]]]", "models: aqt.models.Models"],
-        return_type="List[Tuple[str, Callable[[aqt.models.Models], None]]]",
+        args=[
+            "buttons: List[Tuple[str, Callable[[], None]]]",
+            "models: aqt.models.Models",
+        ],
+        return_type="List[Tuple[str, Callable[[], None]]]",
         doc="""Allows adding buttons to the Model dialog""",
     ),
     # Stats

--- a/qt/tools/genhooks_gui.py
+++ b/qt/tools/genhooks_gui.py
@@ -688,8 +688,8 @@ hooks = [
     Hook(name="models_advanced_will_show", args=["advanced: QDialog"],),
     Hook(
         name="models_did_init_buttons",
-        args=["buttons: List[Tuple[str, Callable[[Models], None]]]", "models: Models"],
-        return_type="List[Tuple[str, Callable[[Models], None]]]",
+        args=["buttons: List[Tuple[str, Callable[[aqt.models.Models], None]]]", "models: aqt.models.Models"],
+        return_type="List[Tuple[str, Callable[[aqt.models.Models], None]]]",
         doc="""Allows adding buttons to the Model dialog""",
     ),
     # Stats

--- a/qt/tools/genhooks_gui.py
+++ b/qt/tools/genhooks_gui.py
@@ -689,7 +689,7 @@ hooks = [
     Hook(
         name="models_did_init_buttons",
         args=["buttons: List[Tuple[str, Callable[[Models], None]]]", "models: Models"],
-        return_type="buttons: List[Tuple[str, Callable[[Models], None]]]",
+        return_type="List[Tuple[str, Callable[[Models], None]]]",
         doc="""Allows adding buttons to the Model dialog""",
     ),
     # Stats


### PR DESCRIPTION
I have two add-ons which create an additional button in the "Models" dialog, one of them being [Asset Manager](https://ankiweb.net/shared/info/656021484).
I found it much better putting an add-ons configuration here over putting it into the Add-ons dialog, when the add-ons configurations are per note type.