### PR TITLE
remove Optional when Optional is already implied

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -47,6 +47,7 @@ Alexander Presnyakov <flagist0@gmail.com>
 abdo <github.com/ANH25>
 aplaice <plaice.adam+github@gmail.com>
 phwoo <github.com/phwoo> 
+Alex Riina <alex.riina@gmail.com>
 
 ********************
 

--- a/pylib/anki/cards.py
+++ b/pylib/anki/cards.py
@@ -34,7 +34,7 @@ class Card:
     ord: int
 
     def __init__(
-        self, col: anki.collection.Collection, id: Optional[int] = None
+        self, col: anki.collection.Collection, id: int = None
     ) -> None:
         self.col = col.weakref()
         self.timerStarted = None

--- a/pylib/anki/collection.py
+++ b/pylib/anki/collection.py
@@ -43,7 +43,7 @@ class Collection:
     def __init__(
         self,
         path: str,
-        backend: Optional[RustBackend] = None,
+        backend: RustBackend = None,
         server: bool = False,
         log: bool = False,
     ) -> None:
@@ -186,7 +186,7 @@ class Collection:
     ls = property(_get_ls, _set_ls)
 
     # legacy
-    def setMod(self, mod: Optional[int] = None) -> None:
+    def setMod(self, mod: int = None) -> None:
         # this is now a no-op, as modifications to things like the config
         # will mark the collection modified automatically
         pass
@@ -200,7 +200,7 @@ class Collection:
         return self.db.last_begin_at <= self.mod
 
     def save(
-        self, name: Optional[str] = None, mod: Optional[int] = None, trx: bool = True
+        self, name: str = None, mod: int = None, trx: bool = True
     ) -> None:
         "Flush, commit DB, and take out another write lock if trx=True."
         # commit needed?
@@ -457,8 +457,8 @@ class Collection:
         nids: List[int],
         src: str,
         dst: str,
-        regex: Optional[bool] = None,
-        field: Optional[str] = None,
+        regex: bool = None,
+        field: str = None,
         fold: bool = True,
     ) -> int:
         return anki.find.findReplace(self, nids, src, dst, regex, field, fold)

--- a/pylib/anki/decks.py
+++ b/pylib/anki/decks.py
@@ -311,7 +311,7 @@ class DeckManager:
         )
 
     def add_config(
-        self, name: str, clone_from: Optional[DeckConfig] = None
+        self, name: str, clone_from: DeckConfig = None
     ) -> DeckConfig:
         if clone_from is not None:
             conf = copy.deepcopy(clone_from)
@@ -323,7 +323,7 @@ class DeckManager:
         return conf
 
     def add_config_returning_id(
-        self, name: str, clone_from: Optional[DeckConfig] = None
+        self, name: str, clone_from: DeckConfig = None
     ) -> int:
         return self.add_config(name, clone_from)["id"]
 
@@ -509,7 +509,7 @@ class DeckManager:
         return childMap
 
     def parents(
-        self, did: int, nameMap: Optional[Dict[str, Deck]] = None
+        self, did: int, nameMap: Dict[str, Deck] = None
     ) -> List[Deck]:
         "All parents of did."
         # get parent and grandparent names

--- a/pylib/anki/exporting.py
+++ b/pylib/anki/exporting.py
@@ -28,8 +28,8 @@ class Exporter:
     def __init__(
         self,
         col: Collection,
-        did: Optional[int] = None,
-        cids: Optional[List[int]] = None,
+        did: int = None,
+        cids: List[int] = None,
     ) -> None:
         self.col = col.weakref()
         self.did = did

--- a/pylib/anki/find.py
+++ b/pylib/anki/find.py
@@ -34,7 +34,7 @@ def findReplace(
     src: str,
     dst: str,
     regex: bool = False,
-    field: Optional[str] = None,
+    field: str = None,
     fold: bool = True,
 ) -> int:
     "Find and replace fields in a note. Returns changed note count."

--- a/pylib/anki/httpclient.py
+++ b/pylib/anki/httpclient.py
@@ -24,7 +24,7 @@ class HttpClient:
     # args are (upload_bytes_in_chunk, download_bytes_in_chunk)
     progress_hook: Optional[ProgressCallback] = None
 
-    def __init__(self, progress_hook: Optional[ProgressCallback] = None) -> None:
+    def __init__(self, progress_hook: ProgressCallback = None) -> None:
         self.progress_hook = progress_hook
         self.session = requests.Session()
 

--- a/pylib/anki/importing/anki2.py
+++ b/pylib/anki/importing/anki2.py
@@ -398,7 +398,7 @@ insert or ignore into revlog values (?,?,?,?,?,?,?,?,?)""",
             if fname.startswith("_") and not self.dst.media.have(fname):
                 self._writeDstMedia(fname, self._srcMediaData(fname))
 
-    def _mediaData(self, fname: str, dir: Optional[str] = None) -> bytes:
+    def _mediaData(self, fname: str, dir: str = None) -> bytes:
         if not dir:
             dir = self.src.media.dir()
         path = os.path.join(dir, fname)

--- a/pylib/anki/media.py
+++ b/pylib/anki/media.py
@@ -188,7 +188,7 @@ class MediaManager:
         return output
 
     def render_all_latex(
-        self, progress_cb: Optional[Callable[[int], bool]] = None
+        self, progress_cb: Callable[[int], bool] = None
     ) -> Optional[Tuple[int, str]]:
         """Render any LaTeX that is missing.
 
@@ -244,7 +244,7 @@ class MediaManager:
 
     addFile = add_file
 
-    def writeData(self, opath: str, data: bytes, typeHint: Optional[str] = None) -> str:
+    def writeData(self, opath: str, data: bytes, typeHint: str = None) -> str:
         fname = os.path.basename(opath)
         if typeHint:
             fname = self.add_extension_based_on_mime(fname, typeHint)

--- a/pylib/anki/notes.py
+++ b/pylib/anki/notes.py
@@ -21,8 +21,8 @@ class Note:
     def __init__(
         self,
         col: anki.collection.Collection,
-        model: Optional[NoteType] = None,
-        id: Optional[int] = None,
+        model: NoteType = None,
+        id: int = None,
     ) -> None:
         assert not (model and id)
         self.col = col.weakref()

--- a/pylib/anki/rsbackend.py
+++ b/pylib/anki/rsbackend.py
@@ -198,8 +198,8 @@ class Progress:
 class RustBackend(RustBackendGenerated):
     def __init__(
         self,
-        ftl_folder: Optional[str] = None,
-        langs: Optional[List[str]] = None,
+        ftl_folder: str = None,
+        langs: List[str] = None,
         server: bool = False,
     ) -> None:
         # pick up global defaults if not provided

--- a/pylib/anki/rsbackend.py
+++ b/pylib/anki/rsbackend.py
@@ -17,7 +17,7 @@ import enum
 import json
 import os
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Sequence, Union
 
 import ankirspy  # pytype: disable=import-error
 

--- a/pylib/anki/sched.py
+++ b/pylib/anki/sched.py
@@ -90,7 +90,7 @@ class Scheduler(V2):
         card.usn = self.col.usn()
         card.flush()
 
-    def counts(self, card: Optional[Card] = None) -> Tuple[int, int, int]:
+    def counts(self, card: Card = None) -> Tuple[int, int, int]:
         counts = [self.newCount, self.lrnCount, self.revCount]
         if card:
             idx = self.countIdx(card)
@@ -397,7 +397,7 @@ limit %d"""
             time.sleep(0.01)
             log()
 
-    def removeLrn(self, ids: Optional[List[int]] = None) -> None:
+    def removeLrn(self, ids: List[int] = None) -> None:
         "Remove cards from the learning queues."
         if ids:
             extra = " and id in " + ids2str(ids)
@@ -628,7 +628,7 @@ did = ? and queue = {QUEUE_TYPE_REV} and due <= ? limit ?""",
     # Dynamic deck handling
     ##########################################################################
 
-    def rebuildDyn(self, did: Optional[int] = None) -> Optional[Sequence[int]]:  # type: ignore[override]
+    def rebuildDyn(self, did: int = None) -> Optional[Sequence[int]]:  # type: ignore[override]
         "Rebuild a dynamic deck."
         did = did or self.col.decks.selected()
         deck = self.col.decks.get(did)
@@ -658,7 +658,7 @@ did = ? and queue = {QUEUE_TYPE_REV} and due <= ? limit ?""",
         self._moveToDyn(deck["id"], ids)
         return ids
 
-    def emptyDyn(self, did: Optional[int], lim: Optional[str] = None) -> None:
+    def emptyDyn(self, did: Optional[int], lim: str = None) -> None:
         if not lim:
             lim = "did = %s" % did
         self.col.log(self.col.db.list("select id from cards where %s" % lim))

--- a/pylib/anki/schedv2.py
+++ b/pylib/anki/schedv2.py
@@ -158,7 +158,7 @@ class Scheduler:
             self.newCount = node.new_count
             self.revCount = node.review_count
 
-    def counts(self, card: Optional[Card] = None) -> Tuple[int, int, int]:
+    def counts(self, card: Card = None) -> Tuple[int, int, int]:
         counts = [self.newCount, self.lrnCount, self.revCount]
         if card:
             idx = self.countIdx(card)
@@ -358,7 +358,7 @@ order by due"""
             return None
 
     def _deckNewLimit(
-        self, did: int, fn: Optional[Callable[[Deck], int]] = None
+        self, did: int, fn: Callable[[Deck], int] = None
     ) -> int:
         if not fn:
             fn = self._deckNewLimitSingle
@@ -580,7 +580,7 @@ did = ? and queue = {QUEUE_TYPE_DAY_LEARN_RELEARN} and due <= ? limit ?""",
         self._rescheduleLrnCard(card, conf, delay=delay)
 
     def _rescheduleLrnCard(
-        self, card: Card, conf: QueueConfig, delay: Optional[int] = None
+        self, card: Card, conf: QueueConfig, delay: int = None
     ) -> Any:
         # normal delay for the current step?
         if delay is None:
@@ -668,7 +668,7 @@ did = ? and queue = {QUEUE_TYPE_DAY_LEARN_RELEARN} and due <= ? limit ?""",
         return tot + tod * 1000
 
     def _leftToday(
-        self, delays: List[int], left: int, now: Optional[int] = None,
+        self, delays: List[int], left: int, now: int = None,
     ) -> int:
         "The number of steps that can be completed by the day cutoff."
         if not now:
@@ -774,7 +774,7 @@ and due <= ? limit ?)""",
         return self._deckRevLimitSingle(d)
 
     def _deckRevLimitSingle(
-        self, d: Dict[str, Any], parentLimit: Optional[int] = None
+        self, d: Dict[str, Any], parentLimit: int = None
     ) -> int:
         # invalid deck selected?
         if not d:
@@ -1049,7 +1049,7 @@ else
 end)
 """
 
-    def rebuildDyn(self, did: Optional[int] = None) -> Optional[int]:
+    def rebuildDyn(self, did: int = None) -> Optional[int]:
         "Rebuild a dynamic deck."
         did = did or self.col.decks.selected()
         deck = self.col.decks.get(did)
@@ -1081,7 +1081,7 @@ end)
             total += len(ids)
         return total
 
-    def emptyDyn(self, did: Optional[int], lim: Optional[str] = None) -> None:
+    def emptyDyn(self, did: Optional[int], lim: str = None) -> None:
         if not lim:
             lim = "did = %s" % did
         self.col.log(self.col.db.list("select id from cards where %s" % lim))
@@ -1704,7 +1704,7 @@ and due >= ? and queue = {QUEUE_TYPE_NEW}"""
                 self.orderCards(did)
 
     # for post-import
-    def maybeRandomizeDeck(self, did: Optional[int] = None) -> None:
+    def maybeRandomizeDeck(self, did: int = None) -> None:
         if not did:
             did = self.col.decks.selected()
         conf = self.col.decks.confForDid(did)

--- a/pylib/anki/stats.py
+++ b/pylib/anki/stats.py
@@ -258,7 +258,7 @@ and due = ?"""
         return self._lineTbl(i)
 
     def _due(
-        self, start: Optional[int] = None, end: Optional[int] = None, chunk: int = 1
+        self, start: int = None, end: int = None, chunk: int = 1
     ) -> Any:
         lim = ""
         if start is not None:
@@ -389,7 +389,7 @@ group by day order by day"""
         first: int,
         unit: str,
         convHours: bool = False,
-        total: Optional[int] = None,
+        total: int = None,
     ) -> Tuple[str, int]:
         assert totd
         tot = totd[-1][1]
@@ -950,7 +950,7 @@ from cards where did in %s"""
         self,
         id: str,
         data: Any,
-        conf: Optional[Any] = None,
+        conf: Any = None,
         type: str = "bars",
         xunit: int = 1,
         ylabel: str = _("Cards"),

--- a/pylib/anki/tags.py
+++ b/pylib/anki/tags.py
@@ -40,7 +40,7 @@ class TagManager:
     #############################################################
 
     def register(
-        self, tags: Collection[str], usn: Optional[int] = None, clear=False
+        self, tags: Collection[str], usn: int = None, clear=False
     ) -> None:
         if usn is None:
             preserve_usn = False
@@ -53,7 +53,7 @@ class TagManager:
             tags=" ".join(tags), preserve_usn=preserve_usn, usn=usn_, clear_first=clear
         )
 
-    def registerNotes(self, nids: Optional[List[int]] = None) -> None:
+    def registerNotes(self, nids: List[int] = None) -> None:
         "Add any missing tags from notes to the tags list."
         # when called without an argument, the old list is cleared first.
         if nids:

--- a/pylib/anki/tags.py
+++ b/pylib/anki/tags.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 import pprint
 import re
-from typing import Collection, List, Optional, Tuple
+from typing import Collection, List, Tuple
 
 import anki  # pylint: disable=unused-import
 from anki.utils import ids2str

--- a/pylib/anki/template.py
+++ b/pylib/anki/template.py
@@ -139,7 +139,7 @@ class TemplateRenderContext:
         note: Note,
         browser: bool = False,
         notetype: NoteType = None,
-        template: Optional[Dict] = None,
+        template: Dict = None,
         fill_empty: bool = False,
     ) -> None:
         self._col = col.weakref()

--- a/qt/aqt/__init__.py
+++ b/qt/aqt/__init__.py
@@ -139,7 +139,7 @@ class DialogManager:
         return True
 
     def register_dialog(
-        self, name: str, creator: Union[Callable, type], instance: Optional[Any] = None
+        self, name: str, creator: Union[Callable, type], instance: Any = None
     ):
         """Allows add-ons to register a custom dialog to be managed by Anki's dialog
         manager, which ensures that only one copy of the window is open at once,
@@ -181,7 +181,7 @@ _qtrans: Optional[QTranslator] = None
 
 
 def setupLangAndBackend(
-    pm: ProfileManager, app: QApplication, force: Optional[str] = None
+    pm: ProfileManager, app: QApplication, force: str = None
 ) -> RustBackend:
     global _qtrans
     try:

--- a/qt/aqt/addons.py
+++ b/qt/aqt/addons.py
@@ -268,7 +268,7 @@ class AddonManager:
         with open(path, "w", encoding="utf8") as f:
             json.dump(meta, f)
 
-    def toggleEnabled(self, dir: str, enable: Optional[bool] = None) -> None:
+    def toggleEnabled(self, dir: str, enable: bool = None) -> None:
         addon = self.addon_meta(dir)
         should_enable = enable if enable is not None else not addon.enabled
         if should_enable is True:
@@ -865,7 +865,7 @@ class AddonsDialog(QDialog):
         else:
             tooltip(_("No updates available."))
 
-    def onInstallFiles(self, paths: Optional[List[str]] = None) -> Optional[bool]:
+    def onInstallFiles(self, paths: List[str] = None) -> Optional[bool]:
         if not paths:
             key = _("Packaged Anki Add-on") + " (*{})".format(self.mgr.ext)
             paths = getFile(
@@ -1124,7 +1124,7 @@ def download_addons(
     mgr: AddonManager,
     ids: List[int],
     on_done: Callable[[List[DownloadLogEntry]], None],
-    client: Optional[HttpClient] = None,
+    client: HttpClient = None,
 ) -> None:
     if client is None:
         client = HttpClient()
@@ -1390,7 +1390,7 @@ class ConfigEditor(QDialog):
 def installAddonPackages(
     addonsManager: AddonManager,
     paths: List[str],
-    parent: Optional[QWidget] = None,
+    parent: QWidget = None,
     warn: bool = False,
     strictly_modal: bool = False,
     advise_restart: bool = False,

--- a/qt/aqt/clayout.py
+++ b/qt/aqt/clayout.py
@@ -4,7 +4,7 @@
 import copy
 import json
 import re
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List
 
 import aqt
 from anki.cards import Card

--- a/qt/aqt/clayout.py
+++ b/qt/aqt/clayout.py
@@ -43,7 +43,7 @@ class CardLayout(QDialog):
         mw: AnkiQt,
         note: Note,
         ord=0,
-        parent: Optional[QWidget] = None,
+        parent: QWidget = None,
         fill_empty: bool = False,
     ):
         QDialog.__init__(self, parent or mw, Qt.Window)

--- a/qt/aqt/editor.py
+++ b/qt/aqt/editor.py
@@ -252,7 +252,7 @@ class Editor:
         cmd: str,
         tip: str = "",
         label: str = "",
-        id: Optional[str] = None,
+        id: str = None,
         toggleable: bool = False,
         disables: bool = True,
     ) -> str:

--- a/qt/aqt/exporting.py
+++ b/qt/aqt/exporting.py
@@ -21,8 +21,8 @@ class ExportDialog(QDialog):
     def __init__(
         self,
         mw: aqt.main.AnkiQt,
-        did: Optional[int] = None,
-        cids: Optional[List[int]] = None,
+        did: int = None,
+        cids: List[int] = None,
     ):
         QDialog.__init__(self, mw, Qt.Window)
         self.mw = mw

--- a/qt/aqt/main.py
+++ b/qt/aqt/main.py
@@ -400,7 +400,7 @@ close the profile or restart Anki."""
 
         self.taskman.run_in_background(downgrade, on_done)
 
-    def loadProfile(self, onsuccess: Optional[Callable] = None) -> None:
+    def loadProfile(self, onsuccess: Callable = None) -> None:
         if not self.loadCollection():
             return
 
@@ -753,7 +753,7 @@ from the profile screen."
         self,
         link: str,
         name: str,
-        key: Optional[str] = None,
+        key: str = None,
         class_: str = "",
         id: str = "",
         extra: str = "",
@@ -1552,7 +1552,7 @@ will be lost. Continue?"""
             _dummy1 = windll
             _dummy2 = wintypes
 
-    def maybeHideAccelerators(self, tgt: Optional[Any] = None) -> None:
+    def maybeHideAccelerators(self, tgt: Any = None) -> None:
         if not self.hideMenuAccels:
             return
         tgt = tgt or self

--- a/qt/aqt/models.py
+++ b/qt/aqt/models.py
@@ -187,7 +187,7 @@ class Models(QDialog):
 class AddModel(QDialog):
     model: Optional[NoteType]
 
-    def __init__(self, mw: AnkiQt, parent: Optional[QWidget] = None):
+    def __init__(self, mw: AnkiQt, parent: QWidget = None):
         self.parent_ = parent or mw
         self.mw = mw
         self.col = mw.col

--- a/qt/aqt/progress.py
+++ b/qt/aqt/progress.py
@@ -92,7 +92,7 @@ class ProgressManager:
         value=None,
         process=True,
         maybeShow=True,
-        max: Optional[int] = None,
+        max: int = None,
     ) -> None:
         # print self._min, self._counter, self._max, label, time.time() - self._lastTime
         if not self.mw.inMainThread():

--- a/qt/aqt/taskman.py
+++ b/qt/aqt/taskman.py
@@ -40,8 +40,8 @@ class TaskManager(QObject):
     def run_in_background(
         self,
         task: Callable,
-        on_done: Optional[Callable[[Future], None]] = None,
-        args: Optional[Dict[str, Any]] = None,
+        on_done: Callable[[Future], None] = None,
+        args: Dict[str, Any] = None,
     ) -> Future:
         """Run task on a background thread.
 
@@ -64,9 +64,9 @@ class TaskManager(QObject):
     def with_progress(
         self,
         task: Callable,
-        on_done: Optional[Callable[[Future], None]] = None,
-        parent: Optional[QWidget] = None,
-        label: Optional[str] = None,
+        on_done: Callable[[Future], None] = None,
+        parent: QWidget = None,
+        label: str = None,
         immediate: bool = False,
     ):
         self.mw.progress.start(parent=parent, label=label, immediate=immediate)

--- a/qt/aqt/taskman.py
+++ b/qt/aqt/taskman.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 from concurrent.futures import Future
 from concurrent.futures.thread import ThreadPoolExecutor
 from threading import Lock
-from typing import Any, Callable, Dict, List, Optional
+from typing import Any, Callable, Dict, List
 
 from PyQt5.QtCore import QObject, pyqtSignal
 

--- a/qt/aqt/theme.py
+++ b/qt/aqt/theme.py
@@ -3,7 +3,7 @@
 # License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
 import platform
-from typing import Dict, Optional
+from typing import Dict
 
 from anki.utils import isMac
 from aqt import QApplication, gui_hooks, isWin

--- a/qt/aqt/theme.py
+++ b/qt/aqt/theme.py
@@ -54,7 +54,7 @@ class ThemeManager:
 
         return cache.setdefault(path, icon)
 
-    def body_class(self, night_mode: Optional[bool] = None) -> str:
+    def body_class(self, night_mode: bool = None) -> str:
         "Returns space-separated class list for platform/theme."
         classes = []
         if isWin:
@@ -73,7 +73,7 @@ class ThemeManager:
         return " ".join(classes)
 
     def body_classes_for_card_ord(
-        self, card_ord: int, night_mode: Optional[bool] = None
+        self, card_ord: int, night_mode: bool = None
     ) -> str:
         "Returns body classes used when showing a card."
         return f"card card{card_ord+1} {self.body_class(night_mode)}"

--- a/qt/aqt/toolbar.py
+++ b/qt/aqt/toolbar.py
@@ -40,8 +40,8 @@ class Toolbar:
     def draw(
         self,
         buf: str = "",
-        web_context: Optional[Any] = None,
-        link_handler: Optional[Callable[[str], Any]] = None,
+        web_context: Any = None,
+        link_handler: Callable[[str], Any] = None,
     ) -> None:
         web_context = web_context or TopToolbar(self)
         link_handler = link_handler or self._linkHandler
@@ -67,8 +67,8 @@ class Toolbar:
         cmd: str,
         label: str,
         func: Callable,
-        tip: Optional[str] = None,
-        id: Optional[str] = None,
+        tip: str = None,
+        id: str = None,
     ) -> str:
         """Generates HTML link element and registers link handler
         
@@ -221,8 +221,8 @@ class BottomBar(Toolbar):
     def draw(
         self,
         buf: str = "",
-        web_context: Optional[Any] = None,
-        link_handler: Optional[Callable[[str], Any]] = None,
+        web_context: Any = None,
+        link_handler: Callable[[str], Any] = None,
     ) -> None:
         # note: some screens may override this
         web_context = web_context or BottomToolbar(self)

--- a/qt/aqt/toolbar.py
+++ b/qt/aqt/toolbar.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Dict, Optional
+from typing import Any, Dict
 
 import aqt
 from anki.lang import _

--- a/qt/aqt/webview.py
+++ b/qt/aqt/webview.py
@@ -194,7 +194,7 @@ class WebContent:
 
 class AnkiWebView(QWebEngineView):
     def __init__(
-        self, parent: Optional[QWidget] = None, title: str = "default"
+        self, parent: QWidget = None, title: str = "default"
     ) -> None:
         QWebEngineView.__init__(self, parent=parent)
         self.title = title  # type: ignore
@@ -362,10 +362,10 @@ class AnkiWebView(QWebEngineView):
     def stdHtml(
         self,
         body: str,
-        css: Optional[List[str]] = None,
-        js: Optional[List[str]] = None,
+        css: List[str] = None,
+        js: List[str] = None,
         head: str = "",
-        context: Optional[Any] = None,
+        context: Any = None,
     ):
 
         web_content = WebContent(


### PR DESCRIPTION
In a parameter assignment, if the default value is None, then `Optional[]` is implied

```python
# optional_test.py

def test(x: int = None):
    reveal_type(x)
```

```
$ mypy optional_test.py
optional_test.py:4: note: Revealed type is 'Union[builtins.int, None]'
```

I noticed this come up in https://github.com/ankitects/anki/pull/410#discussion_r362962695 and confirmed that Optional there is not required. This pull request removes all extra Optiona[] annotations.

Note: Optional is not implied in variable assignment like `x: int = None` though I'm not sure why not.