### PR TITLE
Only autoplay added media when recording in editor

### DIFF
--- a/qt/aqt/editor.py
+++ b/qt/aqt/editor.py
@@ -741,6 +741,7 @@ to a cloze type first, via 'Notes>Change Note Type'"""
             )
             return
         if file:
+            av_player.play_file(file)
             self.addMedia(file)
 
     # Media downloads
@@ -758,7 +759,6 @@ to a cloze type first, via 'Notes>Change Note Type'"""
             name = urllib.parse.quote(fname.encode("utf8"))
             return '<img src="%s">' % name
         else:
-            av_player.play_file(fname)
             return "[sound:%s]" % fname
 
     def urlToFile(self, url: str) -> Optional[str]:


### PR DESCRIPTION
With the recent change in drag & drop code, dropping media files onto the editor screen outside fields still play these files even though they're not added to the note. This is because the dropped data is processed before detecting if the drop falls in the fields area.
Doing `doDrop`'s job in the drag & drop event handlers (and before calling `_processMime`) instead seems to be a bit involved since accepting or rejecting the events would depend on the result of the asynchronous evalWithCallback.

I think it's better to only autoplay media when recording. Autoplay in this case is useful to check how the recorded audio sounds, but in other cases users can simply open the media file they're adding if they want to check it.

A bit unrelated, but audio recording has a delay issue where actual recording starts several seconds after the recording message box appears (at least in my case).