### PR TITLE
Fix unanchored regex in bulk tag add routine

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -47,6 +47,7 @@ Alexander Presnyakov <flagist0@gmail.com>
 abdo <github.com/ANH25>
 aplaice <plaice.adam+github@gmail.com>
 phwoo <github.com/phwoo> 
+Soren Bjornstad <anki@sorenbjornstad.com>
 
 ********************
 

--- a/rslib/src/tags.rs
+++ b/rslib/src/tags.rs
@@ -152,7 +152,7 @@ impl Collection {
         let matcher = regex::RegexSet::new(
             tags.iter()
                 .map(|s| regex::escape(s))
-                .map(|s| format!("(?i){}", s)),
+                .map(|s| format!("(?i)^{}$", s)),
         )
         .map_err(|_| AnkiError::invalid_input("invalid regex"))?;
 


### PR DESCRIPTION
Previously, attempting to add a substring of an existing tag, for instance using the "Add Tags" option in the browser, sometimes did nothing. For example, with the tag `foobar` present on a note, you could not add the tag `foo`, `bar` or `oob`. Because the match was unanchored, the regex checking whether the tag already existed would match the longer string and thus conclude that the tag was already present when it was not.

Looks like my last contribution was before the introduction of the `CONTRIBUTORS` file, so filling that in too.

`make check` is not passing, but the format errors it is showing are files I did not touch, and I just pulled from master under an hour ago. Let me know if there's something else I should be doing.

```
python -m black --check -t py36 anki tests setup.py tools/*.py --exclude='_pb2|buildinfo|_gen'
would reformat /home/soren/cabinet/World/Software/Linux/Cache/anki/pylib/anki/cards.py
would reformat /home/soren/cabinet/World/Software/Linux/Cache/anki/pylib/tools/genhooks.py
would reformat /home/soren/cabinet/World/Software/Linux/Cache/anki/pylib/anki/rsbackend.py
would reformat /home/soren/cabinet/World/Software/Linux/Cache/anki/pylib/anki/models.py
would reformat /home/soren/cabinet/World/Software/Linux/Cache/anki/pylib/anki/hooks.py
would reformat /home/soren/cabinet/World/Software/Linux/Cache/anki/pylib/anki/decks.py
would reformat /home/soren/cabinet/World/Software/Linux/Cache/anki/pylib/anki/stats.py
would reformat /home/soren/cabinet/World/Software/Linux/Cache/anki/pylib/anki/schedv2.py
Oh no! 💥 💔 💥
8 files would be reformatted, 56 files would be left unchanged.
make[1]: *** [Makefile:97: .build/fmt] Error 1
make[1]: Leaving directory '/home/soren/cabinet/World/Software/Linux/Cache/anki/pylib'
make: *** [Makefile:158: check] Error 2
```