### PR TITLE
Remove unicode isolation markers from add-on config editor title

### DIFF
--- a/qt/aqt/addons.py
+++ b/qt/aqt/addons.py
@@ -25,7 +25,7 @@ import anki
 import aqt
 import aqt.forms
 from anki.httpclient import HttpClient
-from anki.lang import _, ngettext
+from anki.lang import _, ngettext, without_unicode_isolation
 from aqt import gui_hooks
 from aqt.qt import *
 from aqt.utils import (
@@ -1293,9 +1293,11 @@ class ConfigEditor(QDialog):
         restoreGeom(self, "addonconf")
         restoreSplitter(self.form.splitter, "addonconf")
         self.setWindowTitle(
-            tr(
-                TR.ADDONS_CONFIG_WINDOW_TITLE,
-                name=self.mgr.addon_meta(addon).human_name(),
+            without_unicode_isolation(
+                tr(
+                    TR.ADDONS_CONFIG_WINDOW_TITLE,
+                    name=self.mgr.addon_meta(addon).human_name(),
+                )
             )
         )
         self.show()


### PR DESCRIPTION
They show as squares in some systems (e.g. Windows 7).

![anki-demo-1](https://user-images.githubusercontent.com/41397710/91670041-6d192000-eb22-11ea-8ca3-87e4655f79a4.PNG)
