### PR TITLE
Tweak stats range box items' padding

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -54,7 +54,7 @@ neitrinoweb <github.com/neitrinoweb/>
 Andreas Reis <github.com/rathsky>
 Matt Krump <github.com/mkrump>
 Alexander Presnyakov <flagist0@gmail.com>
-abdo <github.com/ANH25>
+abdo <github.com/abdnh>
 aplaice <plaice.adam+github@gmail.com>
 phwoo <github.com/phwoo>
 Soren Bjornstad <anki@sorenbjornstad.com>

--- a/ts/src/stats/graphs.scss
+++ b/ts/src/stats/graphs.scss
@@ -108,7 +108,7 @@
 }
 
 .range-box-inner > * {
-    padding-right: 1em;
+    padding-inline-end: 1em;
 }
 
 .graph .area {


### PR DESCRIPTION
Just a small padding tweak to fix a cramped radio button in RTL layout.

<img src="https://user-images.githubusercontent.com/41397710/92422141-b7cf1380-f184-11ea-9686-1ef958d9a0ed.PNG" width="340">
<img src="https://user-images.githubusercontent.com/41397710/92422170-e64cee80-f184-11ea-9a7c-e0709ae4302f.PNG" width="340">
