### PR TITLE
Change 'Show Both Sides' to 'Answer Side Only'

### DIFF
--- a/qt/aqt/previewer.py
+++ b/qt/aqt/previewer.py
@@ -81,8 +81,8 @@ class Previewer(QDialog):
         qconnect(self._replay.clicked, self._on_replay_audio)
 
         answer_only_button = QCheckBox(_("Answer Side Only"))
-        answer_only_button.setShortcut(QKeySequence("B"))
-        answer_only_button.setToolTip(_("Shortcut key: %s" % "B"))
+        answer_only_button.setShortcut(QKeySequence("A"))
+        answer_only_button.setToolTip(_("Shortcut key: %s" % "A"))
         self.bbox.addButton(answer_only_button, QDialogButtonBox.ActionRole)
         self._show_only_answer = self.mw.col.conf.get("previewOnlyAnswer", False)
         answer_only_button.setChecked(self._show_only_answer)


### PR DESCRIPTION
See https://forums.ankiweb.net/t/misnamed-button-in-card-previewer/3485

Should the autoplay code be changed? maybe to only play audio from answer side, or additionally play question side only in the presence of FrontSide, or maybe we shoud just call `_on_replay_audio` (in this case, playback when this is toggled on will depend on the “Always include question side when replaying audio“ deck option I think)?
