### PR TITLE
Fix previewer not refreshing when selecting multiple cards in browser

### DIFF
--- a/qt/aqt/browser.py
+++ b/qt/aqt/browser.py
@@ -877,6 +877,7 @@ QTableView {{ gridline-color: {grid} }}
         if not show:
             self.editor.setNote(None)
             self.singleCard = False
+            self._renderPreview()
         else:
             self.editor.setNote(self.card.note(reload=True), focusTo=self.focusTo)
             self.focusTo = None


### PR DESCRIPTION
See https://forums.ankiweb.net/t/previewer-nonetype-error-for-audio-if-additional-card-selected/3638

The call to Editor.setNote in Browser._onRowChanged eventually results in a call
to Browser._renderPreview only when `note` is not None (i.e., when a single card is selected).
I just added an explicit call to Browser._renderPreview.

