### PR TITLE
Escape browser sidebar search terms

### DIFF
--- a/qt/aqt/browser.py
+++ b/qt/aqt/browser.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import html
+import re
 import time
 from dataclasses import dataclass
 from enum import Enum
@@ -1219,7 +1220,7 @@ QTableView {{ gridline-color: {grid} }}
                 if c % 2 == 0:
                     txt += a + ":"
                 else:
-                    txt += a
+                    txt += re.sub(r"(\*|%|_)", r"\\\1", a)
                     for chr in " 　()":
                         if chr in txt:
                             txt = '"%s"' % txt


### PR DESCRIPTION
Special characters (`*`, `%`, `_`) in the browser sidebar search terms are not escaped.

I noticed this after this [forum post](https://forums.ankiweb.net/t/filtering-symbols/3692).

Another issue not fixed here: escape sequences don't seem to work when searching in fields (e.g. the asterisk is not escaped in `front:\*`).
