### PR TITLE
added *.sh eol=lf to .gitattributes 

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 *.ftl eol=lf
+*.sh eol=lf

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -60,6 +60,7 @@ phwoo <github.com/phwoo>
 Soren Bjornstad <anki@sorenbjornstad.com>
 Aleksa Sarai <cyphar@cyphar.com>
 Jakub Kaczmarzyk <jakub.kaczmarzyk@gmail.com>
+lukkea <github.com/lukkea/>
 
 ********************
 


### PR DESCRIPTION
git wouldn't pick up the .sh files with crlf endings but I suspect it was my environment that caused this rather than crlf existing in the codebase.
this change should ensure such changes don't make it into the codebase.