### PR TITLE
Process local ico files like other image formats

### DIFF
--- a/qt/aqt/editor.py
+++ b/qt/aqt/editor.py
@@ -43,7 +43,7 @@ from aqt.utils import (
 )
 from aqt.webview import AnkiWebView
 
-pics = ("jpg", "jpeg", "png", "tif", "tiff", "gif", "svg", "webp")
+pics = ("jpg", "jpeg", "png", "tif", "tiff", "gif", "svg", "webp", "ico")
 audio = (
     "wav",
     "mp3",


### PR DESCRIPTION
Local icons are being pasted as normal links (through _processText) in the editor even though they can be displayed with img tags.