### PR TITLE
fix: sizing issue with scale UI

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -60,6 +60,7 @@ phwoo <github.com/phwoo>
 Soren Bjornstad <anki@sorenbjornstad.com>
 Aleksa Sarai <cyphar@cyphar.com>
 Jakub Kaczmarzyk <jakub.kaczmarzyk@gmail.com>
+Akshara Balachandra <akshara.bala.18@gmail.com>
 
 ********************
 

--- a/qt/aqt/webview.py
+++ b/qt/aqt/webview.py
@@ -4,7 +4,6 @@
 
 import dataclasses
 import json
-import math
 import re
 import sys
 from typing import Any, Callable, List, Optional, Sequence, Tuple
@@ -580,12 +579,7 @@ body {{ zoom: {zoom}; background: {background}; direction: {lang_dir}; {font} }}
             mw.progress.timer(1000, mw.reset, False)
             return
 
-        scaleFactor = self.zoomFactor()
-        if scaleFactor == 1:
-            scaleFactor = mw.pm.uiScale()
-
-        height = math.ceil(qvar * scaleFactor)
-        self.setFixedHeight(height)
+        self.setFixedHeight(qvar)
 
     def set_bridge_command(self, func: Callable[[str], Any], context: Any) -> None:
         """Set a handler for pycmd() messages received from Javascript.


### PR DESCRIPTION
Fixes ankitects/help-wanted#18. Height of webview should be the height
of the contents inside it. Previously, scale factors increased fixed
height of the container webview, thus creating empty space (e.g.
at 200% scaling, height of webview was double the height of the inner
HTML page). Now height of webview is always the height of the contained
element.