### PR TITLE
Always focus main web instead of bottom web in reviewer

### DIFF
--- a/qt/aqt/reviewer.py
+++ b/qt/aqt/reviewer.py
@@ -201,9 +201,7 @@ class Reviewer:
         self._drawFlag()
         self._drawMark()
         self._showAnswerButton()
-        # if we have a type answer field, focus main web
-        if self.typeCorrect:
-            self.mw.web.setFocus()
+        self.mw.web.setFocus()
         # user hook
         gui_hooks.reviewer_did_show_question(c)
 
@@ -242,6 +240,7 @@ class Reviewer:
         # render and update bottom
         self.web.eval("_showAnswer(%s);" % json.dumps(a))
         self._showEaseButtons()
+        self.mw.web.setFocus()
         # user hook
         gui_hooks.reviewer_did_show_answer(c)
 
@@ -574,8 +573,6 @@ time = %(time)d;
         )
 
     def _showAnswerButton(self) -> None:
-        if not self.typeCorrect:
-            self.bottom.web.setFocus()
         middle = """
 <span class=stattxt>%s</span><br>
 <button title="%s" id=ansbut onclick='pycmd("ans");'>%s</button>""" % (
@@ -596,7 +593,6 @@ time = %(time)d;
         self.bottom.web.adjustHeightToFit()
 
     def _showEaseButtons(self) -> None:
-        self.bottom.web.setFocus()
         middle = self._answerButtons()
         self.bottom.web.eval("showAnswer(%s);" % json.dumps(middle))
 

--- a/qt/aqt/reviewer.py
+++ b/qt/aqt/reviewer.py
@@ -575,7 +575,7 @@ time = %(time)d;
     def _showAnswerButton(self) -> None:
         middle = """
 <span class=stattxt>%s</span><br>
-<button title="%s" id=ansbut onclick='pycmd("ans");'>%s</button>""" % (
+<button title="%s" id="ansbut" class="focus" onclick='pycmd("ans");'>%s</button>""" % (
             self._remaining(),
             _("Shortcut key: %s") % _("Space"),
             _("Show Answer"),
@@ -644,7 +644,7 @@ time = %(time)d;
 
         def but(i, label):
             if i == default:
-                extra = "id=defease"
+                extra = """id="defease" class="focus" """
             else:
                 extra = ""
             due = self._buttonTime(i)

--- a/qt/ts/scss/reviewer-bottom.scss
+++ b/qt/ts/scss/reviewer-bottom.scss
@@ -41,7 +41,7 @@ button {
     outline: 5px auto rgba(0, 103, 244, 0.247);
 
     &:focus {
-        outline-color: rgba(92, 160, 255, 0.247);
+        outline-color: rgba(103, 103, 244, 0.247);
     }
 }
 

--- a/qt/ts/scss/reviewer-bottom.scss
+++ b/qt/ts/scss/reviewer-bottom.scss
@@ -40,8 +40,12 @@ button {
 .focus {
     outline: 5px auto rgba(0, 103, 244, 0.247);
 
-    &:focus {
-        outline-color: rgba(103, 103, 244, 0.247);
+    #innertable:focus-within & {
+        outline: unset;
+
+        &:focus {
+            outline: 5px auto rgba(0, 103, 244, 0.247);
+        }
     }
 }
 

--- a/qt/ts/scss/reviewer-bottom.scss
+++ b/qt/ts/scss/reviewer-bottom.scss
@@ -33,7 +33,17 @@ button {
     white-space: nowrap;
 }
 
-#ansbut { margin-bottom: 1em; }
+#ansbut {
+    margin-bottom: 1em;
+}
+
+.focus {
+    outline: 5px auto rgba(0, 103, 244, 0.247);
+
+    &:focus {
+        outline-color: rgba(92, 160, 255, 0.247);
+    }
+}
 
 .nobold {
     font-weight: normal;

--- a/qt/ts/src/reviewer-bottom.ts
+++ b/qt/ts/src/reviewer-bottom.ts
@@ -36,14 +36,12 @@ let updateTime = function () {
 function showQuestion(txt, maxTime_) {
     // much faster than jquery's .html()
     $("#middle")[0].innerHTML = txt;
-    $("#ansbut").focus();
     time = 0;
     maxTime = maxTime_;
 }
 
 function showAnswer(txt) {
     $("#middle")[0].innerHTML = txt;
-    $("#defease").focus();
 }
 
 function selectedAnswerButton() {


### PR DESCRIPTION
The reviewer by default usually focuses the bottom bar, unless there's a typing field in the card.

However there are many cases, where you'd still prefer focusing the main web instead of the bottom bar: That is, if there are key event listeners on the card, which some card types do (like Image Occlusion Enhanced, and my Closet card types).

There's this [add-on](https://ankiweb.net/shared/info/1642550423), which realizes this by using the gui hooks. I have used this add-on for a very long time now. And I don't really see the point of the Anki built-in functionality as opposed to what this add-on does.

Key events sent to the main web can still be received by the bottom bar (1, 2, 3, 4, Space, and E, etc.), so it seems like no functionality is lost.