### PR TITLE
Fix "Sign Up" link location

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -62,6 +62,7 @@ Aleksa Sarai <cyphar@cyphar.com>
 Jakub Kaczmarzyk <jakub.kaczmarzyk@gmail.com>
 Akshara Balachandra <akshara.bala.18@gmail.com>
 lukkea <github.com/lukkea/>
+David Allison <davidallisongithub@gmail.com>
 
 ********************
 

--- a/qt/aqt/sync.py
+++ b/qt/aqt/sync.py
@@ -292,7 +292,7 @@ def get_id_and_pass_from_user(
     vbox = QVBoxLayout()
     info_label = QLabel(
         without_unicode_isolation(
-            tr(TR.SYNC_ACCOUNT_REQUIRED, link="https://ankiweb.net/account/login")
+            tr(TR.SYNC_ACCOUNT_REQUIRED, link="https://ankiweb.net/account/register")
         )
     )
     info_label.setOpenExternalLinks(True)


### PR DESCRIPTION
String states "Sign Up", but currently points to the "Sign In" screen: https://ankiweb.net/account/login

https://github.com/ankitects/anki/blob/aff28a38e56356582179c3330c3de00e02ae2ec4/rslib/ftl/sync.ftl#L38-L42

----

Untested as this is a trivial fix