### PR TITLE
Fix late blur causing IndexError

### DIFF
--- a/qt/aqt/editor.py
+++ b/qt/aqt/editor.py
@@ -388,7 +388,7 @@ class Editor:
                 nid = int(nid)
             except ValueError:
                 nid = 0
-            if nid != self.note.id:
+            if nid != self.note.id or ord >= len(self.note.fields):
                 print("ignored late blur")
                 return
 


### PR DESCRIPTION
In the Add screen, changing note type to another type with less fields using Ctrl+N throws an exception
if a field in the previous type with an ordinal higher than the maximum field ordinal
of the new type was focused prior to the note type change.
This is due to late blur processing in onBridgeCmd.

I'm not sure if this is the right way to fix it, since late blur events with in-range `ord` values are still processed. But this doesn't seem to cause any visible issues (aside from unnecessary processing maybe).
I remember reading a post by some user somewhere in the forum that the id of the note being created changed to be always 0 recently, so I assume `nid != self.note.id` was a sufficient condition.
