### PR TITLE
Refactor Buttons in editor and add editor_did_init_left_buttons gui_hook

### DIFF
--- a/qt/aqt/editor.py
+++ b/qt/aqt/editor.py
@@ -216,7 +216,7 @@ class Editor:
 
     def addButton(
         self,
-        icon: str,
+        icon: Optional[str],
         cmd: str,
         func: Callable[["Editor"], None],
         tip: str = "",
@@ -250,7 +250,7 @@ class Editor:
 
     def _addButton(
         self,
-        icon: str,
+        icon: Optional[str],
         cmd: str,
         tip: str = "",
         label: str = "",

--- a/qt/aqt/editor.py
+++ b/qt/aqt/editor.py
@@ -284,12 +284,11 @@ class Editor:
         else:
             toggleScript = ""
         tip = shortcut(tip)
-        theclass = class_
         if not disables:
-            theclass += " perm"
+            class_ += " perm"
         return """ <button tabindex=-1
                         {id}
-                        class="{theclass}"
+                        class="{class_}"
                         type="button"
                         title="{tip}"
                         onclick="pycmd('{cmd}');{togglesc}return false;"
@@ -303,7 +302,7 @@ class Editor:
             labelelm=labelelm,
             id=idstr,
             togglesc=toggleScript,
-            theclass=theclass,
+            class_=class_,
         )
 
     def setupShortcuts(self) -> None:

--- a/qt/aqt/editor.py
+++ b/qt/aqt/editor.py
@@ -137,6 +137,8 @@ class Editor:
             ),
         ]
 
+        gui_hooks.editor_did_init_left_buttons(lefttopbtns, self)
+
         righttopbtns: List[str] = [
             self._addButton("text_bold", "bold", _("Bold text (Ctrl+B)"), id="bold"),
             self._addButton(

--- a/qt/aqt/editor.py
+++ b/qt/aqt/editor.py
@@ -118,6 +118,25 @@ class Editor:
         self.web.set_bridge_command(self.onBridgeCmd, self)
         self.outerLayout.addWidget(self.web, 1)
 
+        lefttopbtns: List[str] = [
+            self._addButton(
+                None,
+                "fields",
+                _("Customize Fields"),
+                _("Fields") + "...",
+                class_="",
+                disables=False,
+            ),
+            self._addButton(
+                None,
+                "cards",
+                _("Customize Card Templates (Ctrl+L)"),
+                _("Cards") + "...",
+                class_="",
+                disables=False,
+            ),
+        ]
+
         righttopbtns: List[str] = [
             self._addButton("text_bold", "bold", _("Bold text (Ctrl+B)"), id="bold"),
             self._addButton(
@@ -131,68 +150,47 @@ class Editor:
             ),
             self._addButton("text_sub", "sub", _("Subscript (Ctrl+=)"), id="subscript"),
             self._addButton("text_clear", "clear", _("Remove formatting (Ctrl+R)")),
+            self._addButton(
+                None,
+                "colour",
+                _("Set foreground colour (F7)"),
+                """
+<div id="forecolor"
+     style="display: inline-block; background: #000; border-radius: 5px;"
+     class="topbut"
+>""",
+            ),
+            self._addButton(
+                None,
+                "changeCol",
+                _("Change colour (F8)"),
+                """
+<div style="display: inline-block; border-radius: 5px;"
+     class="topbut rainbow"
+>""",
+            ),
+            self._addButton("text_cloze", "cloze", _("Cloze deletion (Ctrl+Shift+C)")),
+            self._addButton(
+                "paperclip", "attach", _("Attach pictures/audio/video (F3)")
+            ),
+            self._addButton("media-record", "record", _("Record audio (F5)")),
+            self._addButton("more", "more"),
         ]
-        # The color selection buttons do not use an icon so the HTML must be specified manually
-        tip = _("Set foreground colour (F7)")
-        righttopbtns.append(
-            """ <button tabindex=-1
-                        class=linkb
-                        title="{}"
-                        type="button"
-                        onclick="pycmd('colour'); return false;"
-                >
-                    <div id=forecolor
-                         style="display:inline-block; background: #000;border-radius: 5px;"
-                         class=topbut
-                    >
-                    </div>
-                </button>""".format(
-                tip
-            )
-        )
-        tip = _("Change colour (F8)")
-        righttopbtns.extend(
-            [
-                """<button tabindex=-1
-                        class=linkb
-                        title="{}"
-                        type="button"
-                        onclick="pycmd('changeCol');return false;"
-                >
-                    <div style="display:inline-block; border-radius: 5px;"
-                         class="topbut rainbow"
-                    >
-                    </div>
-                </button>""".format(
-                    tip
-                ),
-                self._addButton(
-                    "text_cloze", "cloze", _("Cloze deletion (Ctrl+Shift+C)")
-                ),
-                self._addButton(
-                    "paperclip", "attach", _("Attach pictures/audio/video (F3)")
-                ),
-                self._addButton("media-record", "record", _("Record audio (F5)")),
-                self._addButton("more", "more"),
-            ]
-        )
+
         gui_hooks.editor_did_init_buttons(righttopbtns, self)
         # legacy filter
         righttopbtns = runFilter("setupEditorButtons", righttopbtns, self)
+
         topbuts = """
             <div id="topbutsleft" style="float:left;">
-                <button title='%(fldsTitle)s' onclick="pycmd('fields')">%(flds)s...</button>
-                <button title='%(cardsTitle)s' onclick="pycmd('cards')">%(cards)s...</button>
+                %(leftbts)s
             </div>
             <div id="topbutsright" style="float:right;">
                 %(rightbts)s
             </div>
         """ % dict(
-            flds=_("Fields"),
-            cards=_("Cards"),
+            leftbts="".join(lefttopbtns),
             rightbts="".join(righttopbtns),
-            fldsTitle=_("Customize Fields"),
-            cardsTitle=shortcut(_("Customize Card Templates (Ctrl+L)")),
         )
         bgcol = self.mw.app.palette().window().color().name()  # type: ignore
         # then load page
@@ -227,6 +225,7 @@ class Editor:
         toggleable: bool = False,
         keys: str = None,
         disables: bool = True,
+        class_: str = "linkb",
     ):
         """Assign func to bridge cmd, register shortcut, return button"""
         if func:
@@ -245,6 +244,7 @@ class Editor:
             id=id,
             toggleable=toggleable,
             disables=disables,
+            class_=class_,
         )
         return btn
 
@@ -257,6 +257,7 @@ class Editor:
         id: Optional[str] = None,
         toggleable: bool = False,
         disables: bool = True,
+        class_: str = "linkb",
     ) -> str:
         if icon:
             if icon.startswith("qrc:/"):
@@ -281,7 +282,7 @@ class Editor:
         else:
             toggleScript = ""
         tip = shortcut(tip)
-        theclass = "linkb"
+        theclass = class_
         if not disables:
             theclass += " perm"
         return """ <button tabindex=-1

--- a/qt/aqt/editor.py
+++ b/qt/aqt/editor.py
@@ -124,16 +124,16 @@ class Editor:
                 "fields",
                 _("Customize Fields"),
                 _("Fields") + "...",
-                class_="",
                 disables=False,
+                rightside=False,
             ),
             self._addButton(
                 None,
                 "cards",
                 _("Customize Card Templates (Ctrl+L)"),
                 _("Cards") + "...",
-                class_="",
                 disables=False,
+                rightside=False,
             ),
         ]
 
@@ -227,7 +227,7 @@ class Editor:
         toggleable: bool = False,
         keys: str = None,
         disables: bool = True,
-        class_: str = "linkb",
+        rightside: bool = True,
     ):
         """Assign func to bridge cmd, register shortcut, return button"""
         if func:
@@ -246,7 +246,7 @@ class Editor:
             id=id,
             toggleable=toggleable,
             disables=disables,
-            class_=class_,
+            rightside=rightside,
         )
         return btn
 
@@ -259,7 +259,7 @@ class Editor:
         id: Optional[str] = None,
         toggleable: bool = False,
         disables: bool = True,
-        class_: str = "linkb",
+        rightside: bool = True,
     ) -> str:
         if icon:
             if icon.startswith("qrc:/"):
@@ -284,6 +284,10 @@ class Editor:
         else:
             toggleScript = ""
         tip = shortcut(tip)
+        if rightside:
+            class_ = "linkb"
+        else:
+            class_ = ""
         if not disables:
             class_ += " perm"
         return """ <button tabindex=-1

--- a/qt/aqt/gui_hooks.py
+++ b/qt/aqt/gui_hooks.py
@@ -1401,6 +1401,33 @@ class _EditorDidInitButtonsHook:
 editor_did_init_buttons = _EditorDidInitButtonsHook()
 
 
+class _EditorDidInitLeftButtonsHook:
+    _hooks: List[Callable[[List[str], "aqt.editor.Editor"], None]] = []
+
+    def append(self, cb: Callable[[List[str], "aqt.editor.Editor"], None]) -> None:
+        """(buttons: List[str], editor: aqt.editor.Editor)"""
+        self._hooks.append(cb)
+
+    def remove(self, cb: Callable[[List[str], "aqt.editor.Editor"], None]) -> None:
+        if cb in self._hooks:
+            self._hooks.remove(cb)
+
+    def count(self) -> int:
+        return len(self._hooks)
+
+    def __call__(self, buttons: List[str], editor: aqt.editor.Editor) -> None:
+        for hook in self._hooks:
+            try:
+                hook(buttons, editor)
+            except:
+                # if the hook fails, remove it
+                self._hooks.remove(hook)
+                raise
+
+
+editor_did_init_left_buttons = _EditorDidInitLeftButtonsHook()
+
+
 class _EditorDidInitShortcutsHook:
     _hooks: List[Callable[[List[Tuple], "aqt.editor.Editor"], None]] = []
 

--- a/qt/tools/genhooks_gui.py
+++ b/qt/tools/genhooks_gui.py
@@ -607,6 +607,10 @@ gui_hooks.webview_did_inject_style_into_page.append(mytest)
     # Editing
     ###################
     Hook(
+        name="editor_did_init_left_buttons",
+        args=["buttons: List[str]", "editor: aqt.editor.Editor"],
+    ),
+    Hook(
         name="editor_did_init_buttons",
         args=["buttons: List[str]", "editor: aqt.editor.Editor"],
     ),


### PR DESCRIPTION
This will adds a new parameter to the `Editor._addButton` and `Editor.addButton` methods, so that they can used for the "Fields..." and "Cards..." buttons in the editor as well.

It also adds the `editor_did_init_left_buttons` hook, which works analogously to `editor_did_init_buttons`.

My personal use case is for the [Asset Manager](https://ankiweb.net/shared/info/656021484) add-on, which allows you to manage assets per note type. Adding a button directly in the editor, which lets you access these assets would be a nice feature.