### PR TITLE
Add .opus as an audio extension

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -63,6 +63,7 @@ Jakub Kaczmarzyk <jakub.kaczmarzyk@gmail.com>
 Akshara Balachandra <akshara.bala.18@gmail.com>
 lukkea <github.com/lukkea/>
 David Allison <davidallisongithub@gmail.com>
+Piotr Kubowicz <piotr.kubowicz@gmail.com>
 
 ********************
 

--- a/qt/aqt/sound.py
+++ b/qt/aqt/sound.py
@@ -72,14 +72,15 @@ class Player(ABC):
 
 
 AUDIO_EXTENSIONS = {
-    "wav",
-    "mp3",
-    "ogg",
+    "3gp",
     "flac",
     "m4a",
-    "3gp",
-    "spx",
+    "mp3",
     "oga",
+    "ogg",
+    "opus",
+    "spx",
+    "wav",
 }
 
 


### PR DESCRIPTION
Wikimedia Commons has pronunciation recordings with .opus extension.
Anki is able to play such files, but until now adding them required
changing the extension to .ogg or some other supported one.

Also sort the audio extensions list.