### PR TITLE
Don't apply suggestion when no suggestion list is shown in tagedit

### DIFF
--- a/qt/aqt/tagedit.py
+++ b/qt/aqt/tagedit.py
@@ -56,7 +56,10 @@ class TagEdit(QLineEdit):
             if not self.completer.setCurrentRow(cur_row + 1):
                 self.completer.setCurrentRow(0)
             return
-        if evt.key() in (Qt.Key_Enter, Qt.Key_Return):
+        if (
+            evt.key() in (Qt.Key_Enter, Qt.Key_Return)
+            and self.completer.popup().isVisible()
+        ):
             # apply first completion if no suggestion selected
             selected_row = self.completer.popup().currentIndex().row()
             if selected_row == -1:


### PR DESCRIPTION
Pressing Enter on a tagedit selects a suggestion even when the suggestion list is not shown in some cases. This could cause confusion especially in the deck override option, where clicking Enter (with no text entered) selects some deck and closes the widget without giving any indicator that the option was activated.
