### PR TITLE
Set card to None in reviewer cleanup

### DIFF
--- a/qt/aqt/reviewer.py
+++ b/qt/aqt/reviewer.py
@@ -76,6 +76,7 @@ class Reviewer:
 
     def cleanup(self) -> None:
         gui_hooks.reviewer_will_end()
+        self.card = None
 
     # Fetching a card
     ##########################################################################


### PR DESCRIPTION
Is there a reason reviewer.card is kept after cleanup? This causes the browser to show the card whenever it's opened.
This came up in this [forum thread](https://forums.ankiweb.net/t/stop-anki-from-showing-the-next-card-when-opening-browser-from-the-study-screen/2651) previously.
I originally thought this was causing an importing problem I had but I was wrong, then I figured this could be a useful change anyway.