### PR TITLE
NF: uses consts and update comment according to code

### DIFF
--- a/pylib/tests/test_schedv1.py
+++ b/pylib/tests/test_schedv1.py
@@ -135,8 +135,8 @@ def test_learn():
     note["Front"] = "one"
     note["Back"] = "two"
     col.addNote(note)
-    # set as a learn card and rebuild queues
-    col.db.execute("update cards set queue=0, type=0")
+    # set as a new card and rebuild queues
+    col.db.execute(f"update cards set queue={QUEUE_TYPE_NEW}, type={CARD_TYPE_NEW}")
     col.reset()
     # sched.getCard should return it, since it's due in the past
     c = col.sched.getCard()
@@ -215,8 +215,8 @@ def test_learn_collapsed():
     note = col.newNote()
     note["Front"] = "2"
     col.addNote(note)
-    # set as a learn card and rebuild queues
-    col.db.execute("update cards set queue=0, type=0")
+    # set as a new card and rebuild queues
+    col.db.execute(f"update cards set queue={QUEUE_TYPE_NEW}, type={CARD_TYPE_NEW}")
     col.reset()
     # should get '1' first
     c = col.sched.getCard()

--- a/pylib/tests/test_schedv2.py
+++ b/pylib/tests/test_schedv2.py
@@ -137,8 +137,8 @@ def test_learn():
     note["Front"] = "one"
     note["Back"] = "two"
     col.addNote(note)
-    # set as a learn card and rebuild queues
-    col.db.execute("update cards set queue=0, type=0")
+    # set as a new card and rebuild queues
+    col.db.execute(f"update cards set queue={QUEUE_TYPE_NEW}, type={CARD_TYPE_NEW}")
     col.reset()
     # sched.getCard should return it, since it's due in the past
     c = col.sched.getCard()
@@ -252,8 +252,8 @@ def test_learn_collapsed():
     note = col.newNote()
     note["Front"] = "2"
     col.addNote(note)
-    # set as a learn card and rebuild queues
-    col.db.execute("update cards set queue=0, type=0")
+    # set as a new card and rebuild queues
+    col.db.execute(f"update cards set queue={QUEUE_TYPE_NEW}, type={CARD_TYPE_NEW}")
     col.reset()
     # should get '1' first
     c = col.sched.getCard()


### PR DESCRIPTION
The comment did not correctly described the action done. I corrected the comment, but maybe the code should be corrected. It is not clear to me. After all, setting a card to new seems useless. However, setting the card to lern is also useless since it naturally goes to learning mode 


Probably unrelated:  I can't run `make fix`, it leads to

> info: rolling back changes
> error: could not rename component file from '/home/milchior/.rustup/tmp/_l4h4dum3v_7ijjw_dir/bk' to '/home/milchior/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/share/zsh'
> error: could not rename component file from '/home/milchior/.rustup/tmp/s987bokzjjimz4nk_dir/bk' to '/home/milchior/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/etc'
> error: failed to install component: 'rustc-x86_64-unknown-linux-gnu', detected conflict: '"bin/rust-lldb"'
> make[1]: *** [Makefile:91: .build/tools] Error 1
> make[1]: Leaving directory '/home/milchior/anki/source/rspy'
> make: *** [Makefile:94: develop] Error 2
> 