### PR TITLE
Escape double quotes in search

### DIFF
--- a/qt/aqt/browser.py
+++ b/qt/aqt/browser.py
@@ -1221,9 +1221,9 @@ QTableView {{ gridline-color: {grid} }}
                     txt += a + ":"
                 else:
                     txt += re.sub(r"(\*|%|_)", r"\\\1", a)
-                    for chr in " 　()":
+                    for chr in ' 　()"':
                         if chr in txt:
-                            txt = '"%s"' % txt
+                            txt = '"%s"' % txt.replace('"', '\\"')
                             break
                     items.append(txt)
                     txt = ""


### PR DESCRIPTION
Double quotes are allowed in all kinds of names except in decks, but they are not escaped in search.

Is there a reason they are disallowed only in deck names? At least in the case of tags, it seems this was the [old behavior](https://github.com/ankitects/anki/commit/da66844f6bfb505fad66c349a3ab627298425556), but it was lost with the transition to Rust in https://github.com/ankitects/anki/commit/ac4284b2de285efd5451146e68d3e5195bbfd2df.

By the way, the issue was also noted by BlueGreenMagick in this [forum thread](https://forums.ankiweb.net/t/when-clicking-browser-sidebar-item-whose-name-contains-or/54).