### PR TITLE
Introduce Browser.search_for and Browser.update_search

### DIFF
--- a/qt/aqt/browser.py
+++ b/qt/aqt/browser.py
@@ -760,7 +760,7 @@ class Browser(QMainWindow):
         self.form.searchEdit.addItems(
             [self._searchPrompt] + self.mw.pm.profile["searchHistory"]
         )
-        self.search_for("is:current")
+        self.search_for("is:current", self._searchPrompt)
         # then replace text for easily showing the deck
         self.form.searchEdit.lineEdit().selectAll()
         self.form.searchEdit.setFocus()

--- a/qt/aqt/browser.py
+++ b/qt/aqt/browser.py
@@ -760,10 +760,8 @@ class Browser(QMainWindow):
         self.form.searchEdit.addItems(
             [self._searchPrompt] + self.mw.pm.profile["searchHistory"]
         )
-        self._lastSearchTxt = "is:current"
-        self.search()
+        self.search_for("is:current")
         # then replace text for easily showing the deck
-        self.form.searchEdit.lineEdit().setText(self._searchPrompt)
         self.form.searchEdit.lineEdit().selectAll()
         self.form.searchEdit.setFocus()
 
@@ -772,12 +770,14 @@ class Browser(QMainWindow):
         self.editor.saveNow(self._onSearchActivated)
 
     def _onSearchActivated(self):
-        # convert guide text before we save history
-        if self.form.searchEdit.lineEdit().text() == self._searchPrompt:
-            self.form.searchEdit.lineEdit().setText("deck:current ")
-
         # grab search text and normalize
-        txt = self.form.searchEdit.lineEdit().text()
+        prompt = self.form.searchEdit.lineEdit().text()
+
+        # convert guide text before we save history
+        if prompt == self._searchPrompt:
+            txt = "deck:current "
+        else:
+            txt = prompt
 
         # update history
         sh = self.mw.pm.profile["searchHistory"]
@@ -791,8 +791,7 @@ class Browser(QMainWindow):
 
         # keep track of search string so that we reuse identical search when
         # refreshing, rather than whatever is currently in the search field
-        self._lastSearchTxt = txt
-        self.search()
+        self.search_for(txt)
 
     def search_for(self, search: str, prompt: Optional[str] = None) -> None:
         self._lastSearchTxt = search
@@ -1802,13 +1801,13 @@ where id in %s"""
 
     def _selectNotes(self):
         nids = self.selectedNotes()
-        # bypass search history
-        self._lastSearchTxt = "nid:" + ",".join([str(x) for x in nids])
-        self.form.searchEdit.lineEdit().setText(self._lastSearchTxt)
         # clear the selection so we don't waste energy preserving it
         tv = self.form.tableView
         tv.selectionModel().clear()
-        self.search()
+
+        search = "nid:" + ",".join([str(x) for x in nids])
+        self.search_for(search)
+
         tv.selectAll()
 
     def invertSelection(self):
@@ -2031,10 +2030,7 @@ where id in %s"""
         tooltip(_("Notes tagged."))
 
     def dupeLinkClicked(self, link):
-        self.form.searchEdit.lineEdit().setText(link)
-        # manually, because we've already saved
-        self._lastSearchTxt = link
-        self.search()
+        self.search_for(link)
         self.onNote()
 
     # Jumping

--- a/qt/aqt/browser.py
+++ b/qt/aqt/browser.py
@@ -794,6 +794,11 @@ class Browser(QMainWindow):
         self._lastSearchTxt = txt
         self.search()
 
+    def search_for(self, search: str, prompt: Optional[str] = None) -> None:
+        self._lastSearchTxt = search
+        self.form.searchEdit.lineEdit().setText(prompt or search)
+        self.search()
+
     # search triggered programmatically. caller must have saved note first.
     def search(self) -> None:
         if "is:current" in self._lastSearchTxt:

--- a/qt/aqt/browser.py
+++ b/qt/aqt/browser.py
@@ -774,24 +774,22 @@ class Browser(QMainWindow):
         prompt = self.form.searchEdit.lineEdit().text()
 
         # convert guide text before we save history
-        if prompt == self._searchPrompt:
-            txt = "deck:current "
-        else:
-            txt = prompt
-
-        # update history
-        sh = self.mw.pm.profile["searchHistory"]
-        if txt in sh:
-            sh.remove(txt)
-        sh.insert(0, txt)
-        sh = sh[:30]
-        self.form.searchEdit.clear()
-        self.form.searchEdit.addItems(sh)
-        self.mw.pm.profile["searchHistory"] = sh
+        txt = "deck:current " if prompt == self._searchPrompt else prompt
+        self.update_history(txt)
 
         # keep track of search string so that we reuse identical search when
         # refreshing, rather than whatever is currently in the search field
         self.search_for(txt)
+
+    def update_history(self, search: str) -> None:
+        sh = self.mw.pm.profile["searchHistory"]
+        if search in sh:
+            sh.remove(search)
+        sh.insert(0, search)
+        sh = sh[:30]
+        self.form.searchEdit.clear()
+        self.form.searchEdit.addItems(sh)
+        self.mw.pm.profile["searchHistory"] = sh
 
     def search_for(self, search: str, prompt: Optional[str] = None) -> None:
         self._lastSearchTxt = search


### PR DESCRIPTION
There are 4 methods on `Browser` which search while avoiding using `_onSearchActivated`:
- `setupSearch`
- `_selectNotes`
- `dupeLinkClicked`

I've generalized these, plus `_onSearchActivated` to use a method called `search_for` instead.
This method is also really useful for add-on developers to search something in the browser for the user, and give the appropriate visual feedback.

`update_search` is also a useful method for the add-on developer, to write to history without invoking `_onSearchActivated`.