### PR TITLE
Different first weekday support

### DIFF
--- a/qt/aqt/preferences.py
+++ b/qt/aqt/preferences.py
@@ -23,6 +23,7 @@ class Preferences(QDialog):
         self.silentlyClose = True
         self.prefs = self.mw.col.backend.get_preferences()
         self.setupLang()
+        self.setup_first_weekday()
         self.setupCollection()
         self.setupNetwork()
         self.setupBackup()
@@ -70,6 +71,21 @@ class Preferences(QDialog):
         code = anki.lang.langs[idx][1]
         self.mw.pm.setLang(code)
         showInfo(_("Please restart Anki to complete language change."), parent=self)
+
+    # First weekday
+    ######################################################################
+
+    def setup_first_weekday(self):
+        f = self.form
+        f.firstWeekday.setCurrentIndex(self.first_weekday_idx())
+        qconnect(f.firstWeekday.currentIndexChanged, self.on_first_weekday_idx_changed)
+
+    def first_weekday_idx(self):
+        idx = self.mw.pm.first_weekday()
+        return idx if idx <= 1 else idx - 3
+
+    def on_first_weekday_idx_changed(self, idx):
+        self.mw.pm.set_first_weekday(idx if idx <= 1 else idx + 3)
 
     # Collection options
     ######################################################################

--- a/qt/aqt/profiles.py
+++ b/qt/aqt/profiles.py
@@ -606,6 +606,12 @@ create table if not exists profiles
     def set_night_mode(self, on: bool) -> None:
         self.meta["night_mode"] = on
 
+    def first_weekday(self) -> int:
+        return self.meta.get("first_weekday", 0)
+
+    def set_first_weekday(self, weekday: int) -> None:
+        self.meta["first_weekday"] = weekday
+
     def dark_mode_widgets(self) -> bool:
         return self.meta.get("dark_mode_widgets", False)
 

--- a/qt/aqt/webview.py
+++ b/qt/aqt/webview.py
@@ -617,10 +617,13 @@ document.head.appendChild(style);
         from aqt import mw
 
         self.set_open_links_externally(False)
+        search = "?firstWeekday=%s" % mw.pm.first_weekday()
+
         if theme_manager.night_mode:
-            extra = "#night"
+            hash = "#night"
         else:
-            extra = ""
+            hash = ""
+
         self.hide_while_preserving_layout()
-        self.load(QUrl(f"{mw.serverURL()}_anki/{name}.html" + extra))
+        self.load(QUrl(f"{mw.serverURL()}_anki/{name}.html" + search + hash))
         self.inject_dynamic_style_and_show()

--- a/qt/designer/preferences.ui
+++ b/qt/designer/preferences.ui
@@ -56,6 +56,57 @@
         </widget>
        </item>
        <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_2">
+         <property name="sizeConstraint">
+          <enum>QLayout::SetDefaultConstraint</enum>
+         </property>
+         <item>
+          <widget class="QLabel" name="label">
+           <property name="text">
+            <string>First Weekday</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QComboBox" name="firstWeekday">
+           <item>
+            <property name="text">
+             <string>Sunday</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>Monday</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>Friday</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>Saturday</string>
+            </property>
+           </item>
+          </widget>
+         </item>
+         <item>
+          <spacer name="horizontalSpacer_5">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+        </layout>
+       </item>
+       <item>
         <widget class="QCheckBox" name="hwAccel">
          <property name="text">
           <string>Hardware acceleration (faster, may cause display issues)</string>

--- a/ts/src/firstweekday.ts
+++ b/ts/src/firstweekday.ts
@@ -1,0 +1,9 @@
+// Copyright: Ankitects Pty Ltd and contributors
+// License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
+
+export function checkFirstWeekday(): number {
+    const params = new URLSearchParams(window.location.search)
+    const firstWeekday = Number(params.get('firstWeekday'))
+
+    return firstWeekday;
+}

--- a/ts/src/firstweekday.ts
+++ b/ts/src/firstweekday.ts
@@ -1,9 +1,24 @@
 // Copyright: Ankitects Pty Ltd and contributors
 // License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
-export function checkFirstWeekday(): number {
-    const params = new URLSearchParams(window.location.search)
-    const firstWeekday = Number(params.get('firstWeekday'))
+import type { CountableTimeInterval } from 'd3-time';
 
-    return firstWeekday;
+import { timeSunday, timeMonday, timeFriday, timeSaturday } from "d3-time";
+
+export function checkFirstWeekday(): CountableTimeInterval {
+    const params = new URLSearchParams(window.location.search);
+    const firstWeekday = Number(params.get('firstWeekday'));
+
+    switch (firstWeekday) {
+        case 0:
+            return timeSunday;
+        case 1:
+            return timeMonday;
+        case 5:
+            return timeFriday;
+        case 6:
+            return timeSaturday;
+        default:
+            return timeSunday;
+    }
 }

--- a/ts/src/i18n.ts
+++ b/ts/src/i18n.ts
@@ -4,6 +4,7 @@
 import pb from "./backend/proto";
 import "intl-pluralrules";
 import { FluentBundle, FluentResource, FluentNumber } from "@fluent/bundle/compat";
+import { timeSaturday, timeSunday, timeMonday } from "d3-time";
 
 type RecordVal = number | string | FluentNumber;
 
@@ -57,6 +58,27 @@ export class I18n {
         } else {
             return "ltr";
         }
+    }
+
+    firstWeekday(): any {
+        const firstLang = this.bundles[0].locales;
+        if (
+            firstLang.startsWith("ar") ||
+            firstLang.startsWith("he") ||
+            firstLang.startsWith("fa")
+        ) {
+            return timeSaturday;
+        }
+
+        if (
+            firstLang === 'en' ||
+            firstLang.startsWith("ja") ||
+            firstLang.startsWith("ko-KR")
+        ) {
+            return timeSunday;
+        }
+
+        return timeMonday;
     }
 
     private keyName(msg: pb.BackendProto.FluentString): string {

--- a/ts/src/i18n.ts
+++ b/ts/src/i18n.ts
@@ -4,7 +4,6 @@
 import pb from "./backend/proto";
 import "intl-pluralrules";
 import { FluentBundle, FluentResource, FluentNumber } from "@fluent/bundle/compat";
-import { timeSaturday, timeSunday, timeMonday } from "d3-time";
 
 type RecordVal = number | string | FluentNumber;
 
@@ -58,27 +57,6 @@ export class I18n {
         } else {
             return "ltr";
         }
-    }
-
-    firstWeekday(): any {
-        const firstLang = this.bundles[0].locales;
-        if (
-            firstLang.startsWith("ar") ||
-            firstLang.startsWith("he") ||
-            firstLang.startsWith("fa")
-        ) {
-            return timeSaturday;
-        }
-
-        if (
-            firstLang === 'en' ||
-            firstLang.startsWith("ja") ||
-            firstLang.startsWith("ko-KR")
-        ) {
-            return timeSunday;
-        }
-
-        return timeMonday;
     }
 
     private keyName(msg: pb.BackendProto.FluentString): string {

--- a/ts/src/stats/calendar.ts
+++ b/ts/src/stats/calendar.ts
@@ -15,7 +15,7 @@ import { showTooltip, hideTooltip } from "./tooltip";
 import { GraphBounds, setDataAvailable, RevlogRange } from "./graphs";
 import { timeDay, timeYear } from "d3-time";
 import { I18n } from "../i18n";
-import { checkFirstWeekday } from '../firstweekday'
+import { checkFirstWeekday } from "../firstweekday";
 
 export interface GraphData {
     // indexed by day, where day is relative to today
@@ -63,7 +63,7 @@ export function renderCalendar(
     const nowForYear = new Date();
     nowForYear.setFullYear(targetYear);
 
-    const firstWeekday = checkFirstWeekday()
+    const firstWeekday = checkFirstWeekday();
     const x = scaleLinear()
         .range([bounds.marginLeft, bounds.width - bounds.marginRight])
         .domain([0, 53]);

--- a/ts/src/stats/calendar.ts
+++ b/ts/src/stats/calendar.ts
@@ -15,6 +15,7 @@ import { showTooltip, hideTooltip } from "./tooltip";
 import { GraphBounds, setDataAvailable, RevlogRange } from "./graphs";
 import { timeDay, timeYear } from "d3-time";
 import { I18n } from "../i18n";
+import { checkFirstWeekday } from '../firstweekday'
 
 export interface GraphData {
     // indexed by day, where day is relative to today
@@ -62,7 +63,7 @@ export function renderCalendar(
     const nowForYear = new Date();
     nowForYear.setFullYear(targetYear);
 
-    const firstWeekday = i18n.firstWeekday()
+    const firstWeekday = checkFirstWeekday()
     const x = scaleLinear()
         .range([bounds.marginLeft, bounds.width - bounds.marginRight])
         .domain([0, 53]);

--- a/ts/src/stats/calendar.ts
+++ b/ts/src/stats/calendar.ts
@@ -13,7 +13,7 @@ import { select, mouse } from "d3-selection";
 import { scaleLinear, scaleSequential } from "d3-scale";
 import { showTooltip, hideTooltip } from "./tooltip";
 import { GraphBounds, setDataAvailable, RevlogRange } from "./graphs";
-import { timeDay, timeYear, timeWeek } from "d3-time";
+import { timeDay, timeYear } from "d3-time";
 import { I18n } from "../i18n";
 
 export interface GraphData {
@@ -62,6 +62,7 @@ export function renderCalendar(
     const nowForYear = new Date();
     nowForYear.setFullYear(targetYear);
 
+    const firstWeekday = i18n.firstWeekday()
     const x = scaleLinear()
         .range([bounds.marginLeft, bounds.width - bounds.marginRight])
         .domain([0, 53]);
@@ -73,8 +74,8 @@ export function renderCalendar(
         if (date.getFullYear() != targetYear) {
             continue;
         }
-        const weekNumber = timeWeek.count(timeYear(date), date);
-        const weekDay = timeDay.count(timeWeek(date), date);
+        const weekNumber = firstWeekday.count(timeYear(date), date);
+        const weekDay = timeDay.count(firstWeekday(date), date);
         const yearDay = timeDay.count(timeYear(date), date);
         dayMap.set(yearDay, { day, count, weekNumber, weekDay, date } as DayDatum);
         if (count > maxCount) {
@@ -105,8 +106,8 @@ export function renderCalendar(
         }
         const yearDay = timeDay.count(timeYear(date), date);
         if (!dayMap.has(yearDay)) {
-            const weekNumber = timeWeek.count(timeYear(date), date);
-            const weekDay = timeDay.count(timeWeek(date), date);
+            const weekNumber = firstWeekday.count(timeYear(date), date);
+            const weekDay = timeDay.count(firstWeekday(date), date);
             dayMap.set(yearDay, {
                 day: yearDay,
                 count: 0,


### PR DESCRIPTION
This is about the calendar graph in the Stats screen.
By default, weeks start there on Sundays, however switching it to another first week day would be quite trivial.

I think the only problem here is how should the first weekday be decided? Solely by locale, or make it settable in the preferences.

If the locale should decide over it, then I implemented a first draft of a method, however it would still need to account for many more languages.