### PR TITLE
Strip double quotes from names

### DIFF
--- a/qt/aqt/clayout.py
+++ b/qt/aqt/clayout.py
@@ -581,7 +581,7 @@ class CardLayout(QDialog):
 
     def onRename(self):
         template = self.current_template()
-        name = getOnlyText(_("New name:"), default=template["name"])
+        name = getOnlyText(_("New name:"), default=template["name"]).strip('"')
         if not name.strip():
             return
 

--- a/qt/aqt/fields.py
+++ b/qt/aqt/fields.py
@@ -80,7 +80,7 @@ class FieldDialog(QDialog):
         self.loadField(idx)
 
     def _uniqueName(self, prompt, ignoreOrd=None, old=""):
-        txt = getOnlyText(prompt, default=old)
+        txt = getOnlyText(prompt, default=old).strip('"')
         if not txt:
             return
         for f in self.model["flds"]:

--- a/qt/aqt/models.py
+++ b/qt/aqt/models.py
@@ -85,8 +85,9 @@ class Models(QDialog):
     def onRename(self) -> None:
         nt = self.current_notetype()
         txt = getText(_("New name:"), default=nt["name"])
-        if txt[1] and txt[0]:
-            nt["name"] = txt[0]
+        name = txt[0].strip('"')
+        if txt[1] and name:
+            nt["name"] = name
             self.saveAndRefresh(nt)
 
     def saveAndRefresh(self, nt: NoteType) -> None:
@@ -119,7 +120,7 @@ class Models(QDialog):
     def onAdd(self) -> None:
         m = AddModel(self.mw, self).get()
         if m:
-            txt = getText(_("Name:"), default=m["name"])[0]
+            txt = getText(_("Name:"), default=m["name"])[0].strip('"')
             if txt:
                 m["name"] = txt
             self.saveAndRefresh(m)

--- a/rslib/src/notetype/fields.rs
+++ b/rslib/src/notetype/fields.rs
@@ -37,7 +37,7 @@ impl NoteField {
 
     pub(crate) fn fix_name(&mut self) {
         // remove special characters
-        let bad_chars = |c| c == ':' || c == '{' || c == '}';
+        let bad_chars = |c| c == ':' || c == '{' || c == '}' || c == '"';
         if self.name.contains(bad_chars) {
             self.name = self.name.replace(bad_chars, "");
         }

--- a/rslib/src/notetype/mod.rs
+++ b/rslib/src/notetype/mod.rs
@@ -223,8 +223,13 @@ impl NoteType {
         if self.templates.is_empty() {
             return Err(AnkiError::invalid_input("1 template required"));
         }
+        let bad_chars = |c| c == '"';
+        if self.name.contains(bad_chars) {
+            self.name = self.name.replace(bad_chars, "");
+        }
         self.normalize_names();
         self.fix_field_names();
+        self.fix_template_names();
         self.ensure_names_unique();
         self.reposition_sort_idx();
 
@@ -320,6 +325,10 @@ impl NoteType {
 
     fn fix_field_names(&mut self) {
         self.fields.iter_mut().for_each(NoteField::fix_name);
+    }
+
+    fn fix_template_names(&mut self) {
+        self.templates.iter_mut().for_each(CardTemplate::fix_name);
     }
 
     /// Find the field index of the provided field name.

--- a/rslib/src/notetype/templates.rs
+++ b/rslib/src/notetype/templates.rs
@@ -88,4 +88,11 @@ impl CardTemplate {
             },
         }
     }
+
+    pub(crate) fn fix_name(&mut self) {
+        let bad_chars = |c| c == '"';
+        if self.name.contains(bad_chars) {
+            self.name = self.name.replace(bad_chars, "");
+        }
+    }
 }

--- a/rslib/src/tags.rs
+++ b/rslib/src/tags.rs
@@ -29,7 +29,7 @@ fn is_tag_separator(c: char) -> bool {
 }
 
 fn invalid_char_for_tag(c: char) -> bool {
-    c.is_ascii_control() || is_tag_separator(c)
+    c.is_ascii_control() || is_tag_separator(c) || c == '"'
 }
 
 impl Collection {


### PR DESCRIPTION
See https://github.com/ankitects/anki/pull/798

Is it on purpose that the backend allows creating note types, fields, etc. with empty names?
