### PR TITLE
Work around Qt's focus bug (fix help-wanted#22)

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -65,6 +65,7 @@ lukkea <github.com/lukkea/>
 David Allison <davidallisongithub@gmail.com>
 Tsung-Han Yu <johan456789@gmail.com>
 Piotr Kubowicz <piotr.kubowicz@gmail.com>
+RumovZ <gp5glkw78@relay.firefox.com>
 
 ********************
 

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -65,7 +65,7 @@ lukkea <github.com/lukkea/>
 David Allison <davidallisongithub@gmail.com>
 Tsung-Han Yu <johan456789@gmail.com>
 Piotr Kubowicz <piotr.kubowicz@gmail.com>
-RumovZ <gp5glkw78@relay.firefox.com>
+RumovZ <gp5glkw78@relay.firefox.com> 
 
 ********************
 

--- a/qt/aqt/addcards.py
+++ b/qt/aqt/addcards.py
@@ -195,6 +195,10 @@ class AddCards(QDialog):
         self.editor.saveAddModeVars()
         if not self.addNote(self.editor.note):
             return
+
+        # workaround for PyQt focus bug
+        self.editor.hideCompleters()
+
         tooltip(_("Added"), period=500)
         av_player.stop_and_clear_queue()
         self.onReset(keep=True)

--- a/qt/aqt/browser.py
+++ b/qt/aqt/browser.py
@@ -1061,6 +1061,9 @@ QTableView {{ gridline-color: {grid} }}
         self.maybeRefreshSidebar()
 
     def focusSidebar(self) -> None:
+        # workaround for PyQt focus bug
+        self.editor.hideCompleters()
+
         self.sidebarDockWidget.setVisible(True)
         self.sidebarTree.setFocus()
 
@@ -2072,10 +2075,16 @@ where id in %s"""
         sm.select(item, QItemSelectionModel.SelectCurrent | QItemSelectionModel.Rows)
 
     def onFind(self):
+        # workaround for PyQt focus bug
+        self.editor.hideCompleters()
+
         self.form.searchEdit.setFocus()
         self.form.searchEdit.lineEdit().selectAll()
 
     def onNote(self):
+        # workaround for PyQt focus bug
+        self.editor.hideCompleters()
+
         self.editor.web.setFocus()
         self.editor.loadNote(focusTo=0)
 


### PR DESCRIPTION
Manually hide the editor's completer popup before accepting a short cut which changes the focus widget. Thus, work around the bug in PyQt 5.15 where a QLineEdit with open QCompleter popup won't get notified about focus changes handled by the Main Window, leading to inconsistent focus.