### PR TITLE
Set MIME type for javascript files

### DIFF
--- a/qt/aqt/mediasrv.py
+++ b/qt/aqt/mediasrv.py
@@ -131,6 +131,8 @@ def allroutes(pathin):
         if fullpath.endswith(".css"):
             # some users may have invalid mime type in the Windows registry
             mimetype = "text/css"
+        elif fullpath.endswith(".js"):
+            mimetype = "application/javascript"
         else:
             # autodetect
             mimetype = None


### PR DESCRIPTION
Right now, when the reviewer requests a file ending in `.js`, it is not certain, whether the web view will actually recognize it as a application/javascript file, or text/plain.

The Anki on my Mac does it correctly, however [Windows doesn't seem to do it](https://github.com/hgiesel/closet/issues/33). This prevents the user from using dynamic importing via `import()`.