### PR TITLE
align rslib get_subnode impl with anki pythonapi find_deck_in_tree

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -66,7 +66,7 @@ David Allison <davidallisongithub@gmail.com>
 Tsung-Han Yu <johan456789@gmail.com>
 Piotr Kubowicz <piotr.kubowicz@gmail.com>
 RumovZ <gp5glkw78@relay.firefox.com> 
-Cecini <github.com/cecini>
+Cecini <github.com/cecini> 
 
 ********************
 

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -66,6 +66,7 @@ David Allison <davidallisongithub@gmail.com>
 Tsung-Han Yu <johan456789@gmail.com>
 Piotr Kubowicz <piotr.kubowicz@gmail.com>
 RumovZ <gp5glkw78@relay.firefox.com> 
+Cecini <github.com/cecini>
 
 ********************
 

--- a/rslib/src/decks/tree.rs
+++ b/rslib/src/decks/tree.rs
@@ -175,9 +175,12 @@ fn hide_default_deck(node: &mut DeckTreeNode) {
 }
 
 fn get_subnode(top: DeckTreeNode, target: DeckID) -> Option<DeckTreeNode> {
+    if top.deck_id == target.0 {
+        return Some(top);
+    }
     for child in top.children {
-        if child.deck_id == target.0 {
-            return Some(child);
+        if let Some(node) = get_subnode(child, target) {
+            return Some(node);
         }
     }
 


### PR DESCRIPTION
Fix nestdeck due counts issue
Here ankidesktop will use get_subnode in sanity_check to get the schedduecounts, but if other client or server impl use the anki pythonapi find_deck_in_tree when using nestdeck, then will alway fail the comparison between server and client's  sanitycheck results and lead to the unexpected scene.

