### PR TITLE
Add Ctrl+Shift combo to update filters in card search

### DIFF
--- a/qt/aqt/browser.py
+++ b/qt/aqt/browser.py
@@ -1231,11 +1231,13 @@ QTableView {{ gridline-color: {grid} }}
                 # update instances of 'key':'anything' in the old search
                 if mods & Qt.ControlModifier and mods & Qt.ShiftModifier:
                     if len(args) == 2:
-                        quoted = "\"" + args[0] + r":(\\\\|\\\"|[^\"])*\""
+                        quoted = '"' + args[0] + r":(\\\\|\\\"|[^\"])*\""
                         partially = args[0] + r":\"(\\\\|\\\"|[^\"])*\""
                         unquoted = args[0] + r":[^\)\s\"]*(?=($|\)|\s))"
                         before = r"(?<![^\s\(])(?<!\\\()-?"
-                        pattern = re.compile(f"{before}({quoted}|{partially}|{unquoted})")
+                        pattern = re.compile(
+                            f"{before}({quoted}|{partially}|{unquoted})"
+                        )
                         txt = pattern.sub(txt, cur)
                 elif mods & Qt.ControlModifier:
                     txt = cur + " " + txt


### PR DESCRIPTION
If a deck, note type or tag filter is clicked with the control and shift modifiers, corresponding filters in the current search expression will be replaced with the clicked filter.
E.g., ctrl+shift clicking a deck “new deck” transforms the current search expression `is:due deck:"old deck"` to `is:due deck:"new deck"`.

(Also fixes two minor bugs where clicking “Whole collection” with modifiers lead to invalid or undesired searches and the shift modifier didn't check for the default search prompt.)