### PR TITLE
Start with default value in reposition spinbox selected

### DIFF
--- a/qt/aqt/browser.py
+++ b/qt/aqt/browser.py
@@ -1743,6 +1743,7 @@ where id in %s"""
         txt = _("Queue top: %d") % pmin
         txt += "\n" + _("Queue bottom: %d") % pmax
         frm.label.setText(txt)
+        frm.start.selectAll()
         if not d.exec_():
             return
         self.model.beginReset()


### PR DESCRIPTION
This has been annoying me for a while. Starting with the contents of the spinbox selected saves a keystroke if you want to replace the default value, since you can just type over it.

I don't think this will make life harder on anyone. If you want to accept the default value, you can still hit enter or tab immediately. It's hard to imagine a situation in which you would want to *prepend* characters to the default value, which is what the current behavior would be optimized for (cursor starts at position 0 with nothing selected).