### PR TITLE
Improve compatibility with graphics pad/touchscreen

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -67,6 +67,7 @@ Tsung-Han Yu <johan456789@gmail.com>
 Piotr Kubowicz <piotr.kubowicz@gmail.com>
 RumovZ <gp5glkw78@relay.firefox.com> 
 Cecini <github.com/cecini> 
+Krish Shah <github.com/k12ish>
 
 ********************
 

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -67,7 +67,6 @@ Tsung-Han Yu <johan456789@gmail.com>
 Piotr Kubowicz <piotr.kubowicz@gmail.com>
 RumovZ <gp5glkw78@relay.firefox.com> 
 Cecini <github.com/cecini> 
-Krish Shah <github.com/k12ish>
 
 ********************
 

--- a/qt/aqt/data/web/css/reviewer-bottom.scss
+++ b/qt/aqt/data/web/css/reviewer-bottom.scss
@@ -65,6 +65,8 @@ button {
 
 #outer {
     border-top: 1px solid var(--border);
+    /* Better compatibility with graphics pad/touchscreen */
+    -webkit-user-select: none;
 }
 
 #innertable {


### PR DESCRIPTION
When using Anki with a graphics pad, text is often selected on accident. This one line snippet of CSS will fix that issue.

I have not tested this code, but the other two instances of `-webkit-user-select: none;` in Anki prevent text from being selected and work as required.