### PR TITLE
Specify full path to bazelisk and output root on Windows

### DIFF
--- a/bazel.bat
+++ b/bazel.bat
@@ -1,2 +1,2 @@
 @set PATH=c:\msys64\usr\bin;c:\python;%PATH%
-\bazel\bazel  --output_user_root=\bazel\anki %*
+c:\bazel\bazel  --output_user_root=c:\bazel\anki %*


### PR DESCRIPTION
Building fails if Anki's source directory is not in the same drive as bazelisk.