### PR TITLE
Fix handling of no-break spaces when showing duplicates

### DIFF
--- a/pylib/anki/utils.py
+++ b/pylib/anki/utils.py
@@ -61,19 +61,19 @@ reEnts = re.compile(r"&#?\w+;")
 reMedia = re.compile("(?i)<img[^>]+src=[\"']?([^\"'>]+)[\"']?[^>]*>")
 
 
-def stripHTML(s: str) -> str:
+def stripHTML(s: str, nbsp_to_sp: bool = True) -> str:
     s = reComment.sub("", s)
     s = reStyle.sub("", s)
     s = reScript.sub("", s)
     s = reTag.sub("", s)
-    s = entsToTxt(s)
+    s = entsToTxt(s, nbsp_to_sp)
     return s
 
 
-def stripHTMLMedia(s: str) -> str:
+def stripHTMLMedia(s: str, nbsp_to_sp: bool = True) -> str:
     "Strip HTML but keep media filenames"
     s = reMedia.sub(" \\1 ", s)
-    return stripHTML(s)
+    return stripHTML(s, nbsp_to_sp)
 
 
 def minimizeHTML(s: str) -> str:
@@ -98,10 +98,11 @@ def htmlToTextLine(s: str) -> str:
     return s
 
 
-def entsToTxt(html: str) -> str:
-    # entitydefs defines nbsp as \xa0 instead of a standard space, so we
-    # replace it first
-    html = html.replace("&nbsp;", " ")
+def entsToTxt(html: str, nbsp_to_sp: bool = True) -> str:
+    if nbsp_to_sp:
+        # entitydefs defines nbsp as \xa0 instead of a standard space, so we
+        # replace it first
+        html = html.replace("&nbsp;", " ")
 
     def fixup(m):
         text = m.group(0)

--- a/qt/aqt/editor.py
+++ b/qt/aqt/editor.py
@@ -500,9 +500,13 @@ class Editor:
         self.web.eval("setBackgrounds(%s);" % json.dumps(cols))
 
     def showDupes(self):
-        contents = html.escape(
-            stripHTMLMedia(self.note.fields[0]), quote=False
-        ).replace('"', r"\"")
+        contents = (
+            html.escape(
+                stripHTMLMedia(self.note.fields[0], nbsp_to_sp=False), quote=False
+            )
+            .replace('"', r"\"")
+            .replace("\xa0", "&nbsp;")
+        )
         browser = aqt.dialogs.open("Browser", self.mw)
         browser.form.searchEdit.lineEdit().setText(
             '"dupe:%s,%s"' % (self.note.model()["id"], contents)


### PR DESCRIPTION
no-break spaces are replaced with normal spaces in showDupes, which causes browser search to fail to find duplicate notes containing no-break spaces.

I've imported lots of duplicate notes recently and started to hit this issue every day and I'm a bit surprised this has not been reported until now considering that notes usually have a lot of non-breaking spaces since Anki inserts them automatically.

By the way, I noticed that non-breaking spaces (the character `\xa0`, not `&nbsp;`) are also stored as normal spaces in the database, but I can't find in which file this is done. I thought this is due to unicode normalization but Anki does NFC which preserves non-breaking spaces (while NFKC actually converts them). Out of curiosity, where is this done?