### PR TITLE
Improvements to MathJax and ts hooks

### DIFF
--- a/qt/aqt/data/web/js/mathjax.js
+++ b/qt/aqt/data/web/js/mathjax.js
@@ -3,17 +3,19 @@ window.MathJax = {
     displayMath: [["\\[", "\\]"]],
     processRefs: false,
     processEnvironments: false,
-    packages: [
-      'base',
-      'ams',
-      'noerrors',
-      'noundefined',
-      'mhchem',
-      'require',
-    ]
+    packages: {
+      '[+]': [
+        'noerrors',
+        'mhchem',
+      ],
+    }
   },
   startup: {
-    typeset: false
+    typeset: false,
+    pageReady: () => {
+      console.log('page is ready');
+      return MathJax.startup.defaultPageReady();
+    },
   },
   options: {
     renderActions: {
@@ -21,13 +23,12 @@ window.MathJax = {
       checkLoading: []
     },
     ignoreHtmlClass: 'tex2jax_ignore',
-    processHtmlClass: 'tex2jax_process'
+    processHtmlClass: 'tex2jax_process',
   },
   loader: {
     load: [
       '[tex]/noerrors',
       '[tex]/mhchem',
-      '[tex]/require',
     ]
   }
 };

--- a/qt/aqt/data/web/js/mathjax.js
+++ b/qt/aqt/data/web/js/mathjax.js
@@ -3,7 +3,14 @@ window.MathJax = {
     displayMath: [["\\[", "\\]"]],
     processRefs: false,
     processEnvironments: false,
-    packages: ['base', 'ams', 'noerrors', 'noundefined', 'mhchem']
+    packages: [
+      'base',
+      'ams',
+      'noerrors',
+      'noundefined',
+      'mhchem',
+      'require',
+    ]
   },
   startup: {
     typeset: false
@@ -17,6 +24,10 @@ window.MathJax = {
     processHtmlClass: 'tex2jax_process'
   },
   loader: {
-    load: ['[tex]/noerrors', '[tex]/mhchem']
+    load: [
+      '[tex]/noerrors',
+      '[tex]/mhchem',
+      '[tex]/require',
+    ]
   }
 };

--- a/qt/aqt/data/web/js/mathjax.js
+++ b/qt/aqt/data/web/js/mathjax.js
@@ -1,34 +1,28 @@
 window.MathJax = {
-  tex: {
-    displayMath: [["\\[", "\\]"]],
-    processRefs: false,
-    processEnvironments: false,
-    packages: {
-      '[+]': [
-        'noerrors',
-        'mhchem',
-      ],
-    }
-  },
-  startup: {
-    typeset: false,
-    pageReady: () => {
-      console.log('page is ready');
-      return MathJax.startup.defaultPageReady();
+    tex: {
+        displayMath: [["\\[", "\\]"]],
+        processRefs: false,
+        processEnvironments: false,
+        packages: {
+            "[+]": ["noerrors", "mhchem"],
+        },
     },
-  },
-  options: {
-    renderActions: {
-      addMenu: [],
-      checkLoading: []
+    startup: {
+        typeset: false,
+        pageReady: () => {
+            console.log("page is ready");
+            return MathJax.startup.defaultPageReady();
+        },
     },
-    ignoreHtmlClass: 'tex2jax_ignore',
-    processHtmlClass: 'tex2jax_process',
-  },
-  loader: {
-    load: [
-      '[tex]/noerrors',
-      '[tex]/mhchem',
-    ]
-  }
+    options: {
+        renderActions: {
+            addMenu: [],
+            checkLoading: [],
+        },
+        ignoreHtmlClass: "tex2jax_ignore",
+        processHtmlClass: "tex2jax_process",
+    },
+    loader: {
+        load: ["[tex]/noerrors", "[tex]/mhchem"],
+    },
 };

--- a/qt/aqt/data/web/js/reviewer.ts
+++ b/qt/aqt/data/web/js/reviewer.ts
@@ -39,13 +39,13 @@ function _updateQA(html, fadeTime, onupdate, onshown) {
     var qa = $("#qa");
 
     // fade out current text
-    qa.fadeOut(fadeTime).promise()
+    qa.fadeOut(fadeTime)
+        .promise()
         // update text
         .then(() => {
             try {
-                qa.html(html)
-            }
-            catch (err) {
+                qa.html(html);
+            } catch (err) {
                 qa.html(
                     (
                         `Invalid HTML on card: ${String(err).substring(0, 2000)}\n` +
@@ -55,19 +55,20 @@ function _updateQA(html, fadeTime, onupdate, onshown) {
             }
         })
         .then(() => _runHook(onUpdateHook))
-        // @ts-ignore wait for mathjax to ready
-        .then(() => MathJax.startup.promise
-            .then(() => {
+        .then(() =>
+            // @ts-ignore wait for mathjax to ready
+            MathJax.startup.promise.then(() => {
                 // @ts-ignore clear MathJax buffer
                 MathJax.typesetClear();
 
                 // @ts-ignore typeset
                 return MathJax.typesetPromise(qa.slice(0, 1));
-            }))
+            })
+        )
         // and reveal when processing is done
         .then(() => qa.fadeIn(fadeTime).promise())
         .then(() => _runHook(onShownHook))
-        .then(() => _updatingQA = false);
+        .then(() => (_updatingQA = false));
 }
 
 function _showQuestion(q, bodyclass) {

--- a/qt/aqt/data/web/js/reviewer.ts
+++ b/qt/aqt/data/web/js/reviewer.ts
@@ -11,10 +11,14 @@ var aFade = 0;
 var onUpdateHook;
 var onShownHook;
 
-function _runHook(arr) {
+function _runHook(arr: () => Promise<any>[]): Promise<any[]> {
+    var promises = [];
+
     for (var i = 0; i < arr.length; i++) {
-        arr[i]();
+        promises.push(arr[i]());
     }
+
+    return Promise.all(promises);
 }
 
 function _updateQA(html, fadeTime, onupdate, onshown) {
@@ -32,35 +36,38 @@ function _updateQA(html, fadeTime, onupdate, onshown) {
     onUpdateHook = [onupdate];
     onShownHook = [onshown];
 
-    // fade out current text
     var qa = $("#qa");
-    qa.fadeTo(fadeTime, 0, function () {
-        // update text
-        try {
-            qa.html(html);
-        } catch (err) {
-            qa.html(
-                (
-                    `Invalid HTML on card: ${String(err).substring(0, 2000)}\n` +
-                    String(err.stack).substring(0, 2000)
-                ).replace(/\n/g, "<br />")
-            );
-        }
-        _runHook(onUpdateHook);
 
-        // @ts-ignore
-        MathJax.startup.promise
-            // render mathjax
-            // @ts-ignore
-            .then(MathJax.typesetPromise)
-            // and reveal when processing is done
-            .then(function () {
-                qa.fadeTo(fadeTime, 1, function () {
-                    _runHook(onShownHook);
-                    _updatingQA = false;
-                });
-            });
-    });
+    // fade out current text
+    qa.fadeOut(fadeTime).promise()
+        // update text
+        .then(() => {
+            try {
+                qa.html(html)
+            }
+            catch (err) {
+                qa.html(
+                    (
+                        `Invalid HTML on card: ${String(err).substring(0, 2000)}\n` +
+                        String(err.stack).substring(0, 2000)
+                    ).replace(/\n/g, "<br />")
+                );
+            }
+        })
+        .then(() => _runHook(onUpdateHook))
+        // @ts-ignore wait for mathjax to ready
+        .then(() => MathJax.startup.promise
+            .then(() => {
+                // @ts-ignore clear MathJax buffer
+                MathJax.typesetClear();
+
+                // @ts-ignore typeset
+                return MathJax.typesetPromise(qa.slice(0, 1));
+            }))
+        // and reveal when processing is done
+        .then(() => qa.fadeIn(fadeTime).promise())
+        .then(() => _runHook(onShownHook))
+        .then(() => _updatingQA = false);
 }
 
 function _showQuestion(q, bodyclass) {


### PR DESCRIPTION
1. I added the default MathJax packages for tex-chtml, which include:
    1. require: using \require{package-name} to load a package
    1. autoload: using a command from a different package automatically loads it
    1. configmacros: allows for definition of predefined macros

This would allow users to use dynamically load Mathjax extensions. For example, [in this case, where a user wanted "boldsymbol"](https://forums.ankiweb.net/t/bold-math-does-not-work-in-mathjax-on-the-linux-desktop-client/5073), he could now simply use `\require{boldsymbol}`
However there's a big catch here: [MathJax 3 internally relies on the "onload" event of a script tag being fired](https://github.com/mathjax/MathJax-src/blob/fbd71f3f7ca06dc71304e8a2c03f13be233ccac5/ts/components/package.ts#L326), which does not work in the AnkiWebView (possibly, again, because it is a data URL), and which atm makes the rendering simply stop within Anki. To actually take advantage of this feature, the user has to handily call `MathJax.typesetPromise()` again.

2. I changed the way ts hooks work: Rather than just executing a function returning `void`, the function can now optionally return a Promise, which is then waited upon using [`Promise.all`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/all). This way, add-on developers can register asynchronous actions on ts hooks.

I also added a `typesetClear` call, which is recommended to be executed before you start a new typeset.