### PR TITLE
Switch from jQuery pre 3.0.0 pseudo promises to ES6 promises for ts hooks

### DIFF
--- a/qt/aqt/data/web/js/reviewer.ts
+++ b/qt/aqt/data/web/js/reviewer.ts
@@ -39,8 +39,7 @@ function _updateQA(html, fadeTime, onupdate, onshown) {
     var qa = $("#qa");
 
     // fade out current text
-    qa.fadeOut(fadeTime)
-        .promise()
+    new Promise((resolve) => qa.fadeOut(fadeTime, () => resolve()))
         // update text
         .then(() => {
             try {
@@ -66,7 +65,7 @@ function _updateQA(html, fadeTime, onupdate, onshown) {
             })
         )
         // and reveal when processing is done
-        .then(() => qa.fadeIn(fadeTime).promise())
+        .then(() => new Promise((resolve) => qa.fadeIn(fadeTime, () => resolve())))
         .then(() => _runHook(onShownHook))
         .then(() => (_updatingQA = false));
 }


### PR DESCRIPTION
I slipped up a little bit. While the previous PR was not broken, it didn't achieve what I intended it to.

Turns out that [pre-3.0.0 jQuery had a different kind of promise/deferred](https://jquery.com/upgrade-guide/3.0/#breaking-change-and-feature-jquery-deferred-is-now-promises-a-compatible), which didn't behave like the ES6 promises I'm used to, especially when it comes to returning promises in the callback function.

More specifically, the `.then(_runHook(onUpdateHook/onShownHook))` lines did not wait on the promises returned, but rather continued immediately with the next `.then(f)`