### PR TITLE
Strip isolation characters from more strings

### DIFF
--- a/qt/aqt/clayout.py
+++ b/qt/aqt/clayout.py
@@ -9,6 +9,7 @@ from typing import Any, Dict, List, Optional
 import aqt
 from anki.cards import Card
 from anki.consts import *
+from anki.lang import without_unicode_isolation
 from anki.notes import Note
 from anki.rsbackend import TemplateError
 from anki.template import TemplateRenderContext
@@ -66,7 +67,9 @@ class CardLayout(QDialog):
         self.setupButtons()
         self.setupShortcuts()
         self.setWindowTitle(
-            tr(TR.CARD_TEMPLATES_CARD_TYPES_FOR, val=self.model["name"])
+            without_unicode_isolation(
+                tr(TR.CARD_TEMPLATES_CARD_TYPES_FOR, val=self.model["name"])
+            )
         )
         v1 = QVBoxLayout()
         v1.addWidget(self.topArea)

--- a/qt/aqt/deckconf.py
+++ b/qt/aqt/deckconf.py
@@ -8,6 +8,7 @@ from PyQt5.QtWidgets import QLineEdit
 
 import aqt
 from anki.consts import NEW_CARDS_RANDOM
+from anki.lang import without_unicode_isolation
 from aqt import gui_hooks
 from aqt.qt import *
 from aqt.utils import (
@@ -44,7 +45,9 @@ class DeckConf(QDialog):
             self.form.buttonBox.button(QDialogButtonBox.RestoreDefaults).clicked,
             self.onRestore,
         )
-        self.setWindowTitle(tr(TR.ACTIONS_OPTIONS_FOR, val=self.deck["name"]))
+        self.setWindowTitle(
+            without_unicode_isolation(tr(TR.ACTIONS_OPTIONS_FOR, val=self.deck["name"]))
+        )
         # qt doesn't size properly with altered fonts otherwise
         restoreGeom(self, "deckconf", adjustSize=True)
         gui_hooks.deck_conf_will_show(self)

--- a/qt/aqt/dyndeckconf.py
+++ b/qt/aqt/dyndeckconf.py
@@ -4,6 +4,7 @@
 from typing import List, Optional
 
 import aqt
+from anki.lang import without_unicode_isolation
 from aqt.qt import *
 from aqt.utils import TR, askUser, openHelp, restoreGeom, saveGeom, showWarning, tr
 
@@ -24,7 +25,9 @@ class DeckConf(QDialog):
         self.mw.checkpoint(tr(TR.ACTIONS_OPTIONS))
         self.setWindowModality(Qt.WindowModal)
         qconnect(self.form.buttonBox.helpRequested, lambda: openHelp("filtered-decks"))
-        self.setWindowTitle(tr(TR.ACTIONS_OPTIONS_FOR, val=self.deck["name"]))
+        self.setWindowTitle(
+            without_unicode_isolation(tr(TR.ACTIONS_OPTIONS_FOR, val=self.deck["name"]))
+        )
         restoreGeom(self, "dyndeckconf")
         self.initialSetup()
         self.loadConf()

--- a/qt/aqt/fields.py
+++ b/qt/aqt/fields.py
@@ -3,6 +3,7 @@
 
 import aqt
 from anki.consts import *
+from anki.lang import without_unicode_isolation
 from anki.models import NoteType
 from anki.rsbackend import TemplateError
 from aqt import AnkiQt, gui_hooks
@@ -23,7 +24,9 @@ class FieldDialog(QDialog):
         self.change_tracker = ChangeTracker(self.mw)
         self.form = aqt.forms.fields.Ui_Dialog()
         self.form.setupUi(self)
-        self.setWindowTitle(tr(TR.FIELDS_FIELDS_FOR, val=self.model["name"]))
+        self.setWindowTitle(
+            without_unicode_isolation(tr(TR.FIELDS_FIELDS_FOR, val=self.model["name"]))
+        )
         self.form.buttonBox.button(QDialogButtonBox.Help).setAutoDefault(False)
         self.form.buttonBox.button(QDialogButtonBox.Cancel).setAutoDefault(False)
         self.form.buttonBox.button(QDialogButtonBox.Save).setAutoDefault(False)

--- a/qt/aqt/main.py
+++ b/qt/aqt/main.py
@@ -29,6 +29,7 @@ from anki import hooks
 from anki.collection import Collection
 from anki.decks import Deck
 from anki.hooks import runHook
+from anki.lang import without_unicode_isolation
 from anki.rsbackend import RustBackend
 from anki.sound import AVTag, SoundOrVideoTag
 from anki.utils import devMode, ids2str, intTime, isMac, isWin, splitFields
@@ -1129,9 +1130,11 @@ title="%s" %s>%s</button>""" % (
         if not search:
             if not deck["dyn"]:
                 search = 'deck:"%s" ' % deck["name"]
-        while self.col.decks.id_for_name(tr(TR.QT_MISC_FILTERED_DECK, val=n)):
+        while self.col.decks.id_for_name(
+            without_unicode_isolation(tr(TR.QT_MISC_FILTERED_DECK, val=n))
+        ):
             n += 1
-        name = tr(TR.QT_MISC_FILTERED_DECK, val=n)
+        name = without_unicode_isolation(tr(TR.QT_MISC_FILTERED_DECK, val=n))
         did = self.col.decks.new_filtered(name)
         diag = aqt.dyndeckconf.DeckConf(self, first=True, search=search)
         if not diag.ok:

--- a/qt/aqt/models.py
+++ b/qt/aqt/models.py
@@ -7,6 +7,7 @@ from typing import Any, List, Optional, Sequence
 import aqt.clayout
 from anki import stdmodels
 from anki.backend_pb2 import NoteTypeNameIDUseCount
+from anki.lang import without_unicode_isolation
 from anki.models import NoteType
 from anki.notes import Note
 from anki.rsbackend import pb
@@ -159,7 +160,9 @@ class Models(QDialog):
         frm.latexsvg.setChecked(nt.get("latexsvg", False))
         frm.latexHeader.setText(nt["latexPre"])
         frm.latexFooter.setText(nt["latexPost"])
-        d.setWindowTitle(tr(TR.ACTIONS_OPTIONS_FOR, val=nt["name"]))
+        d.setWindowTitle(
+            without_unicode_isolation(tr(TR.ACTIONS_OPTIONS_FOR, val=nt["name"]))
+        )
         qconnect(frm.buttonBox.helpRequested, lambda: openHelp("math?id=latex"))
         restoreGeom(d, "modelopts")
         gui_hooks.models_advanced_will_show(d)


### PR DESCRIPTION
By the way, does the string `QT_MISC_DEFAULT` used a couple of times in [deckchooser.py](https://github.com/ankitects/anki/blob/98a4a1927a8e781a1c0b4a297caa8e86134ac027/qt/aqt/deckchooser.py#L50) need stripping?
It seems the string `DeckConfigDefaultName` is used [here](https://github.com/ankitects/anki/blob/ccfd6244de9802a10ddf11687a8c86d0c1309cb4/rslib/src/storage/deck/mod.rs#L269) to create the default deck without any stripping so I'm not sure.

Update: I forgot that argumentless strings don't have isolation characters so we don't need to strip them.