### PR TITLE
Fix description of exporters

### DIFF
--- a/pylib/tests/test_exporting.py
+++ b/pylib/tests/test_exporting.py
@@ -161,4 +161,4 @@ def test_export_textnote():
 
 
 def test_exporters():
-    assert "*.apkg" in str(exporters())
+    assert "*.apkg" in str(exporters(getEmptyCol()))

--- a/qt/aqt/exporting.py
+++ b/qt/aqt/exporting.py
@@ -34,7 +34,7 @@ class ExportDialog(QDialog):
         self.exec_()
 
     def setup(self, did: Optional[int]):
-        self.exporters = exporters()
+        self.exporters = exporters(self.col)
         # if a deck specified, start with .apkg type selected
         idx = 0
         if did or self.cids:
@@ -114,7 +114,7 @@ class ExportDialog(QDialog):
 
         filename = "{0}{1}".format(deck_name, self.exporter.ext)
         if callable(self.exporter.key):
-            key_str = self.exporter.key()
+            key_str = self.exporter.key(self.col)
         else:
             key_str = self.exporter.key
         while 1:


### PR DESCRIPTION
Description broke yet again with the full migration to Fluent.

<img src="https://user-images.githubusercontent.com/41397710/99718502-03266c00-2abc-11eb-9b7e-9086a4535f96.png" alt="drawing" width="500"/>
