### PR TITLE
Initialize translation system to default language on first run

### DIFF
--- a/qt/aqt/profiles.py
+++ b/qt/aqt/profiles.py
@@ -490,7 +490,6 @@ create table if not exists profiles
 
         d = self.langDiag = NoCloseDiag()
         f = self.langForm = aqt.forms.setlang.Ui_Dialog()
-        f.setupUi(d)
         qconnect(d.accepted, self._onLangSelected)
         qconnect(d.rejected, lambda: True)
         # default to the system language
@@ -510,6 +509,9 @@ create table if not exists profiles
         # if the system language isn't available, revert to english
         if idx is None:
             idx = en
+            lang = "en_US"
+        anki.lang.set_lang(lang, locale_dir())
+        f.setupUi(d)
         # update list
         f.lang.addItems([x[0] for x in anki.lang.langs])
         f.lang.setCurrentRow(idx)


### PR DESCRIPTION
The setlang screen is trying to use the translation system before we initialize it, causing an AttributeError.

There are some useful but untranslated error messages in `__init__.py` and `profiles.py`. Could not we initialize the translation system to the system language early on in _run (instead of setDefaultLang) and make those strings translatable? I can look into this if there are no caveats I'm not aware of.