### PR TITLE
Fix fields_did_rename_field gui hook

### DIFF
--- a/qt/aqt/fields.py
+++ b/qt/aqt/fields.py
@@ -100,9 +100,10 @@ class FieldDialog(QDialog):
         if not name:
             return
 
+        old_name = f["name"]
         self.change_tracker.mark_basic()
         self.mm.rename_field(self.model, f, name)
-        gui_hooks.fields_did_rename_field(self, f, f["name"])
+        gui_hooks.fields_did_rename_field(self, f, old_name)
 
         self.saveField()
         self.fillFields()


### PR DESCRIPTION
Current implementation didn't act like I specified. It should be newly renamed field, and the old name as a string, however you just had the new field, and the new name.