### PR TITLE
Switch back to fadeTo rather than fadeIn/fadeOut

### DIFF
--- a/qt/aqt/data/web/js/reviewer.ts
+++ b/qt/aqt/data/web/js/reviewer.ts
@@ -39,7 +39,7 @@ function _updateQA(html, fadeTime, onupdate, onshown) {
     var qa = $("#qa");
 
     // fade out current text
-    new Promise((resolve) => qa.fadeOut(fadeTime, () => resolve()))
+    new Promise((resolve) => qa.fadeTo(fadeTime, 0, () => resolve()))
         // update text
         .then(() => {
             try {
@@ -65,7 +65,7 @@ function _updateQA(html, fadeTime, onupdate, onshown) {
             })
         )
         // and reveal when processing is done
-        .then(() => new Promise((resolve) => qa.fadeIn(fadeTime, () => resolve())))
+        .then(() => new Promise((resolve) => qa.fadeTo(fadeTime, 1, () => resolve())))
         .then(() => _runHook(onShownHook))
         .then(() => (_updatingQA = false));
 }


### PR DESCRIPTION
This is the fix to https://github.com/ankitects/anki/pull/824#issuecomment-741725158.

It's a weird one: It seems `$.fadeTo` and `$.fadeIn` / `$.fadeOut` work differently in this aspect. I'm sorry for (unnecessarily) breaking it.

It seems like, `$.fadeIn` / `$.fadeOut` first alter the opacity, just like `$.fadeTo`, but at the end, they set `display: none/block`. With `display: none`, the text won't occupy any space, which is why scrolling to it doesn't move the screen.