### PR TITLE
Remove unicode isolation from card type names

### DIFF
--- a/qt/aqt/clayout.py
+++ b/qt/aqt/clayout.py
@@ -630,7 +630,7 @@ class CardLayout(QDialog):
     def _newCardName(self):
         n = len(self.templates) + 1
         while 1:
-            name = tr(TR.CARD_TEMPLATES_CARD, val=n)
+            name = without_unicode_isolation(tr(TR.CARD_TEMPLATES_CARD, val=n))
             if name not in [t["name"] for t in self.templates]:
                 break
             n += 1


### PR DESCRIPTION
Right now, Anki saves unicode isolate characters in card type names.

This breaks browser search `card:"Card 2"`, will not match the card type name `Card ⁨2⁩`, because of invisible characters.