### PR TITLE
Resolved some mypy errors in qt

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -69,7 +69,7 @@ RumovZ <gp5glkw78@relay.firefox.com>
 Cecini <github.com/cecini> 
 Krish Shah <github.com/k12ish>
 ianki <iankigit@gmail.com>
-Lifan Chu <github.com/lifanchu>
+Chu <github.com/lifanchu>
 
 ********************
 

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -69,6 +69,7 @@ RumovZ <gp5glkw78@relay.firefox.com>
 Cecini <github.com/cecini> 
 Krish Shah <github.com/k12ish>
 ianki <iankigit@gmail.com>
+Lifan Chu <github.com/lifanchu>
 
 ********************
 

--- a/qt/aqt/browser.py
+++ b/qt/aqt/browser.py
@@ -9,7 +9,7 @@ import time
 from dataclasses import dataclass
 from enum import Enum
 from operator import itemgetter
-from typing import Callable, List, Optional, Sequence, Tuple, Union, Dict, Any, cast
+from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Union, cast
 
 import anki
 import aqt

--- a/qt/aqt/browser.py
+++ b/qt/aqt/browser.py
@@ -9,7 +9,7 @@ import time
 from dataclasses import dataclass
 from enum import Enum
 from operator import itemgetter
-from typing import Callable, List, Optional, Sequence, Tuple, Union, cast
+from typing import Callable, List, Optional, Sequence, Tuple, Union, Dict, Any, cast
 
 import anki
 import aqt

--- a/qt/mypy.ini
+++ b/qt/mypy.ini
@@ -8,6 +8,7 @@ warn_redundant_casts = True
 warn_unused_configs = True
 check_untyped_defs = true
 strict_equality = true
+mypy_path = ../pylib
 
 [mypy-aqt.mpv]
 ignore_errors=true


### PR DESCRIPTION
- Added two missing type imports in `browser.py`
- Added `mypy_path` to `qt/mypy.ini`. This resolves the "Cannot find implementation or library stub" import errors. Currently requires user to be in the same directory as `mypy.ini`, but this will be fixed in a future version of mypy (see [here](https://github.com/python/mypy/pull/9414)).