### PR TITLE
Add method `card_count_from_did()`

### DIFF
--- a/pylib/anki/collection.py
+++ b/pylib/anki/collection.py
@@ -379,6 +379,16 @@ class Collection:
     def cardCount(self) -> Any:
         return self.db.scalar("select count() from cards")
 
+    def card_count_from_did(self, did, recursive=False):
+        dids = [did]
+        if recursive:
+            dids += [r[1] for r in self.decks.children(did)]
+        count = self.db.scalar(
+            "select count() from cards where did in {0} or "
+            "odid in {0}".format(ids2str(dids))
+        )
+        return count
+
     def remove_cards_and_orphaned_notes(self, card_ids: Sequence[int]):
         "You probably want .remove_notes_by_card() instead."
         self.backend.remove_cards(card_ids=card_ids)

--- a/pylib/anki/collection.py
+++ b/pylib/anki/collection.py
@@ -379,9 +379,9 @@ class Collection:
     def cardCount(self) -> Any:
         return self.db.scalar("select count() from cards")
 
-    def card_count_from_did(self, did, recursive=False):
-        dids = [did]
-        if recursive:
+    def card_count_from_did(self, did: int, count_subdecks: bool = False) -> Any:
+        dids: List[int] = [did]
+        if count_subdecks:
             dids += [r[1] for r in self.decks.children(did)]
         count = self.db.scalar(
             "select count() from cards where did in {0} or "

--- a/qt/aqt/deckbrowser.py
+++ b/qt/aqt/deckbrowser.py
@@ -278,13 +278,9 @@ class DeckBrowser:
         self.mw.checkpoint(tr(TR.DECKS_DELETE_DECK))
         deck = self.mw.col.decks.get(did)
         if not deck["dyn"]:
-            dids = [did] + [r[1] for r in self.mw.col.decks.children(did)]
-            cnt = self.mw.col.db.scalar(
-                "select count() from cards where did in {0} or "
-                "odid in {0}".format(ids2str(dids))
-            )
-            if cnt:
-                extra = tr(TR.DECKS_IT_HAS_CARD, count=cnt)
+            count = self.mw.col.card_count_from_did(did, recursive=True)
+            if count:
+                extra = tr(TR.DECKS_IT_HAS_CARD, count=count)
             else:
                 extra = None
         if (

--- a/qt/aqt/deckbrowser.py
+++ b/qt/aqt/deckbrowser.py
@@ -265,7 +265,7 @@ class DeckBrowser:
             node.collapsed = not node.collapsed
         self._renderPage(reuse=True)
 
-    def _dragDeckOnto(self, draggedDeckDid, ontoDeckDid):
+    def _dragDeckOnto(self, draggedDeckDid: int, ontoDeckDid: int):
         try:
             self.mw.col.decks.renameForDragAndDrop(draggedDeckDid, ontoDeckDid)
             gui_hooks.sidebar_should_refresh_decks()
@@ -274,11 +274,11 @@ class DeckBrowser:
 
         self.show()
 
-    def _delete(self, did):
+    def _delete(self, did: int):
         self.mw.checkpoint(tr(TR.DECKS_DELETE_DECK))
         deck = self.mw.col.decks.get(did)
         if not deck["dyn"]:
-            count = self.mw.col.card_count_from_did(did, recursive=True)
+            count = self.mw.col.card_count_from_did(did, count_subdecks=True)
             if count:
                 extra = tr(TR.DECKS_IT_HAS_CARD, count=count)
             else:


### PR DESCRIPTION
Finding the number of cards in a given deck is a common operation, add-on developers shouldn't require database queries for this.

The code for `card_count_from_did` is taken from the `_delete` method from deckbrowser.py and seems to work desirably. 