### PR TITLE
Wrap field name in editor in a span

### DIFF
--- a/qt/aqt/data/web/js/editor.ts
+++ b/qt/aqt/data/web/js/editor.ts
@@ -351,7 +351,9 @@ function setFields(fields) {
         }
         txt += `
         <tr>
-            <td class=fname id="name${i}">${n}</td>
+            <td class=fname id="name${i}">
+                <span class="fieldname">${n}</span>
+            </td>
         </tr>
         <tr>
             <td width=100%>


### PR DESCRIPTION
I would like to add the functionality to click a field name in the Editor view while holding modifiers to clear the associated field.

However the field names parent element is the `td` element, which is a block element which takes up the whole horizontal space.

This PR wraps the field name into a simple span, so you can put event listeners on only the span, rather than the whole horizontal space.