### PR TITLE
Remove placeholder `<br>`s in empty fields in editor

### DIFF
--- a/qt/aqt/data/web/css/editor.scss
+++ b/qt/aqt/data/web/css/editor.scss
@@ -8,9 +8,14 @@
     padding: 5px;
     overflow-wrap: break-word;
     overflow: auto;
+
+    &:empty::after {
+        content: "\A";
+        white-space: pre;
+    }
 }
 
-.clearfix:after {
+.clearfix::after {
     content: "";
     display: table;
     clear: both;

--- a/qt/aqt/data/web/js/editor.ts
+++ b/qt/aqt/data/web/js/editor.ts
@@ -121,11 +121,6 @@ function inPreEnvironment() {
 }
 
 function onInput() {
-    // empty field?
-    if (currentField.innerHTML === "") {
-        currentField.innerHTML = "<br>";
-    }
-
     // make sure IME changes get saved
     triggerKeyTimer();
 }
@@ -346,9 +341,6 @@ function setFields(fields) {
     for (let i = 0; i < fields.length; i++) {
         const n = fields[i][0];
         let f = fields[i][1];
-        if (!f) {
-            f = "<br>";
-        }
         txt += `
         <tr>
             <td class=fname id="name${i}">${n}</td>
@@ -408,20 +400,12 @@ function hideDupes() {
     $("#dupes").hide();
 }
 
-/// If the field has only an empty br, remove it first.
-let insertHtmlRemovingInitialBR = function (html: string) {
-    if (html !== "") {
-        // remove <br> in empty field
-        if (currentField && currentField.innerHTML === "<br>") {
-            currentField.innerHTML = "";
-        }
-        setFormat("inserthtml", html);
-    }
-};
-
 let pasteHTML = function (html, internal, extendedMode) {
     html = filterHTML(html, internal, extendedMode);
-    insertHtmlRemovingInitialBR(html);
+
+    if (html !== "") {
+        setFormat("inserthtml", html);
+    }
 };
 
 let filterHTML = function (html, internal, extendedMode) {


### PR DESCRIPTION
This replaces the insertion of `<br>` elements in the editor view, and replaces it with a neat small CSS specifier.

I left the filtering of `<br>` and `<div><br></div>` sequences in editor.py, as otherwise users might end up with a lot of those text sequences in their notes.

One way users can notice this change is when they select the whole content of a field (Ctrl-A), delete it, and undo it using `Ctrl-Z`, it won't "insert" a extra newline on the start.