### PR TITLE
Consider removing special handling of Shift+Tab in Editor on macOS

### DIFF
--- a/qt/aqt/data/web/js/editor.ts
+++ b/qt/aqt/data/web/js/editor.ts
@@ -54,12 +54,6 @@ function onKey(evt: KeyboardEvent) {
         currentField.blur();
         return;
     }
-    // shift+tab goes to previous field
-    if (navigator.platform === "MacIntel" && evt.which === 9 && evt.shiftKey) {
-        evt.preventDefault();
-        focusPrevious();
-        return;
-    }
 
     // fix Ctrl+right/left handling in RTL fields
     if (currentField.dir === "rtl") {
@@ -204,16 +198,6 @@ function focusField(n) {
         return;
     }
     $("#f" + n).focus();
-}
-
-function focusPrevious() {
-    if (!currentField) {
-        return;
-    }
-    const previous = currentFieldOrdinal() - 1;
-    if (previous >= 0) {
-        focusField(previous);
-    }
 }
 
 function focusIfField(x, y) {


### PR DESCRIPTION
I was confused by some weird Tab behavior, when I noticed this piece of code.

I'm running BigSur, and I can use the `Shift+Tab` shortcut without this piece of code. In fact, it runs better without, because it respects HTML semantics, like `tab-index`.

According to 53fb3b0e8c86131914eb7e4679b59c4347788c26, it seemed to be necessary at some point, but I cannot confirm this necessity anymore.

