### PR TITLE
Hide stats buttons in reviewer bottom bar, if window width is too small

### DIFF
--- a/qt/aqt/data/web/css/reviewer-bottom.scss
+++ b/qt/aqt/data/web/css/reviewer-bottom.scss
@@ -20,6 +20,10 @@ button {
 
 .stat {
     padding-top: 5px;
+
+    @media (max-width: 583px) {
+        display: none;
+    }
 }
 
 .stat2 {
@@ -78,3 +82,4 @@ button {
         border-top-color: var(--faint-border);
     }
 }
+


### PR DESCRIPTION
Specifically the "Edit" and "More..." buttons.

Before:
<img width="512" alt="Screenshot 2020-12-26 at 15 53 29" src="https://user-images.githubusercontent.com/7188844/103153705-b9076900-4792-11eb-9d9c-bfe0009f418c.png">

After:
<img width="512" alt="Screenshot 2020-12-26 at 15 49 56" src="https://user-images.githubusercontent.com/7188844/103153707-bc025980-4792-11eb-82bf-754e87e620f6.png">

Two caveats:
1. The specific pixel size prevents a scroll bar from ever appearing. I don't whether this is applicable for every platform though. 
2. The hiding is not really necessary on the front side, but I would argue hiding it there as well makes for a cleaner UI (otherwise buttons appear on the front, disappear on the back, and only reappear, if you make it bigger, which I would consider odd behavior).
