### PR TITLE
Prevent stats screen from overscrolling

### DIFF
--- a/ts/graphs/graphs.scss
+++ b/ts/graphs/graphs.scss
@@ -17,6 +17,10 @@
     --area-stroke-opacity: 0.18;
 }
 
+* {
+    overscroll-behavior: none;
+}
+
 .graph-tooltip {
     position: absolute;
     padding: 15px;


### PR DESCRIPTION
If you're on the stats screen, and you scroll all the way to the bottom, or from the bottom all the way to the top, you _overscroll_ the page, which causes a "bouncing" effect of the scroll bar, which is annoying for the user, as it takes half a second too finish, for no good use.

This PR gets rid of this animation.