### PR TITLE
Decouple GraphsPage from individual graphs and RangeBox

### DIFF
--- a/ts/graphs/BUILD.bazel
+++ b/ts/graphs/BUILD.bazel
@@ -30,6 +30,7 @@ ts_library(
         "GraphsPage",
         "lib",
         "//ts/lib",
+        "@npm//svelte",
         "@npm//svelte2tsx",
     ],
 )

--- a/ts/graphs/GraphsPage.svelte
+++ b/ts/graphs/GraphsPage.svelte
@@ -13,6 +13,7 @@
 
     export let search: string;
     export let days: number;
+    export let withRangeBox: boolean;
 
     let sourceData: pb.BackendProto.GraphsOut | null = null;
 
@@ -95,44 +96,46 @@
     }
 </style>
 
-<div class="range-box">
-    <div class="spin {refreshing ? 'active' : ''}">◐</div>
+{#if withRangeBox}
+    <div class="range-box">
+        <div class="spin {refreshing ? 'active' : ''}">◐</div>
 
-    <div class="range-box-inner">
-        <label>
-            <input type="radio" bind:group={searchRange} value={SearchRange.Deck} />
-            {deck}
-        </label>
-        <label>
+        <div class="range-box-inner">
+            <label>
+                <input type="radio" bind:group={searchRange} value={SearchRange.Deck} />
+                {deck}
+            </label>
+            <label>
+                <input
+                    type="radio"
+                    bind:group={searchRange}
+                    value={SearchRange.Collection} />
+                {collection}
+            </label>
+
             <input
-                type="radio"
-                bind:group={searchRange}
-                value={SearchRange.Collection} />
-            {collection}
-        </label>
-
-        <input
-            type="text"
-            bind:value={displayedSearch}
-            on:keyup={searchKeyUp}
-            on:focus={() => {
+                type="text"
+                bind:value={displayedSearch}
+                on:keyup={searchKeyUp}
+                on:focus={() => {
                 searchRange = SearchRange.Custom;
-            }}
-            placeholder={searchLabel} />
-    </div>
+                }}
+                placeholder={searchLabel} />
+        </div>
 
-    <div class="range-box-inner">
-        <label>
-            <input type="radio" bind:group={revlogRange} value={RevlogRange.Year} />
-            {year}
-        </label>
-        <label>
-            <input type="radio" bind:group={revlogRange} value={RevlogRange.All} />
-            {all}
-        </label>
+        <div class="range-box-inner">
+            <label>
+                <input type="radio" bind:group={revlogRange} value={RevlogRange.Year} />
+                {year}
+            </label>
+            <label>
+                <input type="radio" bind:group={revlogRange} value={RevlogRange.All} />
+                {all}
+            </label>
+        </div>
     </div>
-</div>
-<div class="range-box-pad" />
+    <div class="range-box-pad" />
+{/if}
 
 <div tabindex="-1" class="no-focus-outline">
     {#if sourceData}

--- a/ts/graphs/GraphsPage.svelte
+++ b/ts/graphs/GraphsPage.svelte
@@ -17,10 +17,12 @@
     export let days: number;
     export let withRangeBox: boolean;
 
+    let active = false;
     let sourceData: pb.BackendProto.GraphsOut | null = null;
     let revlogRange: RevlogRange;
 
     const refreshWith = async (search: string, days: number) => {
+        active = true;
         try {
             sourceData = await getGraphData(search, days);
             revlogRange = days > 365 || days === 0
@@ -30,14 +32,11 @@
             sourceData = null;
             alert(i18n.tr(i18n.TR.STATISTICS_ERROR_FETCHING));
         }
+        active = false;
     }
 
-    let active = false;
-
     const refresh = (event: CustomEvent) => {
-        active = true;
         refreshWith(event.detail.search, event.detail.days)
-        active = false;
     }
 
     refreshWith(search, days)

--- a/ts/graphs/GraphsPage.svelte
+++ b/ts/graphs/GraphsPage.svelte
@@ -3,7 +3,7 @@
 </script>
 
 <script lang="typescript">
-    import type { SvelteComnponent } from "svelte/internal";
+    import type { SvelteComponent } from "svelte/internal";
     import type { I18n } from "anki/i18n";
     import type pb from "anki/backend_proto";
     import { getGraphData, RevlogRange } from "./graph-helpers";

--- a/ts/graphs/GraphsPage.svelte
+++ b/ts/graphs/GraphsPage.svelte
@@ -3,7 +3,7 @@
 </script>
 
 <script lang="typescript">
-    import type { SvelteComnponent } from 'svelte/internal';
+    import type { SvelteComnponent } from "svelte/internal";
     import type { I18n } from "anki/i18n";
     import type pb from "anki/backend_proto";
     import { getGraphData, RevlogRange } from "./graph-helpers";
@@ -24,31 +24,40 @@
         active = true;
         try {
             sourceData = await getGraphData(search, days);
-            revlogRange = days > 365 || days === 0
-                ? RevlogRange.All
-                : RevlogRange.Year;
+            revlogRange = days > 365 || days === 0 ? RevlogRange.All : RevlogRange.Year;
         } catch (e) {
             sourceData = null;
             alert(i18n.tr(i18n.TR.STATISTICS_ERROR_FETCHING));
         }
         active = false;
-    }
+    };
 
     const refresh = (event: CustomEvent) => {
-        refreshWith(event.detail.search, event.detail.days)
-    }
+        refreshWith(event.detail.search, event.detail.days);
+    };
 
-    refreshWith(search, days)
+    refreshWith(search, days);
 </script>
 
 {#if controller}
-    <svelte:component this={controller} {i18n} {search} {days} {active} on:update={refresh} />
+    <svelte:component
+        this={controller}
+        {i18n}
+        {search}
+        {days}
+        {active}
+        on:update={refresh} />
 {/if}
 
 {#if sourceData}
     <div tabindex="-1" class="no-focus-outline">
         {#each graphs as graph}
-            <svelte:component this={graph} {sourceData} {revlogRange} {i18n} {nightMode} />
+            <svelte:component
+                this={graph}
+                {sourceData}
+                {revlogRange}
+                {i18n}
+                {nightMode} />
         {/each}
     </div>
 {/if}

--- a/ts/graphs/GraphsPage.svelte
+++ b/ts/graphs/GraphsPage.svelte
@@ -3,7 +3,8 @@
 </script>
 
 <script lang="typescript">
-    import { fade } from 'svelte/transition';
+    import { afterUpdate } from 'svelte';
+
     import type { I18n } from "anki/i18n";
     import type pb from "anki/backend_proto";
     import { getGraphData, RevlogRange } from "./graph-helpers";
@@ -81,6 +82,19 @@
         }
     };
 
+    let spinner: HTMLDivElement;
+    let graphsContainer: HTMLDivElement;
+
+    afterUpdate(() => {
+        // make sure graph container retains its size for spinner
+        if (spinner) {
+            graphsContainer.style.minHeight = `${document.documentElement.scrollHeight}px`;
+        }
+        else {
+            graphsContainer.style.minHeight = '';
+        }
+    })
+
     const year = i18n.tr(i18n.TR.STATISTICS_RANGE_1_YEAR_HISTORY);
     const deck = i18n.tr(i18n.TR.STATISTICS_RANGE_DECK);
     const collection = i18n.tr(i18n.TR.STATISTICS_RANGE_COLLECTION);
@@ -127,16 +141,16 @@
     <div class="range-box-pad" />
 {/if}
 
-{#await dataPromise}
-    <div class="spin" transition:fade="{{duration=50}}">◐</div>
-{:then sourceData}
-    <div tabindex="-1" class="no-focus-outline">
-        {#each graphs as Graph}
-            <Graph {sourceData} {revlogRange} {i18n} {nightMode} />
-        {/each}
-    </div>
-{:catch error}
-    <script>
-        alert({i18n.tr(i18n.TR.STATISTICS_ERROR_FETCHING)});
-    </script>
-{/await}
+<div bind:this={graphsContainer} tabindex="-1" class="no-focus-outline">
+    {#await dataPromise}
+        <div bind:this={spinner} class="spin">◐</div>
+    {:then sourceData}
+            {#each graphs as Graph}
+                <Graph {sourceData} {revlogRange} {i18n} {nightMode} />
+            {/each}
+    {:catch error}
+        <script>
+            alert({i18n.tr(i18n.TR.STATISTICS_ERROR_FETCHING)});
+        </script>
+    {/await}
+</div>

--- a/ts/graphs/GraphsPage.svelte
+++ b/ts/graphs/GraphsPage.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script lang="typescript">
+    import { fade } from 'svelte/transition';
     import type { I18n } from "anki/i18n";
     import type pb from "anki/backend_proto";
     import { getGraphData, RevlogRange } from "./graph-helpers";
@@ -127,7 +128,7 @@
 {/if}
 
 {#await dataPromise}
-    <div class="spin">◐</div>
+    <div class="spin" transition:fade="{{duration=50}}">◐</div>
 {:then sourceData}
     <div tabindex="-1" class="no-focus-outline">
         {#each graphs as Graph}

--- a/ts/graphs/GraphsPage.svelte
+++ b/ts/graphs/GraphsPage.svelte
@@ -3,19 +3,18 @@
 </script>
 
 <script lang="typescript">
-    import RangeBox from './RangeBox.svelte'
-
+    import type { SvelteComnponent } from 'svelte/internal';
     import type { I18n } from "anki/i18n";
     import type pb from "anki/backend_proto";
     import { getGraphData, RevlogRange } from "./graph-helpers";
 
     export let i18n: I18n;
     export let nightMode: boolean;
-    export let graphs: any[];
+    export let graphs: SvelteComponent[];
 
     export let search: string;
     export let days: number;
-    export let withRangeBox: boolean;
+    export let controller: SvelteComponent;
 
     let active = false;
     let sourceData: pb.BackendProto.GraphsOut | null = null;
@@ -42,14 +41,14 @@
     refreshWith(search, days)
 </script>
 
-{#if withRangeBox}
-    <RangeBox {i18n} {search} {days} {active} on:update={refresh} />
+{#if controller}
+    <svelte:component this={controller} {i18n} {search} {days} {active} on:update={refresh} />
 {/if}
 
 {#if sourceData}
     <div tabindex="-1" class="no-focus-outline">
-        {#each graphs as Graph}
-            <Graph {sourceData} {revlogRange} {i18n} {nightMode} />
+        {#each graphs as graph}
+            <svelte:component this={graph} {sourceData} {revlogRange} {i18n} {nightMode} />
         {/each}
     </div>
 {/if}

--- a/ts/graphs/GraphsPage.svelte
+++ b/ts/graphs/GraphsPage.svelte
@@ -11,6 +11,9 @@
     export let nightMode: boolean;
     export let graphs: any[];
 
+    export let search: string;
+    export let days: number;
+
     let sourceData: pb.BackendProto.GraphsOut | null = null;
 
     enum SearchRange {
@@ -21,10 +24,8 @@
 
     let searchRange: SearchRange = SearchRange.Deck;
     let revlogRange: RevlogRange = RevlogRange.Year;
-    let days: number = 31;
     let refreshing = false;
 
-    let search = "deck:current";
     let displayedSearch = search;
 
     const refresh = async () => {

--- a/ts/graphs/GraphsPage.svelte
+++ b/ts/graphs/GraphsPage.svelte
@@ -90,12 +90,6 @@
     const all = i18n.tr(i18n.TR.STATISTICS_RANGE_ALL_HISTORY);
 </script>
 
-<style>
-    .no-focus-outline:focus {
-        outline: 0;
-    }
-</style>
-
 {#if withRangeBox}
     <div class="range-box">
         <div class="spin {refreshing ? 'active' : ''}">◐</div>

--- a/ts/graphs/GraphsPage.svelte
+++ b/ts/graphs/GraphsPage.svelte
@@ -6,19 +6,10 @@
     import type { I18n } from "anki/i18n";
     import type pb from "anki/backend_proto";
     import { getGraphData, RevlogRange } from "./graph-helpers";
-    import IntervalsGraph from "./IntervalsGraph.svelte";
-    import EaseGraph from "./EaseGraph.svelte";
-    import AddedGraph from "./AddedGraph.svelte";
-    import TodayStats from "./TodayStats.svelte";
-    import ButtonsGraph from "./ButtonsGraph.svelte";
-    import CardCounts from "./CardCounts.svelte";
-    import HourGraph from "./HourGraph.svelte";
-    import FutureDue from "./FutureDue.svelte";
-    import ReviewsGraph from "./ReviewsGraph.svelte";
-    import CalendarGraph from "./CalendarGraph.svelte";
 
     export let i18n: I18n;
     export let nightMode: boolean;
+    export let graphs: any[];
 
     let sourceData: pb.BackendProto.GraphsOut | null = null;
 
@@ -144,15 +135,8 @@
 
 <div tabindex="-1" class="no-focus-outline">
     {#if sourceData}
-        <TodayStats {sourceData} {i18n} />
-        <FutureDue {sourceData} {i18n} />
-        <CalendarGraph {sourceData} {revlogRange} {i18n} {nightMode} />
-        <ReviewsGraph {sourceData} {revlogRange} {i18n} />
-        <CardCounts {sourceData} {i18n} />
-        <IntervalsGraph {sourceData} {i18n} />
-        <EaseGraph {sourceData} {i18n} />
-        <HourGraph {sourceData} {revlogRange} {i18n} />
-        <ButtonsGraph {sourceData} {revlogRange} {i18n} />
-        <AddedGraph {sourceData} {i18n} />
+        {#each graphs as Graph}
+            <Graph {sourceData} {revlogRange} {i18n} {nightMode} />
+        {/each}
     {/if}
 </div>

--- a/ts/graphs/GraphsPage.svelte
+++ b/ts/graphs/GraphsPage.svelte
@@ -23,7 +23,7 @@
     const refreshWith = async (search: string, days: number) => {
         try {
             sourceData = await getGraphData(search, days);
-            revlogRange = days > 365
+            revlogRange = days > 365 || days === 0
                 ? RevlogRange.All
                 : RevlogRange.Year;
         } catch (e) {

--- a/ts/graphs/GraphsPage.svelte
+++ b/ts/graphs/GraphsPage.svelte
@@ -12,10 +12,11 @@
     export let graphs: any[];
 
     export let search: string;
-    export let days: number;
+    export let revlogRange: RevlogRange;
     export let withRangeBox: boolean;
 
     let sourceData: pb.BackendProto.GraphsOut | null = null;
+    let days;
 
     enum SearchRange {
         Deck = 1,
@@ -24,7 +25,6 @@
     }
 
     let searchRange: SearchRange = SearchRange.Deck;
-    let revlogRange: RevlogRange = RevlogRange.Year;
     let refreshing = false;
 
     let displayedSearch = search;

--- a/ts/graphs/GraphsPage.svelte
+++ b/ts/graphs/GraphsPage.svelte
@@ -127,7 +127,7 @@
 {/if}
 
 {#await dataPromise}
-    <div class="spin {refreshing ? 'active' : ''}">◐</div>
+    <div class="spin">◐</div>
 {:then sourceData}
     <div tabindex="-1" class="no-focus-outline">
         {#each graphs as Graph}

--- a/ts/graphs/RangeBox.svelte
+++ b/ts/graphs/RangeBox.svelte
@@ -18,7 +18,7 @@
 
     const dispatch = createEventDispatcher();
 
-    let revlogRange: RevlogRange = days <= 365
+    let revlogRange: RevlogRange = days > 365 || days === 0
         ? RevlogRange.Year
         : RevlogRange.All;
 

--- a/ts/graphs/RangeBox.svelte
+++ b/ts/graphs/RangeBox.svelte
@@ -1,6 +1,7 @@
 <script lang="typescript">
     import { createEventDispatcher } from 'svelte';
 
+    import type { I18n } from "anki/i18n";
     import { RevlogRange } from "./graph-helpers";
 
     enum SearchRange {
@@ -10,14 +11,23 @@
     }
 
     export let i18n: I18n;
+    export let active: boolean;
+
+    export let days: number;
+    export let search: string;
 
     const dispatch = createEventDispatcher();
 
-    let revlogRange: RevlogRange = RevlogRange.Year;
-    let searchRange: SearchRange = SearchRange.Deck;
+    let revlogRange: RevlogRange = days <= 365
+        ? RevlogRange.Year
+        : RevlogRange.All;
 
-    let days;
-    let search;
+    let searchRange: SearchRange = search === "deck:current"
+        ? SearchRange.Deck
+        : search === ""
+        ? SearchRange.Collection
+        : SearchRange.Custom;
+
     let displayedSearch = search;
 
     const update = () => {
@@ -71,6 +81,8 @@
 
 
 <div class="range-box">
+    <div class="spin" class:active>◐</div>
+
     <div class="range-box-inner">
         <label>
             <input type="radio" bind:group={searchRange} value={SearchRange.Deck} />

--- a/ts/graphs/RangeBox.svelte
+++ b/ts/graphs/RangeBox.svelte
@@ -1,5 +1,5 @@
 <script lang="typescript">
-    import { createEventDispatcher } from 'svelte';
+    import { createEventDispatcher } from "svelte";
 
     import type { I18n } from "anki/i18n";
     import { RevlogRange } from "./graph-helpers";
@@ -18,20 +18,20 @@
 
     const dispatch = createEventDispatcher();
 
-    let revlogRange: RevlogRange = days > 365 || days === 0
-        ? RevlogRange.Year
-        : RevlogRange.All;
+    let revlogRange: RevlogRange =
+        days > 365 || days === 0 ? RevlogRange.Year : RevlogRange.All;
 
-    let searchRange: SearchRange = search === "deck:current"
-        ? SearchRange.Deck
-        : search === ""
-        ? SearchRange.Collection
-        : SearchRange.Custom;
+    let searchRange: SearchRange =
+        search === "deck:current"
+            ? SearchRange.Deck
+            : search === ""
+            ? SearchRange.Collection
+            : SearchRange.Custom;
 
     let displayedSearch = search;
 
     const update = () => {
-        dispatch('update', {
+        dispatch("update", {
             days: days,
             search: search,
             searchRange: searchRange,
@@ -42,11 +42,11 @@
         switch (searchRange as SearchRange) {
             case SearchRange.Deck:
                 search = displayedSearch = "deck:current";
-                update()
+                update();
                 break;
             case SearchRange.Collection:
                 search = displayedSearch = "";
-                update()
+                update();
                 break;
         }
     }
@@ -55,11 +55,11 @@
         switch (revlogRange as RevlogRange) {
             case RevlogRange.Year:
                 days = 365;
-                update()
+                update();
                 break;
             case RevlogRange.All:
                 days = 0;
-                update()
+                update();
                 break;
         }
     }
@@ -68,7 +68,7 @@
         // fetch data on enter
         if (e.key == "Enter") {
             search = displayedSearch;
-            update()
+            update();
         }
     };
 
@@ -78,7 +78,6 @@
     const searchLabel = i18n.tr(i18n.TR.STATISTICS_RANGE_SEARCH);
     const all = i18n.tr(i18n.TR.STATISTICS_RANGE_ALL_HISTORY);
 </script>
-
 
 <div class="range-box">
     <div class="spin" class:active>◐</div>
@@ -101,7 +100,7 @@
             bind:value={displayedSearch}
             on:keyup={searchKeyUp}
             on:focus={() => {
-            searchRange = SearchRange.Custom;
+                searchRange = SearchRange.Custom;
             }}
             placeholder={searchLabel} />
     </div>

--- a/ts/graphs/RangeBox.svelte
+++ b/ts/graphs/RangeBox.svelte
@@ -1,0 +1,109 @@
+<script lang="typescript">
+    import { createEventDispatcher } from 'svelte';
+
+    import { RevlogRange } from "./graph-helpers";
+
+    enum SearchRange {
+        Deck = 1,
+        Collection = 2,
+        Custom = 3,
+    }
+
+    export let i18n: I18n;
+
+    const dispatch = createEventDispatcher();
+
+    let revlogRange: RevlogRange = RevlogRange.Year;
+    let searchRange: SearchRange = SearchRange.Deck;
+
+    let days;
+    let search;
+    let displayedSearch = search;
+
+    const update = () => {
+        dispatch('update', {
+            days: days,
+            search: search,
+            searchRange: searchRange,
+        });
+    };
+
+    $: {
+        switch (searchRange as SearchRange) {
+            case SearchRange.Deck:
+                search = displayedSearch = "deck:current";
+                update()
+                break;
+            case SearchRange.Collection:
+                search = displayedSearch = "";
+                update()
+                break;
+        }
+    }
+
+    $: {
+        switch (revlogRange as RevlogRange) {
+            case RevlogRange.Year:
+                days = 365;
+                update()
+                break;
+            case RevlogRange.All:
+                days = 0;
+                update()
+                break;
+        }
+    }
+
+    const searchKeyUp = (e: KeyboardEvent) => {
+        // fetch data on enter
+        if (e.key == "Enter") {
+            search = displayedSearch;
+            update()
+        }
+    };
+
+    const year = i18n.tr(i18n.TR.STATISTICS_RANGE_1_YEAR_HISTORY);
+    const deck = i18n.tr(i18n.TR.STATISTICS_RANGE_DECK);
+    const collection = i18n.tr(i18n.TR.STATISTICS_RANGE_COLLECTION);
+    const searchLabel = i18n.tr(i18n.TR.STATISTICS_RANGE_SEARCH);
+    const all = i18n.tr(i18n.TR.STATISTICS_RANGE_ALL_HISTORY);
+</script>
+
+
+<div class="range-box">
+    <div class="range-box-inner">
+        <label>
+            <input type="radio" bind:group={searchRange} value={SearchRange.Deck} />
+            {deck}
+        </label>
+        <label>
+            <input
+                type="radio"
+                bind:group={searchRange}
+                value={SearchRange.Collection} />
+            {collection}
+        </label>
+
+        <input
+            type="text"
+            bind:value={displayedSearch}
+            on:keyup={searchKeyUp}
+            on:focus={() => {
+            searchRange = SearchRange.Custom;
+            }}
+            placeholder={searchLabel} />
+    </div>
+
+    <div class="range-box-inner">
+        <label>
+            <input type="radio" bind:group={revlogRange} value={RevlogRange.Year} />
+            {year}
+        </label>
+        <label>
+            <input type="radio" bind:group={revlogRange} value={RevlogRange.All} />
+            {all}
+        </label>
+    </div>
+</div>
+
+<div class="range-box-pad" />

--- a/ts/graphs/bootstrap.ts
+++ b/ts/graphs/bootstrap.ts
@@ -21,6 +21,7 @@ export function graphs(
     graphs: any[], {
         search = "deck:current",
         days = 31,
+        withRangeBox = true,
     } = {},
 ): void {
     const nightMode = checkNightMode();
@@ -34,6 +35,7 @@ export function graphs(
                 nightMode,
                 search,
                 days,
+                withRangeBox,
             },
         });
     });

--- a/ts/graphs/bootstrap.ts
+++ b/ts/graphs/bootstrap.ts
@@ -1,10 +1,13 @@
 // Copyright: Ankitects Pty Ltd and contributors
 // License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
+import type { SvelteComponent } from 'svelte/internal';
+
 import { setupI18n } from "anki/i18n";
 import GraphsPage from "./GraphsPage.svelte";
 import { checkNightMode } from "anki/nightmode";
-import { RevlogRange } from "./graph-helpers";
+
+export { default as RangeBox } from './RangeBox.svelte';
 
 export { default as IntervalsGraph } from "./IntervalsGraph.svelte";
 export { default as EaseGraph } from "./EaseGraph.svelte";
@@ -20,10 +23,10 @@ export { RevlogRange } from "./graph-helpers";
 
 export function graphs(
     target: HTMLDivElement,
-    graphs: any[], {
+    graphs: SvelteComponent[], {
         search = "deck:current",
         days = 365,
-        withRangeBox = true,
+        controller = null,
     } = {},
 ): void {
     const nightMode = checkNightMode();
@@ -37,7 +40,7 @@ export function graphs(
                 nightMode,
                 search,
                 days,
-                withRangeBox,
+                controller,
             },
         });
     });

--- a/ts/graphs/bootstrap.ts
+++ b/ts/graphs/bootstrap.ts
@@ -5,11 +5,28 @@ import { setupI18n } from "anki/i18n";
 import GraphsPage from "./GraphsPage.svelte";
 import { checkNightMode } from "anki/nightmode";
 
-export function graphs(target: HTMLDivElement): void {
+export { default as IntervalsGraph } from "./IntervalsGraph.svelte";
+export { default as EaseGraph } from "./EaseGraph.svelte";
+export { default as AddedGraph } from "./AddedGraph.svelte";
+export { default as TodayStats } from "./TodayStats.svelte";
+export { default as ButtonsGraph } from "./ButtonsGraph.svelte";
+export { default as CardCounts } from "./CardCounts.svelte";
+export { default as HourGraph } from "./HourGraph.svelte";
+export { default as FutureDue } from "./FutureDue.svelte";
+export { default as ReviewsGraph } from "./ReviewsGraph.svelte";
+export { default as CalendarGraph } from "./CalendarGraph.svelte";
+
+export function graphs(target: HTMLDivElement, graphs: any[]): void {
+    const nightMode = checkNightMode();
+
     setupI18n().then((i18n) => {
         new GraphsPage({
             target,
-            props: { i18n, nightMode: checkNightMode() },
+            props: {
+                i18n,
+                graphs,
+                nightMode,
+            },
         });
     });
 }

--- a/ts/graphs/bootstrap.ts
+++ b/ts/graphs/bootstrap.ts
@@ -1,13 +1,13 @@
 // Copyright: Ankitects Pty Ltd and contributors
 // License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
-import type { SvelteComponent } from 'svelte/internal';
+import type { SvelteComponent } from "svelte/internal";
 
 import { setupI18n } from "anki/i18n";
 import GraphsPage from "./GraphsPage.svelte";
 import { checkNightMode } from "anki/nightmode";
 
-export { default as RangeBox } from './RangeBox.svelte';
+export { default as RangeBox } from "./RangeBox.svelte";
 
 export { default as IntervalsGraph } from "./IntervalsGraph.svelte";
 export { default as EaseGraph } from "./EaseGraph.svelte";
@@ -23,11 +23,8 @@ export { RevlogRange } from "./graph-helpers";
 
 export function graphs(
     target: HTMLDivElement,
-    graphs: SvelteComponent[], {
-        search = "deck:current",
-        days = 365,
-        controller = null,
-    } = {},
+    graphs: SvelteComponent[],
+    { search = "deck:current", days = 365, controller = null } = {}
 ): void {
     const nightMode = checkNightMode();
 

--- a/ts/graphs/bootstrap.ts
+++ b/ts/graphs/bootstrap.ts
@@ -16,7 +16,13 @@ export { default as FutureDue } from "./FutureDue.svelte";
 export { default as ReviewsGraph } from "./ReviewsGraph.svelte";
 export { default as CalendarGraph } from "./CalendarGraph.svelte";
 
-export function graphs(target: HTMLDivElement, graphs: any[]): void {
+export function graphs(
+    target: HTMLDivElement,
+    graphs: any[], {
+        search = "deck:current",
+        days = 31,
+    } = {},
+): void {
     const nightMode = checkNightMode();
 
     setupI18n().then((i18n) => {
@@ -26,6 +32,8 @@ export function graphs(target: HTMLDivElement, graphs: any[]): void {
                 i18n,
                 graphs,
                 nightMode,
+                search,
+                days,
             },
         });
     });

--- a/ts/graphs/bootstrap.ts
+++ b/ts/graphs/bootstrap.ts
@@ -4,6 +4,7 @@
 import { setupI18n } from "anki/i18n";
 import GraphsPage from "./GraphsPage.svelte";
 import { checkNightMode } from "anki/nightmode";
+import { RevlogRange } from "./graph-helpers";
 
 export { default as IntervalsGraph } from "./IntervalsGraph.svelte";
 export { default as EaseGraph } from "./EaseGraph.svelte";
@@ -15,12 +16,13 @@ export { default as HourGraph } from "./HourGraph.svelte";
 export { default as FutureDue } from "./FutureDue.svelte";
 export { default as ReviewsGraph } from "./ReviewsGraph.svelte";
 export { default as CalendarGraph } from "./CalendarGraph.svelte";
+export { RevlogRange } from "./graph-helpers";
 
 export function graphs(
     target: HTMLDivElement,
     graphs: any[], {
         search = "deck:current",
-        days = 31,
+        revlogRange = RevlogRange.Year,
         withRangeBox = true,
     } = {},
 ): void {
@@ -34,7 +36,7 @@ export function graphs(
                 graphs,
                 nightMode,
                 search,
-                days,
+                revlogRange,
                 withRangeBox,
             },
         });

--- a/ts/graphs/bootstrap.ts
+++ b/ts/graphs/bootstrap.ts
@@ -22,7 +22,7 @@ export function graphs(
     target: HTMLDivElement,
     graphs: any[], {
         search = "deck:current",
-        revlogRange = RevlogRange.Year,
+        days = 365,
         withRangeBox = true,
     } = {},
 ): void {
@@ -36,7 +36,7 @@ export function graphs(
                 graphs,
                 nightMode,
                 search,
-                revlogRange,
+                days,
                 withRangeBox,
             },
         });

--- a/ts/graphs/graphs.html
+++ b/ts/graphs/graphs.html
@@ -23,7 +23,9 @@
                 anki.HourGraph,
                 anki.ButtonsGraph,
                 anki.AddedGraph,
-            ],
+            ], {
+                controller: anki.RangeBox,
+            }
         );
     </script>
 </html>

--- a/ts/graphs/graphs.html
+++ b/ts/graphs/graphs.html
@@ -12,7 +12,8 @@
     <script src="graphs.js"></script>
     <script>
         anki.graphs(
-            document.getElementById("main"), [
+            document.getElementById("main"),
+            [
                 anki.TodayStats,
                 anki.FutureDue,
                 anki.CalendarGraph,
@@ -23,7 +24,8 @@
                 anki.HourGraph,
                 anki.ButtonsGraph,
                 anki.AddedGraph,
-            ], {
+            ],
+            {
                 controller: anki.RangeBox,
             }
         );

--- a/ts/graphs/graphs.html
+++ b/ts/graphs/graphs.html
@@ -11,6 +11,19 @@
     <script src="../js/vendor/protobuf.min.js"></script>
     <script src="graphs.js"></script>
     <script>
-        anki.graphs(document.getElementById("main"));
+        anki.graphs(
+            document.getElementById("main"), [
+                anki.TodayStats,
+                anki.FutureDue,
+                anki.CalendarGraph,
+                anki.ReviewsGraph,
+                anki.CardCounts,
+                anki.IntervalsGraph,
+                anki.EaseGraph,
+                anki.HourGraph,
+                anki.ButtonsGraph,
+                anki.AddedGraph,
+            ],
+        );
     </script>
 </html>

--- a/ts/graphs/graphs.scss
+++ b/ts/graphs/graphs.scss
@@ -144,7 +144,10 @@
 }
 
 .spin {
-    position: absolute;
+    position: sticky;
+    left: 50%;
+    top: 50%;
+
     animation: spin;
     animation-duration: 1s;
     animation-iteration-count: infinite;

--- a/ts/graphs/graphs.scss
+++ b/ts/graphs/graphs.scss
@@ -189,3 +189,7 @@
 .align-start {
     text-align: start;
 }
+
+.no-focus-outline:focus {
+    outline: 0;
+}

--- a/ts/graphs/graphs.scss
+++ b/ts/graphs/graphs.scss
@@ -150,12 +150,7 @@
     animation-iteration-count: infinite;
     display: inline-block;
     font-size: 2em;
-    opacity: 0;
-}
-
-.spin.active {
     opacity: 0.5;
-    transition: opacity 1s;
 }
 
 .legend-outer {

--- a/ts/graphs/graphs.scss
+++ b/ts/graphs/graphs.scss
@@ -144,16 +144,18 @@
 }
 
 .spin {
-    position: sticky;
-    left: 50%;
-    top: 50%;
-
+    position: absolute;
     animation: spin;
     animation-duration: 1s;
     animation-iteration-count: infinite;
     display: inline-block;
     font-size: 2em;
+    opacity: 0;
+}
+
+.spin.active {
     opacity: 0.5;
+    transition: opacity 1s;
 }
 
 .legend-outer {


### PR DESCRIPTION
This PR aims to decouple some svelte components for the stats, specifically:

1. Decouple GraphsPage from individual graphs:

Graphs are now passed as a list argument, and the GraphsPage has no explicit knowledge about them. They are all passed the same arguments.

This allows to easily create a `GraphsPage` with a different list of graphs, without having to modify it.

2. Decouple GraphsPage from RangeBox:

RangeBox is also passed in as a `controller` argument. It emits the `update` event, which GraphsPage is listening to.

There is some duplicated code here, when transforming `days` into `revlogRange`, which happens both in `GraphsPage` and `RangeBox`.
However I'd argue the duplication here is actually in the individual graphs requiring `revlogRange`, even though that information should already be present in `sourceData`.

This allows to easily create a `GraphsPage` with a different controller unit, or even none.

---
I specifically aimed to not modify any visible behavior. This should be a pure refactor.