### PR TITLE
Open AddonsDialog via dialog manager

### DIFF
--- a/qt/aqt/__init__.py
+++ b/qt/aqt/__init__.py
@@ -69,7 +69,7 @@ except ImportError as e:
 # - make preferences modal? cmd+q does wrong thing
 
 
-from aqt import addcards, browser, editcurrent  # isort:skip
+from aqt import addcards, addons, browser, editcurrent  # isort:skip
 from aqt import stats, about, preferences, mediasync  # isort:skip
 
 
@@ -77,6 +77,7 @@ class DialogManager:
 
     _dialogs: Dict[str, list] = {
         "AddCards": [addcards.AddCards, None],
+        "AddonsDialog": [addons.AddonsDialog, None],
         "Browser": [browser.Browser, None],
         "EditCurrent": [editcurrent.EditCurrent, None],
         "DeckStats": [stats.DeckStats, None],

--- a/qt/aqt/addons.py
+++ b/qt/aqt/addons.py
@@ -218,7 +218,7 @@ class AddonManager:
                 )
 
     def onAddonsDialog(self) -> None:
-        AddonsDialog(self)
+        aqt.dialogs.open("AddonsDialog", self)
 
     # Metadata
     ######################################################################
@@ -731,6 +731,8 @@ class AddonsDialog(QDialog):
 
     def reject(self) -> None:
         saveGeom(self, "addons")
+        aqt.dialogs.markClosed("AddonsDialog")
+
         return QDialog.reject(self)
 
     def name_for_addon_list(self, addon: AddonMeta) -> str:


### PR DESCRIPTION
The real motivation here is to have access to the addons window within config actions for add-ons.

At the moment, I do the following in order to be able to create a window that is modal to the add-ons dialog:

```python
addons_current: Optional[AddonsDialog] = None


def show_settings():
    settings = Settings(addons_current)
    settings.exec_()


def save_addons_window(addons):
    global addons_current
    addons_current = addons


def init_addon_manager():
    mw.addonManager.setConfigAction(__name__, show_settings)
    addons_dialog_will_show.append(save_addons_window)
```

Making it modal to the main window bricks the main window, if you close it in the wrong order. With this PR, it would be easier to access the add-ons window, using `dialogs._dialogs["AddonsDialog"][1]`.