### PR TITLE
Update consts.py

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -70,7 +70,7 @@ Cecini <github.com/cecini>
 Krish Shah <github.com/k12ish>
 ianki <iankigit@gmail.com>
 rye761 <ryebread761@gmail.com>
-
+Guillem Palau Salvà <guillempalausalva@gmail.com>
 ********************
 
 The text of the 3 clause BSD license follows:

--- a/pylib/anki/consts.py
+++ b/pylib/anki/consts.py
@@ -86,6 +86,7 @@ REVLOG_LRN = 0
 REVLOG_REV = 1
 REVLOG_RELRN = 2
 REVLOG_CRAM = 3
+REVLOG_RESCHED = 4
 
 # Labels
 ##########################################################################


### PR DESCRIPTION
I noticed that type 4 is added in the revlog when rescheduling. Reviews are logged as 0 time and type 4. I am not sure when such feature was introduced but I see it is not documented.