### PR TITLE
Contributing shell code in backtick

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -121,8 +121,10 @@ Please make sure 'bazel test //...' completes successfully before submitting cod
 You can do this automatically by adding the following into
 .git/hooks/pre-commit or .git/hooks/pre-push and making it executable.
 
+```sh
 #!/bin/bash
 bazel test //...
+```
 
 If your change is non-trivial and not covered by the existing unit tests, please
 consider adding a unit test at the same time.


### PR DESCRIPTION
Currently, on https://github.com/ankitects/anki/blob/ebc77985d87979ec05994f8fa5fb75c5e4283057/docs/contributing.md the
whole code is on a single line. Copying does not work, as the test is commented