### PR TITLE
New field name checks are more specific

### DIFF
--- a/ftl/core/fields.ftl
+++ b/ftl/core/fields.ftl
@@ -13,3 +13,4 @@ fields-size = Size:
 fields-sort-by-this-field-in-the = Sort by this field in the browser
 fields-that-field-name-is-already-used = That field name is already used.
 fields-name-first-letter-not-valid = The field name should not start with #, ^ or /.
+fields-name-invalid-letter = The field name should not contain :, ", { or }.

--- a/ftl/core/fields.ftl
+++ b/ftl/core/fields.ftl
@@ -12,3 +12,4 @@ fields-reverse-text-direction-rtl = Reverse text direction (RTL)
 fields-size = Size:
 fields-sort-by-this-field-in-the = Sort by this field in the browser
 fields-that-field-name-is-already-used = That field name is already used.
+fields-name-first-letter-not-valid = The field name should not start with #, ^ or /.

--- a/qt/aqt/fields.py
+++ b/qt/aqt/fields.py
@@ -85,6 +85,9 @@ class FieldDialog(QDialog):
         txt = getOnlyText(prompt, default=old).replace('"', "").strip()
         if not txt:
             return
+        if txt[0] in "#^/":
+            showWarning(tr(TR.FIELDS_NAME_FIRST_LETTER_NOT_VALID))
+            return
         for f in self.model["flds"]:
             if ignoreOrd is not None and f["ord"] == ignoreOrd:
                 continue

--- a/qt/aqt/fields.py
+++ b/qt/aqt/fields.py
@@ -88,6 +88,10 @@ class FieldDialog(QDialog):
         if txt[0] in "#^/":
             showWarning(tr(TR.FIELDS_NAME_FIRST_LETTER_NOT_VALID))
             return
+        for letter in """:{"}""":
+            if letter in txt:
+                showWarning(tr(TR.FIELDS_NAME_INVALID_LETTER))
+                return
         for f in self.model["flds"]:
             if ignoreOrd is not None and f["ord"] == ignoreOrd:
                 continue

--- a/qt/aqt/fields.py
+++ b/qt/aqt/fields.py
@@ -82,7 +82,7 @@ class FieldDialog(QDialog):
         self.loadField(idx)
 
     def _uniqueName(self, prompt, ignoreOrd=None, old=""):
-        txt = getOnlyText(prompt, default=old).replace('"', "")
+        txt = getOnlyText(prompt, default=old).replace('"', "").strip()
         if not txt:
             return
         for f in self.model["flds"]:


### PR DESCRIPTION
There are two small bugs.
If you rename "Back" to " Front", it's accepted. Stripping should occur sooner.

If you create a field "#Test", it's accepted, but this field can't be displayed (I mean, it probably can using filters, but that's not really ideal), so I would suggest rejecting it