### PR TITLE
Trim the start of field name if it is #, /, ^ or a whitespace

### DIFF
--- a/rslib/src/notetype/fields.rs
+++ b/rslib/src/notetype/fields.rs
@@ -42,7 +42,8 @@ impl NoteField {
             self.name = self.name.replace(bad_chars, "");
         }
         // and leading/trailing whitespace
-        let trimmed = self.name.trim();
+        let bad_start_chars = |c: char| c == '#' || c == '/' || c == '^' || c.is_whitespace();
+        let trimmed = self.name.trim().trim_start_matches(bad_start_chars);
         if trimmed.len() != self.name.len() {
             self.name = trimmed.into();
         }


### PR DESCRIPTION
I tested and the initial # of "#back" was correctly removed.

I actually need to trim whitespace again to deal with a field name of the form "# foo"

This is a second try at https://github.com/ankitects/anki/pull/869
I leave the other PR open because I believe warnings are important too, even if the PR needs to be corrected