### PR TITLE
Fix deck check and thus blue sync arrow bug

### DIFF
--- a/pylib/anki/decks.py
+++ b/pylib/anki/decks.py
@@ -430,7 +430,7 @@ class DeckManager:
 
     def selected(self) -> int:
         "The currently selected did."
-        return self.col.conf["curDeck"]
+        return int(self.col.conf["curDeck"])
 
     def current(self) -> Deck:
         return self.get(self.selected())


### PR DESCRIPTION
[Your pointer](https://forums.ankiweb.net/t/why-is-my-sync-button-blue/2078/34?u=rumo) was spot on. A string was compared to an integer in `col.decks.select`.

Side note: During troubleshooting I noticed that `did:...` doesn't included cards of child decks (compared to `deck:...`). Is that intentional?