### PR TITLE
Update _updateQa

### DIFF
--- a/qt/aqt/data/web/js/reviewer.ts
+++ b/qt/aqt/data/web/js/reviewer.ts
@@ -53,7 +53,7 @@ async function _updateQA(html, fadeTime, onupdate, onshown) {
                 String(err.stack).substring(0, 2000)
             ).replace(/\n/g, "<br />")
         );
-    };
+    }
     await _runHook(onUpdateHook);
 
     // wait for mathjax to ready

--- a/qt/aqt/data/web/js/reviewer.ts
+++ b/qt/aqt/data/web/js/reviewer.ts
@@ -1,6 +1,8 @@
 /* Copyright: Ankitects Pty Ltd and contributors
  * License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html */
 
+declare var MathJax: any;
+
 var ankiPlatform = "desktop";
 var typeans;
 var _updatingQA = false;
@@ -54,12 +56,11 @@ async function _updateQA(html, fadeTime, onupdate, onshown) {
     };
     await _runHook(onUpdateHook);
 
-    // @ts-ignore wait for mathjax to ready
+    // wait for mathjax to ready
     await MathJax.startup.promise.then(() => {
-        // @ts-ignore clear MathJax buffer
+        // clear MathJax buffers from previous typesets
         MathJax.typesetClear();
 
-        // @ts-ignore typeset
         return MathJax.typesetPromise(qa.slice(0, 1));
     });
 

--- a/qt/aqt/data/web/js/reviewer.ts
+++ b/qt/aqt/data/web/js/reviewer.ts
@@ -8,10 +8,10 @@ var _updatingQA = false;
 var qFade = 50;
 var aFade = 0;
 
-var onUpdateHook;
-var onShownHook;
+var onUpdateHook: Array<() => Promise<void>>;
+var onShownHook: Array<() => Promise<void>>;
 
-function _runHook(arr: () => Promise<any>[]): Promise<any[]> {
+function _runHook(arr: Array<() => Promise<void>>): Promise<void[]> {
     var promises = [];
 
     for (var i = 0; i < arr.length; i++) {

--- a/qt/aqt/data/web/js/reviewer.ts
+++ b/qt/aqt/data/web/js/reviewer.ts
@@ -10,10 +10,10 @@ var _updatingQA = false;
 var qFade = 50;
 var aFade = 0;
 
-var onUpdateHook: Array<() => Promise<void>>;
-var onShownHook: Array<() => Promise<void>>;
+var onUpdateHook: Array<() => void | Promise<void>>;
+var onShownHook: Array<() => void | Promise<void>>;
 
-function _runHook(arr: Array<() => Promise<void>>): Promise<void[]> {
+function _runHook(arr: Array<() => void | Promise<void>>): Promise<void[]> {
     var promises = [];
 
     for (var i = 0; i < arr.length; i++) {


### PR DESCRIPTION
1. Use `jQuery`s `.promise()`, now that we update jQuery to 3.x
2. Fix a typing error I've overseen (`() => Promise<any>[]` is a function that returns an array of promises, not an array of functions returning promises)
3. Prefer `declare var` over `@ts-ignore`
4. Use async/await syntax, making it easier on the eyes