### PR TITLE
Replace `_updatingQA` with promise-based `_updatingQueue`

### DIFF
--- a/qt/aqt/data/web/js/reviewer.ts
+++ b/qt/aqt/data/web/js/reviewer.ts
@@ -27,7 +27,12 @@ function _queueAction(action: () => Promise<void>): void {
     _updatingQueue = _updatingQueue.then(action);
 }
 
-async function _updateQA(html, fadeTime, onupdate, onshown): Promise<void> {
+async function _updateQA(
+    html: string,
+    fadeTime: number,
+    onupdate: () => void,
+    onshown: () => void
+): Promise<void> {
     onUpdateHook = [onupdate];
     onShownHook = [onshown];
 
@@ -62,44 +67,48 @@ async function _updateQA(html, fadeTime, onupdate, onshown): Promise<void> {
     await _runHook(onShownHook);
 }
 
-function _showQuestion(q, bodyclass) {
-    _queueAction(() => _updateQA(
-        q,
-        qFade,
-        function () {
-            // return to top of window
-            window.scrollTo(0, 0);
+function _showQuestion(q: string, bodyclass: string): void {
+    _queueAction(() =>
+        _updateQA(
+            q,
+            qFade,
+            function () {
+                // return to top of window
+                window.scrollTo(0, 0);
 
-            document.body.className = bodyclass;
-        },
-        function () {
-            // focus typing area if visible
-            typeans = document.getElementById("typeans");
-            if (typeans) {
-                typeans.focus();
+                document.body.className = bodyclass;
+            },
+            function () {
+                // focus typing area if visible
+                typeans = document.getElementById("typeans");
+                if (typeans) {
+                    typeans.focus();
+                }
             }
-        }
-    ));
+        )
+    );
 }
 
-function _showAnswer(a, bodyclass) {
-    _queueAction(() => _updateQA(
-        a,
-        aFade,
-        function () {
-            if (bodyclass) {
-                //  when previewing
-                document.body.className = bodyclass;
-            }
+function _showAnswer(a: string, bodyclass: string): void {
+    _queueAction(() =>
+        _updateQA(
+            a,
+            aFade,
+            function () {
+                if (bodyclass) {
+                    //  when previewing
+                    document.body.className = bodyclass;
+                }
 
-            // scroll to answer?
-            var e = $("#answer");
-            if (e[0]) {
-                e[0].scrollIntoView();
-            }
-        },
-        function () {}
-    ));
+                // scroll to answer?
+                var e = $("#answer");
+                if (e[0]) {
+                    e[0].scrollIntoView();
+                }
+            },
+            function () {}
+        )
+    );
 }
 
 const _flagColours = {
@@ -109,7 +118,7 @@ const _flagColours = {
     4: "#77aaff",
 };
 
-function _drawFlag(flag) {
+function _drawFlag(flag: 0 | 1 | 2 | 3): void {
     var elem = $("#_flag");
     if (flag === 0) {
         elem.hide();
@@ -119,7 +128,7 @@ function _drawFlag(flag) {
     elem.css("color", _flagColours[flag]);
 }
 
-function _drawMark(mark) {
+function _drawMark(mark: boolean): void {
     var elem = $("#_mark");
     if (!mark) {
         elem.hide();
@@ -128,13 +137,13 @@ function _drawMark(mark) {
     }
 }
 
-function _typeAnsPress() {
+function _typeAnsPress(): void {
     if ((window.event as KeyboardEvent).keyCode === 13) {
         pycmd("ans");
     }
 }
 
-function _emulateMobile(enabled: boolean) {
+function _emulateMobile(enabled: boolean): void {
     const list = document.documentElement.classList;
     if (enabled) {
         list.add("mobile");

--- a/qt/aqt/data/web/js/reviewer.ts
+++ b/qt/aqt/data/web/js/reviewer.ts
@@ -3,6 +3,8 @@
 
 declare var MathJax: any;
 
+type Callback = () => void | Promise<void>;
+
 var ankiPlatform = "desktop";
 var typeans;
 var _updatingQueue: Promise<void> = Promise.resolve();
@@ -10,10 +12,10 @@ var _updatingQueue: Promise<void> = Promise.resolve();
 var qFade = 50;
 var aFade = 0;
 
-var onUpdateHook: Array<() => void | Promise<void>>;
-var onShownHook: Array<() => void | Promise<void>>;
+var onUpdateHook: Array<Callback>;
+var onShownHook: Array<Callback>;
 
-function _runHook(arr: Array<() => void | Promise<void>>): Promise<void[]> {
+function _runHook(arr: Array<Callback>): Promise<void[]> {
     var promises = [];
 
     for (var i = 0; i < arr.length; i++) {
@@ -23,15 +25,15 @@ function _runHook(arr: Array<() => void | Promise<void>>): Promise<void[]> {
     return Promise.all(promises);
 }
 
-function _queueAction(action: () => Promise<void>): void {
+function _queueAction(action: Callback): void {
     _updatingQueue = _updatingQueue.then(action);
 }
 
 async function _updateQA(
     html: string,
     fadeTime: number,
-    onupdate: () => void,
-    onshown: () => void
+    onupdate: Callback,
+    onshown: Callback
 ): Promise<void> {
     onUpdateHook = [onupdate];
     onShownHook = [onshown];


### PR DESCRIPTION
This PR revises the synchronization mechanism in `reviewer.ts`.
Before this, you used a `_updatingQa` boolean flag, to check whether an update was already running.
This PR replaces this with a promise-based synchronization mechanism.
All updates are pushed to the global `_updatingQueue`. This ensures (unlike before) that queued actions are executed in order.

A fun way to test it, is executing this inside the webview:
```js
_queueAction(() => new Promise((resolve) => setTimeout(() => { console.log('First'); resolve(); }, 5000)));
_queueAction(() => new Promise((resolve) => setTimeout(() => { console.log('Second'); resolve(); }, 5000)));
_showAnswer('<i>Third</i>')
```
After 5s, "First" is logged. After another 5s, "Second" is logged. Almost immediately afterwards the web view will be replaced with an italic "Third". 

Additionally, I added types for the remaining functions in reviewer.ts.