### PR TITLE
Add Alt text to latex image

### DIFF
--- a/rslib/src/latex.rs
+++ b/rslib/src/latex.rs
@@ -66,7 +66,7 @@ pub(crate) fn extract_latex(text: &str, svg: bool) -> (String, Vec<ExtractedLate
         };
         let latex_text = strip_html_for_latex(&latex);
         let fname = fname_for_latex(&latex_text, svg);
-        let img_link = image_link_for_fname(&fname);
+        let img_link = image_link_for_fname(&latex_text, &fname);
         extracted.push(ExtractedLatex {
             fname,
             latex: latex_text.into(),
@@ -97,8 +97,12 @@ fn fname_for_latex(latex: &str, svg: bool) -> String {
     format!("latex-{}.{}", csum, ext)
 }
 
-fn image_link_for_fname(fname: &str) -> String {
-    format!("<img class=latex src=\"{}\">", fname)
+fn image_link_for_fname(src: &str, fname: &str) -> String {
+    format!(
+        "<img class=latex alt=\"{}\" src=\"{}\">",
+        htmlescape::encode_attribute(src),
+        fname
+    )
 }
 
 #[cfg(test)]
@@ -111,7 +115,10 @@ mod test {
         assert_eq!(
             extract_latex("a[latex]one<br>and<div>two[/latex]b", false),
             (
-                format!("a<img class=latex src=\"{}\">b", fname),
+                format!(
+                    "a<img class=latex alt=\"one&#x0A;and&#x0A;two\" src=\"{}\">b",
+                    fname
+                ),
                 vec![ExtractedLatex {
                     fname: fname.into(),
                     latex: "one\nand\ntwo".into()


### PR DESCRIPTION
I'm trying to go over accessibilities issues in AnkiDroid. Since we'll use rust backend, I thought I might as well go
over it in rust directly. The only side effect in anki is that, if you copy a text with the image, you'll get the LaTeX
copied instead of nothing. Alas, it seems qt does not show alt text.