### PR TITLE
Implement copy_select_files for removing duplication in js dep Bazel recipes

### DIFF
--- a/qt/aqt/data/web/js/reviewer.ts
+++ b/qt/aqt/data/web/js/reviewer.ts
@@ -120,7 +120,7 @@ const _flagColours = {
     4: "#77aaff",
 };
 
-function _drawFlag(flag: 0 | 1 | 2 | 3): void {
+function _drawFlag(flag: 0 | 1 | 2 | 3 | 4): void {
     var elem = $("#_flag");
     if (flag === 0) {
         elem.hide();

--- a/ts/copy.bzl
+++ b/ts/copy.bzl
@@ -27,22 +27,27 @@ def copy_files(ctx, files):
 
     return [DefaultInfo(files = depset(outputs))]
 
-def copy_select_files(ctx, files, include, exclude, unwanted_prefix):
+def remove_prefix(text, prefix):
+    if text.startswith(prefix):
+        return text[len(prefix):]
+    return text
+
+def copy_select_files(ctx, files, include, exclude, base, unwanted_prefix):
     wanted = []
     for f in files.to_list():
-        path = f.path
+        path = remove_prefix(f.path, base)
         want = True
 
         for substr in exclude:
-            if substr in path:
+            if path.startswith(substr):
                 want = False
                 continue
         if not want:
             continue
 
         for substr in include:
-            if substr in path:
-                output = path.replace(unwanted_prefix, "")
+            if path.startswith(substr):
+                output = remove_prefix(path, unwanted_prefix)
                 wanted.append((f, output))
 
     return copy_files(ctx, wanted)

--- a/ts/copy.bzl
+++ b/ts/copy.bzl
@@ -26,3 +26,23 @@ def copy_files(ctx, files):
     )
 
     return [DefaultInfo(files = depset(outputs))]
+
+def copy_select_files(ctx, files, include, exclude, unwanted_prefix):
+    wanted = []
+    for f in files.to_list():
+        path = f.path
+        want = True
+
+        for substr in exclude:
+            if substr in path:
+                want = False
+                continue
+        if not want:
+            continue
+
+        for substr in include:
+            if substr in path:
+                output = path.replace(unwanted_prefix, "")
+                wanted.append((f, output))
+
+    return copy_files(ctx, wanted)

--- a/ts/css-browser-selector.bzl
+++ b/ts/css-browser-selector.bzl
@@ -6,7 +6,8 @@ _include = [
     "css_browser_selector.min.js",
 ]
 
-_unwanted_prefix = "external/npm/node_modules/css-browser-selector/"
+_base = "external/npm/node_modules/css-browser-selector/"
+_unwanted_prefix = ""
 
 def _copy_css_browser_selector_impl(ctx):
     return copy_select_files(
@@ -14,6 +15,7 @@ def _copy_css_browser_selector_impl(ctx):
         ctx.attr.css_browser_selector.files,
         _include,
         [],
+        _base,
         _unwanted_prefix,
     )
 

--- a/ts/css-browser-selector.bzl
+++ b/ts/css-browser-selector.bzl
@@ -1,4 +1,4 @@
-load("//ts:copy.bzl", "copy_files")
+load("//ts:copy.bzl", "copy_select_files")
 
 "Rule to copy css-browser-selector subset from node_modules to vendor folder."
 
@@ -9,17 +9,13 @@ _include = [
 _unwanted_prefix = "external/npm/node_modules/css-browser-selector/"
 
 def _copy_css_browser_selector_impl(ctx):
-    wanted = []
-    for f in ctx.attr.css_browser_selector.files.to_list():
-        path = f.path
-        want = True
-
-        for substr in _include:
-            if substr in path:
-                output = path.replace(_unwanted_prefix, "")
-                wanted.append((f, output))
-
-    return copy_files(ctx, wanted)
+    return copy_select_files(
+        ctx,
+        ctx.attr.css_browser_selector.files,
+        _include,
+        [],
+        _unwanted_prefix,
+    )
 
 copy_css_browser_selector = rule(
     implementation = _copy_css_browser_selector_impl,

--- a/ts/jquery-ui.bzl
+++ b/ts/jquery-ui.bzl
@@ -6,7 +6,8 @@ _include = [
     "jquery-ui.min.js",
 ]
 
-_unwanted_prefix = "external/npm/node_modules/jquery-ui-dist/"
+_base = "external/npm/node_modules/jquery-ui-dist/"
+_unwanted_prefix = ""
 
 def _copy_jquery_ui_impl(ctx):
     return copy_select_files(
@@ -14,6 +15,7 @@ def _copy_jquery_ui_impl(ctx):
         ctx.attr.jquery_ui.files,
         _include,
         [],
+        _base,
         _unwanted_prefix,
     )
 

--- a/ts/jquery-ui.bzl
+++ b/ts/jquery-ui.bzl
@@ -1,4 +1,4 @@
-load("//ts:copy.bzl", "copy_files")
+load("//ts:copy.bzl", "copy_select_files")
 
 "Rule to copy jquery-ui subset from node_modules to vendor folder."
 
@@ -9,17 +9,13 @@ _include = [
 _unwanted_prefix = "external/npm/node_modules/jquery-ui-dist/"
 
 def _copy_jquery_ui_impl(ctx):
-    wanted = []
-    for f in ctx.attr.jquery_ui.files.to_list():
-        path = f.path
-        want = True
-
-        for substr in _include:
-            if substr in path:
-                output = path.replace(_unwanted_prefix, "")
-                wanted.append((f, output))
-
-    return copy_files(ctx, wanted)
+    return copy_select_files(
+        ctx,
+        ctx.attr.jquery_ui.files,
+        _include,
+        [],
+        _unwanted_prefix,
+    )
 
 copy_jquery_ui = rule(
     implementation = _copy_jquery_ui_impl,

--- a/ts/jquery.bzl
+++ b/ts/jquery.bzl
@@ -1,4 +1,4 @@
-load("//ts:copy.bzl", "copy_files")
+load("//ts:copy.bzl", "copy_select_files")
 
 "Rule to copy jquery subset from node_modules to vendor folder."
 
@@ -9,17 +9,13 @@ _include = [
 _unwanted_prefix = "external/npm/node_modules/jquery/dist/"
 
 def _copy_jquery_impl(ctx):
-    wanted = []
-    for f in ctx.attr.jquery.files.to_list():
-        path = f.path
-        want = True
-
-        for substr in _include:
-            if substr in path:
-                output = path.replace(_unwanted_prefix, "")
-                wanted.append((f, output))
-
-    return copy_files(ctx, wanted)
+    return copy_select_files(
+        ctx,
+        ctx.attr.jquery.files,
+        _include,
+        [],
+        _unwanted_prefix,
+    )
 
 copy_jquery = rule(
     implementation = _copy_jquery_impl,

--- a/ts/jquery.bzl
+++ b/ts/jquery.bzl
@@ -6,7 +6,8 @@ _include = [
     "dist/jquery.min.js"
 ]
 
-_unwanted_prefix = "external/npm/node_modules/jquery/dist/"
+_base = "external/npm/node_modules/jquery/"
+_unwanted_prefix = "dist/"
 
 def _copy_jquery_impl(ctx):
     return copy_select_files(
@@ -14,6 +15,7 @@ def _copy_jquery_impl(ctx):
         ctx.attr.jquery.files,
         _include,
         [],
+        _base,
         _unwanted_prefix,
     )
 

--- a/ts/mathjax.bzl
+++ b/ts/mathjax.bzl
@@ -14,7 +14,8 @@ _exclude = [
     "es5/sre/mathmaps/mathmaps_ie.js",
 ]
 
-_unwanted_prefix = "external/npm/node_modules/mathjax/es5/"
+_base = "external/npm/node_modules/mathjax/"
+_unwanted_prefix = "es5/"
 
 def _copy_mathjax_impl(ctx):
     return copy_select_files(
@@ -22,6 +23,7 @@ def _copy_mathjax_impl(ctx):
         ctx.attr.mathjax.files,
         _include,
         _exclude,
+        _base,
         _unwanted_prefix,
     )
 

--- a/ts/mathjax.bzl
+++ b/ts/mathjax.bzl
@@ -1,10 +1,6 @@
-load("//ts:copy.bzl", "copy_files")
+load("//ts:copy.bzl", "copy_select_files")
 
 "Rule to copy mathjax subset from node_modules to vendor folder."
-
-_exclude = [
-    "mathmaps_ie.js",
-]
 
 _include = [
     "es5/tex-chtml.js",
@@ -14,26 +10,20 @@ _include = [
     "es5/sre",
 ]
 
+_exclude = [
+    "mathmaps_ie.js",
+]
+
 _unwanted_prefix = "external/npm/node_modules/mathjax/es5/"
 
 def _copy_mathjax_impl(ctx):
-    wanted = []
-    for f in ctx.attr.mathjax.files.to_list():
-        path = f.path
-        want = True
-        for substr in _exclude:
-            if substr in path:
-                want = False
-                continue
-        if not want:
-            continue
-
-        for substr in _include:
-            if substr in path:
-                output = path.replace(_unwanted_prefix, "")
-                wanted.append((f, output))
-
-    return copy_files(ctx, wanted)
+    return copy_select_files(
+        ctx,
+        ctx.attr.mathjax.files,
+        _include,
+        _exclude,
+        _unwanted_prefix,
+    )
 
 copy_mathjax = rule(
     implementation = _copy_mathjax_impl,

--- a/ts/mathjax.bzl
+++ b/ts/mathjax.bzl
@@ -11,7 +11,7 @@ _include = [
 ]
 
 _exclude = [
-    "mathmaps_ie.js",
+    "es5/sre/mathmaps/mathmaps_ie.js",
 ]
 
 _unwanted_prefix = "external/npm/node_modules/mathjax/es5/"

--- a/ts/protobufjs.bzl
+++ b/ts/protobufjs.bzl
@@ -1,4 +1,4 @@
-load("//ts:copy.bzl", "copy_files")
+load("//ts:copy.bzl", "copy_select_files")
 
 "Rule to copy protobufjs subset from node_modules to vendor folder."
 
@@ -9,17 +9,13 @@ _include = [
 _unwanted_prefix = "external/npm/node_modules/protobufjs/dist/"
 
 def _copy_protobufjs_impl(ctx):
-    wanted = []
-    for f in ctx.attr.protobufjs.files.to_list():
-        path = f.path
-        want = True
-
-        for substr in _include:
-            if substr in path:
-                output = path.replace(_unwanted_prefix, "")
-                wanted.append((f, output))
-
-    return copy_files(ctx, wanted)
+    return copy_select_files(
+        ctx,
+        ctx.attr.protobufjs.files,
+        _include,
+        [],
+        _unwanted_prefix,
+    )
 
 copy_protobufjs = rule(
     implementation = _copy_protobufjs_impl,

--- a/ts/protobufjs.bzl
+++ b/ts/protobufjs.bzl
@@ -6,7 +6,8 @@ _include = [
     "dist/protobuf.min.js",
 ]
 
-_unwanted_prefix = "external/npm/node_modules/protobufjs/dist/"
+_base = "external/npm/node_modules/protobufjs/"
+_unwanted_prefix = "dist/"
 
 def _copy_protobufjs_impl(ctx):
     return copy_select_files(
@@ -14,6 +15,7 @@ def _copy_protobufjs_impl(ctx):
         ctx.attr.protobufjs.files,
         _include,
         [],
+        _base,
         _unwanted_prefix,
     )
 


### PR DESCRIPTION
This avoids the copy-paste of the "selection" algorithm for each js dependency.
I also added another argument, called `base`, which is supposed to be the entry point in the repo, where the search for files to be copied starts. This allowed me to make the search for files a bit stricter, by using `str.startswith()` instead of `in`. This might prevent some unexplainable behavior in the future, where it copies files we did not intend it to.

I also fixed a small typing error for _drawFlag, which otherwise wouldn't be worth a PR.

EDIT: Also, happy new year :)