### PR TITLE
add rename_tag to browser sidebar contextmenu

### DIFF
--- a/ftl/core/actions.ftl
+++ b/ftl/core/actions.ftl
@@ -24,6 +24,7 @@ actions-rebuild = Rebuild
 actions-red-flag = Red Flag
 actions-rename = Rename
 actions-rename-deck = Rename Deck
+actions-rename-tag = Rename Tag
 actions-replay-audio = Replay Audio
 actions-reposition = Reposition
 actions-save = Save

--- a/ftl/core/browsing.ftl
+++ b/ftl/core/browsing.ftl
@@ -94,6 +94,7 @@ browsing-step = Step:
 browsing-studied-today = Studied Today
 browsing-suspended = Suspended
 browsing-tag-duplicates = Tag Duplicates
+browsing-tag-rename-warning-empty = You can't rename a tag that has no notes.
 browsing-target-field = Target field:
 browsing-today = Today
 browsing-toggle-mark = Toggle Mark

--- a/qt/aqt/sidebar.py
+++ b/qt/aqt/sidebar.py
@@ -3,6 +3,7 @@
 # License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 from __future__ import annotations
 
+import re
 from enum import Enum
 
 import aqt
@@ -111,7 +112,9 @@ class NewSidebarTreeView(SidebarTreeViewBase):
 
     def _rename_tag(self, item: "aqt.browser.SidebarItem") -> None:
         old_name = item.name
-        nids = self.col.find_notes("tag:" + old_name)
+        escaped_name = re.sub(r"[*_\\]", r"\\\g<0>", old_name)
+        escaped_name = '"{}"'.format(escaped_name.replace('"', '\\"'))
+        nids = self.col.find_notes("tag:" + escaped_name)
         if len(nids) == 0:
             showInfo(tr(TR.BROWSING_TAG_RENAME_WARNING_EMPTY))
             return

--- a/qt/aqt/sidebar.py
+++ b/qt/aqt/sidebar.py
@@ -7,8 +7,9 @@ from enum import Enum
 
 import aqt
 from anki.errors import DeckRenameError
+from aqt.main import ResetReason
 from aqt.qt import *
-from aqt.utils import TR, getOnlyText, showWarning, tr
+from aqt.utils import TR, getOnlyText, showInfo, showWarning, tr
 
 
 class SidebarItemType(Enum):
@@ -70,6 +71,7 @@ class NewSidebarTreeView(SidebarTreeViewBase):
         self.customContextMenuRequested.connect(self.onContextMenu)  # type: ignore
         self.context_menus = {
             SidebarItemType.DECK: ((tr(TR.ACTIONS_RENAME), self.rename_deck),),
+            SidebarItemType.TAG: ((tr(TR.ACTIONS_RENAME), self.rename_tag),),
         }
 
     def onContextMenu(self, point: QPoint) -> None:
@@ -103,3 +105,23 @@ class NewSidebarTreeView(SidebarTreeViewBase):
             return showWarning(e.description)
         self.browser.maybeRefreshSidebar()
         self.mw.deckBrowser.refresh()
+
+    def rename_tag(self, item: "aqt.browser.SidebarItem") -> None:
+        self.browser.editor.saveNow(lambda: self._rename_tag(item))
+
+    def _rename_tag(self, item: "aqt.browser.SidebarItem") -> None:
+        old_name = item.name
+        nids = self.col.find_notes("tag:" + old_name)
+        if len(nids) == 0:
+            showInfo(tr(TR.BROWSING_TAG_RENAME_WARNING_EMPTY))
+            return
+        new_name = getOnlyText(tr(TR.ACTIONS_NEW_NAME), default=old_name)
+        if new_name == old_name or not new_name:
+            return
+        self.mw.checkpoint(tr(TR.ACTIONS_RENAME_TAG))
+        self.browser.model.beginReset()
+        self.col.tags.bulk_update(list(nids), old_name, new_name, False)
+        self.browser.model.endReset()
+        self.browser.clearUnusedTags()
+        self.mw.requireReset(reason=ResetReason.BrowserAddTags, context=self)
+        self.browser.maybeRefreshSidebar()


### PR DESCRIPTION
This PR adds 'rename' context menu to browser sidebar tags.

Notes

1. To remove old_name tag from the sidebar the code calls `clearUnusedTags()`, which has the side effect of clearing all other unused tags. Even though`clearUnusedTags` is quite heavy, it may be good to consider calling it when initializing Browser.
2. when new_name is blank, the code cancels rename instead of deleting the tag, as I assume a 'delete tag' context menu will be added in the future.
3. Would it be better to add a rename function to tags.py instead of implementing it in sidebar.py?


Related: ankitects/help-wanted#6