### PR TITLE
Escape literal curly braces in Fluent

### DIFF
--- a/ftl/core/fields.ftl
+++ b/ftl/core/fields.ftl
@@ -13,4 +13,4 @@ fields-size = Size:
 fields-sort-by-this-field-in-the = Sort by this field in the browser
 fields-that-field-name-is-already-used = That field name is already used.
 fields-name-first-letter-not-valid = The field name should not start with #, ^ or /.
-fields-name-invalid-letter = The field name should not contain :, ", { or }.
+fields-name-invalid-letter = The field name should not contain :, ", {"{"} or {"}"}.


### PR DESCRIPTION
Pontoon checks fail because `{ or }` is interpreted as a message reference.