### PR TITLE
Add closeWithCallback method to Addons dialog

### DIFF
--- a/qt/aqt/addons.py
+++ b/qt/aqt/addons.py
@@ -735,6 +735,8 @@ class AddonsDialog(QDialog):
 
         return QDialog.reject(self)
 
+    silentlyClose = True
+
     def name_for_addon_list(self, addon: AddonMeta) -> str:
         name = addon.human_name()
 


### PR DESCRIPTION
It seems like, when Anki get's a SIGINT, it tries to `closeWithCallback` on the current dialog.

However, `AddonsDialog` does not have this method, so sending SIGINT, while the addons window is open, evokes this error message:

    AttributeError: 'AddonsDialog' object has no attribute 'closeWithCallback'
