### PR TITLE
Add note_did_load hook

### DIFF
--- a/pylib/anki/notes.py
+++ b/pylib/anki/notes.py
@@ -50,6 +50,7 @@ class Note:
         self.tags = list(n.tags)
         self.fields = list(n.fields)
         self._fmap = self.col.models.fieldMap(self.model())
+        hooks.note_did_load(self)
 
     def to_backend_note(self) -> BackendNote:
         hooks.note_will_flush(self)

--- a/pylib/tools/genhooks.py
+++ b/pylib/tools/genhooks.py
@@ -53,6 +53,11 @@ hooks = [
         field_text or not before returning it.""",
     ),
     Hook(
+        name="note_did_load",
+        args=["note: Note"],
+        doc="Allow to change a note after it was loaded from database / newly created.",
+    ),
+    Hook(
         name="note_will_flush",
         args=["note: Note"],
         doc="Allow to change a note before it is added/updated in the database.",


### PR DESCRIPTION
This hook is the opposite of `note_will_flush`, it is invoked every time a card is loaded from the database, or newly created.

It can be used to set some custom data on the `Note` object.