### PR TITLE
Change meaning of "is:learn" to filter on type, not queue

### DIFF
--- a/rslib/src/search/sqlwriter.rs
+++ b/rslib/src/search/sqlwriter.rs
@@ -279,9 +279,9 @@ impl SqlWriter<'_> {
             ),
             StateKind::Learning => write!(
                 self.sql,
-                "c.queue in ({},{})",
-                CardQueue::Learn as i8,
-                CardQueue::DayLearn as i8
+                "c.type in ({}, {})",
+                CardType::Learn as i8,
+                CardType::Relearn as i8,
             ),
             StateKind::Buried => write!(
                 self.sql,


### PR DESCRIPTION
Currently "is:learn" filters on the queue of a card, not the type.
This makes it impossible to compose with the "is:buried", and "is:suspended" filters. Some examples

1. I'd like to find all my suspended learning cards:
My first instinct would be `is:learn is:suspended`, which would not yield anything currently.
2.  I'd like to find all relearning cards:
The Anki manual suggests: `is:review is:learn`, however this only includes cards which are not also buried a/o suspended. There is currently no way to include those.

I don't think this behaviour makes sense to the uninitiated user. It requires knowledge of the scheduling queues.

After this change (`is:new` | `is:review is:learn` | `is:review -is:learn` | `-is:review is:learn`) would all behave nicely when paired with (`is:buried` | `is:suspended` | negated versions), and all examples in the [manual](https://docs.ankiweb.net/#/searching?id=card-state) still work as described as well.