### PR TITLE
Triggering searches from the stats screen.

### DIFF
--- a/qt/aqt/deckbrowser.py
+++ b/qt/aqt/deckbrowser.py
@@ -65,7 +65,7 @@ class DeckBrowser:
 
     def _linkHandler(self, url):
         if ":" in url:
-            (cmd, arg) = url.split(":")
+            (cmd, arg) = url.split(":", 1)
         else:
             cmd = url
         if cmd == "open":

--- a/qt/aqt/stats.py
+++ b/qt/aqt/stats.py
@@ -51,6 +51,7 @@ class NewDeckStats(QDialog):
         gui_hooks.stats_dialog_will_show(self)
         self.show()
         self.refresh()
+        self.form.web.set_bridge_command(self._on_bridge_cmd, self)
         self.activateWindow()
 
     def reject(self):
@@ -88,6 +89,14 @@ class NewDeckStats(QDialog):
 
     def changeScope(self, type):
         pass
+
+    def _on_bridge_cmd(self, cmd: str) -> bool:
+        if cmd.startswith("browserSearch"):
+            _, query = cmd.split(':', 1)
+            browser = aqt.dialogs.open("Browser", self.mw)
+            browser.search_for(query)
+
+        return False
 
     def refresh(self):
         self.form.web.load_ts_page("graphs")

--- a/qt/aqt/stats.py
+++ b/qt/aqt/stats.py
@@ -92,7 +92,7 @@ class NewDeckStats(QDialog):
 
     def _on_bridge_cmd(self, cmd: str) -> bool:
         if cmd.startswith("browserSearch"):
-            _, query = cmd.split(':', 1)
+            _, query = cmd.split(":", 1)
             browser = aqt.dialogs.open("Browser", self.mw)
             browser.search_for(query)
 

--- a/rslib/backend.proto
+++ b/rslib/backend.proto
@@ -1092,6 +1092,7 @@ message GraphsOut {
   uint32 scheduler_version = 5;
   /// Seconds to add to UTC timestamps to get local time.
   int32 local_offset_secs = 7;
+  bool bridge_commands_supported = 8;
 }
 
 message GraphPreferences {

--- a/rslib/backend.proto
+++ b/rslib/backend.proto
@@ -1092,7 +1092,6 @@ message GraphsOut {
   uint32 scheduler_version = 5;
   /// Seconds to add to UTC timestamps to get local time.
   int32 local_offset_secs = 7;
-  bool bridge_commands_supported = 8;
 }
 
 message GraphPreferences {
@@ -1104,6 +1103,7 @@ message GraphPreferences {
   }
   Weekday calendar_first_day_of_week = 1;
   bool card_counts_separate_inactive = 2;
+  bool browser_links_supported = 3;
 }
 
 message RevlogEntry {

--- a/rslib/src/stats/graphs.rs
+++ b/rslib/src/stats/graphs.rs
@@ -44,7 +44,6 @@ impl Collection {
             next_day_at_secs: timing.next_day_at as u32,
             scheduler_version: self.sched_ver() as u32,
             local_offset_secs: local_offset_secs as i32,
-            bridge_commands_supported: true,
         })
     }
 
@@ -52,6 +51,7 @@ impl Collection {
         Ok(pb::GraphPreferences {
             calendar_first_day_of_week: self.get_first_day_of_week() as i32,
             card_counts_separate_inactive: self.get_card_counts_separate_inactive(),
+            browser_links_supported: true,
         })
     }
 

--- a/rslib/src/stats/graphs.rs
+++ b/rslib/src/stats/graphs.rs
@@ -44,6 +44,7 @@ impl Collection {
             next_day_at_secs: timing.next_day_at as u32,
             scheduler_version: self.sched_ver() as u32,
             local_offset_secs: local_offset_secs as i32,
+            bridge_commands_supported: true,
         })
     }
 

--- a/ts/graphs/AddedGraph.svelte
+++ b/ts/graphs/AddedGraph.svelte
@@ -39,7 +39,7 @@
         <GraphRangeRadios bind:graphRange {i18n} revlogRange={RevlogRange.All} />
     </div>
 
-    <HistogramGraph data={histogramData} {i18n} />
+    <HistogramGraph data={histogramData} {i18n} on:search />
 
     <TableData {i18n} {tableData} />
 </div>

--- a/ts/graphs/AddedGraph.svelte
+++ b/ts/graphs/AddedGraph.svelte
@@ -9,6 +9,7 @@
     import HistogramGraph from "./HistogramGraph.svelte";
     import GraphRangeRadios from "./GraphRangeRadios.svelte";
     import TableData from "./TableData.svelte";
+    import { createEventDispatcher } from "svelte";
 
     export let sourceData: pb.BackendProto.GraphsOut | null = null;
     export let i18n: I18n;
@@ -17,13 +18,15 @@
     let tableData: TableDatum[] = [];
     let graphRange: GraphRange = GraphRange.Month;
 
+    const dispatch = createEventDispatcher();
+
     let addedData: GraphData | null = null;
     $: if (sourceData) {
         addedData = gatherData(sourceData);
     }
 
     $: if (addedData) {
-        [histogramData, tableData] = buildHistogram(addedData, graphRange, i18n);
+        [histogramData, tableData] = buildHistogram(addedData, graphRange, i18n, dispatch);
     }
 
     const title = i18n.tr(i18n.TR.STATISTICS_ADDED_TITLE);

--- a/ts/graphs/AddedGraph.svelte
+++ b/ts/graphs/AddedGraph.svelte
@@ -10,13 +10,16 @@
     import GraphRangeRadios from "./GraphRangeRadios.svelte";
     import TableData from "./TableData.svelte";
     import { createEventDispatcher } from "svelte";
+    import type { PreferenceStore } from "./preferences";
 
     export let sourceData: pb.BackendProto.GraphsOut | null = null;
     export let i18n: I18n;
+    export let preferences: PreferenceStore;
 
     let histogramData = null as HistogramData | null;
     let tableData: TableDatum[] = [];
     let graphRange: GraphRange = GraphRange.Month;
+    let { browserLinksSupported } = preferences;
 
     const dispatch = createEventDispatcher();
 
@@ -26,7 +29,13 @@
     }
 
     $: if (addedData) {
-        [histogramData, tableData] = buildHistogram(addedData, graphRange, i18n, dispatch);
+        [histogramData, tableData] = buildHistogram(
+            addedData,
+            graphRange,
+            i18n,
+            dispatch,
+            $browserLinksSupported
+        );
     }
 
     const title = i18n.tr(i18n.TR.STATISTICS_ADDED_TITLE);
@@ -42,7 +51,7 @@
         <GraphRangeRadios bind:graphRange {i18n} revlogRange={RevlogRange.All} />
     </div>
 
-    <HistogramGraph data={histogramData} {i18n} on:search />
+    <HistogramGraph data={histogramData} {i18n} />
 
     <TableData {i18n} {tableData} />
 </div>

--- a/ts/graphs/CalendarGraph.svelte
+++ b/ts/graphs/CalendarGraph.svelte
@@ -1,4 +1,5 @@
 <script lang="typescript">
+    import { createEventDispatcher } from "svelte";
     import NoDataOverlay from "./NoDataOverlay.svelte";
     import AxisTicks from "./AxisTicks.svelte";
     import { defaultGraphBounds, RevlogRange } from "./graph-helpers";
@@ -15,6 +16,8 @@
     export let nightMode: boolean;
 
     let { calendarFirstDayOfWeek } = preferences;
+    const dispatch = createEventDispatcher();
+
     let graphData: GraphData | null = null;
 
     let bounds = defaultGraphBounds();
@@ -49,6 +52,7 @@
             svg as SVGElement,
             bounds,
             graphData,
+            dispatch,
             targetYear,
             i18n,
             nightMode,

--- a/ts/graphs/CardCounts.svelte
+++ b/ts/graphs/CardCounts.svelte
@@ -89,7 +89,11 @@
                         <!-- prettier-ignore -->
                         <td>
                             <span style="color: {d.colour};">■&nbsp;</span>
-                            <span class="search-link" on:click={() => dispatch('search', { query: d.query })}>{d.label}</span>
+                            {#if sourceData.bridgeCommandsSupported}
+                                <span class="search-link" on:click={() => dispatch('search', { query: d.query })}>{d.label}</span>
+                            {:else}
+                                <span>{d.label}</span>
+                            {/if}
                         </td>
                         <td class="right">{d.count}</td>
                         <td class="right">{d.percent}</td>

--- a/ts/graphs/CardCounts.svelte
+++ b/ts/graphs/CardCounts.svelte
@@ -1,4 +1,5 @@
 <script lang="typescript">
+    import { createEventDispatcher } from "svelte";
     import { defaultGraphBounds } from "./graph-helpers";
     import { gatherData, renderCards } from "./card-counts";
     import type { GraphData, TableDatum } from "./card-counts";
@@ -11,6 +12,8 @@
     export let preferences: PreferenceStore;
 
     let { cardCountsSeparateInactive } = preferences;
+    const dispatch = createEventDispatcher();
+
     let svg = null as HTMLElement | SVGElement | null;
 
     let bounds = defaultGraphBounds();
@@ -52,6 +55,12 @@
     .right {
         text-align: right;
     }
+
+    .search-link:hover {
+        cursor: pointer;
+        color: var(--link);
+        text-decoration: underline;
+    }
 </style>
 
 <div class="graph" id="graph-card-counts">
@@ -79,7 +88,8 @@
                     <tr>
                         <!-- prettier-ignore -->
                         <td>
-                            <span style="color: {d.colour};">■&nbsp;</span>{d.label}
+                            <span style="color: {d.colour};">■&nbsp;</span>
+                            <span class="search-link" on:click={() => dispatch('search', { query: d.query })}>{d.label}</span>
                         </td>
                         <td class="right">{d.count}</td>
                         <td class="right">{d.percent}</td>

--- a/ts/graphs/CardCounts.svelte
+++ b/ts/graphs/CardCounts.svelte
@@ -11,7 +11,7 @@
     export let i18n: I18n;
     export let preferences: PreferenceStore;
 
-    let { cardCountsSeparateInactive } = preferences;
+    let { cardCountsSeparateInactive, browserLinksSupported } = preferences;
     const dispatch = createEventDispatcher();
 
     let svg = null as HTMLElement | SVGElement | null;
@@ -89,7 +89,7 @@
                         <!-- prettier-ignore -->
                         <td>
                             <span style="color: {d.colour};">■&nbsp;</span>
-                            {#if sourceData.bridgeCommandsSupported}
+                            {#if browserLinksSupported}
                                 <span class="search-link" on:click={() => dispatch('search', { query: d.query })}>{d.label}</span>
                             {:else}
                                 <span>{d.label}</span>

--- a/ts/graphs/EaseGraph.svelte
+++ b/ts/graphs/EaseGraph.svelte
@@ -26,7 +26,7 @@
 
     <div class="subtitle">{subtitle}</div>
 
-    <HistogramGraph data={histogramData} {i18n} />
+    <HistogramGraph data={histogramData} {i18n} on:search />
 
     <TableData {i18n} {tableData} />
 </div>

--- a/ts/graphs/EaseGraph.svelte
+++ b/ts/graphs/EaseGraph.svelte
@@ -7,17 +7,25 @@
     import type { TableDatum } from "./graph-helpers";
     import TableData from "./TableData.svelte";
     import { createEventDispatcher } from "svelte";
+    import type { PreferenceStore } from "./preferences";
 
     export let sourceData: pb.BackendProto.GraphsOut | null = null;
     export let i18n: I18n;
+    export let preferences: PreferenceStore;
 
     const dispatch = createEventDispatcher();
 
     let histogramData = null as HistogramData | null;
     let tableData: TableDatum[] = [];
+    let { browserLinksSupported } = preferences;
 
     $: if (sourceData) {
-        [histogramData, tableData] = prepareData(gatherData(sourceData), i18n, dispatch);
+        [histogramData, tableData] = prepareData(
+            gatherData(sourceData),
+            i18n,
+            dispatch,
+            $browserLinksSupported
+        );
     }
 
     const title = i18n.tr(i18n.TR.STATISTICS_CARD_EASE_TITLE);
@@ -29,7 +37,7 @@
 
     <div class="subtitle">{subtitle}</div>
 
-    <HistogramGraph data={histogramData} {i18n} on:search />
+    <HistogramGraph data={histogramData} {i18n} />
 
     <TableData {i18n} {tableData} />
 </div>

--- a/ts/graphs/EaseGraph.svelte
+++ b/ts/graphs/EaseGraph.svelte
@@ -6,15 +6,18 @@
     import type { I18n } from "anki/i18n";
     import type { TableDatum } from "./graph-helpers";
     import TableData from "./TableData.svelte";
+    import { createEventDispatcher } from "svelte";
 
     export let sourceData: pb.BackendProto.GraphsOut | null = null;
     export let i18n: I18n;
+
+    const dispatch = createEventDispatcher();
 
     let histogramData = null as HistogramData | null;
     let tableData: TableDatum[] = [];
 
     $: if (sourceData) {
-        [histogramData, tableData] = prepareData(gatherData(sourceData), i18n);
+        [histogramData, tableData] = prepareData(gatherData(sourceData), i18n, dispatch);
     }
 
     const title = i18n.tr(i18n.TR.STATISTICS_CARD_EASE_TITLE);

--- a/ts/graphs/FutureDue.svelte
+++ b/ts/graphs/FutureDue.svelte
@@ -9,9 +9,12 @@
     import HistogramGraph from "./HistogramGraph.svelte";
     import GraphRangeRadios from "./GraphRangeRadios.svelte";
     import TableData from "./TableData.svelte";
+    import { createEventDispatcher } from "svelte";
 
     export let sourceData: pb.BackendProto.GraphsOut | null = null;
     export let i18n: I18n;
+
+    const dispatch = createEventDispatcher();
 
     let graphData = null as GraphData | null;
     let histogramData = null as HistogramData | null;
@@ -28,7 +31,8 @@
             graphData,
             graphRange,
             backlog,
-            i18n
+            i18n,
+            dispatch,
         ));
     }
 

--- a/ts/graphs/FutureDue.svelte
+++ b/ts/graphs/FutureDue.svelte
@@ -10,9 +10,11 @@
     import GraphRangeRadios from "./GraphRangeRadios.svelte";
     import TableData from "./TableData.svelte";
     import { createEventDispatcher } from "svelte";
+    import type { PreferenceStore } from "./preferences";
 
     export let sourceData: pb.BackendProto.GraphsOut | null = null;
     export let i18n: I18n;
+    export let preferences: PreferenceStore;
 
     const dispatch = createEventDispatcher();
 
@@ -21,6 +23,7 @@
     let tableData: TableDatum[] = [] as any;
     let backlog: boolean = true;
     let graphRange: GraphRange = GraphRange.Month;
+    let { browserLinksSupported } = preferences;
 
     $: if (sourceData) {
         graphData = gatherData(sourceData);
@@ -33,6 +36,7 @@
             backlog,
             i18n,
             dispatch,
+            $browserLinksSupported
         ));
     }
 
@@ -57,7 +61,7 @@
         <GraphRangeRadios bind:graphRange {i18n} revlogRange={RevlogRange.All} />
     </div>
 
-    <HistogramGraph data={histogramData} {i18n} on:search />
+    <HistogramGraph data={histogramData} {i18n} />
 
     <TableData {i18n} {tableData} />
 </div>

--- a/ts/graphs/FutureDue.svelte
+++ b/ts/graphs/FutureDue.svelte
@@ -53,7 +53,7 @@
         <GraphRangeRadios bind:graphRange {i18n} revlogRange={RevlogRange.All} />
     </div>
 
-    <HistogramGraph data={histogramData} {i18n} />
+    <HistogramGraph data={histogramData} {i18n} on:search />
 
     <TableData {i18n} {tableData} />
 </div>

--- a/ts/graphs/GraphsPage.svelte
+++ b/ts/graphs/GraphsPage.svelte
@@ -25,7 +25,7 @@
     const preferencesPromise = getPreferences();
 
     const refreshWith = async (searchNew: string, days: number) => {
-        search = searchNew
+        search = searchNew;
 
         active = true;
         try {
@@ -48,9 +48,9 @@
     refreshWith(search, days);
 
     const browserSearch = (event: CustomEvent) => {
-        const query = `${search} ${event.detail.query}`
-        bridgeCommand(`browserSearch:${query}`)
-    }
+        const query = `${search} ${event.detail.query}`;
+        bridgeCommand(`browserSearch:${query}`);
+    };
 </script>
 
 {#if controller}

--- a/ts/graphs/GraphsPage.svelte
+++ b/ts/graphs/GraphsPage.svelte
@@ -24,7 +24,9 @@
 
     const preferencesPromise = getPreferences();
 
-    const refreshWith = async (search: string, days: number) => {
+    const refreshWith = async (searchNew: string, days: number) => {
+        search = searchNew
+
         active = true;
         try {
             [sourceData, preferences] = await Promise.all([
@@ -44,6 +46,11 @@
     };
 
     refreshWith(search, days);
+
+    const browserSearch = (event: CustomEvent) => {
+        const query = `${search} ${event.detail.query}`
+        bridgeCommand(`browserSearch:${query}`)
+    }
 </script>
 
 {#if controller}
@@ -65,7 +72,8 @@
                 {preferences}
                 {revlogRange}
                 {i18n}
-                {nightMode} />
+                {nightMode}
+                on:search={browserSearch} />
         {/each}
     </div>
 {/if}

--- a/ts/graphs/GraphsPage.svelte
+++ b/ts/graphs/GraphsPage.svelte
@@ -8,6 +8,7 @@
     import type pb from "anki/backend_proto";
     import { getGraphData, RevlogRange, daysToRevlogRange } from "./graph-helpers";
     import { getPreferences } from "./preferences";
+    import { bridgeCommand } from "anki/bridgecommand";
 
     export let i18n: I18n;
     export let nightMode: boolean;

--- a/ts/graphs/HistogramGraph.svelte
+++ b/ts/graphs/HistogramGraph.svelte
@@ -1,5 +1,4 @@
 <script lang="typescript">
-    import { createEventDispatcher } from "svelte";
     import type { HistogramData } from "./histogram-graph";
     import { histogramGraph } from "./histogram-graph";
     import AxisTicks from "./AxisTicks.svelte";
@@ -10,12 +9,10 @@
     export let data: HistogramData | null = null;
     export let i18n: I18n;
 
-    const dispatch = createEventDispatcher();
-
     let bounds = defaultGraphBounds();
     let svg = null as HTMLElement | SVGElement | null;
 
-    $: histogramGraph(svg as SVGElement, bounds, data, dispatch);
+    $: histogramGraph(svg as SVGElement, bounds, data);
 </script>
 
 <svg bind:this={svg} viewBox={`0 0 ${bounds.width} ${bounds.height}`}>

--- a/ts/graphs/HistogramGraph.svelte
+++ b/ts/graphs/HistogramGraph.svelte
@@ -1,4 +1,5 @@
 <script lang="typescript">
+    import { createEventDispatcher } from "svelte";
     import type { HistogramData } from "./histogram-graph";
     import { histogramGraph } from "./histogram-graph";
     import AxisTicks from "./AxisTicks.svelte";
@@ -9,10 +10,12 @@
     export let data: HistogramData | null = null;
     export let i18n: I18n;
 
+    const dispatch = createEventDispatcher();
+
     let bounds = defaultGraphBounds();
     let svg = null as HTMLElement | SVGElement | null;
 
-    $: histogramGraph(svg as SVGElement, bounds, data);
+    $: histogramGraph(svg as SVGElement, bounds, data, dispatch);
 </script>
 
 <svg bind:this={svg} viewBox={`0 0 ${bounds.width} ${bounds.height}`}>

--- a/ts/graphs/IntervalsGraph.svelte
+++ b/ts/graphs/IntervalsGraph.svelte
@@ -12,9 +12,12 @@
     import HistogramGraph from "./HistogramGraph.svelte";
     import type { TableDatum } from "./graph-helpers";
     import TableData from "./TableData.svelte";
+    import { createEventDispatcher } from "svelte";
 
     export let sourceData: pb.BackendProto.GraphsOut | null = null;
     export let i18n: I18n;
+
+    const dispatch = createEventDispatcher();
 
     let intervalData: IntervalGraphData | null = null;
     let histogramData = null as HistogramData | null;
@@ -26,7 +29,7 @@
     }
 
     $: if (intervalData) {
-        [histogramData, tableData] = prepareIntervalData(intervalData, range, i18n);
+        [histogramData, tableData] = prepareIntervalData(intervalData, range, i18n, dispatch);
     }
 
     const title = i18n.tr(i18n.TR.STATISTICS_INTERVALS_TITLE);

--- a/ts/graphs/IntervalsGraph.svelte
+++ b/ts/graphs/IntervalsGraph.svelte
@@ -13,9 +13,11 @@
     import type { TableDatum } from "./graph-helpers";
     import TableData from "./TableData.svelte";
     import { createEventDispatcher } from "svelte";
+    import type { PreferenceStore } from "./preferences";
 
     export let sourceData: pb.BackendProto.GraphsOut | null = null;
     export let i18n: I18n;
+    export let preferences: PreferenceStore;
 
     const dispatch = createEventDispatcher();
 
@@ -23,13 +25,20 @@
     let histogramData = null as HistogramData | null;
     let tableData: TableDatum[] = [];
     let range = IntervalRange.Percentile95;
+    let { browserLinksSupported } = preferences;
 
     $: if (sourceData) {
         intervalData = gatherIntervalData(sourceData);
     }
 
     $: if (intervalData) {
-        [histogramData, tableData] = prepareIntervalData(intervalData, range, i18n, dispatch);
+        [histogramData, tableData] = prepareIntervalData(
+            intervalData,
+            range,
+            i18n,
+            dispatch,
+            $browserLinksSupported
+        );
     }
 
     const title = i18n.tr(i18n.TR.STATISTICS_INTERVALS_TITLE);
@@ -62,7 +71,7 @@
         </label>
     </div>
 
-    <HistogramGraph data={histogramData} {i18n} on:search />
+    <HistogramGraph data={histogramData} {i18n} />
 
     <TableData {i18n} {tableData} />
 </div>

--- a/ts/graphs/IntervalsGraph.svelte
+++ b/ts/graphs/IntervalsGraph.svelte
@@ -59,7 +59,7 @@
         </label>
     </div>
 
-    <HistogramGraph data={histogramData} {i18n} />
+    <HistogramGraph data={histogramData} {i18n} on:search />
 
     <TableData {i18n} {tableData} />
 </div>

--- a/ts/graphs/added.ts
+++ b/ts/graphs/added.ts
@@ -44,6 +44,7 @@ export function buildHistogram(
     range: GraphRange,
     i18n: I18n,
     dispatch: any,
+    browserLinksSupported: boolean
 ): [HistogramData | null, TableDatum[]] {
     // get min/max
     const total = data.daysAdded.length;
@@ -127,7 +128,7 @@ export function buildHistogram(
             bins,
             total: totalInPeriod,
             hoverText,
-            onClick,
+            onClick: browserLinksSupported ? onClick : null,
             colourScale,
             showArea: true,
         },

--- a/ts/graphs/added.ts
+++ b/ts/graphs/added.ts
@@ -102,8 +102,24 @@ export function buildHistogram(
         return `${day}:<br>${cards}<br>${total}: ${totalCards}`;
     }
 
+    function makeQuery(
+        data: HistogramData,
+        binIdx: number,
+    ): string {
+        const start = Math.abs(data.bins[binIdx].x0!) + 1;
+        const include = `added:${start}`
+
+        if (start === 1) {
+            return include
+        }
+
+        const end = Math.abs(data.bins[binIdx].x1!) + 1;
+        const exclude = `-added:${end}`
+        return `${include} ${exclude}`
+    }
+
     return [
-        { scale, bins, total: totalInPeriod, hoverText, colourScale, showArea: true },
+        { scale, bins, total: totalInPeriod, hoverText, makeQuery, colourScale, showArea: true },
         tableData,
     ];
 }

--- a/ts/graphs/added.ts
+++ b/ts/graphs/added.ts
@@ -102,24 +102,29 @@ export function buildHistogram(
         return `${day}:<br>${cards}<br>${total}: ${totalCards}`;
     }
 
-    function makeQuery(
-        data: HistogramData,
-        binIdx: number,
-    ): string {
+    function makeQuery(data: HistogramData, binIdx: number): string {
         const start = Math.abs(data.bins[binIdx].x0!) + 1;
-        const include = `added:${start}`
+        const include = `"added:${start}"`;
 
         if (start === 1) {
-            return include
+            return include;
         }
 
         const end = Math.abs(data.bins[binIdx].x1!) + 1;
-        const exclude = `-added:${end}`
-        return `${include} ${exclude}`
+        const exclude = `-"added:${end}"`;
+        return `${include} AND ${exclude}`;
     }
 
     return [
-        { scale, bins, total: totalInPeriod, hoverText, makeQuery, colourScale, showArea: true },
+        {
+            scale,
+            bins,
+            total: totalInPeriod,
+            hoverText,
+            makeQuery,
+            colourScale,
+            showArea: true,
+        },
         tableData,
     ];
 }

--- a/ts/graphs/calendar.ts
+++ b/ts/graphs/calendar.ts
@@ -114,7 +114,6 @@ export function renderCalendar(
             maxCount = count;
         }
     }
-    console.log("sourceData", sourceData, dayMap);
 
     if (!maxCount) {
         setDataAvailable(svg, false);

--- a/ts/graphs/calendar.ts
+++ b/ts/graphs/calendar.ts
@@ -114,7 +114,7 @@ export function renderCalendar(
             maxCount = count;
         }
     }
-    console.log('sourceData', sourceData, dayMap)
+    console.log("sourceData", sourceData, dayMap);
 
     if (!maxCount) {
         setDataAvailable(svg, false);
@@ -207,8 +207,13 @@ export function renderCalendar(
             showTooltip(tooltipText(d), x, y);
         })
         .on("mouseout", hideTooltip)
+        .attr("class", (d: any): string => {
+            return d.count > 0 ? "clickable" : "";
+        })
         .on("click", function (this: any, d: any) {
-            dispatch("search", { query: `"prop:rated=${d.day}"` });
+            if (d.count > 0) {
+                dispatch("search", { query: `"prop:rated=${d.day}"` });
+            }
         })
         .transition()
         .duration(800)

--- a/ts/graphs/calendar.ts
+++ b/ts/graphs/calendar.ts
@@ -82,6 +82,7 @@ export function renderCalendar(
     svgElem: SVGElement,
     bounds: GraphBounds,
     sourceData: GraphData,
+    dispatch: any,
     targetYear: number,
     i18n: I18n,
     nightMode: boolean,
@@ -113,6 +114,7 @@ export function renderCalendar(
             maxCount = count;
         }
     }
+    console.log('sourceData', sourceData, dayMap)
 
     if (!maxCount) {
         setDataAvailable(svg, false);
@@ -205,6 +207,9 @@ export function renderCalendar(
             showTooltip(tooltipText(d), x, y);
         })
         .on("mouseout", hideTooltip)
+        .on("click", function (this: any, d: any) {
+            dispatch("search", { query: `"prop:rated=${d.day}"` });
+        })
         .transition()
         .duration(800)
         .attr("fill", (d) => (d.count === 0 ? emptyColour : blues(d.count)!));

--- a/ts/graphs/card-counts.ts
+++ b/ts/graphs/card-counts.ts
@@ -86,50 +86,50 @@ function countCards(
         }
     }
 
-    const extraQuery = separateInactive ? " -(is:buried or is:suspended)" : "";
+    const extraQuery = separateInactive ? 'AND -("is:buried" OR "is:suspended")' : "";
 
     const counts: Count[] = [
         [
             i18n.tr(i18n.TR.STATISTICS_COUNTS_NEW_CARDS),
             newCards,
             true,
-            `is:new${extraQuery}`,
+            `"is:new"${extraQuery}`,
         ],
         [
             i18n.tr(i18n.TR.STATISTICS_COUNTS_LEARNING_CARDS),
             learn,
             true,
-            `(-is:review is:learn)${extraQuery}`,
+            `(-"is:review" AND "is:learn")${extraQuery}`,
         ],
         [
             i18n.tr(i18n.TR.STATISTICS_COUNTS_RELEARNING_CARDS),
             relearn,
             true,
-            `(is:review is:learn)${extraQuery}`,
+            `("is:review" AND "is:learn")${extraQuery}`,
         ],
         [
             i18n.tr(i18n.TR.STATISTICS_COUNTS_YOUNG_CARDS),
             young,
             true,
-            `(is:review -is:learn) prop:ivl<21${extraQuery}`,
+            `("is:review" AND -"is:learn") AND "prop:ivl<21"${extraQuery}`,
         ],
         [
             i18n.tr(i18n.TR.STATISTICS_COUNTS_MATURE_CARDS),
             mature,
             true,
-            `(is:review -is:learn) prop:ivl>=21${extraQuery}`,
+            `("is:review" -"is:learn") AND "prop:ivl>=21"${extraQuery}`,
         ],
         [
             i18n.tr(i18n.TR.STATISTICS_COUNTS_SUSPENDED_CARDS),
             suspended,
             separateInactive,
-            "is:suspended",
+            '"is:suspended"',
         ],
         [
             i18n.tr(i18n.TR.STATISTICS_COUNTS_BURIED_CARDS),
             buried,
             separateInactive,
-            "is:buried",
+            '"is:buried"',
         ],
     ];
 

--- a/ts/graphs/ease.ts
+++ b/ts/graphs/ease.ts
@@ -61,6 +61,21 @@ export function prepareData(
         });
     }
 
+    function makeQuery(data: HistogramData, binIdx: number): string {
+        const bin = data.bins[binIdx];
+        const start = bin.x0!;
+        const end = (bin.x1! - 1);
+
+        if (start === end) {
+            return `"prop:ease=${start / 100}"`;
+        }
+
+        const fromQuery = `"prop:ease>=${start / 100}"`;
+        const tillQuery = `"prop:ease<${end / 100}"`;
+
+        return `${fromQuery} AND ${tillQuery}`;
+    }
+
     const xTickFormat = (num: number): string => `${num.toFixed(0)}%`;
     const tableData = [
         {
@@ -70,7 +85,7 @@ export function prepareData(
     ];
 
     return [
-        { scale, bins, total, hoverText, colourScale, showArea: false, xTickFormat },
+        { scale, bins, total, hoverText, makeQuery, colourScale, showArea: false, xTickFormat },
         tableData,
     ];
 }

--- a/ts/graphs/ease.ts
+++ b/ts/graphs/ease.ts
@@ -41,6 +41,7 @@ export function prepareData(
     data: GraphData,
     i18n: I18n,
     dispatch: any,
+    browserLinksSupported: boolean
 ): [HistogramData | null, TableDatum[]] {
     // get min/max
     const allEases = data.eases;
@@ -94,7 +95,7 @@ export function prepareData(
             bins,
             total,
             hoverText,
-            onClick,
+            onClick: browserLinksSupported ? onClick : null,
             colourScale,
             showArea: false,
             xTickFormat,

--- a/ts/graphs/ease.ts
+++ b/ts/graphs/ease.ts
@@ -64,7 +64,7 @@ export function prepareData(
     function makeQuery(data: HistogramData, binIdx: number): string {
         const bin = data.bins[binIdx];
         const start = bin.x0!;
-        const end = (bin.x1! - 1);
+        const end = bin.x1! - 1;
 
         if (start === end) {
             return `"prop:ease=${start / 100}"`;
@@ -85,7 +85,16 @@ export function prepareData(
     ];
 
     return [
-        { scale, bins, total, hoverText, makeQuery, colourScale, showArea: false, xTickFormat },
+        {
+            scale,
+            bins,
+            total,
+            hoverText,
+            makeQuery,
+            colourScale,
+            showArea: false,
+            xTickFormat,
+        },
         tableData,
     ];
 }

--- a/ts/graphs/future-due.ts
+++ b/ts/graphs/future-due.ts
@@ -145,6 +145,24 @@ export function buildHistogram(
         return `${days}:<br>${cards}<br>${totalLabel}: ${cumulative}`;
     }
 
+    function makeQuery(
+        data: HistogramData,
+        binIdx: number,
+    ): string {
+        const bin = data.bins[binIdx];
+        const start = bin.x0!;
+        const end = bin.x1! - 1;
+
+        if (start === end) {
+            return `"prop:due=${start}"`
+        }
+
+        const fromQuery = `"prop:due>=${start}"`
+        const tillQuery = `"prop:due<=${end}"`
+
+        return `${fromQuery} AND ${tillQuery}`
+    }
+
     const periodDays = xMax! - xMin!;
     const tableData = [
         {
@@ -171,6 +189,7 @@ export function buildHistogram(
             bins,
             total,
             hoverText,
+            makeQuery,
             showArea: true,
             colourScale,
             binValue,

--- a/ts/graphs/future-due.ts
+++ b/ts/graphs/future-due.ts
@@ -145,22 +145,19 @@ export function buildHistogram(
         return `${days}:<br>${cards}<br>${totalLabel}: ${cumulative}`;
     }
 
-    function makeQuery(
-        data: HistogramData,
-        binIdx: number,
-    ): string {
+    function makeQuery(data: HistogramData, binIdx: number): string {
         const bin = data.bins[binIdx];
         const start = bin.x0!;
         const end = bin.x1! - 1;
 
         if (start === end) {
-            return `"prop:due=${start}"`
+            return `"prop:due=${start}"`;
         }
 
-        const fromQuery = `"prop:due>=${start}"`
-        const tillQuery = `"prop:due<=${end}"`
+        const fromQuery = `"prop:due>=${start}"`;
+        const tillQuery = `"prop:due<=${end}"`;
 
-        return `${fromQuery} AND ${tillQuery}`
+        return `${fromQuery} AND ${tillQuery}`;
     }
 
     const periodDays = xMax! - xMin!;

--- a/ts/graphs/future-due.ts
+++ b/ts/graphs/future-due.ts
@@ -75,8 +75,7 @@ export interface FutureDueOut {
 function makeQuery(start: number, end: number): string {
     if (start === end) {
         return `"prop:due=${start}"`;
-    }
-    else {
+    } else {
         const fromQuery = `"prop:due>=${start}"`;
         const tillQuery = `"prop:due<=${end}"`;
         return `${fromQuery} AND ${tillQuery}`;
@@ -89,6 +88,7 @@ export function buildHistogram(
     backlog: boolean,
     i18n: I18n,
     dispatch: any,
+    browserLinksSupported: boolean
 ): FutureDueOut {
     const output = { histogramData: null, tableData: [] };
     // get min/max
@@ -190,7 +190,7 @@ export function buildHistogram(
             bins,
             total,
             hoverText,
-            onClick,
+            onClick: browserLinksSupported ? onClick : null,
             showArea: true,
             colourScale,
             binValue,

--- a/ts/graphs/future-due.ts
+++ b/ts/graphs/future-due.ts
@@ -72,11 +72,23 @@ export interface FutureDueOut {
     tableData: TableDatum[];
 }
 
+function makeQuery(start: number, end: number): string {
+    if (start === end) {
+        return `"prop:due=${start}"`;
+    }
+    else {
+        const fromQuery = `"prop:due>=${start}"`;
+        const tillQuery = `"prop:due<=${end}"`;
+        return `${fromQuery} AND ${tillQuery}`;
+    }
+}
+
 export function buildHistogram(
     sourceData: GraphData,
     range: GraphRange,
     backlog: boolean,
-    i18n: I18n
+    i18n: I18n,
+    dispatch: any,
 ): FutureDueOut {
     const output = { histogramData: null, tableData: [] };
     // get min/max
@@ -145,19 +157,11 @@ export function buildHistogram(
         return `${days}:<br>${cards}<br>${totalLabel}: ${cumulative}`;
     }
 
-    function makeQuery(data: HistogramData, binIdx: number): string {
-        const bin = data.bins[binIdx];
+    function onClick(bin: Bin<number, number>): void {
         const start = bin.x0!;
         const end = bin.x1! - 1;
-
-        if (start === end) {
-            return `"prop:due=${start}"`;
-        }
-
-        const fromQuery = `"prop:due>=${start}"`;
-        const tillQuery = `"prop:due<=${end}"`;
-
-        return `${fromQuery} AND ${tillQuery}`;
+        const query = makeQuery(start, end);
+        dispatch("search", { query });
     }
 
     const periodDays = xMax! - xMin!;
@@ -186,7 +190,7 @@ export function buildHistogram(
             bins,
             total,
             hoverText,
-            makeQuery,
+            onClick,
             showArea: true,
             colourScale,
             binValue,

--- a/ts/graphs/graphs.scss
+++ b/ts/graphs/graphs.scss
@@ -197,3 +197,7 @@
 .no-focus-outline:focus {
     outline: 0;
 }
+
+.clickable {
+    cursor: pointer;
+}

--- a/ts/graphs/histogram-graph.ts
+++ b/ts/graphs/histogram-graph.ts
@@ -25,6 +25,10 @@ export interface HistogramData {
         cumulative: number,
         percent: number
     ) => string;
+    makeQuery?: (
+        data: HistogramData,
+        binIdx: number,
+    ) => string;
     showArea: boolean;
     colourScale: ScaleSequential<string>;
     binValue?: (bin: Bin<any, any>) => number;
@@ -34,7 +38,8 @@ export interface HistogramData {
 export function histogramGraph(
     svgElem: SVGElement,
     bounds: GraphBounds,
-    data: HistogramData | null
+    data: HistogramData | null,
+    dispatch: any,
 ): void {
     const svg = select(svgElem);
     const trans = svg.transition().duration(600) as any;
@@ -152,10 +157,21 @@ export function histogramGraph(
         .attr("y", () => y(yMax!)!)
         .attr("width", barWidth)
         .attr("height", () => y(0)! - y(yMax!)!)
+        .on("mouseover", function (this: any) {
+            this.style = "cursor: pointer;";
+        })
         .on("mousemove", function (this: any, d: any, idx) {
             const [x, y] = mouse(document.body);
             const pct = data.showArea ? (areaData[idx + 1] / data.total) * 100 : 0;
             showTooltip(data.hoverText(data, idx, areaData[idx + 1], pct), x, y);
         })
-        .on("mouseout", hideTooltip);
+        .on("mouseout", function (this: any) {
+            hideTooltip;
+            this.style = "";
+        })
+        .on('click', function(this: any, d: any, idx: number) {
+            console.log('clicked', this)
+            if (!data.makeQuery) { return }
+            dispatch("search", { query: data.makeQuery(data, idx) })
+        });
 }

--- a/ts/graphs/histogram-graph.ts
+++ b/ts/graphs/histogram-graph.ts
@@ -136,7 +136,7 @@ export function histogramGraph(
                 "d",
                 area()
                     .curve(curveBasis)
-                    .x((d, idx) => {
+                    .x((_d, idx) => {
                         if (idx === 0) {
                             return x(data.bins[0].x0!)!;
                         } else {
@@ -149,7 +149,7 @@ export function histogramGraph(
     }
 
     // hover/tooltip
-    svg.select("g.hoverzone")
+    const hoverzone = svg.select("g.hoverzone")
         .selectAll("rect")
         .data(data.bins)
         .join("rect")
@@ -157,21 +157,18 @@ export function histogramGraph(
         .attr("y", () => y(yMax!)!)
         .attr("width", barWidth)
         .attr("height", () => y(0)! - y(yMax!)!)
-        .on("mouseover", function (this: any) {
-            this.style = "cursor: pointer;";
-        })
-        .on("mousemove", function (this: any, d: any, idx) {
+        .on("mousemove", function (this: any, _d: any, idx: number) {
             const [x, y] = mouse(document.body);
             const pct = data.showArea ? (areaData[idx + 1] / data.total) * 100 : 0;
             showTooltip(data.hoverText(data, idx, areaData[idx + 1], pct), x, y);
         })
-        .on("mouseout", function (this: any) {
-            hideTooltip;
-            this.style = "";
-        })
-        .on('click', function(this: any, d: any, idx: number) {
-            console.log('clicked', this)
-            if (!data.makeQuery) { return }
-            dispatch("search", { query: data.makeQuery(data, idx) })
-        });
+        .on("mouseout", hideTooltip);
+
+    if (data.makeQuery) {
+        hoverzone
+            .attr("class", "clickable")
+            .on("click", function (this: any, _d: any, idx: number) {
+                dispatch("search", { query: data.makeQuery!(data, idx) })
+            });
+    }
 }

--- a/ts/graphs/histogram-graph.ts
+++ b/ts/graphs/histogram-graph.ts
@@ -25,7 +25,7 @@ export interface HistogramData {
         cumulative: number,
         percent: number
     ) => string;
-    onClick?: (data: Bin<number, number>) => void;
+    onClick: ((data: Bin<number, number>) => void) | null;
     showArea: boolean;
     colourScale: ScaleSequential<string>;
     binValue?: (bin: Bin<any, any>) => number;
@@ -35,7 +35,7 @@ export interface HistogramData {
 export function histogramGraph(
     svgElem: SVGElement,
     bounds: GraphBounds,
-    data: HistogramData | null,
+    data: HistogramData | null
 ): void {
     const svg = select(svgElem);
     const trans = svg.transition().duration(600) as any;
@@ -162,8 +162,6 @@ export function histogramGraph(
         .on("mouseout", hideTooltip);
 
     if (data.onClick) {
-        hoverzone
-            .attr("class", "clickable")
-            .on("click", data.onClick);
+        hoverzone.attr("class", "clickable").on("click", data.onClick);
     }
 }

--- a/ts/graphs/histogram-graph.ts
+++ b/ts/graphs/histogram-graph.ts
@@ -25,10 +25,7 @@ export interface HistogramData {
         cumulative: number,
         percent: number
     ) => string;
-    makeQuery?: (
-        data: HistogramData,
-        binIdx: number,
-    ) => string;
+    makeQuery?: (data: HistogramData, binIdx: number) => string;
     showArea: boolean;
     colourScale: ScaleSequential<string>;
     binValue?: (bin: Bin<any, any>) => number;
@@ -39,7 +36,7 @@ export function histogramGraph(
     svgElem: SVGElement,
     bounds: GraphBounds,
     data: HistogramData | null,
-    dispatch: any,
+    dispatch: any
 ): void {
     const svg = select(svgElem);
     const trans = svg.transition().duration(600) as any;
@@ -149,7 +146,8 @@ export function histogramGraph(
     }
 
     // hover/tooltip
-    const hoverzone = svg.select("g.hoverzone")
+    const hoverzone = svg
+        .select("g.hoverzone")
         .selectAll("rect")
         .data(data.bins)
         .join("rect")
@@ -168,7 +166,7 @@ export function histogramGraph(
         hoverzone
             .attr("class", "clickable")
             .on("click", function (this: any, _d: any, idx: number) {
-                dispatch("search", { query: data.makeQuery!(data, idx) })
+                dispatch("search", { query: data.makeQuery!(data, idx) });
             });
     }
 }

--- a/ts/graphs/histogram-graph.ts
+++ b/ts/graphs/histogram-graph.ts
@@ -25,7 +25,7 @@ export interface HistogramData {
         cumulative: number,
         percent: number
     ) => string;
-    makeQuery?: (data: HistogramData, binIdx: number) => string;
+    onClick?: (data: Bin<number, number>) => void;
     showArea: boolean;
     colourScale: ScaleSequential<string>;
     binValue?: (bin: Bin<any, any>) => number;
@@ -36,7 +36,6 @@ export function histogramGraph(
     svgElem: SVGElement,
     bounds: GraphBounds,
     data: HistogramData | null,
-    dispatch: any
 ): void {
     const svg = select(svgElem);
     const trans = svg.transition().duration(600) as any;
@@ -162,11 +161,9 @@ export function histogramGraph(
         })
         .on("mouseout", hideTooltip);
 
-    if (data.makeQuery) {
+    if (data.onClick) {
         hoverzone
             .attr("class", "clickable")
-            .on("click", function (this: any, _d: any, idx: number) {
-                dispatch("search", { query: data.makeQuery!(data, idx) });
-            });
+            .on("click", data.onClick);
     }
 }

--- a/ts/graphs/intervals.ts
+++ b/ts/graphs/intervals.ts
@@ -134,22 +134,19 @@ export function prepareIntervalData(
         return `${interval}<br>${total}: \u200e${percent.toFixed(1)}%`;
     }
 
-    function makeQuery(
-        data: HistogramData,
-        binIdx: number,
-    ): string {
+    function makeQuery(data: HistogramData, binIdx: number): string {
         const bin = data.bins[binIdx];
         const start = bin.x0!;
         const end = bin.x1! - 1;
 
         if (start === end) {
-            return `"prop:ivl=${start}"`
+            return `"prop:ivl=${start}"`;
         }
 
-        const fromQuery = `"prop:ivl>=${start}"`
-        const tillQuery = `"prop:ivl<=${end}"`
+        const fromQuery = `"prop:ivl>=${start}"`;
+        const tillQuery = `"prop:ivl<=${end}"`;
 
-        return `${fromQuery} AND ${tillQuery}`
+        return `${fromQuery} AND ${tillQuery}`;
     }
 
     const meanInterval = Math.round(mean(allIntervals) ?? 0);
@@ -161,7 +158,15 @@ export function prepareIntervalData(
         },
     ];
     return [
-        { scale, bins, total: totalInPeriod, hoverText, makeQuery, colourScale, showArea: true },
+        {
+            scale,
+            bins,
+            total: totalInPeriod,
+            hoverText,
+            makeQuery,
+            colourScale,
+            showArea: true,
+        },
         tableData,
     ];
 }

--- a/ts/graphs/intervals.ts
+++ b/ts/graphs/intervals.ts
@@ -138,20 +138,18 @@ export function prepareIntervalData(
         data: HistogramData,
         binIdx: number,
     ): string {
-        const onlyReview = "-(is:new or is:learn or is:suspended or is:buried)"
-
         const bin = data.bins[binIdx];
         const start = bin.x0!;
         const end = bin.x1! - 1;
 
         if (start === end) {
-            return `prop:ivl=${start} ${onlyReview}`
+            return `prop:ivl=${start}`
         }
 
         const fromQuery = `prop:ivl>=${start}`
         const tillQuery = `prop:ivl<=${end}`
 
-        return `${fromQuery} ${tillQuery} ${onlyReview}`
+        return `${fromQuery} ${tillQuery}`
     }
 
     const meanInterval = Math.round(mean(allIntervals) ?? 0);

--- a/ts/graphs/intervals.ts
+++ b/ts/graphs/intervals.ts
@@ -143,13 +143,13 @@ export function prepareIntervalData(
         const end = bin.x1! - 1;
 
         if (start === end) {
-            return `prop:ivl=${start}`
+            return `"prop:ivl=${start}"`
         }
 
-        const fromQuery = `prop:ivl>=${start}`
-        const tillQuery = `prop:ivl<=${end}`
+        const fromQuery = `"prop:ivl>=${start}"`
+        const tillQuery = `"prop:ivl<=${end}"`
 
-        return `${fromQuery} ${tillQuery}`
+        return `${fromQuery} AND ${tillQuery}`
     }
 
     const meanInterval = Math.round(mean(allIntervals) ?? 0);

--- a/ts/graphs/intervals.ts
+++ b/ts/graphs/intervals.ts
@@ -134,6 +134,26 @@ export function prepareIntervalData(
         return `${interval}<br>${total}: \u200e${percent.toFixed(1)}%`;
     }
 
+    function makeQuery(
+        data: HistogramData,
+        binIdx: number,
+    ): string {
+        const onlyReview = "-(is:new or is:learn or is:suspended or is:buried)"
+
+        const bin = data.bins[binIdx];
+        const start = bin.x0!;
+        const end = bin.x1! - 1;
+
+        if (start === end) {
+            return `prop:ivl=${start} ${onlyReview}`
+        }
+
+        const fromQuery = `prop:ivl>=${start}`
+        const tillQuery = `prop:ivl<=${end}`
+
+        return `${fromQuery} ${tillQuery} ${onlyReview}`
+    }
+
     const meanInterval = Math.round(mean(allIntervals) ?? 0);
     const meanIntervalString = timeSpan(i18n, meanInterval * 86400, false);
     const tableData = [
@@ -143,7 +163,7 @@ export function prepareIntervalData(
         },
     ];
     return [
-        { scale, bins, total: totalInPeriod, hoverText, colourScale, showArea: true },
+        { scale, bins, total: totalInPeriod, hoverText, makeQuery, colourScale, showArea: true },
         tableData,
     ];
 }

--- a/ts/graphs/intervals.ts
+++ b/ts/graphs/intervals.ts
@@ -72,6 +72,7 @@ export function prepareIntervalData(
     range: IntervalRange,
     i18n: I18n,
     dispatch: any,
+    browserLinksSupported: boolean
 ): [HistogramData | null, TableDatum[]] {
     // get min/max
     const allIntervals = data.intervals;
@@ -161,13 +162,14 @@ export function prepareIntervalData(
             value: meanIntervalString,
         },
     ];
+
     return [
         {
             scale,
             bins,
             total: totalInPeriod,
             hoverText,
-            onClick,
+            onClick: browserLinksSupported ? onClick : null,
             colourScale,
             showArea: true,
         },

--- a/ts/lib/bridgecommand.ts
+++ b/ts/lib/bridgecommand.ts
@@ -1,7 +1,17 @@
 // Copyright: Ankitects Pty Ltd and contributors
 // License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
+declare global {
+    interface Window {
+        bridgeCommand<T>(command: string, callback?: (value: T) => void): void;
+    }
+}
+
 /// HTML <a> tag pointing to a bridge command.
 export function bridgeLink(command: string, label: string): string {
     return `<a href="javascript:bridgeCommand('${command}')">${label}</a>`;
+}
+
+export function bridgeCommand<T>(command: string, callback?: (value: T) => void): void {
+    window.bridgeCommand<T>(command, callback);
 }


### PR DESCRIPTION
This conversation started in https://github.com/ankitects/anki/pull/892

> I don't think we could use the bridgeCommandsSupported trick in this case - GraphsOut is potentially tens of megabytes, and we don't really want the client code to have to deserialize it just to adjust a property, then re-serialize it before passing it on. It could potentially be handled in some other way, but I do wonder whether enough people would find it useful to justify the effort. If this is about discoverability for new users, what about just giving each of the sections a tooltip of the form "To find these cards in the browse screen, search for is:suspended". But we do already have the Filter button→Card State menu item as well.

1. I don't exactly understand how `bridgeCommandsSupported` works, tbh. I think the stats are used on two platforms at the moment, right? Anki and AnkiMobile. And I do see the activated bridgeCommands on both platforms.

2. Also I don't exactly know why the data needs re-serialization? So if I understand correctly, you intercept the `CongratsOut` data, only to set that property and then pass it on?

I would prefer a "show, don't tell" approach in that case. Opening the browser with the search typed in, delivers an obvious message of "Let me google that for you", but can also be used by those, who can't be bothered to remember the queries, or feel overwhelmed by the idea of entering "special commands" to search.