### PR TITLE
remove context help button

### DIFF
--- a/qt/aqt/about.py
+++ b/qt/aqt/about.py
@@ -28,6 +28,7 @@ class ClosableQDialog(QDialog):
 
 def show(mw):
     dialog = ClosableQDialog(mw)
+    dialog.setWindowFlags(self.windowFlags() & ~Qt.WindowContextHelpButtonHint)  # type: ignore
     mw.setupDialogGC(dialog)
     abt = aqt.forms.about.Ui_About()
     abt.setupUi(dialog)

--- a/qt/aqt/addcards.py
+++ b/qt/aqt/addcards.py
@@ -37,6 +37,7 @@ class AddCards(QDialog):
         self.form = aqt.forms.addcards.Ui_Dialog()
         self.form.setupUi(self)
         self.setWindowTitle(tr(TR.ACTIONS_ADD))
+        self.setWindowFlags(self.windowFlags() & ~Qt.WindowContextHelpButtonHint)  # type: ignore
         self.setMinimumHeight(300)
         self.setMinimumWidth(400)
         self.setupChoosers()

--- a/qt/aqt/addons.py
+++ b/qt/aqt/addons.py
@@ -705,6 +705,7 @@ class AddonsDialog(QDialog):
         qconnect(self.form.addonList.itemDoubleClicked, self.onConfig)
         qconnect(self.form.addonList.currentRowChanged, self._onAddonItemSelected)
         self.setWindowTitle(tr(TR.ADDONS_WINDOW_TITLE))
+        self.setWindowFlags(self.windowFlags() & ~Qt.WindowContextHelpButtonHint)  # type: ignore
         self.setAcceptDrops(True)
         self.redrawAddons()
         restoreGeom(self, "addons")
@@ -917,6 +918,7 @@ class GetAddons(QDialog):
             tr(TR.ADDONS_BROWSE_ADDONS), QDialogButtonBox.ActionRole
         )
         qconnect(b.clicked, self.onBrowse)
+        self.setWindowFlags(self.windowFlags() & ~Qt.WindowContextHelpButtonHint)  # type: ignore
         restoreGeom(self, "getaddons", adjustSize=True)
         self.exec_()
         saveGeom(self, "getaddons")
@@ -1294,6 +1296,7 @@ class ConfigEditor(QDialog):
                 )
             )
         )
+        self.setWindowFlags(self.windowFlags() & ~Qt.WindowContextHelpButtonHint)  # type: ignore
         self.show()
 
     def onRestoreDefaults(self) -> None:

--- a/qt/aqt/browser.py
+++ b/qt/aqt/browser.py
@@ -1741,6 +1741,7 @@ where id in %s"""
         if not cids2:
             return showInfo(tr(TR.BROWSING_ONLY_NEW_CARDS_CAN_BE_REPOSITIONED))
         d = QDialog(self)
+        d.setWindowFlags(self.windowFlags() & ~Qt.WindowContextHelpButtonHint)  # type: ignore
         d.setWindowModality(Qt.WindowModal)
         frm = aqt.forms.reposition.Ui_Dialog()
         frm.setupUi(d)
@@ -1776,6 +1777,7 @@ where id in %s"""
 
     def _reschedule(self):
         d = QDialog(self)
+        d.setWindowFlags(self.windowFlags() & ~Qt.WindowContextHelpButtonHint)  # type: ignore
         d.setWindowModality(Qt.WindowModal)
         frm = aqt.forms.reschedule.Ui_Dialog()
         frm.setupUi(d)
@@ -1875,6 +1877,7 @@ where id in %s"""
 
     def _on_find_replace_diag(self, fields: List[str], nids: List[int]) -> None:
         d = QDialog(self)
+        d.setWindowFlags(self.windowFlags() & ~Qt.WindowContextHelpButtonHint)  # type: ignore
         frm = aqt.forms.findreplace.Ui_Dialog()
         frm.setupUi(d)
         d.setWindowModality(Qt.WindowModal)
@@ -1958,6 +1961,7 @@ where id in %s"""
         frm = aqt.forms.finddupes.Ui_Dialog()
         frm.setupUi(d)
         restoreGeom(d, "findDupes")
+        d.setWindowFlags(self.windowFlags() & ~Qt.WindowContextHelpButtonHint)  # type: ignore
         searchHistory = restore_combo_history(frm.search, "findDupesFind")
 
         fields = sorted(
@@ -2123,6 +2127,7 @@ class ChangeModel(QDialog):
         self.oldModel = browser.card.note().model()
         self.form = aqt.forms.changemodel.Ui_Dialog()
         self.form.setupUi(self)
+        self.setWindowFlags(self.windowFlags() & ~Qt.WindowContextHelpButtonHint)  # type: ignore
         self.setWindowModality(Qt.WindowModal)
         self.setup()
         restoreGeom(self, "changeModel")
@@ -2298,6 +2303,7 @@ class CardInfoDialog(QDialog):
     def __init__(self, browser: Browser, *args, **kwargs):
         super().__init__(browser, *args, **kwargs)
         self.browser = browser
+        self.setWindowFlags(self.windowFlags() & ~Qt.WindowContextHelpButtonHint)  # type: ignore
 
     def reject(self):
         saveGeom(self, "revlog")

--- a/qt/aqt/clayout.py
+++ b/qt/aqt/clayout.py
@@ -71,6 +71,7 @@ class CardLayout(QDialog):
                 tr(TR.CARD_TEMPLATES_CARD_TYPES_FOR, val=self.model["name"])
             )
         )
+        self.setWindowFlags(self.windowFlags() & ~Qt.WindowContextHelpButtonHint)  # type: ignore
         v1 = QVBoxLayout()
         v1.addWidget(self.topArea)
         v1.addWidget(self.mainArea)
@@ -700,6 +701,7 @@ class CardLayout(QDialog):
 
     def onBrowserDisplay(self):
         d = QDialog()
+        d.setWindowFlags(self.windowFlags() & ~Qt.WindowContextHelpButtonHint)  # type: ignore
         f = aqt.forms.browserdisp.Ui_Dialog()
         f.setupUi(d)
         t = self.current_template()
@@ -731,6 +733,7 @@ class CardLayout(QDialog):
         t = self.current_template()
         d = QDialog(self)
         d.setWindowTitle("Anki")
+        d.setWindowFlags(self.windowFlags() & ~Qt.WindowContextHelpButtonHint)  # type: ignore
         d.setMinimumWidth(400)
         l = QVBoxLayout()
         lab = QLabel(
@@ -760,6 +763,7 @@ class CardLayout(QDialog):
         diag = QDialog(self)
         form = aqt.forms.addfield.Ui_Dialog()
         form.setupUi(diag)
+        diag.setWindowFlags(self.windowFlags() & ~Qt.WindowContextHelpButtonHint)  # type: ignore
         fields = [f["name"] for f in self.model["flds"]]
         form.fields.addItems(fields)
         form.fields.setCurrentRow(0)

--- a/qt/aqt/customstudy.py
+++ b/qt/aqt/customstudy.py
@@ -28,6 +28,7 @@ class CustomStudy(QDialog):
         self.form = f = aqt.forms.customstudy.Ui_Dialog()
         self.created_custom_study = False
         f.setupUi(self)
+        self.setWindowFlags(self.windowFlags() & ~Qt.WindowContextHelpButtonHint)  # type: ignore
         self.setWindowModality(Qt.WindowModal)
         self.setupSignals()
         f.radioNew.click()

--- a/qt/aqt/deckconf.py
+++ b/qt/aqt/deckconf.py
@@ -48,6 +48,7 @@ class DeckConf(QDialog):
         self.setWindowTitle(
             without_unicode_isolation(tr(TR.ACTIONS_OPTIONS_FOR, val=self.deck["name"]))
         )
+        self.setWindowFlags(self.windowFlags() & ~Qt.WindowContextHelpButtonHint)  # type: ignore
         # qt doesn't size properly with altered fonts otherwise
         restoreGeom(self, "deckconf", adjustSize=True)
         gui_hooks.deck_conf_will_show(self)

--- a/qt/aqt/dyndeckconf.py
+++ b/qt/aqt/dyndeckconf.py
@@ -23,6 +23,7 @@ class DeckConf(QDialog):
             label = tr(TR.ACTIONS_REBUILD)
         self.ok = self.form.buttonBox.addButton(label, QDialogButtonBox.AcceptRole)
         self.mw.checkpoint(tr(TR.ACTIONS_OPTIONS))
+        self.setWindowFlags(self.windowFlags() & ~Qt.WindowContextHelpButtonHint)  # type: ignore
         self.setWindowModality(Qt.WindowModal)
         qconnect(self.form.buttonBox.helpRequested, lambda: openHelp("filtered-decks"))
         self.setWindowTitle(

--- a/qt/aqt/editcurrent.py
+++ b/qt/aqt/editcurrent.py
@@ -16,6 +16,7 @@ class EditCurrent(QDialog):
         self.form = aqt.forms.editcurrent.Ui_Dialog()
         self.form.setupUi(self)
         self.setWindowTitle(tr(TR.EDITING_EDIT_CURRENT))
+        self.setWindowFlags(self.windowFlags() & ~Qt.WindowContextHelpButtonHint)  # type: ignore
         self.setMinimumHeight(400)
         self.setMinimumWidth(250)
         self.form.buttonBox.button(QDialogButtonBox.Close).setShortcut(

--- a/qt/aqt/editor.py
+++ b/qt/aqt/editor.py
@@ -555,6 +555,7 @@ class Editor:
         form = aqt.forms.edithtml.Ui_Dialog()
         form.setupUi(d)
         restoreGeom(d, "htmlEditor")
+        d.setWindowFlags(self.windowFlags() & ~Qt.WindowContextHelpButtonHint)  # type: ignore
         qconnect(form.buttonBox.helpRequested, lambda: openHelp("editing?id=features"))
         form.textEdit.setPlainText(self.note.fields[field])
         d.show()

--- a/qt/aqt/emptycards.py
+++ b/qt/aqt/emptycards.py
@@ -38,6 +38,7 @@ class EmptyCardsDialog(QDialog):
         self.form.setupUi(self)
         restoreGeom(self, "emptycards")
         self.setWindowTitle(tr(TR.EMPTY_CARDS_WINDOW_TITLE))
+        self.setWindowFlags(self.windowFlags() & ~Qt.WindowContextHelpButtonHint)  # type: ignore
         self.form.keep_notes.setText(tr(TR.EMPTY_CARDS_PRESERVE_NOTES_CHECKBOX))
         self.form.webview.title = "empty cards"
         self.form.webview.set_bridge_command(self._on_note_link_clicked, self)

--- a/qt/aqt/exporting.py
+++ b/qt/aqt/exporting.py
@@ -30,6 +30,7 @@ class ExportDialog(QDialog):
         self.frm.setupUi(self)
         self.exporter: Optional[Exporter] = None
         self.cids = cids
+        self.setWindowFlags(self.windowFlags() & ~Qt.WindowContextHelpButtonHint)  # type: ignore
         self.setup(did)
         self.exec_()
 

--- a/qt/aqt/fields.py
+++ b/qt/aqt/fields.py
@@ -27,6 +27,7 @@ class FieldDialog(QDialog):
         self.setWindowTitle(
             without_unicode_isolation(tr(TR.FIELDS_FIELDS_FOR, val=self.model["name"]))
         )
+        self.setWindowFlags(self.windowFlags() & ~Qt.WindowContextHelpButtonHint)  # type: ignore
         self.form.buttonBox.button(QDialogButtonBox.Help).setAutoDefault(False)
         self.form.buttonBox.button(QDialogButtonBox.Cancel).setAutoDefault(False)
         self.form.buttonBox.button(QDialogButtonBox.Save).setAutoDefault(False)

--- a/qt/aqt/importing.py
+++ b/qt/aqt/importing.py
@@ -38,6 +38,7 @@ class ChangeMap(QDialog):
         self.model = model
         self.frm = aqt.forms.changemap.Ui_ChangeMap()
         self.frm.setupUi(self)
+        self.setWindowFlags(self.windowFlags() & ~Qt.WindowContextHelpButtonHint)  # type: ignore
         n = 0
         setCurrent = False
         for field in self.model["flds"]:
@@ -85,6 +86,7 @@ class ImportDialog(QDialog):
         qconnect(
             self.frm.buttonBox.button(QDialogButtonBox.Help).clicked, self.helpRequested
         )
+        self.setWindowFlags(self.windowFlags() & ~Qt.WindowContextHelpButtonHint)  # type: ignore
         self.setupMappingFrame()
         self.setupOptions()
         self.modelChanged()

--- a/qt/aqt/main.py
+++ b/qt/aqt/main.py
@@ -1345,6 +1345,7 @@ title="%s" %s>%s</button>""" % (
 
         d = self.debugDiag = DebugDialog()
         d.silentlyClose = True
+        d.setWindowFlags(self.windowFlags() & ~Qt.WindowContextHelpButtonHint)  # type: ignore
         frm.setupUi(d)
         restoreGeom(d, "DebugConsoleWindow")
         restoreSplitter(frm.splitter, "DebugConsoleWindow")

--- a/qt/aqt/mediacheck.py
+++ b/qt/aqt/mediacheck.py
@@ -84,6 +84,7 @@ class MediaChecker:
         # show report and offer to delete
         diag = QDialog(self.mw)
         diag.setWindowTitle(tr(TR.MEDIA_CHECK_WINDOW_TITLE))
+        setWindowFlags(self.windowFlags() & ~Qt.WindowContextHelpButtonHint)  # type: ignore
         layout = QVBoxLayout(diag)
         diag.setLayout(layout)
         text = QTextEdit()

--- a/qt/aqt/mediasync.py
+++ b/qt/aqt/mediasync.py
@@ -164,6 +164,7 @@ class MediaSyncDialog(QDialog):
         self.form = aqt.forms.synclog.Ui_Dialog()
         self.form.setupUi(self)
         self.setWindowTitle(tr(TR.SYNC_MEDIA_LOG_TITLE))
+        self.setWindowFlags(self.windowFlags() & ~Qt.WindowContextHelpButtonHint)  # type: ignore
         self.abort_button = QPushButton(tr(TR.SYNC_ABORT_BUTTON))
         qconnect(self.abort_button.clicked, self._on_abort)
         self.abort_button.setAutoDefault(False)

--- a/qt/aqt/models.py
+++ b/qt/aqt/models.py
@@ -155,6 +155,7 @@ class Models(QDialog):
     def onAdvanced(self) -> None:
         nt = self.current_notetype()
         d = QDialog(self)
+        d.setWindowFlags(self.windowFlags() & ~Qt.WindowContextHelpButtonHint)  # type: ignore
         frm = aqt.forms.modelopts.Ui_Dialog()
         frm.setupUi(d)
         frm.latexsvg.setChecked(nt.get("latexsvg", False))
@@ -210,6 +211,7 @@ class AddModel(QDialog):
         self.model = None
         self.dialog = aqt.forms.addmodel.Ui_Dialog()
         self.dialog.setupUi(self)
+        self.setWindowFlags(self.windowFlags() & ~Qt.WindowContextHelpButtonHint)  # type: ignore
         # standard models
         self.models = []
         for (name, func) in stdmodels.get_stock_notetypes(self.col):

--- a/qt/aqt/preferences.py
+++ b/qt/aqt/preferences.py
@@ -31,6 +31,7 @@ class Preferences(QDialog):
         self.prof = self.mw.pm.profile
         self.form = aqt.forms.preferences.Ui_Preferences()
         self.form.setupUi(self)
+        self.setWindowFlags(self.windowFlags() & ~Qt.WindowContextHelpButtonHint)  # type: ignore
         self.form.buttonBox.button(QDialogButtonBox.Help).setAutoDefault(False)
         self.form.buttonBox.button(QDialogButtonBox.Close).setAutoDefault(False)
         qconnect(self.form.buttonBox.helpRequested, lambda: openHelp("preferences"))

--- a/qt/aqt/previewer.py
+++ b/qt/aqt/previewer.py
@@ -43,6 +43,7 @@ class Previewer(QDialog):
         self.mw = mw
         icon = QIcon()
         icon.addPixmap(QPixmap(":/icons/anki.png"), QIcon.Normal, QIcon.Off)
+        self.setWindowFlags(self.windowFlags() & ~Qt.WindowContextHelpButtonHint)  # type: ignore
         self.setWindowIcon(icon)
 
     def card(self) -> Optional[Card]:

--- a/qt/aqt/profiles.py
+++ b/qt/aqt/profiles.py
@@ -542,6 +542,7 @@ create table if not exists profiles
         d = self.langDiag = NoCloseDiag()
         f = self.langForm = aqt.forms.setlang.Ui_Dialog()
         f.setupUi(d)
+        d.setWindowFlags(self.windowFlags() & ~Qt.WindowContextHelpButtonHint)  # type: ignore
         qconnect(d.accepted, self._onLangSelected)
         qconnect(d.rejected, lambda: True)
         # update list

--- a/qt/aqt/progress.py
+++ b/qt/aqt/progress.py
@@ -211,6 +211,7 @@ class ProgressManager:
 class ProgressDialog(QDialog):
     def __init__(self, parent):
         QDialog.__init__(self, parent)
+        self.setWindowFlags(self.windowFlags() & ~Qt.WindowContextHelpButtonHint)  # type: ignore
         self.form = aqt.forms.progress.Ui_Dialog()
         self.form.setupUi(self)
         self._closingDown = False

--- a/qt/aqt/sound.py
+++ b/qt/aqt/sound.py
@@ -707,6 +707,7 @@ class RecordDialog(QDialog):
         self._parent = parent
         self.mw = mw
         self._on_success = on_success
+        self.setWindowFlags(self.windowFlags() & ~Qt.WindowContextHelpButtonHint)  # type: ignore
 
         self._start_recording()
         self._setup_dialog()

--- a/qt/aqt/stats.py
+++ b/qt/aqt/stats.py
@@ -34,6 +34,7 @@ class NewDeckStats(QDialog):
         self.oldPos = None
         self.wholeCollection = False
         self.setMinimumWidth(700)
+        self.setWindowFlags(self.windowFlags() & ~Qt.WindowContextHelpButtonHint)  # type: ignore
         f = self.form
         f.setupUi(self)
         f.groupBox.setVisible(False)
@@ -104,6 +105,7 @@ class DeckStats(QDialog):
         self.oldPos = None
         self.wholeCollection = False
         self.setMinimumWidth(700)
+        self.setWindowFlags(self.windowFlags() & ~Qt.WindowContextHelpButtonHint)  # type: ignore
         f = self.form
         if theme_manager.night_mode and not theme_manager.macos_dark_mode():
             # the grouping box renders incorrectly in the fusion theme. 5.9+

--- a/qt/aqt/studydeck.py
+++ b/qt/aqt/studydeck.py
@@ -42,6 +42,7 @@ class StudyDeck(QDialog):
         gui_hooks.state_did_reset.append(self.onReset)
         self.geomKey = "studyDeck-" + geomKey
         restoreGeom(self, self.geomKey)
+        self.setWindowFlags(self.windowFlags() & ~Qt.WindowContextHelpButtonHint)  # type: ignore
         if not cancel:
             self.form.buttonBox.removeButton(
                 self.form.buttonBox.button(QDialogButtonBox.Cancel)

--- a/qt/aqt/sync.py
+++ b/qt/aqt/sync.py
@@ -290,6 +290,7 @@ def get_id_and_pass_from_user(
 ) -> Tuple[str, str]:
     diag = QDialog(mw)
     diag.setWindowTitle("Anki")
+    diag.setWindowFlags(self.windowFlags() & ~Qt.WindowContextHelpButtonHint)  # type: ignore
     diag.setWindowModality(Qt.WindowModal)
     vbox = QVBoxLayout()
     info_label = QLabel(

--- a/qt/aqt/taglimit.py
+++ b/qt/aqt/taglimit.py
@@ -16,6 +16,7 @@ class TagLimit(QDialog):
         self.deck = self.parent.deck
         self.dialog = aqt.forms.taglimit.Ui_Dialog()
         self.dialog.setupUi(self)
+        self.setWindowFlags(self.windowFlags() & ~Qt.WindowContextHelpButtonHint)  # type: ignore
         s = QShortcut(
             QKeySequence("ctrl+d"), self.dialog.activeList, context=Qt.WidgetShortcut
         )

--- a/qt/aqt/utils.py
+++ b/qt/aqt/utils.py
@@ -127,6 +127,7 @@ def showText(
         parent = aqt.mw.app.activeWindow() or aqt.mw
     diag = QDialog(parent)
     diag.setWindowTitle(title)
+    diag.setWindowFlags(self.windowFlags() & ~Qt.WindowContextHelpButtonHint)  # type: ignore
     layout = QVBoxLayout(diag)
     diag.setLayout(layout)
     text = QTextBrowser()
@@ -245,6 +246,7 @@ class GetTextDialog(QDialog):
     ):
         QDialog.__init__(self, parent)
         self.setWindowTitle(title)
+        self.setWindowFlags(self.windowFlags() & ~Qt.WindowContextHelpButtonHint)  # type: ignore
         self.question = question
         self.help = help
         self.qlabel = QLabel(question)
@@ -316,6 +318,7 @@ def chooseList(prompt, choices, startrow=0, parent=None):
     if not parent:
         parent = aqt.mw.app.activeWindow()
     d = QDialog(parent)
+    d.setWindowFlags(self.windowFlags() & ~Qt.WindowContextHelpButtonHint)  # type: ignore
     d.setWindowModality(Qt.WindowModal)
     l = QVBoxLayout()
     d.setLayout(l)


### PR DESCRIPTION
![Screenshot_20210106_221752](https://user-images.githubusercontent.com/50060875/103772775-628d0b00-506d-11eb-8500-341447ef488f.png)

This PR removes 'context help' button from all dialogs, which doesn't do anything when clicked.

For some reason, mypy thinks the type of `dialog.setWindowFlags(self.windowFlags() & ~Qt.WindowContextHelpButtonHint` is an `int`, even though it's actually `Qt.WindowFlags`