### PR TITLE
replace broken help link

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -72,7 +72,7 @@ ianki <iankigit@gmail.com>
 rye761 <ryebread761@gmail.com>
 Guillem Palau Salvà <guillempalausalva@gmail.com>
 Meredith Derecho <meredithderecho@gmail.com>
-Daniel Wallgren <github.com/walgrenen>
+Daniel Wallgren <github.com/wallgrenen>
 ********************
 
 The text of the 3 clause BSD license follows:

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -72,6 +72,7 @@ ianki <iankigit@gmail.com>
 rye761 <ryebread761@gmail.com>
 Guillem Palau Salvà <guillempalausalva@gmail.com>
 Meredith Derecho <meredithderecho@gmail.com>
+Daniel Wallgren <github.com/walgrenen>
 ********************
 
 The text of the 3 clause BSD license follows:

--- a/qt/aqt/addcards.py
+++ b/qt/aqt/addcards.py
@@ -170,7 +170,7 @@ class AddCards(QDialog):
             problem = tr(TR.ADDING_THE_FIRST_FIELD_IS_EMPTY)
         problem = gui_hooks.add_cards_will_add_note(problem, note)
         if problem is not None:
-            showWarning(problem, help="AddItems#AddError")
+            showWarning(problem, help="editing?id=adding-cards-and-notes")
             return None
         if note.model()["type"] == MODEL_CLOZE:
             if not note.cloze_numbers_in_fields():


### PR DESCRIPTION
The previous link gave a 404 error.

I chose to use the same link as the one in helpRequested() in qt/aqt/addcards.py that was chosen in  #782 