### PR TITLE
Writer cleanup

### DIFF
--- a/pylib/anki/rsbackend.py
+++ b/pylib/anki/rsbackend.py
@@ -46,6 +46,7 @@ TagUsnTuple = pb.TagUsnTuple
 NoteType = pb.NoteType
 DeckTreeNode = pb.DeckTreeNode
 StockNoteType = pb.StockNoteType
+ConcatSeparator = pb.ConcatenateSearchesIn.Separator
 SyncAuth = pb.SyncAuth
 SyncOutput = pb.SyncCollectionOut
 SyncStatus = pb.SyncStatusOut

--- a/pylib/rsbridge/lib.rs
+++ b/pylib/rsbridge/lib.rs
@@ -53,6 +53,10 @@ fn want_release_gil(method: u32) -> bool {
                 | BackendMethod::LatestProgress
                 | BackendMethod::SetWantsAbort
                 | BackendMethod::I18nResources
+                | BackendMethod::NormalizeSearch
+                | BackendMethod::NegateSearch
+                | BackendMethod::ConcatenateSearches
+                | BackendMethod::ReplaceSearchTerm
         )
     } else {
         false

--- a/qt/aqt/browser.py
+++ b/qt/aqt/browser.py
@@ -21,7 +21,7 @@ from anki.consts import *
 from anki.lang import without_unicode_isolation
 from anki.models import NoteType
 from anki.notes import Note
-from anki.rsbackend import DeckTreeNode, InvalidInput, pb
+from anki.rsbackend import DeckTreeNode, InvalidInput, ConcatSeparator
 from anki.stats import CardStats
 from anki.utils import htmlToTextLine, ids2str, isMac, isWin
 from aqt import AnkiQt, gui_hooks
@@ -1236,13 +1236,13 @@ QTableView {{ gridline-color: {grid} }}
                 elif mods & Qt.ControlModifier:
                     txt = self.col.backend.concatenate_searches(
                         # pylint: disable=no-member
-                        sep=pb.ConcatenateSearchesIn.Separator.AND,
+                        sep=ConcatSeparator.AND,
                         searches=[cur, txt],
                     )
                 elif mods & Qt.ShiftModifier:
                     txt = self.col.backend.concatenate_searches(
                         # pylint: disable=no-member
-                        sep=pb.ConcatenateSearchesIn.Separator.OR,
+                        sep=ConcatSeparator.OR,
                         searches=[cur, txt],
                     )
         except InvalidInput as e:

--- a/qt/aqt/browser.py
+++ b/qt/aqt/browser.py
@@ -21,7 +21,7 @@ from anki.consts import *
 from anki.lang import without_unicode_isolation
 from anki.models import NoteType
 from anki.notes import Note
-from anki.rsbackend import DeckTreeNode, InvalidInput, ConcatSeparator
+from anki.rsbackend import ConcatSeparator, DeckTreeNode, InvalidInput
 from anki.stats import CardStats
 from anki.utils import htmlToTextLine, ids2str, isMac, isWin
 from aqt import AnkiQt, gui_hooks

--- a/rslib/src/backend/mod.rs
+++ b/rslib/src/backend/mod.rs
@@ -33,7 +33,8 @@ use crate::{
     sched::cutoff::local_minutes_west_for_stamp,
     sched::timespan::{answer_button_time, time_span},
     search::{
-        concatenate_searches, negate_search, normalize_search, replace_search_term, SortMode,
+        concatenate_searches, negate_search, normalize_search, replace_search_term, BoolSeparator,
+        SortMode,
     },
     stats::studied_today,
     sync::{
@@ -273,6 +274,17 @@ impl From<pb::DeckConfigId> for DeckConfID {
     }
 }
 
+impl From<i32> for BoolSeparator {
+    fn from(sep: i32) -> Self {
+        use pb::concatenate_searches_in::Separator;
+        match Separator::from_i32(sep) {
+            Some(Separator::And) => BoolSeparator::And,
+            Some(Separator::Or) => BoolSeparator::Or,
+            None => BoolSeparator::And,
+        }
+    }
+}
+
 impl BackendService for Backend {
     fn latest_progress(&self, _input: Empty) -> BackendResult<pb::Progress> {
         let progress = self.progress_state.lock().unwrap().last_progress;
@@ -437,7 +449,7 @@ impl BackendService for Backend {
     }
 
     fn concatenate_searches(&self, input: pb::ConcatenateSearchesIn) -> Result<pb::String> {
-        Ok(concatenate_searches(input.sep, &input.searches)?.into())
+        Ok(concatenate_searches(input.sep.into(), &input.searches)?.into())
     }
 
     fn replace_search_term(&self, input: pb::ReplaceSearchTermIn) -> Result<pb::String> {

--- a/rslib/src/search/mod.rs
+++ b/rslib/src/search/mod.rs
@@ -5,4 +5,6 @@ mod sqlwriter;
 mod writer;
 
 pub use cards::SortMode;
-pub use writer::{concatenate_searches, negate_search, normalize_search, replace_search_term};
+pub use writer::{
+    concatenate_searches, negate_search, normalize_search, replace_search_term, BoolSeparator,
+};


### PR DESCRIPTION
I've tried to implement your notes from #860 but am not quite sure I got it right. Please let me know if anything's still off.
Concerning rsbackend.py: Did you mean there should be a wrapper for `self.col.backend.negate_search` etc. or was it only about the pb enum? Since we don't use `ConcatenateSearchesIn` explicitly, I didn't see the need to import it.