### PR TITLE
Streamlining `is:due`, `prop:due`, and the FutureDue graph

### DIFF
--- a/rslib/src/search/sqlwriter.rs
+++ b/rslib/src/search/sqlwriter.rs
@@ -294,12 +294,13 @@ impl SqlWriter<'_> {
                 self.sql,
                 "(
     (c.queue in ({rev},{daylrn}) and c.due <= {today}) or
-    (c.queue = {lrn} and c.due <= {learncutoff})
+    (c.queue in ({lrn},{previewrepeat}) and c.due <= {learncutoff})
     )",
                 rev = CardQueue::Review as i8,
                 daylrn = CardQueue::DayLearn as i8,
                 today = timing.days_elapsed,
                 lrn = CardQueue::Learn as i8,
+                previewrepeat = CardQueue::PreviewRepeat as i8,
                 learncutoff = TimestampSecs::now().0 + (self.col.learn_ahead_secs() as i64),
             ),
             StateKind::UserBuried => write!(self.sql, "c.queue = {}", CardQueue::UserBuried as i8),

--- a/rslib/src/search/sqlwriter.rs
+++ b/rslib/src/search/sqlwriter.rs
@@ -241,6 +241,7 @@ impl SqlWriter<'_> {
                 let day = days + (timing.days_elapsed as i32);
                 write!(
                     self.sql,
+                    // SQL does integer division if both parameters are integers
                     "(\
                     (c.queue in ({rev},{daylrn}) and c.due {op} {day}) or \
                     (c.queue in ({lrn},{previewrepeat}) and ((c.due - {cutoff}) / 86400) {op} {days})\

--- a/rslib/src/search/sqlwriter.rs
+++ b/rslib/src/search/sqlwriter.rs
@@ -241,9 +241,9 @@ impl SqlWriter<'_> {
                 let day = days + (timing.days_elapsed as i32);
                 write!(
                     self.sql,
-                    "(
-                    (c.queue in ({rev},{daylrn}) and c.due {op} {day}) or
-                    (c.queue in ({lrn},{previewrepeat}) and ((c.due - {cutoff}) / 86400) {op} {days})
+                    "(\
+                    (c.queue in ({rev},{daylrn}) and c.due {op} {day}) or \
+                    (c.queue in ({lrn},{previewrepeat}) and ((c.due - {cutoff}) / 86400) {op} {days})\
                     )",
                     rev = CardQueue::Review as u8,
                     daylrn = CardQueue::DayLearn as u8,
@@ -300,10 +300,10 @@ impl SqlWriter<'_> {
             StateKind::Suspended => write!(self.sql, "c.queue = {}", CardQueue::Suspended as i8),
             StateKind::Due => write!(
                 self.sql,
-                "(
-    (c.queue in ({rev},{daylrn}) and c.due <= {today}) or
-    (c.queue in ({lrn},{previewrepeat}) and c.due <= {learncutoff})
-    )",
+                "(\
+                (c.queue in ({rev},{daylrn}) and c.due <= {today}) or \
+                (c.queue in ({lrn},{previewrepeat}) and c.due <= {learncutoff})\
+                )",
                 rev = CardQueue::Review as i8,
                 daylrn = CardQueue::DayLearn as i8,
                 today = timing.days_elapsed,
@@ -734,8 +734,9 @@ mod test {
         assert_eq!(
             s(ctx, "prop:due!=-1").0,
             format!(
-                "((c.queue in (2,3) and due != {}))",
-                timing.days_elapsed - 1
+                "(((c.queue in (2,3) and c.due != {days}) or (c.queue in (1,4) and ((c.due - {cutoff}) / 86400) != -1)))",
+                days = timing.days_elapsed - 1,
+                cutoff = timing.next_day_at
             )
         );
 

--- a/ts/graphs/future-due.ts
+++ b/ts/graphs/future-due.ts
@@ -40,7 +40,7 @@ export function gatherData(data: pb.BackendProto.GraphsOut): GraphData {
             let dueDay: number;
 
             if (isLearning(c)) {
-                const offset = c.due - data.nextDayAtSecs
+                const offset = c.due - data.nextDayAtSecs;
                 dueDay = Math.floor(offset / 86_400) + 1;
             } else {
                 // - testing just odue fails on day 1
@@ -48,12 +48,11 @@ export function gatherData(data: pb.BackendProto.GraphsOut): GraphData {
                 //   have due calculated at regraduation time
                 const due = c.originalDeckId && c.originalDue ? c.originalDue : c.due;
                 dueDay = due - data.daysElapsed;
-
             }
 
             haveBacklog = haveBacklog || dueDay < 0;
 
-            return dueDay
+            return dueDay;
         });
 
     const dueCounts = rollup(

--- a/ts/graphs/future-due.ts
+++ b/ts/graphs/future-due.ts
@@ -42,7 +42,6 @@ export function gatherData(data: pb.BackendProto.GraphsOut): GraphData {
             if (isLearning(c)) {
                 const offset = c.due - data.nextDayAtSecs
                 dueDay = Math.floor(offset / 86_400) + 1;
-
             } else {
                 // - testing just odue fails on day 1
                 // - testing just odid fails on lapsed cards that

--- a/ts/lib/time.ts
+++ b/ts/lib/time.ts
@@ -151,8 +151,8 @@ export function dayLabel(i18n: I18n, daysStart: number, daysEnd: number): string
             });
         } else {
             return i18n.tr(i18n.TR.STATISTICS_DAYS_AGO_RANGE, {
-                daysStart: Math.abs(daysEnd),
-                daysEnd: -daysStart - 1,
+                daysStart: Math.abs(daysEnd - 1),
+                daysEnd: -daysStart,
             });
         }
     }


### PR DESCRIPTION
These are all issues that rose up, when I was working on #897, specifically on the `FutureDue` graph.

1. This one is definitely a bug:
The Histogram graph for the stats had a one-off error, when displaying past ranges. The easiest way is to look at the `FutureDue` graph with Backlog enabled.
The first "future" label reads: "In 0-4 days".
The first past label reads: "0-4 days ago". This should actually be "1-5" days ago.

1. This rest of the changes streamline how `is:due`, `prop:due`, and the `FutureDue` graph deal with due dates:
* The FutureDue showed learning and preview repeat cards, which were scheduled for the past as being scheduled today (In fact it displayed all learning cards as scheduled today). Now it correctly displays them as backlog.
* The `is:due` selector did not consider PreviewRepeat cards. Now it does.
* The `prop:due` selector did not search for Learning or PreviewRepeat cards. Now it does. This requires having SQL do some math. Something I stumbled upon is that in SQL, dividing two integer values automatically does integer division.

Now these three features allow for a few sanity tests:
1. `-prop:due<=0 is:due` should only ever show learning / preview repeat cards, which will be due some time later today, but are not yet.
2. When the FutureDue graph shows: "In x-y days: n cards due", searching for `prop:due>=x prop:due<=y` should yield n cards. Additionally, when it shows "x-y days ago: n cards due", searching for `prop:due<=-x prop:due>=-y` should yield n cards.