### PR TITLE
Include many more cards in the Review Intervals graph

### DIFF
--- a/ts/graphs/intervals.ts
+++ b/ts/graphs/intervals.ts
@@ -9,7 +9,7 @@
 import type pb from "anki/backend_proto";
 import { extent, histogram, quantile, sum, mean } from "d3-array";
 import { scaleLinear, scaleSequential } from "d3-scale";
-import { CardQueue } from "anki/cards";
+import { CardType } from "anki/cards";
 import type { HistogramData } from "./histogram-graph";
 import { interpolateBlues } from "d3-scale-chromatic";
 import type { I18n } from "anki/i18n";
@@ -29,7 +29,7 @@ export enum IntervalRange {
 
 export function gatherIntervalData(data: pb.BackendProto.GraphsOut): IntervalGraphData {
     const intervals = (data.cards as pb.BackendProto.Card[])
-        .filter((c) => c.queue == CardQueue.Review)
+        .filter((c) => [CardType.Review, CardType.Relearn].includes(c.ctype))
         .map((c) => c.interval);
     return { intervals };
 }


### PR DESCRIPTION
Right now the **Review Intervals** graph only includes cards from the Review Queue.

This leads to many weird scenarios:

**Scenario A: Buried cards**
1. A user has two notes with each 3 cards, and sibling burying enabled.
2. Before review, he looks at the graph and sees six cards there.
3. He does two reviews.
4. He looks at the graph again, and all but 2 vanished.

**Scenario B: Relearning cards**
1. A user fails a card
2. The card vanishes from the Review Intervals graph, even though it already has its new interval set

I thought maybe hiding suspended cards makes, sense, but I would say, if the user wants to hide those suspended cards from the graph, he could still use `-is:suspended` in the search. If we exclude it from the very beginning, we take the choice from him, and he can't decide otherwise.

The only cards which would be excluded from the graph after this PR are those which are guaranteed to have an `ivl` of 0: New and learning cards. In fact, in my 22k card collection, `prop:ivl=0` and `is:new or (is:learn -is:review)` yields the exact same cards.