### PR TITLE
Omit zero interval, and don't nice the values in Review intervals graph

### DIFF
--- a/ts/graphs/card-counts.ts
+++ b/ts/graphs/card-counts.ts
@@ -197,7 +197,7 @@ export function renderCards(
 
     x.range([bounds.marginLeft, bounds.width - bounds.marginRight]);
 
-    const tableData = (data as any).flatMap((d: SummedDatum, idx: number) => {
+    const tableData = data.flatMap((d: SummedDatum, idx: number) => {
         const percent = ((d.count / xMax) * 100).toFixed(1);
         return d.show
             ? ({

--- a/ts/graphs/intervals.ts
+++ b/ts/graphs/intervals.ts
@@ -108,9 +108,7 @@ export function prepareIntervalData(
 
     const bins = histogram()
         .domain(scale.domain() as [number, number])
-        .thresholds((scale.ticks(desiredBars) as any).flatMap(adjustTicks))(
-        allIntervals
-    );
+        .thresholds(scale.ticks(desiredBars).flatMap(adjustTicks))(allIntervals);
 
     // empty graph?
     const totalInPeriod = sum(bins, (bin) => bin.length);

--- a/ts/graphs/intervals.ts
+++ b/ts/graphs/intervals.ts
@@ -92,10 +92,10 @@ export function prepareIntervalData(
     xMax = xMax! + 1;
 
     // do not show the zero interval
-    const increment = (x: number) => x + 1;
+    const increment = (x: number): number => x + 1;
 
-    const adjustTicks = (x: number, idx: number, ticks: number[]) =>
-        idx === ticks.length - 1 ? [x - (ticks[0] - 1), x + 1] : x - (ticks[0] - 1);
+    const adjustTicks = (x: number, idx: number, ticks: number[]): number[] =>
+        idx === ticks.length - 1 ? [x - (ticks[0] - 1), x + 1] : [x - (ticks[0] - 1)];
 
     // cap bars to available range
     const desiredBars = Math.min(70, xMax! - xMin!);

--- a/ts/graphs/intervals.ts
+++ b/ts/graphs/intervals.ts
@@ -84,13 +84,12 @@ export function prepareIntervalData(
         case IntervalRange.All:
             break;
     }
-    const xMin = 0;
+    const xMin = 1;
     xMax = xMax! + 1;
 
     // cap bars to available range
     const desiredBars = Math.min(70, xMax! - xMin!);
-
-    const scale = scaleLinear().domain([xMin!, xMax!]).nice();
+    const scale = scaleLinear().domain([xMin!, xMax!]);
     const bins = histogram()
         .domain(scale.domain() as any)
         .thresholds(scale.ticks(desiredBars))(allIntervals);

--- a/ts/graphs/intervals.ts
+++ b/ts/graphs/intervals.ts
@@ -67,32 +67,50 @@ export function prepareIntervalData(
         return [null, []];
     }
 
-    const [_xMinOrig, origXMax] = extent(allIntervals);
-    let xMax = origXMax;
+    const xMin = 0;
+    let [, xMax] = extent(allIntervals);
+    let niceNecessary = false;
 
     // cap max to selected range
     switch (range) {
         case IntervalRange.Month:
-            xMax = Math.min(xMax!, 31);
+            xMax = Math.min(xMax!, 30);
             break;
         case IntervalRange.Percentile50:
             xMax = quantile(allIntervals, 0.5);
+            niceNecessary = true;
             break;
         case IntervalRange.Percentile95:
             xMax = quantile(allIntervals, 0.95);
+            niceNecessary = true;
             break;
         case IntervalRange.All:
+            niceNecessary = true;
             break;
     }
-    const xMin = 1;
+
     xMax = xMax! + 1;
+
+    // do not show the zero interval
+    const increment = (x: number) => x + 1;
+
+    const adjustTicks = (x: number, idx: number, ticks: number[]) =>
+        idx === ticks.length - 1 ? [x - (ticks[0] - 1), x + 1] : x - (ticks[0] - 1);
 
     // cap bars to available range
     const desiredBars = Math.min(70, xMax! - xMin!);
-    const scale = scaleLinear().domain([xMin!, xMax!]);
+
+    const prescale = scaleLinear().domain([xMin!, xMax!]);
+
+    const scale = scaleLinear().domain(
+        (niceNecessary ? prescale.nice() : prescale).domain().map(increment)
+    );
+
     const bins = histogram()
-        .domain(scale.domain() as any)
-        .thresholds(scale.ticks(desiredBars))(allIntervals);
+        .domain(scale.domain() as [number, number])
+        .thresholds((scale.ticks(desiredBars) as any).flatMap(adjustTicks))(
+        allIntervals
+    );
 
     // empty graph?
     const totalInPeriod = sum(bins, (bin) => bin.length);

--- a/ts/tsconfig.json
+++ b/ts/tsconfig.json
@@ -3,7 +3,7 @@
     "compilerOptions": {
         "target": "es6",
         "module": "es6",
-        "lib": ["es2016", "dom"],
+        "lib": ["es2016", "es2019.array", "dom"],
         "baseUrl": ".",
         "paths": {
             "anki/*": ["../bazel-bin/ts/lib/*"]


### PR DESCRIPTION
This is a follow up to #905, but independent of it.

1. The graph starts at cards with 0 day intervals atm, which are cards in the new or learning cards, however those are by the definition of the graph never going to be used for filling in the graph.

2. Right now, the interval days are "niced", which causes 34 days to be shown for a month.
The call to `.nice()` could technically be kept for percentile options, however I don't notice a great improvement in display there, because the review interval tends to converge to zero anyway.

After this PR, the interval graph starts at 1, and is capped at 31 days, if you click on 1 month.