### PR TITLE
Reset ease to 0 for after rescheduling cards as new

### DIFF
--- a/rslib/src/sched/new.rs
+++ b/rslib/src/sched/new.rs
@@ -21,11 +21,7 @@ impl Card {
         self.ctype = CardType::New;
         self.queue = CardQueue::New;
         self.interval = 0;
-        if self.ease_factor == 0 {
-            // unlike the old Python code, we leave the ease factor alone
-            // if it's already set
-            self.ease_factor = INITIAL_EASE_FACTOR_THOUSANDS;
-        }
+        self.ease_factor = 0;
     }
 
     /// If the card is new, change its position.

--- a/rslib/src/sched/new.rs
+++ b/rslib/src/sched/new.rs
@@ -4,7 +4,6 @@
 use crate::{
     card::{Card, CardID, CardQueue, CardType},
     collection::Collection,
-    deckconf::INITIAL_EASE_FACTOR_THOUSANDS,
     decks::DeckID,
     err::Result,
     notes::NoteID,


### PR DESCRIPTION
I think not resetting the ease when rescheduling as new cards is a bad idea.

1. Scenario: **Rescheduling cards in the browser**:
When I use the "Reschedule as New" functionality in the browser, it gives me the impression that I made a completely blank slate.
That actually happened to me: I got an deck as an example from a user of my add-ons, and I liked it so much, that I just rescheduled it as new and kept it. Now I realised that I also kept his ease factors.

2. Scenario: **Importing a deck**:
As far as I can tell, even if you choose to export without scheduling, the cards will retain their ease factors after they're imported into a new profile. This means, that it's impossible to reset ease factors in general, and you'd have to keep a master copy with unchanged ease factors.

I think the old python code reset ease to the default ease, however I think resetting to zero makes more sense.

1. Setting to default ease will muddle up searching using `prop:ease`, as new and learning cards will be included, even though they haven't done anything yet to "deserve" the ease yet.

2. In the case I want to export a deck for users, they'd be stuck with the default ease of my deck settings. If ease was reset to zero, they can first could change the default ease of the deck after importing it, and then start reviewing it, with the cards being set to the ease, that they intended.

3. Also it will nicely mirror the interval, as only new and learning cards have a 0 interval, and after this, also only new and learning cards will have 0 ease.