### PR TITLE
Exclude aqt/hooks_gen.py from formatting

### DIFF
--- a/qt/tests/run_format.py
+++ b/qt/tests/run_format.py
@@ -22,7 +22,7 @@ if __name__ == "__main__":
             "black",
             "-t",
             "py38",
-            "--exclude=aqt/forms|colors",
+            "--exclude=aqt/forms|colors|_gen",
             "aqt",
             "tests",
             "tools",


### PR DESCRIPTION
This was causing qt:format to fail.