### PR TITLE
Add explicit errors when entering added/edited/rated:0 or rated:>365

### DIFF
--- a/pylib/tests/test_find.py
+++ b/pylib/tests/test_find.py
@@ -204,13 +204,21 @@ def test_findCards():
         assert len(col.findCards("rated:1:1")) == 1
         assert len(col.findCards("rated:1:2")) == 1
         assert len(col.findCards("rated:1")) == 2
-        assert len(col.findCards("rated:0:2")) == 0
         assert len(col.findCards("rated:2:2")) == 1
+        with pytest.raises(Exception):
+            col.findCards("rated:0")
+
+        with pytest.raises(Exception):
+            col.findCards("rated:366")
         # added
-        assert len(col.findCards("added:0")) == 0
         col.db.execute("update cards set id = id - 86400*1000 where id = ?", id)
         assert len(col.findCards("added:1")) == col.cardCount() - 1
         assert len(col.findCards("added:2")) == col.cardCount()
+        with pytest.raises(Exception):
+            col.findCards("added:0")
+
+        with pytest.raises(Exception):
+            col.findCards("edited:0")
     else:
         print("some find tests disabled near cutoff")
     # empty field

--- a/rslib/src/search/parser.rs
+++ b/rslib/src/search/parser.rs
@@ -273,8 +273,8 @@ fn search_node_for_text_with_argument<'a>(
     val: &'a str,
 ) -> ParseResult<SearchNode<'a>> {
     Ok(match key.to_ascii_lowercase().as_str() {
-        "added" => SearchNode::AddedInDays(val.parse()?),
-        "edited" => SearchNode::EditedInDays(val.parse()?),
+        "added" => parse_added(val)?,
+        "edited" => parse_edited(val)?,
         "deck" => SearchNode::Deck(unescape(val)?),
         "note" => SearchNode::NoteType(unescape(val)?),
         "tag" => SearchNode::Tag(unescape(val)?),
@@ -309,6 +309,26 @@ fn check_id_list(s: &str) -> ParseResult<&str> {
     }
 }
 
+/// eg added:1
+fn parse_added(s: &str) -> ParseResult<SearchNode<'static>> {
+    let n: u32 = s.parse()?;
+    if n == 0 {
+        Err(ParseError {})
+    } else {
+        Ok(SearchNode::AddedInDays(n))
+    }
+}
+
+/// eg edited:1
+fn parse_edited(s: &str) -> ParseResult<SearchNode<'static>> {
+    let n: u32 = s.parse()?;
+    if n == 0 {
+        Err(ParseError {})
+    } else {
+        Ok(SearchNode::EditedInDays(n))
+    }
+}
+
 /// eg is:due
 fn parse_state(s: &str) -> ParseResult<SearchNode<'static>> {
     use StateKind::*;
@@ -339,7 +359,12 @@ fn parse_flag(s: &str) -> ParseResult<SearchNode<'static>> {
 /// second arg must be between 0-4
 fn parse_rated(val: &str) -> ParseResult<SearchNode<'static>> {
     let mut it = val.splitn(2, ':');
+
     let days = it.next().unwrap().parse()?;
+    if days == 0 || days > 365 {
+        return Err(ParseError {});
+    }
+
     let ease = match it.next() {
         Some(v) => {
             let n: u8 = v.parse()?;

--- a/rslib/src/search/sqlwriter.rs
+++ b/rslib/src/search/sqlwriter.rs
@@ -722,7 +722,7 @@ mod test {
             )
         );
         assert_eq!(
-            s(ctx, "rated:400:1").0,
+            s(ctx, "rated:365:1").0,
             format!(
                 "(c.id in (select cid from revlog where id>{} and ease=1))",
                 (timing.next_day_at - (86_400 * 365)) * 1_000

--- a/rslib/src/search/sqlwriter.rs
+++ b/rslib/src/search/sqlwriter.rs
@@ -721,6 +721,7 @@ mod test {
                 (timing.next_day_at - (86_400 * 2)) * 1_000
             )
         );
+
         assert_eq!(
             s(ctx, "rated:365:1").0,
             format!(


### PR DESCRIPTION
This will throw errors when users search for e.g. `added:0`. By definition `added:1` searches for cards added today, so `added:0` is a nonsensical query. Same for `edited`, and `rated`.
Especially because other queries like `prop:due=0` carry the meaning of 0 = today, it would be nice, if a user typed `rated:0`, expecting cards reviewed today and doesn't see what he expected, he would instead get an error message, making it less obscure. 

Additionally it will throw an error if users search `rated:366`. Right now the value is silently coerced to 365 later down the line, which is not obvious to the user. This would also allow for making the query creation function more "pure" (follow-up PR).

Custom error messages would be very nice here, telling the user what exactly he did wrong, and I'd be happy for any pointers on that.