### PR TITLE
Fix ordinal case in write_template

### DIFF
--- a/rslib/src/search/writer.rs
+++ b/rslib/src/search/writer.rs
@@ -149,7 +149,7 @@ fn write_single_field(field: &str, text: &str, is_re: bool) -> String {
 
 fn write_template(template: &TemplateKind) -> String {
     match template {
-        TemplateKind::Ordinal(u) => format!("\"card:{}\"", u),
+        TemplateKind::Ordinal(u) => format!("\"card:{}\"", u + 1),
         TemplateKind::Name(s) => format!("\"card:{}\"", s),
     }
 }


### PR DESCRIPTION
Internal card ordinals start at 0, so add 1 again when writing a template search string from a parsed ordinal.