### PR TITLE
Preview Button in Editor instead of Browser

### DIFF
--- a/qt/aqt/browser.py
+++ b/qt/aqt/browser.py
@@ -868,18 +868,24 @@ QTableView {{ gridline-color: {grid} }}
     def setupEditor(self):
         def add_preview_button(leftbuttons, editor):
             preview_shortcut = "Ctrl+Shift+P"
-            leftbuttons.insert(0, editor.addButton(
-                None,
-                "preview",
-                lambda _editor: self.onTogglePreview(),
-                tr(TR.BROWSING_PREVIEW_SELECTED_CARD, val=preview_shortcut),
-                tr(TR.ACTIONS_PREVIEW),
-                id="previewButton",
-                keys=preview_shortcut,
-                disables=False,
-                rightside=False,
-                toggleable=True,
-            ))
+            leftbuttons.insert(
+                0,
+                editor.addButton(
+                    None,
+                    "preview",
+                    lambda _editor: self.onTogglePreview(),
+                    tr(
+                        TR.BROWSING_PREVIEW_SELECTED_CARD,
+                        val=shortcut(preview_shortcut),
+                    ),
+                    tr(TR.ACTIONS_PREVIEW),
+                    id="previewButton",
+                    keys=preview_shortcut,
+                    disables=False,
+                    rightside=False,
+                    toggleable=True,
+                ),
+            )
 
         gui_hooks.editor_did_init_left_buttons.append(add_preview_button)
         self.editor = aqt.editor.Editor(self.mw, self.form.fieldsArea, self)

--- a/qt/aqt/browser.py
+++ b/qt/aqt/browser.py
@@ -867,13 +867,15 @@ QTableView {{ gridline-color: {grid} }}
 
     def setupEditor(self):
         def add_preview_button(leftbuttons, editor):
+            preview_shortcut = "Ctrl+Shift+P"
             leftbuttons.insert(0, editor.addButton(
                 None,
                 "preview",
                 lambda _editor: self.onTogglePreview(),
-                tr(TR.BROWSING_PREVIEW_SELECTED_CARD, val=shortcut("Ctrl+Shift+P")),
+                tr(TR.BROWSING_PREVIEW_SELECTED_CARD, val=preview_shortcut),
                 tr(TR.ACTIONS_PREVIEW),
                 id="previewButton",
+                keys=preview_shortcut,
                 disables=False,
                 rightside=False,
                 toggleable=True,

--- a/qt/aqt/browser.py
+++ b/qt/aqt/browser.py
@@ -622,12 +622,6 @@ class Browser(QMainWindow):
         # pylint: disable=unnecessary-lambda
         # actions
         f = self.form
-        qconnect(f.previewButton.clicked, self.onTogglePreview)
-        f.previewButton.setToolTip(
-            tr(TR.BROWSING_PREVIEW_SELECTED_CARD, val=shortcut("Ctrl+Shift+P"))
-        )
-        f.previewButton.setShortcut("Ctrl+Shift+P")
-
         qconnect(f.filter.clicked, self.onFilterButton)
         # edit
         qconnect(f.actionUndo.triggered, self.mw.onUndo)
@@ -877,8 +871,8 @@ QTableView {{ gridline-color: {grid} }}
                 None,
                 "preview",
                 lambda _editor: self.onTogglePreview(),
-                "Preview Selected Card",
-                "Preview",
+                tr(TR.BROWSING_PREVIEW_SELECTED_CARD, val=shortcut("Ctrl+Shift+P")),
+                tr(TR.ACTIONS_PREVIEW),
                 id="previewButton",
                 disables=False,
                 rightside=False,

--- a/qt/aqt/browser.py
+++ b/qt/aqt/browser.py
@@ -1575,7 +1575,10 @@ where id in %s"""
 
     def _renderPreview(self):
         if self._previewer:
-            self._previewer.render_card()
+            if self.singleCard:
+                self._previewer.render_card()
+            else:
+                self.onTogglePreview()
 
     def _cleanup_preview(self):
         if self._previewer:

--- a/qt/aqt/browser.py
+++ b/qt/aqt/browser.py
@@ -1577,7 +1577,8 @@ where id in %s"""
             self._previewer.close()
 
     def _on_preview_closed(self):
-        self.editor.web.eval("$('#previewButton').removeClass('highlighted')")
+        if self.editor.web:
+            self.editor.web.eval("$('#previewButton').removeClass('highlighted')")
         self._previewer = None
 
     # Card deletion

--- a/qt/aqt/browser.py
+++ b/qt/aqt/browser.py
@@ -872,7 +872,20 @@ QTableView {{ gridline-color: {grid} }}
         self.singleCard = False
 
     def setupEditor(self):
+        def add_preview_button(leftbuttons, editor):
+            leftbuttons.insert(0, editor.addButton(
+                None,
+                "preview",
+                lambda _editor: self.onTogglePreview(),
+                "Preview Selected Card",
+                "Preview",
+                disables=False,
+                rightside=False,
+            ))
+
+        gui_hooks.editor_did_init_left_buttons.append(add_preview_button)
         self.editor = aqt.editor.Editor(self.mw, self.form.fieldsArea, self)
+        gui_hooks.editor_did_init_left_buttons.remove(add_preview_button)
 
     def onRowChanged(self, current, previous):
         "Update current note and hide/show editor."

--- a/qt/aqt/browser.py
+++ b/qt/aqt/browser.py
@@ -879,8 +879,10 @@ QTableView {{ gridline-color: {grid} }}
                 lambda _editor: self.onTogglePreview(),
                 "Preview Selected Card",
                 "Preview",
+                id="previewButton",
                 disables=False,
                 rightside=False,
+                toggleable=True,
             ))
 
         gui_hooks.editor_did_init_left_buttons.append(add_preview_button)
@@ -1579,6 +1581,7 @@ where id in %s"""
             self._previewer.close()
 
     def _on_preview_closed(self):
+        self.editor.web.eval("$('#previewButton').removeClass('highlighted')")
         self._previewer = None
 
     # Card deletion

--- a/qt/aqt/data/web/css/editor.scss
+++ b/qt/aqt/data/web/css/editor.scss
@@ -73,7 +73,13 @@ button.linkb:disabled {
 }
 
 button.highlighted {
-    border-bottom: 3px solid #000;
+    #topbutsleft & {
+        box-shadow: inset 0px 0px 5px #222;
+    }
+
+    #topbutsright & {
+        border-bottom: 3px solid #000;
+    }
 }
 
 #fields {

--- a/qt/aqt/data/web/css/editor.scss
+++ b/qt/aqt/data/web/css/editor.scss
@@ -65,16 +65,28 @@ button.linkb {
     box-shadow: none;
     padding: 0px 2px;
     background: transparent;
+
+    &:disabled {
+        opacity: 0.3;
+        cursor: not-allowed;
+    }
+
+    .nightMode & > img {
+        filter: invert(180);
+    }
 }
 
-button.linkb:disabled {
-    opacity: 0.3;
-    cursor: not-allowed;
+button:focus {
+    outline: none;
 }
 
 button.highlighted {
+    .nightMode #topbutsleft & {
+        background: linear-gradient(0deg, #333333 0%, #434343 100%);
+    }
+
     #topbutsleft & {
-        box-shadow: inset 0px 0px 5px #222;
+        background-color: lightgrey;
     }
 
     #topbutsright & {
@@ -92,12 +104,6 @@ button.highlighted {
 
 #dupes a {
     color: var(--link);
-}
-
-.nightMode {
-    button.linkb > img {
-        filter: invert(180);
-    }
 }
 
 .drawing {

--- a/qt/aqt/editor.py
+++ b/qt/aqt/editor.py
@@ -252,27 +252,29 @@ class Editor:
         """Assign func to bridge cmd, register shortcut, return button"""
         if func:
             self._links[cmd] = func
-        if keys:
 
-            def on_activated():
-                func(self)
+            if keys:
 
-            if toggleable:
-                # generate a random id for triggering toggle
-                id = id or str(randrange(1_000_000))
+                def on_activated():
+                    func(self)
 
-                def on_hotkey():
-                    on_activated()
-                    self.web.eval(f'toggleEditorButton("#{id}");')
+                if toggleable:
+                    # generate a random id for triggering toggle
+                    id = id or str(randrange(1_000_000))
 
-            else:
-                on_hotkey = on_activated
+                    def on_hotkey():
+                        on_activated()
+                        self.web.eval(f'toggleEditorButton("#{id}");')
 
-            QShortcut(  # type: ignore
-                QKeySequence(keys),
-                self.widget,
-                activated=on_hotkey,
-            )
+                else:
+                    on_hotkey = on_activated
+
+                QShortcut(  # type: ignore
+                    QKeySequence(keys),
+                    self.widget,
+                    activated=on_hotkey,
+                )
+
         btn = self._addButton(
             icon,
             cmd,

--- a/qt/aqt/editor.py
+++ b/qt/aqt/editor.py
@@ -253,6 +253,7 @@ class Editor:
         if func:
             self._links[cmd] = func
         if keys:
+
             def on_activated():
                 func(self)
 
@@ -263,6 +264,7 @@ class Editor:
                 def on_hotkey():
                     on_activated()
                     self.web.eval(f'toggleEditorButton("#{id}");')
+
             else:
                 on_hotkey = on_activated
 

--- a/qt/aqt/editor.py
+++ b/qt/aqt/editor.py
@@ -11,6 +11,7 @@ import urllib.error
 import urllib.parse
 import urllib.request
 import warnings
+from random import randrange
 from typing import Callable, List, Optional, Tuple
 
 import bs4
@@ -252,10 +253,23 @@ class Editor:
         if func:
             self._links[cmd] = func
         if keys:
+            def on_activated():
+                func(self)
+
+            if toggleable:
+                # generate a random id for triggering toggle
+                id = id or str(randrange(1_000_000))
+
+                def on_hotkey():
+                    on_activated()
+                    self.web.eval(f'toggleEditorButton("#{id}");')
+            else:
+                on_hotkey = on_activated
+
             QShortcut(  # type: ignore
                 QKeySequence(keys),
                 self.widget,
-                activated=lambda s=self: func(s),
+                activated=on_hotkey,
             )
         btn = self._addButton(
             icon,

--- a/qt/aqt/forms/browser.ui
+++ b/qt/aqt/forms/browser.ui
@@ -114,19 +114,6 @@
             </property>
            </widget>
           </item>
-          <item row="0" column="3">
-           <widget class="QPushButton" name="previewButton">
-            <property name="text">
-             <string>ACTIONS_PREVIEW</string>
-            </property>
-            <property name="shortcut">
-             <string notr="true">Ctrl+Shift+P</string>
-            </property>
-            <property name="checkable">
-             <bool>true</bool>
-            </property>
-           </widget>
-          </item>
           <item row="0" column="0">
            <widget class="QPushButton" name="filter">
             <property name="text">

--- a/qt/aqt/previewer.py
+++ b/qt/aqt/previewer.py
@@ -16,6 +16,7 @@ from aqt.qt import (
     QIcon,
     QKeySequence,
     QPixmap,
+    QShortcut,
     Qt,
     QVBoxLayout,
     QWidget,
@@ -62,6 +63,9 @@ class Previewer(QDialog):
 
     def _create_gui(self):
         self.setWindowTitle(tr(TR.ACTIONS_PREVIEW))
+
+        self.close_shortcut = QShortcut(QKeySequence("Ctrl+Shift+P"), self)
+        qconnect(self.close_shortcut.activated, self.close)
 
         qconnect(self.finished, self._on_finished)
         self.silentlyClose = True

--- a/qt/aqt/previewer.py
+++ b/qt/aqt/previewer.py
@@ -309,9 +309,6 @@ class BrowserPreviewer(MultiCardPreviewer):
             self._last_card_id = c.id
             return changed
 
-    def _on_finished(self, ok):
-        super()._on_finished(ok)
-
     def _on_prev_card(self):
         self._parent.editor.saveNow(
             lambda: self._parent._moveCur(QAbstractItemView.MoveUp)

--- a/qt/aqt/previewer.py
+++ b/qt/aqt/previewer.py
@@ -307,7 +307,6 @@ class BrowserPreviewer(MultiCardPreviewer):
 
     def _on_finished(self, ok):
         super()._on_finished(ok)
-        self._parent.form.previewButton.setChecked(False)
 
     def _on_prev_card(self):
         self._parent.editor.saveNow(


### PR DESCRIPTION
Trying out the new auto-normalize functionality in the Browser, I noticed that the search queries now take up more horizontal space (especially because of the `AND`s). Here's an example:

```
// A common search of mine:
(changes:_* or tag:leech or tag:marked or (is:suspended -tag:ok)) tag:* deck:*jp
// After normalization:
("changes:_*" OR "tag:leech" OR "tag:marked" OR ("is:suspended" AND -"tag:ok")) AND "tag:*" AND "deck:*jp"
```

This PR tries to remedy this a little bit, by moving the Preview button from the browser to the Editor in the Browser window, so it turns from a QT button to an HTML button.

I also fixed some minor issues along the way:
* Don't show the focus ring around buttons in the Editor. They were usually triggered on the left top buttons, and just looked ugly.
* Make `Editor.addButton` usable if you want both `toggleable=True` and have a keys shortcut. The shortcut invocation will now trigger a toggle action (for which it needs a transient id).
* Make the Previewer window closable with "Ctrl+Shift+P", because that's also how you open it, and can close if the browser is the active window.

A change in behavior is that now the Preview window closes, if the search yielded no result, as otherwise, the user would not have access to the preview button anymore.

After looking at it for a while, I think even thematically the button makes more sense in the Editor, so that the top row is now fully occupied with items regarding "Search", and not things regarding individual cards.