### PR TITLE
Introduce `resched:n` instead of `rated:n:0` 

### DIFF
--- a/rslib/src/backend/mod.rs
+++ b/rslib/src/backend/mod.rs
@@ -292,11 +292,11 @@ impl From<pb::FilterToSearchIn> for Node<'_> {
                     NamedFilter::AddedToday => Node::Search(SearchNode::AddedInDays(1)),
                     NamedFilter::StudiedToday => Node::Search(SearchNode::Rated {
                         days: 1,
-                        ease: EaseKind::Reviewed,
+                        ease: EaseKind::AnyAnswerButton,
                     }),
                     NamedFilter::AgainToday => Node::Search(SearchNode::Rated {
                         days: 1,
-                        ease: EaseKind::Rated(1),
+                        ease: EaseKind::AnswerButton(1),
                     }),
                     NamedFilter::New => Node::Search(SearchNode::State(StateKind::New)),
                     NamedFilter::Learn => Node::Search(SearchNode::State(StateKind::Learning)),

--- a/rslib/src/backend/mod.rs
+++ b/rslib/src/backend/mod.rs
@@ -37,7 +37,7 @@ use crate::{
     sched::timespan::{answer_button_time, time_span},
     search::{
         concatenate_searches, negate_search, normalize_search, replace_search_term, write_nodes,
-        BoolSeparator, Node, SearchNode, SortMode, StateKind, TemplateKind,
+        BoolSeparator, EaseKind, Node, SearchNode, SortMode, StateKind, TemplateKind,
     },
     stats::studied_today,
     sync::{
@@ -292,11 +292,11 @@ impl From<pb::FilterToSearchIn> for Node<'_> {
                     NamedFilter::AddedToday => Node::Search(SearchNode::AddedInDays(1)),
                     NamedFilter::StudiedToday => Node::Search(SearchNode::Rated {
                         days: 1,
-                        ease: None,
+                        ease: EaseKind::Reviewed,
                     }),
                     NamedFilter::AgainToday => Node::Search(SearchNode::Rated {
                         days: 1,
-                        ease: Some(1),
+                        ease: EaseKind::Rated(1),
                     }),
                     NamedFilter::New => Node::Search(SearchNode::State(StateKind::New)),
                     NamedFilter::Learn => Node::Search(SearchNode::State(StateKind::Learning)),

--- a/rslib/src/search/mod.rs
+++ b/rslib/src/search/mod.rs
@@ -5,7 +5,7 @@ mod sqlwriter;
 mod writer;
 
 pub use cards::SortMode;
-pub use parser::{Node, PropertyKind, SearchNode, StateKind, TemplateKind};
+pub use parser::{EaseKind, Node, PropertyKind, SearchNode, StateKind, TemplateKind};
 pub use writer::{
     concatenate_searches, negate_search, normalize_search, replace_search_term, write_nodes,
     BoolSeparator,

--- a/rslib/src/search/parser.rs
+++ b/rslib/src/search/parser.rs
@@ -358,7 +358,7 @@ fn parse_flag(s: &str) -> ParseResult<SearchNode<'static>> {
 }
 
 /// eg rated:3 or rated:10:2
-/// second arg must be between 0-4
+/// second arg must be between 1-4
 fn parse_rated(val: &str) -> ParseResult<SearchNode<'static>> {
     let mut it = val.splitn(2, ':');
 
@@ -383,7 +383,10 @@ fn parse_rated(val: &str) -> ParseResult<SearchNode<'static>> {
 /// eg resched:3
 fn parse_resched(val: &str) -> ParseResult<SearchNode<'static>> {
     let mut it = val.splitn(1, ':');
-    let days = it.next().unwrap().parse()?;
+
+    let n: u32 = it.next().unwrap().parse()?;
+    let days = n.max(1).min(365);
+
     let ease = EaseKind::Manually;
 
     Ok(SearchNode::Rated { days, ease })

--- a/rslib/src/search/parser.rs
+++ b/rslib/src/search/parser.rs
@@ -119,22 +119,10 @@ pub enum TemplateKind<'a> {
 }
 
 #[derive(Debug, PartialEq, Clone)]
-pub(super) enum EaseKind {
+pub enum EaseKind {
     Rated(u8),
     Reviewed,
     Manually,
-}
-
-impl std::fmt::Display for EaseKind {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        use EaseKind::*;
-
-        match self {
-            Rated(u) => write!(f, " and ease = {}", u),
-            Reviewed => write!(f, " and ease in (1, 2, 3, 4)"),
-            Manually => write!(f, " and ease = 0"),
-        }
-    }
 }
 
 /// Parse the input string into a list of nodes.
@@ -383,7 +371,7 @@ fn parse_rated(val: &str) -> ParseResult<SearchNode<'static>> {
             if (1..5).contains(&u) {
                 EaseKind::Rated(u)
             } else {
-                return Err(ParseError {})
+                return Err(ParseError {});
             }
         }
         None => EaseKind::Reviewed,

--- a/rslib/src/search/parser.rs
+++ b/rslib/src/search/parser.rs
@@ -120,9 +120,9 @@ pub enum TemplateKind<'a> {
 
 #[derive(Debug, PartialEq, Clone)]
 pub enum EaseKind {
-    Rated(u8),
-    Reviewed,
-    Manually,
+    AnswerButton(u8),
+    AnyAnswerButton,
+    ManualReschedule,
 }
 
 /// Parse the input string into a list of nodes.
@@ -367,14 +367,14 @@ fn parse_rated(val: &str) -> ParseResult<SearchNode<'static>> {
 
     let ease = match it.next() {
         Some(v) => {
-            let u: u8 = v.parse().unwrap();
+            let u: u8 = v.parse()?;
             if (1..5).contains(&u) {
-                EaseKind::Rated(u)
+                EaseKind::AnswerButton(u)
             } else {
                 return Err(ParseError {});
             }
         }
-        None => EaseKind::Reviewed,
+        None => EaseKind::AnyAnswerButton,
     };
 
     Ok(SearchNode::Rated { days, ease })
@@ -387,7 +387,7 @@ fn parse_resched(val: &str) -> ParseResult<SearchNode<'static>> {
     let n: u32 = it.next().unwrap().parse()?;
     let days = n.max(1).min(365);
 
-    let ease = EaseKind::Manually;
+    let ease = EaseKind::ManualReschedule;
 
     Ok(SearchNode::Rated { days, ease })
 }

--- a/rslib/src/search/sqlwriter.rs
+++ b/rslib/src/search/sqlwriter.rs
@@ -1,7 +1,7 @@
 // Copyright: Ankitects Pty Ltd and contributors
 // License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
-use super::parser::{Node, PropertyKind, SearchNode, StateKind, TemplateKind};
+use super::parser::{Node, PropertyKind, SearchNode, StateKind, TemplateKind, EaseKind};
 use crate::{
     card::{CardQueue, CardType},
     collection::Collection,
@@ -144,7 +144,7 @@ impl SqlWriter<'_> {
                 write!(self.sql, "c.did = {}", did).unwrap();
             }
             SearchNode::NoteType(notetype) => self.write_note_type(&norm(notetype))?,
-            SearchNode::Rated { days, ease } => self.write_rated(*days, *ease)?,
+            SearchNode::Rated { days, ease } => self.write_rated(*days, ease)?,
 
             SearchNode::Tag(tag) => self.write_tag(&norm(tag))?,
             SearchNode::State(state) => self.write_state(state)?,
@@ -214,20 +214,16 @@ impl SqlWriter<'_> {
         Ok(())
     }
 
-    fn write_rated(&mut self, days: u32, ease: Option<u8>) -> Result<()> {
+    fn write_rated(&mut self, days: u32, ease: &EaseKind) -> Result<()> {
         let today_cutoff = self.col.timing_today()?.next_day_at;
         let target_cutoff_ms = (today_cutoff - 86_400 * i64::from(days)) * 1_000;
         write!(
             self.sql,
-            "c.id in (select cid from revlog where id>{}",
-            target_cutoff_ms
+            "c.id in (select cid from revlog where id>{}{})",
+            target_cutoff_ms,
+            ease,
         )
         .unwrap();
-        if let Some(ease) = ease {
-            write!(self.sql, " and ease={})", ease).unwrap();
-        } else {
-            write!(self.sql, ")").unwrap();
-        }
 
         Ok(())
     }

--- a/rslib/src/search/sqlwriter.rs
+++ b/rslib/src/search/sqlwriter.rs
@@ -226,7 +226,7 @@ impl SqlWriter<'_> {
 
         match ease {
             EaseKind::AnswerButton(u) => write!(self.sql, " and ease = {})", u),
-            EaseKind::AnyAnswerButton => write!(self.sql, " and ease between 1 and 4)"),
+            EaseKind::AnyAnswerButton => write!(self.sql, " and ease > 0)"),
             EaseKind::ManualReschedule => write!(self.sql, " and ease = 0)"),
         }
         .unwrap();
@@ -719,7 +719,7 @@ mod test {
         assert_eq!(
             s(ctx, "rated:2").0,
             format!(
-                "(c.id in (select cid from revlog where id>{} and ease between 1 and 4))",
+                "(c.id in (select cid from revlog where id>{} and ease > 0))",
                 (timing.next_day_at - (86_400 * 2)) * 1_000
             )
         );

--- a/rslib/src/search/sqlwriter.rs
+++ b/rslib/src/search/sqlwriter.rs
@@ -1,7 +1,7 @@
 // Copyright: Ankitects Pty Ltd and contributors
 // License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
-use super::parser::{Node, PropertyKind, SearchNode, StateKind, TemplateKind, EaseKind};
+use super::parser::{EaseKind, Node, PropertyKind, SearchNode, StateKind, TemplateKind};
 use crate::{
     card::{CardQueue, CardType},
     collection::Collection,
@@ -219,10 +219,16 @@ impl SqlWriter<'_> {
         let target_cutoff_ms = (today_cutoff - 86_400 * i64::from(days)) * 1_000;
         write!(
             self.sql,
-            "c.id in (select cid from revlog where id>{}{})",
+            "c.id in (select cid from revlog where id>{}",
             target_cutoff_ms,
-            ease,
         )
+        .unwrap();
+
+        match ease {
+            EaseKind::Rated(u) => write!(self.sql, " and ease = {})", u),
+            EaseKind::Reviewed => write!(self.sql, " and ease in (1, 2, 3, 4))"),
+            EaseKind::Manually => write!(self.sql, " and ease = 0)"),
+        }
         .unwrap();
 
         Ok(())

--- a/rslib/src/search/sqlwriter.rs
+++ b/rslib/src/search/sqlwriter.rs
@@ -732,6 +732,15 @@ mod test {
         );
         assert_eq!(s(ctx, "rated:0").0, s(ctx, "rated:1").0);
 
+        // resched
+        assert_eq!(
+            s(ctx, "resched:400").0,
+            format!(
+                "(c.id in (select cid from revlog where id>{} and ease = 0))",
+                (timing.next_day_at - (86_400 * 365)) * 1_000
+            )
+        );
+
         // props
         assert_eq!(s(ctx, "prop:lapses=3").0, "(lapses = 3)".to_string());
         assert_eq!(s(ctx, "prop:ease>=2.5").0, "(factor >= 2500)".to_string());

--- a/rslib/src/search/sqlwriter.rs
+++ b/rslib/src/search/sqlwriter.rs
@@ -226,7 +226,7 @@ impl SqlWriter<'_> {
 
         match ease {
             EaseKind::Rated(u) => write!(self.sql, " and ease = {})", u),
-            EaseKind::Reviewed => write!(self.sql, " and ease in (1, 2, 3, 4))"),
+            EaseKind::Reviewed => write!(self.sql, " and ease between 1 and 4)"),
             EaseKind::Manually => write!(self.sql, " and ease = 0)"),
         }
         .unwrap();
@@ -719,14 +719,14 @@ mod test {
         assert_eq!(
             s(ctx, "rated:2").0,
             format!(
-                "(c.id in (select cid from revlog where id>{}))",
+                "(c.id in (select cid from revlog where id>{} and ease between 1 and 4))",
                 (timing.next_day_at - (86_400 * 2)) * 1_000
             )
         );
         assert_eq!(
             s(ctx, "rated:400:1").0,
             format!(
-                "(c.id in (select cid from revlog where id>{} and ease=1))",
+                "(c.id in (select cid from revlog where id>{} and ease = 1))",
                 (timing.next_day_at - (86_400 * 365)) * 1_000
             )
         );

--- a/rslib/src/search/sqlwriter.rs
+++ b/rslib/src/search/sqlwriter.rs
@@ -225,9 +225,9 @@ impl SqlWriter<'_> {
         .unwrap();
 
         match ease {
-            EaseKind::Rated(u) => write!(self.sql, " and ease = {})", u),
-            EaseKind::Reviewed => write!(self.sql, " and ease between 1 and 4)"),
-            EaseKind::Manually => write!(self.sql, " and ease = 0)"),
+            EaseKind::AnswerButton(u) => write!(self.sql, " and ease = {})", u),
+            EaseKind::AnyAnswerButton => write!(self.sql, " and ease between 1 and 4)"),
+            EaseKind::ManualReschedule => write!(self.sql, " and ease = 0)"),
         }
         .unwrap();
 

--- a/rslib/src/search/writer.rs
+++ b/rslib/src/search/writer.rs
@@ -159,7 +159,7 @@ fn write_rated(days: &u32, ease: &EaseKind) -> String {
     match ease {
         Rated(n) => format!("\"rated:{}:{}\"", days, n),
         Reviewed => format!("\"rated:{}\"", days),
-        All => format!("\"rated:{}:a\"", days),
+        Manually => format!("\"resched:{}\"", days),
     }
 }
 

--- a/rslib/src/search/writer.rs
+++ b/rslib/src/search/writer.rs
@@ -5,7 +5,7 @@ use crate::{
     decks::DeckID as DeckIDType,
     err::Result,
     notetype::NoteTypeID as NoteTypeIDType,
-    search::parser::{parse, Node, PropertyKind, SearchNode, StateKind, TemplateKind, EaseKind},
+    search::parser::{parse, EaseKind, Node, PropertyKind, SearchNode, StateKind, TemplateKind},
 };
 use itertools::Itertools;
 use std::mem;

--- a/rslib/src/search/writer.rs
+++ b/rslib/src/search/writer.rs
@@ -157,9 +157,9 @@ fn write_template(template: &TemplateKind) -> String {
 fn write_rated(days: &u32, ease: &EaseKind) -> String {
     use EaseKind::*;
     match ease {
-        Rated(n) => format!("\"rated:{}:{}\"", days, n),
-        Reviewed => format!("\"rated:{}\"", days),
-        Manually => format!("\"resched:{}\"", days),
+        AnswerButton(n) => format!("\"rated:{}:{}\"", days, n),
+        AnyAnswerButton => format!("\"rated:{}\"", days),
+        ManualReschedule => format!("\"resched:{}\"", days),
     }
 }
 

--- a/rslib/src/search/writer.rs
+++ b/rslib/src/search/writer.rs
@@ -5,7 +5,7 @@ use crate::{
     decks::DeckID as DeckIDType,
     err::Result,
     notetype::NoteTypeID as NoteTypeIDType,
-    search::parser::{parse, Node, PropertyKind, SearchNode, StateKind, TemplateKind},
+    search::parser::{parse, Node, PropertyKind, SearchNode, StateKind, TemplateKind, EaseKind},
 };
 use itertools::Itertools;
 use std::mem;
@@ -154,10 +154,12 @@ fn write_template(template: &TemplateKind) -> String {
     }
 }
 
-fn write_rated(days: &u32, ease: &Option<u8>) -> String {
+fn write_rated(days: &u32, ease: &EaseKind) -> String {
+    use EaseKind::*;
     match ease {
-        Some(u) => format!("\"rated:{}:{}\"", days, u),
-        None => format!("\"rated:{}\"", days),
+        Rated(n) => format!("\"rated:{}:{}\"", days, n),
+        Reviewed => format!("\"rated:{}\"", days),
+        All => format!("\"rated:{}:a\"", days),
     }
 }
 


### PR DESCRIPTION
Currently, searching for `rated:1` will give you cards studied today, OR rescheduled today.
However the Anki manual and Anki itself tries to skim over this, and simply says "Studied Today", which however would technically be `rated:1:1 or rated:1:2 or rated:1:3 or rated:1:4`, but does make sense, because this is what the user probably wants to search for. I'd say this is an implementation detail leaking to the user.

That's what this PR is trying to solve: `rated:n` will now be restricted to revlog entries with `ease between 1 and 4`. The old  behavior of `rated:n` can now be recreated with `rated:n or resched:n`.