### PR TITLE
Prefer <br> over <div></div> in Editor

### DIFF
--- a/qt/aqt/data/web/js/editor.ts
+++ b/qt/aqt/data/web/js/editor.ts
@@ -55,6 +55,13 @@ function onKey(evt: KeyboardEvent) {
         return;
     }
 
+    // prefer <br> instead of <div></div>
+    if (evt.which === 13) {
+        evt.preventDefault();
+        document.execCommand("insertLineBreak");
+        return;
+    }
+
     // fix Ctrl+right/left handling in RTL fields
     if (currentField.dir === "rtl") {
         const selection = window.getSelection();

--- a/qt/aqt/data/web/js/editor.ts
+++ b/qt/aqt/data/web/js/editor.ts
@@ -56,7 +56,8 @@ function onKey(evt: KeyboardEvent) {
     }
 
     // prefer <br> instead of <div></div>
-    if (evt.which === 13) {
+    if (evt.which === 13 && !inListItem()) {
+        console.log("Enter");
         evt.preventDefault();
         document.execCommand("insertLineBreak");
         return;
@@ -87,6 +88,25 @@ function onKey(evt: KeyboardEvent) {
     triggerKeyTimer();
 }
 
+function nodeIsElement(node: Node): node is Element {
+    return node.nodeType == Node.ELEMENT_NODE;
+}
+
+function inListItem(): boolean {
+    const anchor = window.getSelection().anchorNode;
+
+    let n = nodeIsElement(anchor) ? anchor : anchor.parentElement;
+
+    let inList = false;
+
+    while (n) {
+        inList = inList || window.getComputedStyle(n).display == "list-item";
+        n = n.parentElement;
+    }
+
+    return inList;
+}
+
 function insertNewline() {
     if (!inPreEnvironment()) {
         setFormat("insertText", "\n");
@@ -113,11 +133,10 @@ function insertNewline() {
 }
 
 // is the cursor in an environment that respects whitespace?
-function inPreEnvironment() {
-    let n = window.getSelection().anchorNode as Element;
-    if (n.nodeType === 3) {
-        n = n.parentNode as Element;
-    }
+function inPreEnvironment(): boolean {
+    const anchor = window.getSelection().anchorNode;
+    const n = nodeIsElement(anchor) ? anchor : anchor.parentElement;
+
     return window.getComputedStyle(n).whiteSpace.startsWith("pre");
 }
 

--- a/qt/aqt/data/web/js/editor.ts
+++ b/qt/aqt/data/web/js/editor.ts
@@ -57,7 +57,6 @@ function onKey(evt: KeyboardEvent) {
 
     // prefer <br> instead of <div></div>
     if (evt.which === 13 && !inListItem()) {
-        console.log("Enter");
         evt.preventDefault();
         document.execCommand("insertLineBreak");
         return;
@@ -86,6 +85,23 @@ function onKey(evt: KeyboardEvent) {
     }
 
     triggerKeyTimer();
+}
+
+function onKeyUp(evt: KeyboardEvent) {
+    // Avoid div element on remove
+    if (evt.which === 8 || evt.which === 13) {
+        const anchor = window.getSelection().anchorNode;
+
+        if (
+            nodeIsElement(anchor) &&
+            anchor.tagName === "DIV" &&
+            !anchor.classList.contains("field") &&
+            anchor.childElementCount === 1 &&
+            anchor.children[0].tagName === "BR"
+        ) {
+            anchor.replaceWith(anchor.children[0]);
+        }
+    }
 }
 
 function nodeIsElement(node: Node): node is Element {
@@ -364,19 +380,19 @@ function setFields(fields) {
         </tr>
         <tr>
             <td width=100%>
-                <div id=f${i}
-                     onkeydown='onKey(window.event);'
-                     oninput='onInput();'
-                     onmouseup='onKey(window.event);'
-                     onfocus='onFocus(this);'
-                     onblur='onBlur();'
-                     class='field clearfix'
-                     onpaste='onPaste(this);'
-                     oncopy='onCutOrCopy(this);'
-                     oncut='onCutOrCopy(this);'
-                     contentEditable=true
-                     class=field
-                     style='color: ${color}'
+                <div id="f${i}"
+                     onkeydown="onKey(window.event);"
+                     onkeyup="onKeyUp(window.event);"
+                     oninput="onInput();"
+                     onmouseup="onKey(window.event);"
+                     onfocus="onFocus(this);"
+                     onblur="onBlur();"
+                     class="field clearfix"
+                     onpaste="onPaste(this);"
+                     oncopy="onCutOrCopy(this);"
+                     oncut="onCutOrCopy(this);"
+                     contentEditable
+                     style="color: ${color}"
                 >${f}</div>
             </td>
         </tr>`;


### PR DESCRIPTION
In the Anki Editor, pressing Enter will create a mix of `<div></div>` and `<br>`.

Most WYSIWYG editors out there either use `<div></div>` or even `<p></p>`. But I think the Anki Editor is somewhat special here, because it allows you to use templating tools, like MathJax or Anki clozes.

This behavior of occasionally using `<div>` makes using these template languages significantly harder.

1. You have to fit MathJax into one line. MathJax can get quite out of hand sometimes, but in Anki, you always have to fit it in a single line, making it very hard to read. MathJax offers an [option to allow specific self-closing tags within itself](http://docs.mathjax.org/en/latest/options/document.html), which Anki would greatly benefit from.

**EDIT**: I noticed that actually Anki strips html inside MathJax tags now, and at the time of writing I wasn't aware of "Shift+Enter". So this problem is somewhat alleviated now.

2. Anki Clozes break when used with multiple lines. This is an example of a `Cloze 1` with broken Anki Clozes:
![Screenshot 2021-01-14 at 14 01 48](https://user-images.githubusercontent.com/7188844/104594215-219a8500-5671-11eb-87cc-b1ba46160ca7.png)

There's three things wrong here:
1. The clozes are missing the blue highlight entirely (sometimes only the first line has it), because the Anki cloze wants to wrap it in a span, but the `div`s, break the layout.
2. The newlines are inconsistent. `}}` on a new line might or might not create a newline.
3. When clicking three times on a line, and activating the cloze shortcut, you might get one of the following results:

```
{{c1::Another line}}
// or
{{c1::Another line
}}
// or
{{c1::
Another line
}}
```

What I would expect is the first behavior, always.

I introduced this small change into `editor.ts`, which would change this behavior to always insert `<br>` instead. After that, you get consistent behavior in that regard:

![Screenshot 2021-01-14 at 13 30 45](https://user-images.githubusercontent.com/7188844/104595317-b94ca300-5672-11eb-84e5-9c7cd3f38635.png)

Wondering about this, I dug a little bit in Anki history, and found [this old post](https://anki.tenderapp.com/discussions/ankidesktop/4363-div-instead-of-br-are-now-inserted-when-pressing-enter), and this old commit 077d6b8187db4e5b2cfc44fe58acad2bd6614c53 from 2013, which seem to imply that this used to be the behavior, but was changed because of unspecified issues (at least I couldn't find an exact description).

Considerations:
* `execCommand("insertLineBreak")` [only works in WebKit](https://w3c.github.io/editing/docs/execCommand/#the-insertlinebreak-command), which means it won't work on AnkiMobile (even though I don't know whether the editor there is a webview).