### PR TITLE
Introduce "prop:rated" and "prop:resched"

### DIFF
--- a/ftl/core/search.ftl
+++ b/ftl/core/search.ftl
@@ -17,7 +17,7 @@ search-invalid-argument = `{ $term }` was given an invalid argument '`{ $argumen
 search-invalid-flag = `flag:` must be followed by a valid flag number: `1` (red), `2` (orange), `3` (green), `4` (blue) or `0` (no flag).
 search-invalid-followed-by-positive-days = `{ $term }` must be followed by a positive number of days.
 search-invalid-rated-days = `rated:` must be followed by a positive number of days.
-search-invalid-rated-ease = `rated:{ $val }:` must be followed by `1` (again), `2` (hard), `3` (good) or `4` (easy).
+search-invalid-rated-ease = `{ $val }:` must be followed by `1` (again), `2` (hard), `3` (good) or `4` (easy).
 search-invalid-prop-operator = `prop:{ $val }` must be followed by one of the comparison operators: `=`, `!=`, `<`, `>`, `<=` or `>=`.
 search-invalid-prop-float = `prop:{ $val }` must be followed by a decimal number.
 search-invalid-prop-integer = `prop:{ $val }` must be followed by a whole number.

--- a/rslib/src/search/parser.rs
+++ b/rslib/src/search/parser.rs
@@ -87,7 +87,7 @@ pub enum PropertyKind {
     Lapses(u32),
     Ease(f32),
     Position(u32),
-    Rated(u32, Option<u8>),
+    Rated(u32, EaseKind),
 }
 
 #[derive(Debug, PartialEq, Clone)]
@@ -433,7 +433,16 @@ fn parse_prop(s: &str) -> ParseResult<SearchNode> {
                 }
             }
             None => EaseKind::AnyAnswerButton,
-        }
+        };
+
+        PropertyKind::Rated(days, ease)
+    } else if key == "resched" {
+        let mut it = val.splitn(2, ':');
+
+        let n: u32 = it.next().unwrap().parse()?;
+        let days = n.max(1).min(365);
+
+        let ease = EaseKind::ManualReschedule;
 
         PropertyKind::Rated(days, ease)
     } else if key == "resched" {

--- a/rslib/src/search/parser.rs
+++ b/rslib/src/search/parser.rs
@@ -461,7 +461,10 @@ fn parse_prop(s: &str) -> ParseResult<SearchNode> {
         ));
     };
 
-    Ok(SearchNode::Property { operator, kind })
+    Ok(SearchNode::Property {
+        operator: operator.to_string(),
+        kind,
+    })
 }
 
 /// eg added:1

--- a/rslib/src/search/parser.rs
+++ b/rslib/src/search/parser.rs
@@ -87,7 +87,7 @@ pub enum PropertyKind {
     Lapses(u32),
     Ease(f32),
     Position(u32),
-    Rated(u32, EaseKind),
+    Rated(i32, EaseKind),
 }
 
 #[derive(Debug, PartialEq, Clone)]
@@ -439,8 +439,8 @@ fn parse_prop(s: &str) -> ParseResult<SearchNode> {
     } else if key == "resched" {
         let mut it = val.splitn(2, ':');
 
-        let n: u32 = it.next().unwrap().parse()?;
-        let days = n.max(1).min(365);
+        let n: i32 = it.next().unwrap().parse()?;
+        let days = n.max(-365).min(0);
 
         let ease = EaseKind::ManualReschedule;
 

--- a/rslib/src/search/parser.rs
+++ b/rslib/src/search/parser.rs
@@ -406,7 +406,7 @@ fn parse_prop(s: &str) -> ParseResult<SearchNode> {
         let mut it = num.splitn(2, ':');
 
         let days: i32 = if let Ok(i) = it.next().unwrap().parse::<i32>() {
-            i
+            i.min(0)
         } else {
             return Err(parse_failure(
                 s,
@@ -438,7 +438,7 @@ fn parse_prop(s: &str) -> ParseResult<SearchNode> {
         PropertyKind::Rated(days, ease)
     } else if prop == "resched" {
         if let Ok(days) = num.parse::<i32>() {
-            PropertyKind::Rated(days, EaseKind::ManualReschedule)
+            PropertyKind::Rated(days.min(0), EaseKind::ManualReschedule)
         } else {
             return Err(parse_failure(
                 s,
@@ -489,6 +489,7 @@ fn parse_edited(s: &str) -> ParseResult<SearchNode> {
 fn parse_rated(s: &str) -> ParseResult<SearchNode> {
     let mut it = s.splitn(2, ':');
     if let Ok(days) = it.next().unwrap().parse::<u32>() {
+        let days = days.max(1);
         let ease = if let Some(tail) = it.next() {
             if let Ok(u) = tail.parse::<u8>() {
                 if u > 0 && u < 5 {

--- a/rslib/src/search/parser.rs
+++ b/rslib/src/search/parser.rs
@@ -402,7 +402,7 @@ fn parse_prop(s: &str) -> ParseResult<SearchNode> {
                 FailKind::InvalidPropInteger(format!("{}{}", prop, operator)),
             ));
         }
-    } else if key == "rated" {
+    } else if prop == "rated" {
         let mut it = num.splitn(2, ':');
 
         let days: i32 = if let Ok(i) = it.next().unwrap().parse::<i32>() {
@@ -412,13 +412,13 @@ fn parse_prop(s: &str) -> ParseResult<SearchNode> {
                 s,
                 FailKind::InvalidPropInteger(format!("{}{}", prop, operator)),
             ));
-        }
+        };
 
         let ease = match it.next() {
             Some(v) => {
-                let n: u8 = if let Ok(i) = v.parse() {
-                    if (1..5).contains(i) {
-                        EaseKind::AnswerButton(i)
+                if let Ok(u) = v.parse::<u8>() {
+                    if (1..5).contains(&u) {
+                        EaseKind::AnswerButton(u)
                     } else {
                         return Err(parse_failure(
                             s,
@@ -436,16 +436,7 @@ fn parse_prop(s: &str) -> ParseResult<SearchNode> {
         };
 
         PropertyKind::Rated(days, ease)
-    } else if key == "resched" {
-        let mut it = val.splitn(2, ':');
-
-        let n: i32 = it.next().unwrap().parse()?;
-        let days = n.max(-365).min(0);
-
-        let ease = EaseKind::ManualReschedule;
-
-        PropertyKind::Rated(days, ease)
-    } else if key == "resched" {
+    } else if prop == "resched" {
         if let Ok(days) = num.parse::<i32>() {
             PropertyKind::Rated(days, EaseKind::ManualReschedule)
         } else {

--- a/rslib/src/search/parser.rs
+++ b/rslib/src/search/parser.rs
@@ -351,9 +351,9 @@ fn parse_flag(s: &str) -> ParseResult<SearchNode> {
 
 /// eg resched:3
 fn parse_resched(s: &str) -> ParseResult<SearchNode> {
-    if let Ok(d) = s.parse::<u32>() {
+    if let Ok(days) = s.parse::<u32>() {
         Ok(SearchNode::Rated {
-            days: d.max(1).min(365),
+            days,
             ease: EaseKind::ManualReschedule,
         })
     } else {
@@ -488,8 +488,7 @@ fn parse_edited(s: &str) -> ParseResult<SearchNode> {
 /// second arg must be between 1-4
 fn parse_rated(s: &str) -> ParseResult<SearchNode> {
     let mut it = s.splitn(2, ':');
-    if let Ok(d) = it.next().unwrap().parse::<u32>() {
-        let days = d.max(1).min(365);
+    if let Ok(days) = it.next().unwrap().parse::<u32>() {
         let ease = if let Some(tail) = it.next() {
             if let Ok(u) = tail.parse::<u8>() {
                 if u > 0 && u < 5 {

--- a/rslib/src/search/parser.rs
+++ b/rslib/src/search/parser.rs
@@ -371,6 +371,7 @@ fn parse_prop(s: &str) -> ParseResult<SearchNode> {
         tag("ease"),
         tag("pos"),
         tag("rated"),
+        tag("resched"),
     ))(s)
     .map_err(|_| parse_failure(s, FailKind::InvalidPropProperty(s.into())))?;
 
@@ -460,10 +461,7 @@ fn parse_prop(s: &str) -> ParseResult<SearchNode> {
         ));
     };
 
-    Ok(SearchNode::Property {
-        operator: operator.to_string(),
-        kind,
-    })
+    Ok(SearchNode::Property { operator, kind })
 }
 
 /// eg added:1

--- a/rslib/src/search/parser.rs
+++ b/rslib/src/search/parser.rs
@@ -423,7 +423,7 @@ fn parse_prop(s: &str) -> ParseResult<SearchNode> {
                     } else {
                         return Err(parse_failure(
                             s,
-                            FailKind::InvalidPropInteger(format!("{}{}", prop, operator)),
+                            FailKind::InvalidRatedEase(format!("prop:{}{}{}", prop, operator, days.to_string())),
                         ));
                     }
                 } else {
@@ -498,13 +498,13 @@ fn parse_rated(s: &str) -> ParseResult<SearchNode> {
                 } else {
                     return Err(parse_failure(
                         s,
-                        FailKind::InvalidRatedEase(days.to_string()),
+                        FailKind::InvalidRatedEase(format!("rated:{}", days.to_string())),
                     ));
                 }
             } else {
                 return Err(parse_failure(
                     s,
-                    FailKind::InvalidRatedEase(days.to_string()),
+                    FailKind::InvalidRatedEase(format!("rated:{}", days.to_string())),
                 ));
             }
         } else {

--- a/rslib/src/search/parser.rs
+++ b/rslib/src/search/parser.rs
@@ -423,7 +423,12 @@ fn parse_prop(s: &str) -> ParseResult<SearchNode> {
                     } else {
                         return Err(parse_failure(
                             s,
-                            FailKind::InvalidRatedEase(format!("prop:{}{}{}", prop, operator, days.to_string())),
+                            FailKind::InvalidRatedEase(format!(
+                                "prop:{}{}{}",
+                                prop,
+                                operator,
+                                days.to_string()
+                            )),
                         ));
                     }
                 } else {
@@ -918,10 +923,10 @@ mod test {
         assert_err_kind("rated:", InvalidRatedDays);
         assert_err_kind("rated:foo", InvalidRatedDays);
 
-        assert_err_kind("rated:1:", InvalidRatedEase("1".to_string()));
-        assert_err_kind("rated:2:-1", InvalidRatedEase("2".to_string()));
-        assert_err_kind("rated:3:1.1", InvalidRatedEase("3".to_string()));
-        assert_err_kind("rated:0:foo", InvalidRatedEase("1".to_string()));
+        assert_err_kind("rated:1:", InvalidRatedEase("rated:1".to_string()));
+        assert_err_kind("rated:2:-1", InvalidRatedEase("rated:2".to_string()));
+        assert_err_kind("rated:3:1.1", InvalidRatedEase("rated:3".to_string()));
+        assert_err_kind("rated:0:foo", InvalidRatedEase("rated:1".to_string()));
 
         assert_err_kind("resched:", FailKind::InvalidResched);
         assert_err_kind("resched:-1", FailKind::InvalidResched);

--- a/rslib/src/search/sqlwriter.rs
+++ b/rslib/src/search/sqlwriter.rs
@@ -264,22 +264,21 @@ impl SqlWriter<'_> {
                     days = days
                 ).unwrap()
             }
-            PropertyKind::Position(pos) => {
-                write!(
-                    self.sql,
-                    "(c.type = {t} and due {op} {pos})",
-                    t = CardType::New as u8,
-                    op = op,
-                    pos = pos
-                ).unwrap()
-            }
+            PropertyKind::Position(pos) => write!(
+                self.sql,
+                "(c.type = {t} and due {op} {pos})",
+                t = CardType::New as u8,
+                op = op,
+                pos = pos
+            )
+            .unwrap(),
             PropertyKind::Interval(ivl) => write!(self.sql, "ivl {} {}", op, ivl).unwrap(),
             PropertyKind::Reps(reps) => write!(self.sql, "reps {} {}", op, reps).unwrap(),
             PropertyKind::Lapses(days) => write!(self.sql, "lapses {} {}", op, days).unwrap(),
             PropertyKind::Ease(ease) => {
                 write!(self.sql, "factor {} {}", op, (ease * 1000.0) as u32).unwrap()
             }
-            PropertyKind::Rated(days, ease) => self.write_rated(i64::from(*days), ease, op)?
+            PropertyKind::Rated(days, ease) => self.write_rated(i64::from(*days), ease, op)?,
         }
 
         Ok(())

--- a/rslib/src/search/sqlwriter.rs
+++ b/rslib/src/search/sqlwriter.rs
@@ -272,6 +272,9 @@ impl SqlWriter<'_> {
             PropertyKind::Ease(ease) => {
                 write!(self.sql, "factor {} {}", op, (ease * 1000.0) as u32)
             }
+            PropertyKind::Rated(days, ease) => {
+                write!(self.sql, "")
+            }
         }
         .unwrap();
         Ok(())

--- a/rslib/src/search/sqlwriter.rs
+++ b/rslib/src/search/sqlwriter.rs
@@ -116,7 +116,6 @@ impl SqlWriter<'_> {
 
     fn write_search_node_to_sql(&mut self, node: &SearchNode) -> Result<()> {
         use normalize_to_nfc as norm;
-        use std::cmp::max;
         match node {
             // note fields related
             SearchNode::UnqualifiedText(text) => self.write_unqualified(&self.norm_note(text)),
@@ -218,7 +217,7 @@ impl SqlWriter<'_> {
     fn write_rated(&mut self, days: u32, ease: &EaseKind, op: &str) -> Result<()> {
         let today_cutoff = self.col.timing_today()?.next_day_at;
         let target_cutoff_ms = (today_cutoff - 86_400 * i64::from(days)) * 1_000;
-        let day_before_cutoff_ms = (today_cutoff - 86_400 * (days)) * 1_000;
+        let day_before_cutoff_ms = (today_cutoff - 86_400 * i64::from(days - 1)) * 1_000;
 
         write!(
             self.sql,
@@ -286,7 +285,7 @@ impl SqlWriter<'_> {
             PropertyKind::Ease(ease) => {
                 write!(self.sql, "factor {} {}", op, (ease * 1000.0) as u32).unwrap()
             }
-            PropertyKind::Rated(days, ease) => self.write_rated(*days, *ease, op)?
+            PropertyKind::Rated(days, ease) => self.write_rated(*days, ease, op)?
         }
 
         Ok(())

--- a/rslib/src/search/sqlwriter.rs
+++ b/rslib/src/search/sqlwriter.rs
@@ -144,7 +144,7 @@ impl SqlWriter<'_> {
                 write!(self.sql, "c.did = {}", did).unwrap();
             }
             SearchNode::NoteType(notetype) => self.write_note_type(&norm(notetype))?,
-            SearchNode::Rated { days, ease } => self.write_rated(-i64::from(*days), ease, ">")?,
+            SearchNode::Rated { days, ease } => self.write_rated(">", -i64::from(*days), ease)?,
 
             SearchNode::Tag(tag) => self.write_tag(&norm(tag))?,
             SearchNode::State(state) => self.write_state(state)?,
@@ -214,7 +214,7 @@ impl SqlWriter<'_> {
         Ok(())
     }
 
-    fn write_rated(&mut self, days: i64, ease: &EaseKind, op: &str) -> Result<()> {
+    fn write_rated(&mut self, op: &str, days: i64, ease: &EaseKind) -> Result<()> {
         let today_cutoff = self.col.timing_today()?.next_day_at;
         let target_cutoff_ms = (today_cutoff + 86_400 * days) * 1_000;
         let day_before_cutoff_ms = (today_cutoff + 86_400 * (days - 1)) * 1_000;
@@ -278,7 +278,7 @@ impl SqlWriter<'_> {
             PropertyKind::Ease(ease) => {
                 write!(self.sql, "factor {} {}", op, (ease * 1000.0) as u32).unwrap()
             }
-            PropertyKind::Rated(days, ease) => self.write_rated(i64::from(*days), ease, op)?,
+            PropertyKind::Rated(days, ease) => self.write_rated(op, i64::from(*days), ease)?,
         }
 
         Ok(())

--- a/rslib/src/search/sqlwriter.rs
+++ b/rslib/src/search/sqlwriter.rs
@@ -222,12 +222,12 @@ impl SqlWriter<'_> {
         write!(self.sql, "c.id in (select cid from revlog where id").unwrap();
 
         match op {
-            ">" => write!(self.sql, " {} {}", ">", target_cutoff_ms),
-            "<" => write!(self.sql, " {} {}", "<", day_before_cutoff_ms),
-            ">=" => write!(self.sql, " {} {}", ">", day_before_cutoff_ms),
-            "<=" => write!(self.sql, " {} {}", "<", target_cutoff_ms),
-            "=" => write!(self.sql, " between {} and {}", day_before_cutoff_ms, target_cutoff_ms),
-            _ /* "!=" */ => write!(self.sql, " not between {} and {}", day_before_cutoff_ms, target_cutoff_ms),
+            ">" => write!(self.sql, " >= {}", target_cutoff_ms),
+            ">=" => write!(self.sql, " >= {}", day_before_cutoff_ms),
+            "<" => write!(self.sql, " < {}", day_before_cutoff_ms),
+            "<=" => write!(self.sql, " < {}", target_cutoff_ms),
+            "=" => write!(self.sql, " between {} and {}", day_before_cutoff_ms, target_cutoff_ms - 1),
+            _ /* "!=" */ => write!(self.sql, " not between {} and {}", day_before_cutoff_ms, target_cutoff_ms - 1),
         }
         .unwrap();
 
@@ -726,14 +726,14 @@ mod test {
         assert_eq!(
             s(ctx, "rated:2").0,
             format!(
-                "(c.id in (select cid from revlog where id > {} and ease > 0))",
+                "(c.id in (select cid from revlog where id >= {} and ease > 0))",
                 (timing.next_day_at - (86_400 * 2)) * 1_000
             )
         );
         assert_eq!(
             s(ctx, "rated:400:1").0,
             format!(
-                "(c.id in (select cid from revlog where id > {} and ease = 1))",
+                "(c.id in (select cid from revlog where id >= {} and ease = 1))",
                 (timing.next_day_at - (86_400 * 365)) * 1_000
             )
         );
@@ -743,7 +743,7 @@ mod test {
         assert_eq!(
             s(ctx, "resched:400").0,
             format!(
-                "(c.id in (select cid from revlog where id > {} and ease = 0))",
+                "(c.id in (select cid from revlog where id >= {} and ease = 0))",
                 (timing.next_day_at - (86_400 * 365)) * 1_000
             )
         );

--- a/rslib/src/search/sqlwriter.rs
+++ b/rslib/src/search/sqlwriter.rs
@@ -226,8 +226,19 @@ impl SqlWriter<'_> {
             ">=" => write!(self.sql, " >= {}", day_before_cutoff_ms),
             "<" => write!(self.sql, " < {}", day_before_cutoff_ms),
             "<=" => write!(self.sql, " < {}", target_cutoff_ms),
-            "=" => write!(self.sql, " between {} and {}", day_before_cutoff_ms, target_cutoff_ms - 1),
-            _ /* "!=" */ => write!(self.sql, " not between {} and {}", day_before_cutoff_ms, target_cutoff_ms - 1),
+            "=" => write!(
+                self.sql,
+                " between {} and {}",
+                day_before_cutoff_ms,
+                target_cutoff_ms - 1
+            ),
+            "!=" => write!(
+                self.sql,
+                " not between {} and {}",
+                day_before_cutoff_ms,
+                target_cutoff_ms - 1
+            ),
+            _ => unreachable!("unexpected op"),
         }
         .unwrap();
 

--- a/rslib/src/search/sqlwriter.rs
+++ b/rslib/src/search/sqlwriter.rs
@@ -734,7 +734,7 @@ mod test {
             s(ctx, "rated:400:1").0,
             format!(
                 "(c.id in (select cid from revlog where id >= {} and ease = 1))",
-                (timing.next_day_at - (86_400 * 365)) * 1_000
+                (timing.next_day_at - (86_400 * 400)) * 1_000
             )
         );
         assert_eq!(s(ctx, "rated:0").0, s(ctx, "rated:1").0);
@@ -744,7 +744,7 @@ mod test {
             s(ctx, "resched:400").0,
             format!(
                 "(c.id in (select cid from revlog where id >= {} and ease = 0))",
-                (timing.next_day_at - (86_400 * 365)) * 1_000
+                (timing.next_day_at - (86_400 * 400)) * 1_000
             )
         );
 
@@ -759,6 +759,7 @@ mod test {
                 cutoff = timing.next_day_at
             )
         );
+        assert_eq!(s(ctx, "prop:rated>-5:3").0, s(ctx, "rated:5:3").0);
 
         // note types by name
         assert_eq!(

--- a/rslib/src/search/writer.rs
+++ b/rslib/src/search/writer.rs
@@ -195,6 +195,10 @@ fn write_property(operator: &str, kind: &PropertyKind) -> String {
         Lapses(u) => format!("\"prop:lapses{}{}\"", operator, u),
         Ease(f) => format!("\"prop:ease{}{}\"", operator, f),
         Position(u) => format!("\"prop:pos{}{}\"", operator, u),
+        Rated(u, ease) => match ease {
+            Some(val) => format!("\"prop:rated{}{}:{}\"", operator, u, val),
+            None => format!("\"prop:rated{}{}\"", operator, u),
+        }
     }
 }
 

--- a/rslib/src/search/writer.rs
+++ b/rslib/src/search/writer.rs
@@ -199,7 +199,7 @@ fn write_property(operator: &str, kind: &PropertyKind) -> String {
             EaseKind::AnswerButton(val) => format!("\"prop:rated{}{}:{}\"", operator, u, val),
             EaseKind::AnyAnswerButton => format!("\"prop:rated{}{}\"", operator, u),
             EaseKind::ManualReschedule => format!("\"prop:resched{}{}\"", operator, u),
-        }
+        },
     }
 }
 

--- a/rslib/src/search/writer.rs
+++ b/rslib/src/search/writer.rs
@@ -196,8 +196,9 @@ fn write_property(operator: &str, kind: &PropertyKind) -> String {
         Ease(f) => format!("\"prop:ease{}{}\"", operator, f),
         Position(u) => format!("\"prop:pos{}{}\"", operator, u),
         Rated(u, ease) => match ease {
-            Some(val) => format!("\"prop:rated{}{}:{}\"", operator, u, val),
-            None => format!("\"prop:rated{}{}\"", operator, u),
+            EaseKind::AnswerButton(val) => format!("\"prop:rated{}{}:{}\"", operator, u, val),
+            EaseKind::AnyAnswerButton => format!("\"prop:rated{}{}\"", operator, u),
+            EaseKind::ManualReschedule => format!("\"prop:resched{}{}\"", operator, u),
         }
     }
 }


### PR DESCRIPTION
There is still an issue with the `rated` and `resched` queries.

Let's say I want to search which cards I reviewed 20 days ago from today.

You would think, it would be as simple as `rated:21 -rated:20`, however that's not the case. It would be the case for queries like `added`, and `edited`, but not for rated.

`rated:21 -rated:20` actually gives you the cards, which you studied 20 days ago,  but will also exclude those, which you happened to study starting today till 19 days ago. So cards you reviewed that day, but haven't since.

This PR is trying to solve this, by introducing equivalent `prop` searches, which allow for more specificity when searching for past reviews. So searching for 20 days ago would be as simple as `prop:rated=-20`.

This also means There is some overlay with `rated:n`. In fact `rated:n:m` would be fully equivalent to `prop:rated>=(-n + 1):m`

There are some considerations, and also some open issues:
* I decided to keep negative indices for `prop:rated`, because I modelled it to be similiar to `prop:due`. So `prop:due=-1 or prop:rated=-1` would give you cards which you reviewed yesterday, or are still due from yesterday.
* This also means that `prop:rated` only accepts integers `<= 0`.
* At the moment there is no functionality to cap rated searches, which go the other way, like `prop:rated<0`
* While those would be easy to cap to 365 days, `prop:rated!=n` is not quite as straightforward to put a cap on. I could cap it 182 days in each direction. Another idea would be to throw a new UnsupportedOperator error in this case.

And one question out of curiosity:
* I don't really have that many cards/reviews in my collection, so I don't really know how out-of-hand such a query can get, but I wonder what would be the consequences of lifting that one year cap?