### PR TITLE
Different first weekday support for Calendar View, Take 2

### DIFF
--- a/rslib/backend.proto
+++ b/rslib/backend.proto
@@ -1082,6 +1082,12 @@ message GraphsIn {
 }
 
 message GraphsOut {
+  enum Weekday {
+    SUNDAY = 0;
+    MONDAY = 1;
+    FRIDAY = 5;
+    SATURDAY = 6;
+  }
   repeated Card cards = 1;
   repeated RevlogEntry revlog = 2;
   uint32 days_elapsed = 3;
@@ -1090,6 +1096,7 @@ message GraphsOut {
   uint32 scheduler_version = 5;
   /// Seconds to add to UTC timestamps to get local time.
   int32 local_offset_secs = 7;
+  Weekday first_weekday = 8;
 }
 
 message RevlogEntry {

--- a/rslib/src/config.rs
+++ b/rslib/src/config.rs
@@ -18,6 +18,7 @@ pub(crate) fn schema11_config_as_string() -> String {
         "curDeck": 1,
         "newSpread": 0,
         "collapseTime": 1200,
+        "firstWeekday": 0,
         "timeLim": 0,
         "estTimes": true,
         "dueCounts": true,
@@ -47,6 +48,7 @@ pub(crate) enum ConfigKey {
     ShowRemainingDueCountsInStudy,
     ShowIntervalsAboveAnswerButtons,
     NewReviewMix,
+    FirstWeekday,
     AnswerTimeLimitSecs,
     ShowDayLearningCardsFirst,
     LastUnburiedDay,
@@ -75,6 +77,7 @@ impl From<ConfigKey> for &'static str {
             ConfigKey::ShowRemainingDueCountsInStudy => "dueCounts",
             ConfigKey::ShowIntervalsAboveAnswerButtons => "estTimes",
             ConfigKey::NewReviewMix => "newSpread",
+            ConfigKey::FirstWeekday => "firstWeekday",
             ConfigKey::AnswerTimeLimitSecs => "timeLim",
             ConfigKey::ShowDayLearningCardsFirst => "dayLearnFirst",
             ConfigKey::LastUnburiedDay => "lastUnburied",
@@ -227,6 +230,16 @@ impl Collection {
         self.set_config(ConfigKey::NewReviewMix, &(mix as u8))
     }
 
+
+    pub(crate) fn get_first_weekday(&self) -> Weekday {
+        match self.get_config_default::<u8, _>(ConfigKey::FirstWeekday) {
+            1 => Weekday::Monday,
+            5 => Weekday::Friday,
+            6 => Weekday::Saturday,
+            _ => Weekday::Sunday,
+        }
+    }
+
     pub(crate) fn get_show_due_counts(&self) -> bool {
         self.get_config_optional(ConfigKey::ShowRemainingDueCountsInStudy)
             .unwrap_or(true)
@@ -307,6 +320,13 @@ pub(crate) enum NewReviewMix {
     Mix = 0,
     ReviewsFirst = 1,
     NewFirst = 2,
+}
+
+pub(crate) enum Weekday {
+    Sunday = 0,
+    Monday = 1,
+    Friday = 5,
+    Saturday = 6,
 }
 
 #[cfg(test)]

--- a/rslib/src/config.rs
+++ b/rslib/src/config.rs
@@ -230,7 +230,6 @@ impl Collection {
         self.set_config(ConfigKey::NewReviewMix, &(mix as u8))
     }
 
-
     pub(crate) fn get_first_weekday(&self) -> Weekday {
         match self.get_config_default::<u8, _>(ConfigKey::FirstWeekday) {
             1 => Weekday::Monday,

--- a/rslib/src/stats/graphs.rs
+++ b/rslib/src/stats/graphs.rs
@@ -25,7 +25,6 @@ impl Collection {
         let offset = self.local_utc_offset_for_user()?;
         let local_offset_secs = offset.local_minus_utc() as i64;
 
-
         let cards = self.storage.all_searched_cards()?;
         let revlog = if all {
             self.storage.get_all_revlog_entries(revlog_start)?

--- a/rslib/src/stats/graphs.rs
+++ b/rslib/src/stats/graphs.rs
@@ -25,6 +25,7 @@ impl Collection {
         let offset = self.local_utc_offset_for_user()?;
         let local_offset_secs = offset.local_minus_utc() as i64;
 
+
         let cards = self.storage.all_searched_cards()?;
         let revlog = if all {
             self.storage.get_all_revlog_entries(revlog_start)?
@@ -42,6 +43,7 @@ impl Collection {
             next_day_at_secs: timing.next_day_at as u32,
             scheduler_version: self.sched_ver() as u32,
             local_offset_secs: local_offset_secs as i32,
+            first_weekday: self.get_first_weekday() as i32,
         })
     }
 }

--- a/ts/graphs/calendar.ts
+++ b/ts/graphs/calendar.ts
@@ -13,14 +13,21 @@ import { select, mouse } from "d3-selection";
 import { scaleLinear, scaleSequential } from "d3-scale";
 import { showTooltip, hideTooltip } from "./tooltip";
 import { GraphBounds, setDataAvailable, RevlogRange } from "./graph-helpers";
-import { timeDay, timeYear, timeSunday, timeMonday, timeFriday, timeSaturday } from "d3-time";
+import {
+    timeDay,
+    timeYear,
+    timeSunday,
+    timeMonday,
+    timeFriday,
+    timeSaturday,
+} from "d3-time";
 import type { CountableTimeInterval } from "d3-time";
 import type { I18n } from "anki/i18n";
 
 export interface GraphData {
     // indexed by day, where day is relative to today
     reviewCount: Map<number, number>;
-    timeFunction: CountableTimeInterval,
+    timeFunction: CountableTimeInterval;
 }
 
 interface DayDatum {
@@ -47,13 +54,14 @@ export function gatherData(data: pb.BackendProto.GraphsOut): GraphData {
         reviewCount.set(day, count + 1);
     }
 
-    let timeFunction = data.firstWeekday === 1
-        ? timeMonday
-        : data.firstWeekday === 5
-        ? timeFriday
-        : data.firstWeekday === 6
-        ? timeSaturday
-        : timeSunday;
+    const timeFunction =
+        data.firstWeekday === 1
+            ? timeMonday
+            : data.firstWeekday === 5
+            ? timeFriday
+            : data.firstWeekday === 6
+            ? timeSaturday
+            : timeSunday;
 
     return { reviewCount, timeFunction };
 }


### PR DESCRIPTION
Another take on https://github.com/ankitects/anki/pull/800.
After having worked with the backend for a bit, this was now quite easy to do.

Right now, you can only set it after opening the console via, and executing `mw.col.config.set("firstWeekday", n)`, where

    n = 0 is for Sunday
    n = 1 is for Monday
    n = 5 is for Friday
    n = 6 is for Saturday