### PR TITLE
Retouch the reviews graph a little bit

### DIFF
--- a/ts/graphs/reviews.ts
+++ b/ts/graphs/reviews.ts
@@ -253,7 +253,11 @@ export function renderReviews(
                 i18n.tr(i18n.TR.STATISTICS_COUNTS_EARLY_CARDS),
                 valueLabel(totals[4]),
             ],
-            ["grey", i18n.tr(i18n.TR.STATISTICS_RUNNING_TOTAL), valueLabel(cumulative)],
+            [
+                "transparent",
+                i18n.tr(i18n.TR.STATISTICS_RUNNING_TOTAL),
+                valueLabel(cumulative),
+            ],
         ];
         for (const [colour, label, detail] of lines) {
             buf += `<tr>


### PR DESCRIPTION
* Put the card types in a similiar order to the card counts:
  1. Learning
  2. Relearning
  3. Young
  4. Mature
  5. Early

* Adjust the colors of the card counts
  1. Learning cards right now are blue, however this color is typically associated with new cards. I changed it to orange to match the Card counts.
  2. Now that orange is taken up by learning again, I changed the color of Early to purple, to have a new color, because early reviews don't really fit in with the existing card type colors.
* Remove (by turning transparent) the grey box in front of Running total (because there's nothing grey in the graph itself to associate it with)