### PR TITLE
Add labels to calendar days

### DIFF
--- a/ftl/core/statistics.ftl
+++ b/ftl/core/statistics.ftl
@@ -156,6 +156,13 @@ statistics-hours-subtitle = Review success rate for each hour of the day.
 # shown when graph is empty
 statistics-no-data = NO DATA
 statistics-calendar-title = Calendar
+statistics-calendar-label-sunday = S
+statistics-calendar-label-monday = M
+statistics-calendar-label-tuesday = T
+statistics-calendar-label-wednesday = W
+statistics-calendar-label-thursday = T
+statistics-calendar-label-friday = F
+statistics-calendar-label-saturday = S
 
 ## An amount of elapsed time, used in the graphs to show the amount of
 ## time spent studying. For example, English would show "5s" for 5 seconds,

--- a/ftl/core/statistics.ftl
+++ b/ftl/core/statistics.ftl
@@ -156,13 +156,6 @@ statistics-hours-subtitle = Review success rate for each hour of the day.
 # shown when graph is empty
 statistics-no-data = NO DATA
 statistics-calendar-title = Calendar
-statistics-calendar-label-sunday = S
-statistics-calendar-label-monday = M
-statistics-calendar-label-tuesday = T
-statistics-calendar-label-wednesday = W
-statistics-calendar-label-thursday = T
-statistics-calendar-label-friday = F
-statistics-calendar-label-saturday = S
 
 ## An amount of elapsed time, used in the graphs to show the amount of
 ## time spent studying. For example, English would show "5s" for 5 seconds,

--- a/ts/graphs/CalendarGraph.svelte
+++ b/ts/graphs/CalendarGraph.svelte
@@ -74,6 +74,7 @@
     </div>
 
     <svg bind:this={svg} viewBox={`0 0 ${bounds.width} ${bounds.height}`}>
+        <g class="weekdays" />
         <g class="days" />
         <AxisTicks {bounds} />
         <NoDataOverlay {bounds} {i18n} />

--- a/ts/graphs/CalendarGraph.svelte
+++ b/ts/graphs/CalendarGraph.svelte
@@ -25,7 +25,7 @@
     let targetYear = maxYear;
 
     $: if (sourceData) {
-        graphData = gatherData(sourceData);
+        graphData = gatherData(sourceData, i18n);
     }
 
     $: {

--- a/ts/graphs/CalendarGraph.svelte
+++ b/ts/graphs/CalendarGraph.svelte
@@ -25,7 +25,7 @@
     let targetYear = maxYear;
 
     $: if (sourceData) {
-        graphData = gatherData(sourceData, i18n);
+        graphData = gatherData(sourceData);
     }
 
     $: {

--- a/ts/graphs/calendar.ts
+++ b/ts/graphs/calendar.ts
@@ -41,7 +41,7 @@ interface DayDatum {
     date: Date;
 }
 
-export function gatherData(data: pb.BackendProto.GraphsOut, i18n: I18n): GraphData {
+export function gatherData(data: pb.BackendProto.GraphsOut): GraphData {
     const reviewCount = new Map<number, number>();
 
     for (const review of data.revlog as pb.BackendProto.RevlogEntry[]) {
@@ -64,15 +64,7 @@ export function gatherData(data: pb.BackendProto.GraphsOut, i18n: I18n): GraphDa
             ? timeSaturday
             : timeSunday;
 
-    const weekdayLabels = [
-        i18n.tr(i18n.TR.STATISTICS_CALENDAR_LABEL_SUNDAY),
-        i18n.tr(i18n.TR.STATISTICS_CALENDAR_LABEL_MONDAY),
-        i18n.tr(i18n.TR.STATISTICS_CALENDAR_LABEL_TUESDAY),
-        i18n.tr(i18n.TR.STATISTICS_CALENDAR_LABEL_WEDNESDAY),
-        i18n.tr(i18n.TR.STATISTICS_CALENDAR_LABEL_THURSDAY),
-        i18n.tr(i18n.TR.STATISTICS_CALENDAR_LABEL_FRIDAY),
-        i18n.tr(i18n.TR.STATISTICS_CALENDAR_LABEL_SATURDAY),
-    ];
+    const weekdayLabels = ["S", "M", "T", "W", "T", "F", "S"];
 
     for (let i = 0; i < data.firstWeekday; i++) {
         const shifted = weekdayLabels.shift() as string;

--- a/ts/graphs/calendar.ts
+++ b/ts/graphs/calendar.ts
@@ -28,6 +28,7 @@ export interface GraphData {
     // indexed by day, where day is relative to today
     reviewCount: Map<number, number>;
     timeFunction: CountableTimeInterval;
+    weekdayLabels: string[];
 }
 
 interface DayDatum {
@@ -63,7 +64,14 @@ export function gatherData(data: pb.BackendProto.GraphsOut): GraphData {
             ? timeSaturday
             : timeSunday;
 
-    return { reviewCount, timeFunction };
+    const weekdayLabels = ["S", "M", "T", "W", "T", "F", "S"];
+
+    for (let i = 0; i < data.firstWeekday; i++) {
+        const shifted = weekdayLabels.shift() as string;
+        weekdayLabels.push(shifted);
+    }
+
+    return { reviewCount, timeFunction, weekdayLabels };
 }
 
 export function renderCalendar(
@@ -82,7 +90,8 @@ export function renderCalendar(
 
     const x = scaleLinear()
         .range([bounds.marginLeft, bounds.width - bounds.marginRight])
-        .domain([0, 53]);
+        .domain([-1, 53]);
+
     // map of 0-365 -> day
     const dayMap: Map<number, DayDatum> = new Map();
     let maxCount = 0;
@@ -153,20 +162,30 @@ export function renderCalendar(
     }
 
     const height = bounds.height / 10;
-    let emptyColour = "#ddd";
-    if (nightMode) {
-        emptyColour = "#333";
-    }
-    svg.select(`g.days`)
+    const emptyColour = nightMode ? "#333" : "#ddd";
+
+    svg.select("g.weekdays")
+        .selectAll("text")
+        .data(sourceData.weekdayLabels)
+        .join("text")
+        .text((d) => d)
+        .attr("width", x(-1)! - 2)
+        .attr("height", height - 2)
+        .attr("x", x(0)!)
+        .attr("y", (_d, index) => bounds.marginTop + index * height)
+        .attr("dominant-baseline", "hanging")
+        .attr("font-size", "small")
+        .attr("font-family", "monospace")
+        .style("user-select", "none");
+
+    svg.select("g.days")
         .selectAll("rect")
         .data(data)
         .join("rect")
         .attr("fill", emptyColour)
-        .attr("width", (d) => {
-            return x(d.weekNumber + 1)! - x(d.weekNumber)! - 2;
-        })
+        .attr("width", (d) => x(d.weekNumber + 1)! - x(d.weekNumber)! - 2)
         .attr("height", height - 2)
-        .attr("x", (d) => x(d.weekNumber)!)
+        .attr("x", (d) => x(d.weekNumber + 1)!)
         .attr("y", (d) => bounds.marginTop + d.weekDay * height)
         .on("mousemove", function (this: any, d: any) {
             const [x, y] = mouse(document.body);

--- a/ts/graphs/calendar.ts
+++ b/ts/graphs/calendar.ts
@@ -179,9 +179,10 @@ export function renderCalendar(
         .text((d) => d)
         .attr("width", x(-1)! - 2)
         .attr("height", height - 2)
-        .attr("x", x(0)!)
+        .attr("x", x(1)! - 3)
         .attr("y", (_d, index) => bounds.marginTop + index * height)
         .attr("dominant-baseline", "hanging")
+        .attr("text-anchor", "end")
         .attr("font-size", "small")
         .attr("font-family", "monospace")
         .style("user-select", "none");

--- a/ts/graphs/calendar.ts
+++ b/ts/graphs/calendar.ts
@@ -28,7 +28,7 @@ export interface GraphData {
     // indexed by day, where day is relative to today
     reviewCount: Map<number, number>;
     timeFunction: CountableTimeInterval;
-    weekdayLabels: string[];
+    weekdayLabels: number[];
 }
 
 interface DayDatum {
@@ -64,11 +64,9 @@ export function gatherData(data: pb.BackendProto.GraphsOut): GraphData {
             ? timeSaturday
             : timeSunday;
 
-    const weekdayLabels = ["S", "M", "T", "W", "T", "F", "S"];
-
-    for (let i = 0; i < data.firstWeekday; i++) {
-        const shifted = weekdayLabels.shift() as string;
-        weekdayLabels.push(shifted);
+    const weekdayLabels: number[] = [];
+    for (let i = 0; i < 7; i++) {
+        weekdayLabels.push((data.firstWeekday + i) % 7);
     }
 
     return { reviewCount, timeFunction, weekdayLabels };
@@ -168,7 +166,7 @@ export function renderCalendar(
         .selectAll("text")
         .data(sourceData.weekdayLabels)
         .join("text")
-        .text((d) => d)
+        .text((d: number) => i18n.weekdayLabel(d))
         .attr("width", x(-1)! - 2)
         .attr("height", height - 2)
         .attr("x", x(1)! - 3)

--- a/ts/graphs/calendar.ts
+++ b/ts/graphs/calendar.ts
@@ -41,7 +41,7 @@ interface DayDatum {
     date: Date;
 }
 
-export function gatherData(data: pb.BackendProto.GraphsOut): GraphData {
+export function gatherData(data: pb.BackendProto.GraphsOut, i18n: I18n): GraphData {
     const reviewCount = new Map<number, number>();
 
     for (const review of data.revlog as pb.BackendProto.RevlogEntry[]) {
@@ -64,7 +64,15 @@ export function gatherData(data: pb.BackendProto.GraphsOut): GraphData {
             ? timeSaturday
             : timeSunday;
 
-    const weekdayLabels = ["S", "M", "T", "W", "T", "F", "S"];
+    const weekdayLabels = [
+        i18n.tr(i18n.TR.STATISTICS_CALENDAR_LABEL_SUNDAY),
+        i18n.tr(i18n.TR.STATISTICS_CALENDAR_LABEL_MONDAY),
+        i18n.tr(i18n.TR.STATISTICS_CALENDAR_LABEL_TUESDAY),
+        i18n.tr(i18n.TR.STATISTICS_CALENDAR_LABEL_WEDNESDAY),
+        i18n.tr(i18n.TR.STATISTICS_CALENDAR_LABEL_THURSDAY),
+        i18n.tr(i18n.TR.STATISTICS_CALENDAR_LABEL_FRIDAY),
+        i18n.tr(i18n.TR.STATISTICS_CALENDAR_LABEL_SATURDAY),
+    ];
 
     for (let i = 0; i < data.firstWeekday; i++) {
         const shifted = weekdayLabels.shift() as string;

--- a/ts/lib/i18n.ts
+++ b/ts/lib/i18n.ts
@@ -59,6 +59,13 @@ export class I18n {
         }
     }
 
+    weekdayLabel(n: number): string {
+        const firstLang = this.bundles[0].locales[0];
+        return new Date(86_400_000 * (3 + n)).toLocaleDateString(firstLang, {
+            weekday: "narrow",
+        });
+    }
+
     private keyName(msg: pb.FluentProto.FluentString): string {
         return this.TR[msg].toLowerCase().replace(/_/g, "-");
     }


### PR DESCRIPTION
This adds labels on the left of the calendar graph to show the weekday. Right now it shows "S" for Sunday, "M" for Monday, etc.

I added support for localization, and made sure that it supports weekday labels longer than one character, because I know at least a few languages where it is uncommon to have a single character as a day label (e.g. German, or Spanish)

![image](https://user-images.githubusercontent.com/7188844/105235639-2927c580-5b6c-11eb-91f9-7580f9605344.png)

My main motivation here in fact is to have an inconspicuous target for setting the first weekday in https://github.com/ankitects/anki/pull/897.