### PR TITLE
Add manage note types menu item to the sidebar

### DIFF
--- a/qt/aqt/browser.py
+++ b/qt/aqt/browser.py
@@ -1230,6 +1230,7 @@ QTableView {{ gridline-color: {grid} }}
                 ":/icons/notetype.svg",
                 self._note_filter(m.name),
                 item_type=SidebarItemType.NOTETYPE,
+                id=m.id,
             )
             root.addChild(item)
 

--- a/qt/aqt/models.py
+++ b/qt/aqt/models.py
@@ -28,10 +28,17 @@ from aqt.utils import (
 
 
 class Models(QDialog):
-    def __init__(self, mw: AnkiQt, parent=None, fromMain=False):
+    def __init__(
+        self,
+        mw: AnkiQt,
+        parent=None,
+        fromMain=False,
+        selected_notetype_id: Optional[int] = None,
+    ):
         self.mw = mw
         parent = parent or mw
         self.fromMain = fromMain
+        self.selected_notetype_id = selected_notetype_id
         QDialog.__init__(self, parent, Qt.Window)
         self.col = mw.col.weakref()
         assert self.col
@@ -50,6 +57,15 @@ class Models(QDialog):
 
     # Models
     ##########################################################################
+
+    def maybe_select_provided_notetype(self):
+        if not self.selected_notetype_id:
+            self.form.modelsList.setCurrentRow(0)
+            return
+        for i, m in enumerate(self.models):
+            if m.id == self.selected_notetype_id:
+                self.form.modelsList.setCurrentRow(i)
+                break
 
     def setupModels(self) -> None:
         self.model = None
@@ -80,8 +96,7 @@ class Models(QDialog):
 
         def on_done(fut) -> None:
             self.updateModelsList(fut.result())
-            f.modelsList.setCurrentRow(0)
-            gui_hooks.models_dialog_will_show(self)
+            self.maybe_select_provided_notetype()
 
         self.mw.taskman.with_progress(self.col.models.all_use_counts, on_done, self)
         maybeHideClose(box)

--- a/qt/aqt/models.py
+++ b/qt/aqt/models.py
@@ -80,9 +80,10 @@ class Models(QDialog):
 
         def on_done(fut) -> None:
             self.updateModelsList(fut.result())
+            f.modelsList.setCurrentRow(0)
+            gui_hooks.models_dialog_will_show(self)
 
         self.mw.taskman.with_progress(self.col.models.all_use_counts, on_done, self)
-        f.modelsList.setCurrentRow(0)
         maybeHideClose(box)
 
     def onRename(self) -> None:

--- a/qt/aqt/sidebar.py
+++ b/qt/aqt/sidebar.py
@@ -8,7 +8,9 @@ from enum import Enum
 
 import aqt
 from anki.errors import DeckRenameError
+from aqt import gui_hooks
 from aqt.main import ResetReason
+from aqt.models import Models
 from aqt.qt import *
 from aqt.utils import TR, getOnlyText, showInfo, showWarning, tr
 
@@ -84,6 +86,7 @@ class NewSidebarTreeView(SidebarTreeViewBase):
                 (tr(TR.ACTIONS_RENAME), self.rename_filter),
                 (tr(TR.ACTIONS_DELETE), self.remove_filter),
             ),
+            SidebarItemType.NOTETYPE: ((tr(TR.ACTIONS_MANAGE), self.manage_notetype),),
         }
 
     def onContextMenu(self, point: QPoint) -> None:
@@ -192,3 +195,14 @@ class NewSidebarTreeView(SidebarTreeViewBase):
 
     def rename_filter(self, item: "aqt.browser.SidebarItem") -> None:
         self.browser.renameFilter(item.name)
+
+    def manage_notetype(self, item: "aqt.browser.SidebarItem") -> None:
+        def select(dialog: QDialog):
+            for i, m in enumerate(dialog.models):
+                if m.name == item.name:
+                    dialog.form.modelsList.setCurrentRow(i)
+                    break
+
+        gui_hooks.models_dialog_will_show.append(select)
+        Models(self.mw, parent=self.browser, fromMain=True)
+        gui_hooks.models_dialog_will_show.remove(select)

--- a/qt/aqt/sidebar.py
+++ b/qt/aqt/sidebar.py
@@ -8,7 +8,6 @@ from enum import Enum
 
 import aqt
 from anki.errors import DeckRenameError
-from aqt import gui_hooks
 from aqt.main import ResetReason
 from aqt.models import Models
 from aqt.qt import *
@@ -197,12 +196,6 @@ class NewSidebarTreeView(SidebarTreeViewBase):
         self.browser.renameFilter(item.name)
 
     def manage_notetype(self, item: "aqt.browser.SidebarItem") -> None:
-        def select(dialog: QDialog):
-            for i, m in enumerate(dialog.models):
-                if m.name == item.name:
-                    dialog.form.modelsList.setCurrentRow(i)
-                    break
-
-        gui_hooks.models_dialog_will_show.append(select)
-        Models(self.mw, parent=self.browser, fromMain=True)
-        gui_hooks.models_dialog_will_show.remove(select)
+        Models(
+            self.mw, parent=self.browser, fromMain=True, selected_notetype_id=item.id
+        )

--- a/qt/tools/genhooks_gui.py
+++ b/qt/tools/genhooks_gui.py
@@ -743,6 +743,11 @@ gui_hooks.webview_did_inject_style_into_page.append(mytest)
     # Model
     ###################
     Hook(
+        name="models_dialog_will_show",
+        args=["dialog: QDialog"],
+        doc="""Allows changing the models dialog before it is shown.""",
+    ),
+    Hook(
         name="models_advanced_will_show",
         args=["advanced: QDialog"],
     ),

--- a/qt/tools/genhooks_gui.py
+++ b/qt/tools/genhooks_gui.py
@@ -743,11 +743,6 @@ gui_hooks.webview_did_inject_style_into_page.append(mytest)
     # Model
     ###################
     Hook(
-        name="models_dialog_will_show",
-        args=["dialog: QDialog"],
-        doc="""Allows changing the models dialog before it is shown.""",
-    ),
-    Hook(
         name="models_advanced_will_show",
         args=["advanced: QDialog"],
     ),


### PR DESCRIPTION
This adds a "Manage..." menu item for note types in the sidebar as discussed in https://github.com/ankitects/help-wanted/issues/6#issuecomment-764184198

For preselecting the note type, I preferred the general solution of adding a new hook, `models_dialog_will_show`, instead of changing the signature of the Models class. Not sure if there is a simpler solution.

By by the way, what is the reason behind the fromMain parameter of Models's init function that is used for hiding the Fields and Cards buttons when the dialog is opened from the model chooser?
