### PR TITLE
Leave resizing of editor top buttons to CSS

### DIFF
--- a/qt/aqt/data/web/css/editor.scss
+++ b/qt/aqt/data/web/css/editor.scss
@@ -34,12 +34,10 @@ body {
 }
 
 #topbutsOuter {
-    position: fixed;
+    position: sticky;
     top: 0;
-    padding: 2px;
     left: 0;
-    right: 0;
-    z-index: 1;
+    padding: 2px;
 }
 
 .topbut {
@@ -92,10 +90,6 @@ button.highlighted {
     #topbutsright & {
         border-bottom: 3px solid #000;
     }
-}
-
-#fields {
-    margin-top: 35px;
 }
 
 .dupe {

--- a/qt/aqt/data/web/js/editor.ts
+++ b/qt/aqt/data/web/js/editor.ts
@@ -606,17 +606,3 @@ let filterNode = function (node: Node, extendedMode: boolean): void {
         }
     }
 };
-
-document.addEventListener("click", (evt: MouseEvent): void => {
-    const src = evt.target as Element;
-    if (src.tagName === "IMG") {
-        // image clicked; find contenteditable parent
-        let p = src;
-        while ((p = p.parentNode as Element)) {
-            if (p.className === "field") {
-                document.getElementById(p.id).focus();
-                break;
-            }
-        }
-    }
-});

--- a/qt/aqt/data/web/js/editor.ts
+++ b/qt/aqt/data/web/js/editor.ts
@@ -607,12 +607,6 @@ let filterNode = function (node: Node, extendedMode: boolean): void {
     }
 };
 
-let adjustFieldsTopMargin = function (): void {
-    const topHeight = $("#topbuts").height();
-    const margin = topHeight + 8;
-    document.getElementById("fields").style.marginTop = `${margin}px`;
-};
-
 document.addEventListener("click", (evt: MouseEvent): void => {
     const src = evt.target as Element;
     if (src.tagName === "IMG") {
@@ -625,12 +619,4 @@ document.addEventListener("click", (evt: MouseEvent): void => {
             }
         }
     }
-});
-
-window.addEventListener("resize", () => {
-    adjustFieldsTopMargin();
-});
-
-$(function (): void {
-    adjustFieldsTopMargin();
 });

--- a/qt/aqt/editor.py
+++ b/qt/aqt/editor.py
@@ -74,12 +74,14 @@ _html = """
 html { background: %s; }
 #topbutsOuter { background: %s; }
 </style>
-<div id="topbutsOuter">
-    <div id="topbuts" class="clearfix">
-%s
+<div>
+    <div id="topbutsOuter">
+        <div id="topbuts" class="clearfix">
+    %s
+        </div>
     </div>
-</div>
-<div id="fields">
+    <div id="fields">
+    </div>
 </div>
 <div id="dupes" style="display:none;">
     <a href="#" onclick="pycmd('dupes');return false;">


### PR DESCRIPTION
Right now some `adjustFieldsTopMargin`, makes sure that the editor toolbar doesn't overlap with the first fieldname label. This can easier be solved by moving `#fields` and `#topbutsOuter` into a common div, and making `#topbutsOuter` sticky.

The event listener for clicking images was never triggered, because the `.className` property of fields will yield "field clearfix".