### PR TITLE
Small refactor of topbar buttons

### DIFF
--- a/qt/aqt/data/web/css/editor.scss
+++ b/qt/aqt/data/web/css/editor.scss
@@ -33,7 +33,11 @@ body {
     margin: 0;
 }
 
-#topbutsOuter {
+#topbuts {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+
     position: sticky;
     top: 0;
     left: 0;

--- a/qt/aqt/data/web/css/editor.scss
+++ b/qt/aqt/data/web/css/editor.scss
@@ -44,7 +44,7 @@ body {
     padding: 2px;
 }
 
-.topbuts > button {
+.topbuts > * {
     margin: 0 1px;
 
     &:first-child {
@@ -75,6 +75,7 @@ body {
 
 button.linkb {
     -webkit-appearance: none;
+    margin-bottom: -3px;
     border: 0;
     box-shadow: none;
     padding: 0px 2px;
@@ -95,12 +96,12 @@ button:focus {
 }
 
 button.highlighted {
-    .nightMode #topbutsleft & {
-        background: linear-gradient(0deg, #333333 0%, #434343 100%);
-    }
-
     #topbutsleft & {
         background-color: lightgrey;
+
+        .nightMode & {
+            background: linear-gradient(0deg, #333333 0%, #434343 100%);
+        }
     }
 
     #topbutsright & {

--- a/qt/aqt/data/web/css/editor.scss
+++ b/qt/aqt/data/web/css/editor.scss
@@ -33,7 +33,7 @@ body {
     margin: 0;
 }
 
-#topbuts {
+#topbutsOuter {
     display: flex;
     flex-wrap: wrap;
     justify-content: space-between;
@@ -42,6 +42,18 @@ body {
     top: 0;
     left: 0;
     padding: 2px;
+}
+
+.topbuts > button {
+    margin: 0 1px;
+
+    &:first-child {
+        margin-left: 0;
+    }
+
+    &:last-child {
+        margin-right: 0;
+    }
 }
 
 .topbut {

--- a/qt/aqt/editor.py
+++ b/qt/aqt/editor.py
@@ -72,10 +72,10 @@ audio = (
 _html = """
 <style>
 html { background: %s; }
-#topbuts { background: %s; }
+#topbutsOuter { background: %s; }
 </style>
 <div>
-    <div id="topbuts">
+    <div id="topbutsOuter">
         %s
     </div>
     <div id="fields">
@@ -204,10 +204,10 @@ class Editor:
         righttopbtns = runFilter("setupEditorButtons", righttopbtns, self)
 
         topbuts = """
-            <div id="topbutsleft">
+            <div id="topbutsleft" class="topbuts">
                 %(leftbts)s
             </div>
-            <div id="topbutsright">
+            <div id="topbutsright" class="topbuts">
                 %(rightbts)s
             </div>
         """ % dict(
@@ -328,7 +328,7 @@ class Editor:
             class_ = ""
         if not disables:
             class_ += " perm"
-        return """ <button tabindex=-1
+        return """<button tabindex=-1
                         {id}
                         class="{class_}"
                         type="button"

--- a/qt/aqt/editor.py
+++ b/qt/aqt/editor.py
@@ -72,13 +72,11 @@ audio = (
 _html = """
 <style>
 html { background: %s; }
-#topbutsOuter { background: %s; }
+#topbuts { background: %s; }
 </style>
 <div>
-    <div id="topbutsOuter">
-        <div id="topbuts" class="clearfix">
-    %s
-        </div>
+    <div id="topbuts">
+        %s
     </div>
     <div id="fields">
     </div>
@@ -206,10 +204,10 @@ class Editor:
         righttopbtns = runFilter("setupEditorButtons", righttopbtns, self)
 
         topbuts = """
-            <div id="topbutsleft" style="float:left;">
+            <div id="topbutsleft">
                 %(leftbts)s
             </div>
-            <div id="topbutsright" style="float:right;">
+            <div id="topbutsright">
                 %(rightbts)s
             </div>
         """ % dict(


### PR DESCRIPTION
1. `flex-wrap` + `justify-content: space-between` solves the issue of wanting both left-floating and right-floating items. There's a small change in behavior here: once the buttons split up to two rows, the right buttons will also be left aligned. The old behavior could be recreated with `margin-left: auto`, but I think this behavior is somewhat more natural.

2. I changed the spacing individual buttons to be done using margins, instead of spaces between the `button` elements. A much better way to do that would have been `row-gap`, but it is not yet supported in the underlying chromium version, but I still think a more verbose CSS solution is better than the implicit HTML solution.

3. When e.g. the bold button is highlighted, it will shift the topbar ever so slightly. I added a negative margin to avoid this behavior.