### PR TITLE
Render card templates as trees in the sidebar

### DIFF
--- a/qt/aqt/browser.py
+++ b/qt/aqt/browser.py
@@ -1224,14 +1224,25 @@ QTableView {{ gridline-color: {grid} }}
 
     def _modelTree(self, root) -> None:
         assert self.col
-        for m in self.col.models.all_names_and_ids():
+
+        for nt in sorted(self.col.models.all(), key=lambda nt: nt["name"].lower()):
             item = SidebarItem(
-                m.name,
+                nt["name"],
                 ":/icons/notetype.svg",
-                self._note_filter(m.name),
+                self._note_filter(nt["name"]),
                 item_type=SidebarItemType.NOTETYPE,
-                id=m.id,
+                id=nt["id"],
             )
+
+            for c, tmpl in enumerate(nt["tmpls"]):
+                child = SidebarItem(
+                    tmpl["name"],
+                    ":/icons/notetype.svg",
+                    self._template_filter(nt["name"], c),
+                    item_type=SidebarItemType.TEMPLATE,
+                )
+                item.addChild(child)
+
             root.addChild(item)
 
     # Filter tree

--- a/qt/aqt/sidebar.py
+++ b/qt/aqt/sidebar.py
@@ -23,6 +23,7 @@ class SidebarItemType(Enum):
     NOTETYPE = 5
     TAG = 6
     CUSTOM = 7
+    TEMPLATE = 8
 
 
 class SidebarTreeViewBase(QTreeView):


### PR DESCRIPTION
See https://github.com/ankitects/help-wanted/issues/6#issuecomment-765170983

Reusing the note type icon and not caring about saving collapse state for now.


I hacked together an icon with my horrible Inkscape skills. See https://gist.github.com/abdnh/0c9b19e8b78358e1ea87156d13e61174

I can add it If you think this is palatable, or maybe someone can contribute a nicer one.
I think a new icon will be more useful when the search bar gets implemented, as that will make distinguishing note types and templates easier if we will flatten all entries (even though template names are usually predictable enough to make them distinguishable).
