### PR TITLE
Use scaleSqrt for calendar review values

### DIFF
--- a/ts/graphs/calendar.ts
+++ b/ts/graphs/calendar.ts
@@ -10,7 +10,7 @@ import type pb from "anki/backend_proto";
 import { interpolateBlues } from "d3-scale-chromatic";
 import "d3-transition";
 import { select, mouse } from "d3-selection";
-import { scaleLinear, scaleSequential } from "d3-scale";
+import { scaleLinear, scaleSequentialSqrt } from "d3-scale";
 import { showTooltip, hideTooltip } from "./tooltip";
 import { GraphBounds, setDataAvailable, RevlogRange } from "./graph-helpers";
 import {
@@ -143,10 +143,9 @@ export function renderCalendar(
     }
     const data = Array.from(dayMap.values());
     const cappedRange = scaleLinear().range([0.2, nightMode ? 0.8 : 1]);
-    const blues = scaleSequential((n) => interpolateBlues(cappedRange(n)!)).domain([
-        0,
-        maxCount,
-    ]);
+    const blues = scaleSequentialSqrt()
+        .domain([0, maxCount])
+        .interpolator((n) => interpolateBlues(cappedRange(n)!));
 
     function tooltipText(d: DayDatum): string {
         const date = d.date.toLocaleString(i18n.langs, {


### PR DESCRIPTION
Here is before:

<img width="914" alt="Screenshot 2021-01-22 at 22 36 51" src="https://user-images.githubusercontent.com/7188844/105551378-f401ab80-5d02-11eb-9668-0c7a42c3ce55.png">

and here is after:

<img width="985" alt="Screenshot 2021-01-22 at 22 32 14" src="https://user-images.githubusercontent.com/7188844/105551399-f82dc900-5d02-11eb-8e45-18661dfc1d3e.png">

When reviewing, it is more likely to have some outlier days, where you do a lot of reviews, usually catching up after having let loose for a while. At the moment, these days are a bit overrepresented in the calendar graph. In the first picture, you can basically only make out three days as outstanding, and the others kind of blend into each other. You wouldn't think that some of those have 20 reviews, whereas others have 200, because they have the same color.

Using `scaleSqrt` devalues these higher outlier days, which I think makes sense for the graph.