### PR TITLE
Fix RangeBox RevlogRange defaulting to All instead of Year

### DIFF
--- a/ts/graphs/GraphsPage.svelte
+++ b/ts/graphs/GraphsPage.svelte
@@ -6,7 +6,7 @@
     import type { I18n } from "anki/i18n";
     import type { PreferenceStore } from "./preferences";
     import type pb from "anki/backend_proto";
-    import { getGraphData, RevlogRange } from "./graph-helpers";
+    import { getGraphData, RevlogRange, daysToRevlogRange } from "./graph-helpers";
     import { getPreferences } from "./preferences";
 
     export let i18n: I18n;
@@ -31,7 +31,7 @@
                 getGraphData(search, days),
                 preferencesPromise,
             ]);
-            revlogRange = days > 365 || days === 0 ? RevlogRange.All : RevlogRange.Year;
+            revlogRange = daysToRevlogRange(days);
         } catch (e) {
             sourceData = null;
             alert(i18n.tr(i18n.TR.STATISTICS_ERROR_FETCHING));

--- a/ts/graphs/RangeBox.svelte
+++ b/ts/graphs/RangeBox.svelte
@@ -2,7 +2,7 @@
     import { createEventDispatcher } from "svelte";
 
     import type { I18n } from "anki/i18n";
-    import { RevlogRange } from "./graph-helpers";
+    import { RevlogRange, daysToRevlogRange } from "./graph-helpers";
 
     enum SearchRange {
         Deck = 1,
@@ -18,9 +18,7 @@
 
     const dispatch = createEventDispatcher();
 
-    let revlogRange: RevlogRange =
-        days > 365 || days === 0 ? RevlogRange.Year : RevlogRange.All;
-
+    let revlogRange = daysToRevlogRange(days);
     let searchRange: SearchRange =
         search === "deck:current"
             ? SearchRange.Deck

--- a/ts/graphs/graph-helpers.ts
+++ b/ts/graphs/graph-helpers.ts
@@ -41,6 +41,10 @@ export enum RevlogRange {
     All = 2,
 }
 
+export function daysToRevlogRange(days: number): RevlogRange {
+    return days > 365 || days === 0 ? RevlogRange.All : RevlogRange.Year;
+}
+
 // period a graph should cover
 export enum GraphRange {
     Month = 0,


### PR DESCRIPTION
That addresses what you mentioned in #934.
It was just a flipped ternary, but I moved it into a helper function avoid the duplicated logic.