### PR TITLE
Correct browse help link

### DIFF
--- a/qt/aqt/browser.py
+++ b/qt/aqt/browser.py
@@ -1305,7 +1305,7 @@ where id in %s"""
             current=current,
             accept=tr(TR.BROWSING_MOVE_CARDS),
             title=tr(TR.BROWSING_CHANGE_DECK),
-            help="browse",
+            help="browsing",
             parent=self,
         )
         if not ret.name:


### PR DESCRIPTION
I found other broken link in 2.1.38 but it seems they were repaired since. I went over all call to openHelp, recursively, and did not find other broken link.

In my opinion, one thing that could help avoid loosing time to find all help link could be to replace `help: str` to `help: HelpSuffix`, a new class which would just encapsulate a string but and would allow to find and test all links easily if needed. As often, I'm available to implement the suggestion I give