### PR TITLE
Add comment explaining why sfld column has type integer

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -73,6 +73,8 @@ rye761 <ryebread761@gmail.com>
 Guillem Palau Salvà <guillempalausalva@gmail.com>
 Meredith Derecho <meredithderecho@gmail.com>
 Daniel Wallgren <github.com/wallgrenen>
+Kerrick Staley <kerrick@kerrickstaley.com>
+
 ********************
 
 The text of the 3 clause BSD license follows:

--- a/rslib/src/storage/schema11.sql
+++ b/rslib/src/storage/schema11.sql
@@ -21,6 +21,8 @@ CREATE TABLE notes (
   usn integer NOT NULL,
   tags text NOT NULL,
   flds text NOT NULL,
+  -- The use of type integer for sfld is deliberate, because it means that integer values in this
+  -- field will sort numerically.
   sfld integer NOT NULL,
   csum integer NOT NULL,
   flags integer NOT NULL,


### PR DESCRIPTION
The `notes.sfld` column in the `collection.anki2` database has type `integer`, even though it contains text. This is [something SQLite allows](https://dba.stackexchange.com/questions/106364/text-string-stored-in-sqlite-integer-column) and was done to allow integer values to sort numerically. Add a comment explaining this.