### PR TITLE
Normalize dyndeck search and handle exception

### DIFF
--- a/qt/aqt/browser.py
+++ b/qt/aqt/browser.py
@@ -10,8 +10,6 @@ from dataclasses import dataclass
 from operator import itemgetter
 from typing import List, Sequence, Tuple, cast
 
-from markdown import markdown
-
 import aqt
 import aqt.forms
 from anki.cards import Card
@@ -64,6 +62,7 @@ from aqt.utils import (
     saveSplitter,
     saveState,
     shortcut,
+    show_invalid_search_error,
     showInfo,
     showWarning,
     tooltip,
@@ -89,14 +88,6 @@ class SearchContext:
     order: Union[bool, str] = True
     # if set, provided card ids will be used instead of the regular search
     card_ids: Optional[Sequence[int]] = None
-
-
-def show_invalid_search_error(err: Exception):
-    "Render search errors in markdown, then display a warning."
-    text = str(err)
-    if isinstance(err, InvalidInput):
-        text = markdown(text)
-    showWarning(text)
 
 
 # Data model

--- a/qt/aqt/utils.py
+++ b/qt/aqt/utils.py
@@ -9,9 +9,11 @@ import subprocess
 import sys
 from typing import TYPE_CHECKING, Any, List, Optional, Union, cast
 
+from markdown import markdown
+
 import anki
 import aqt
-from anki.rsbackend import TR  # pylint: disable=unused-import
+from anki.rsbackend import TR, InvalidInput  # pylint: disable=unused-import
 from anki.utils import invalidFilename, isMac, isWin, noBundledLibs, versionWithBuild
 from aqt.qt import *
 from aqt.theme import theme_manager
@@ -65,6 +67,14 @@ def showWarning(text, parent=None, help="", title="Anki", textFormat=None):
 def showCritical(text, parent=None, help="", title="Anki", textFormat=None):
     "Show a small critical error with an OK button."
     return showInfo(text, parent, help, "critical", title=title, textFormat=textFormat)
+
+
+def show_invalid_search_error(err: Exception):
+    "Render search errors in markdown, then display a warning."
+    text = str(err)
+    if isinstance(err, InvalidInput):
+        text = markdown(text)
+    showWarning(text)
 
 
 def showInfo(


### PR DESCRIPTION
I was aware that the filtered deck search needed some attention to profit from the newer search features, but I only just learned from the forum that search exceptions aren't handled at all here currently.
That's why I wanted to push this out quickly, even though I might soon make another PR to switch the code to the new backend functions.