### PR TITLE
No clicking on empty bins in the Histogram

### DIFF
--- a/ts/graphs/histogram-graph.ts
+++ b/ts/graphs/histogram-graph.ts
@@ -162,6 +162,9 @@ export function histogramGraph(
         .on("mouseout", hideTooltip);
 
     if (data.onClick) {
-        hoverzone.attr("class", "clickable").on("click", data.onClick);
+        hoverzone
+            .filter((d: Bin<number, number>) => d.length > 0)
+            .attr("class", "clickable")
+            .on("click", data.onClick);
     }
 }


### PR DESCRIPTION
This prevents triggering searches from empty bins in the several histograms. I already had this for the Calendar, but I think it also makes sense for the histogram.