### PR TITLE
Add search bar to the sidebar

### DIFF
--- a/qt/aqt/browser.py
+++ b/qt/aqt/browser.py
@@ -35,7 +35,7 @@ from aqt.main import ResetReason
 from aqt.previewer import BrowserPreviewer as PreviewDialog
 from aqt.previewer import Previewer
 from aqt.qt import *
-from aqt.sidebar import SidebarTreeView
+from aqt.sidebar import SidebarSearchBar, SidebarTreeView
 from aqt.theme import theme_manager
 from aqt.utils import (
     TR,
@@ -912,6 +912,17 @@ QTableView {{ gridline-color: {grid} }}
         self.sidebar = SidebarTreeView(self)
         self.sidebarTree = self.sidebar  # legacy alias
         dw.setWidget(self.sidebar)
+        self.sidebar.searchBar = searchBar = SidebarSearchBar(self.sidebar)
+        qconnect(
+            QShortcut(QKeySequence("Ctrl+Shift+B"), self).activated,
+            self.focusSidebarSearchBar,
+        )
+        l = QVBoxLayout()
+        l.addWidget(searchBar)
+        l.addWidget(self.sidebar)
+        w = QWidget()
+        w.setLayout(l)
+        dw.setWidget(w)
         self.sidebarDockWidget.setFloating(False)
 
         self.sidebarDockWidget.setTitleBarWidget(QWidget())
@@ -921,11 +932,18 @@ QTableView {{ gridline-color: {grid} }}
         # UI is more responsive
         self.mw.progress.timer(10, self.sidebar.refresh, False)
 
-    def focusSidebar(self) -> None:
+    def showSidebar(self) -> None:
         # workaround for PyQt focus bug
         self.editor.hideCompleters()
         self.sidebarDockWidget.setVisible(True)
+
+    def focusSidebar(self) -> None:
+        self.showSidebar()
         self.sidebar.setFocus()
+
+    def focusSidebarSearchBar(self) -> None:
+        self.showSidebar()
+        self.sidebar.searchBar.setFocus()
 
     # legacy
     def maybeRefreshSidebar(self) -> None:

--- a/qt/aqt/sidebar.py
+++ b/qt/aqt/sidebar.py
@@ -185,16 +185,24 @@ class SidebarSearchBar(QLineEdit):
     def __init__(self, sidebar: SidebarTreeView):
         QLineEdit.__init__(self, sidebar)
         self.sidebar = sidebar
+        self.timer = QTimer(self)
+        self.timer.setInterval(600)
+        self.timer.setSingleShot(True)
+        qconnect(self.timer.timeout, self.onSearch)
         qconnect(self.textChanged, self.onTextChanged)
 
     def onTextChanged(self, text: str):
-        self.sidebar.search_for(text)
+        if not self.timer.isActive():
+            self.timer.start()
+
+    def onSearch(self):
+        self.sidebar.search_for(self.text())
 
     def keyPressEvent(self, evt):
         if evt.key() in (Qt.Key_Up, Qt.Key_Down):
             self.sidebar.setFocus()
         elif evt.key() in (Qt.Key_Enter, Qt.Key_Return):
-            self.onTextChanged(self.text())
+            self.onSearch()
         else:
             QLineEdit.keyPressEvent(self, evt)
 

--- a/qt/aqt/sidebar.py
+++ b/qt/aqt/sidebar.py
@@ -140,7 +140,7 @@ class SidebarModel(QAbstractItemModel):
         if not index.isValid():
             return QVariant()
 
-        if role not in (Qt.DisplayRole, Qt.DecorationRole, Qt.ToolTipRole):
+        if role not in (Qt.DisplayRole, Qt.DecorationRole, Qt.ToolTipRole, Qt.EditRole):
             return QVariant()
 
         item: SidebarItem = index.internalPointer()
@@ -149,6 +149,8 @@ class SidebarModel(QAbstractItemModel):
             return QVariant(item.name)
         elif role == Qt.ToolTipRole:
             return QVariant(item.tooltip)
+        elif role == Qt.EditRole:
+            return QVariant(item.full_name)
         else:
             return QVariant(theme_manager.icon_from_resources(item.icon))
 
@@ -264,6 +266,7 @@ class SidebarTreeView(QTreeView):
             filter_model.setSourceModel(self.model())
             filter_model.setFilterCaseSensitivity(False)  # type: ignore
             filter_model.setRecursiveFilteringEnabled(True)
+            filter_model.setFilterRole(Qt.EditRole)
             self.setModel(filter_model)
         else:
             filter_model = self.model()
@@ -282,7 +285,7 @@ class SidebarTreeView(QTreeView):
             return super().drawRow(painter, options, idx)
         if not (item := self.model().item_for_index(idx)):
             return super().drawRow(painter, options, idx)
-        if self.current_search.lower() in item.name.lower():
+        if self.current_search.lower() in item.full_name.lower():
             brush = QBrush(QColor("lightyellow"))
             painter.save()
             painter.fillRect(options.rect, brush)

--- a/qt/aqt/sidebar.py
+++ b/qt/aqt/sidebar.py
@@ -259,14 +259,17 @@ class SidebarTreeView(QTreeView):
             # from PyQt5.QtTest import QAbstractItemModelTester
             # tester = QAbstractItemModelTester(model)
 
-            self.current_search = None
             self.setModel(model)
-            expand_where_necessary(model, self)
+            if self.current_search:
+                self.search_for(self.current_search)
+            else:
+                expand_where_necessary(model, self)
 
         self.mw.taskman.run_in_background(self._root_tree, on_done)
 
     def search_for(self, text: str):
         if not text.strip():
+            self.current_search = None
             self.refresh()
             return
         if not isinstance(self.model(), FilterModel):
@@ -528,7 +531,7 @@ class SidebarTreeView(QTreeView):
             self.mw.col.decks.rename(deck, new_name)
         except DeckRenameError as e:
             return showWarning(e.description)
-        self.browser.maybeRefreshSidebar()
+        self.refresh()
         self.mw.deckBrowser.refresh()
 
     def remove_tag(self, item: "aqt.browser.SidebarItem") -> None:
@@ -545,7 +548,7 @@ class SidebarTreeView(QTreeView):
             self.mw.requireReset(reason=ResetReason.BrowserRemoveTags, context=self)
             self.browser.model.endReset()
             fut.result()
-            self.browser.maybeRefreshSidebar()
+            self.refresh()
 
         self.mw.checkpoint(tr(TR.ACTIONS_REMOVE_TAG))
         self.browser.model.beginReset()
@@ -573,7 +576,7 @@ class SidebarTreeView(QTreeView):
                 showInfo(tr(TR.BROWSING_TAG_RENAME_WARNING_EMPTY))
                 return
 
-            self.browser.maybeRefreshSidebar()
+            self.refresh()
 
         self.mw.checkpoint(tr(TR.ACTIONS_RENAME_TAG))
         self.browser.model.beginReset()
@@ -593,7 +596,7 @@ class SidebarTreeView(QTreeView):
                 self.mw.requireReset(reason=ResetReason.BrowserDeleteDeck, context=self)
                 self.browser.search()
                 self.browser.model.endReset()
-                self.browser.maybeRefreshSidebar()
+                self.refresh()
                 res = fut.result()  # Required to check for errors
 
             self.mw.checkpoint(tr(TR.DECKS_DELETE_DECK))

--- a/qt/aqt/sidebar.py
+++ b/qt/aqt/sidebar.py
@@ -123,9 +123,8 @@ class SidebarModel(QAbstractItemModel):
         if parentItem is None or parentItem == self.root:
             return QModelIndex()
 
-        row = parentItem.rowForChild(childItem)
-        if row is None:
-            return QModelIndex()
+        grandparent = parentItem.parentItem or self.root
+        row = grandparent.rowForChild(parentItem)
 
         return self.createIndex(row, 0, parentItem)
 
@@ -269,6 +268,10 @@ class SidebarTreeView(QTreeView):
             model = SidebarModel(root)
             self.flattened_model = model.flattened()
             self.setModel(model)
+
+            #from PyQt5.QtTest import QAbstractItemModelTester
+            #tester = QAbstractItemModelTester(model)
+
             model.expandWhereNeccessary(self)
 
         self.mw.taskman.run_in_background(self._root_tree, on_done)


### PR DESCRIPTION
See https://github.com/ankitects/help-wanted/issues/6

My first idea was to use [QCompleter](https://doc.qt.io/qt-5/qcompleter.html) by setting the sidebar as its pop-up, but it seems the stored SidebarItem objects get lost this way (internalPointer returns None). So I just wrote the matching code manually.

The tree is flattened and the full names of the items are shown for clarity.

I also added the shortcut <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>B</kbd> to focus the search bar.

![image](https://user-images.githubusercontent.com/41397710/105918021-55e44d00-6044-11eb-9d32-52e7bc97ff87.png)
![image](https://user-images.githubusercontent.com/41397710/105917135-06e9e800-6043-11eb-9c43-7526da716bd7.png)
![image](https://user-images.githubusercontent.com/41397710/105917167-0d785f80-6043-11eb-9eee-d7a669e22139.png)
