### PR TITLE
Deal with inline content vs block content and <br> in editor.ts

### DIFF
--- a/qt/aqt/data/web/css/editor.scss
+++ b/qt/aqt/data/web/css/editor.scss
@@ -1,6 +1,12 @@
 /* Copyright: Ankitects Pty Ltd and contributors
  * License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html */
 
+#fields {
+    display: flex;
+    flex-direction: column;
+    margin: 5px;
+}
+
 .field {
     border: 1px solid var(--border);
     background: var(--frame-bg);

--- a/qt/aqt/data/web/css/editor.scss
+++ b/qt/aqt/data/web/css/editor.scss
@@ -5,6 +5,18 @@
     display: flex;
     flex-direction: column;
     margin: 5px;
+
+    & > * {
+        margin: 1px 0;
+
+        &:first-child {
+            margin-top: 0;
+        }
+
+        &:last-child {
+            margin-bottom: 0;
+        }
+    }
 }
 
 .field {

--- a/qt/aqt/data/web/css/editor.scss
+++ b/qt/aqt/data/web/css/editor.scss
@@ -14,12 +14,6 @@
     }
 }
 
-.clearfix::after {
-    content: "";
-    display: table;
-    clear: both;
-}
-
 .fname {
     vertical-align: middle;
     padding: 0;

--- a/qt/aqt/data/web/js/editor.ts
+++ b/qt/aqt/data/web/js/editor.ts
@@ -109,6 +109,10 @@ function nodeIsElement(node: Node): node is Element {
     return node.nodeType === Node.ELEMENT_NODE;
 }
 
+function nodeIsText(node: Node): node is Text {
+    return node.nodeType === Node.TEXT_NODE;
+}
+
 function inListItem(): boolean {
     const anchor = window.getSelection().anchorNode;
 
@@ -273,16 +277,30 @@ function onBlur(): void {
     }
 }
 
+function stripTrailingLinebreakIfInlineElements(field: HTMLDivElement) {
+    if (
+        nodeIsElement(field.lastChild) &&
+        field.lastChild.tagName === "BR" && (
+            nodeIsText(field.lastChild.previousSibling) ||
+            window.getComputedStyle(field.lastChild.previousSibling as Element).getPropertyValue("display").startsWith("inline")
+        )
+    ) {
+        console.log('trimmd!', field.lastChild, field.lastChild.previousSibling)
+        return field.innerHTML.slice(0, -4);
+    }
+
+    return field.innerHTML;
+}
+
 function saveField(type: "blur" | "key"): void {
     clearChangeTimer();
     if (!currentField) {
         // no field has been focused yet
         return;
     }
-    // type is either 'blur' or 'key'
-    pycmd(
-        `${type}:${currentFieldOrdinal()}:${currentNoteId}:${currentField.innerHTML}`
-    );
+
+    const fieldText = stripTrailingLinebreakIfInlineElements(currentField);
+    pycmd(`${type}:${currentFieldOrdinal()}:${currentNoteId}:${fieldText}`);
 }
 
 function currentFieldOrdinal(): string {

--- a/qt/aqt/data/web/js/editor.ts
+++ b/qt/aqt/data/web/js/editor.ts
@@ -176,19 +176,14 @@ const INLINE_TAGS = [
 ];
 
 function nodeIsInline(node: Node): boolean {
-    return (
-        nodeIsText(node) ||
-        INLINE_TAGS.includes((node as Element).tagName)
-    );
+    return !nodeIsElement(node) || INLINE_TAGS.includes(node.tagName);
 }
 
 function inListItem(): boolean {
     const anchor = window.getSelection().anchorNode;
 
-    let n = nodeIsElement(anchor) ? anchor : anchor.parentElement;
-
     let inList = false;
-
+    let n = nodeIsElement(anchor) ? anchor : anchor.parentElement;
     while (n) {
         inList = inList || window.getComputedStyle(n).display == "list-item";
         n = n.parentElement;

--- a/qt/aqt/data/web/js/editor.ts
+++ b/qt/aqt/data/web/js/editor.ts
@@ -105,16 +105,8 @@ function onKeyUp(evt: KeyboardEvent): void {
     }
 }
 
-function nodeIsBRElement(node: Node): node is HTMLBRElement {
-    return nodeIsElement(node) && node.tagName === "BR";
-}
-
 function nodeIsElement(node: Node): node is Element {
     return node.nodeType === Node.ELEMENT_NODE;
-}
-
-function nodeIsText(node: Node): node is Text {
-    return node.nodeType === Node.TEXT_NODE;
 }
 
 const INLINE_TAGS = [

--- a/qt/aqt/data/web/js/editor.ts
+++ b/qt/aqt/data/web/js/editor.ts
@@ -117,14 +117,68 @@ function nodeIsText(node: Node): node is Text {
     return node.nodeType === Node.TEXT_NODE;
 }
 
+const INLINE_TAGS = [
+    "A",
+    "ABBR",
+    "ACRONYM",
+    "AUDIO",
+    "B",
+    "BDI",
+    "BDO",
+    "BIG",
+    "BR",
+    "BUTTON",
+    "CANVAS",
+    "CITE",
+    "CODE",
+    "DATA",
+    "DATALIST",
+    "DEL",
+    "DFN",
+    "EM",
+    "EMBED",
+    "I",
+    "IFRAME",
+    "IMG",
+    "INPUT",
+    "INS",
+    "KBD",
+    "LABEL",
+    "MAP",
+    "MARK",
+    "METER",
+    "NOSCRIPT",
+    "OBJECT",
+    "OUTPUT",
+    "PICTURE",
+    "PROGRESS",
+    "Q",
+    "RUBY",
+    "S",
+    "SAMP",
+    "SCRIPT",
+    "SELECT",
+    "SLOT",
+    "SMALL",
+    "SPAN",
+    "STRONG",
+    "SUB",
+    "SUP",
+    "SVG",
+    "TEMPLATE",
+    "TEXTAREA",
+    "TIME",
+    "U",
+    "TT",
+    "VAR",
+    "VIDEO",
+    "WBR",
+];
+
 function nodeIsInline(node: Node): boolean {
     return (
         nodeIsText(node) ||
-        nodeIsBRElement(node) ||
-        window
-            .getComputedStyle(node as Element)
-            .getPropertyValue("display")
-            .startsWith("inline")
+        INLINE_TAGS.includes((node as Element).tagName)
     );
 }
 

--- a/qt/aqt/data/web/js/editor.ts
+++ b/qt/aqt/data/web/js/editor.ts
@@ -334,7 +334,7 @@ function onBlur(): void {
     }
 }
 
-function fieldIsInInlineMode(field: HTMLDivElement): boolean {
+function fieldContainsInlineContent(field: HTMLDivElement): boolean {
     if (field.childNodes.length === 0) {
         // for now, for all practical purposes, empty fields are in block mode
         return false;
@@ -357,7 +357,8 @@ function saveField(type: "blur" | "key"): void {
     }
 
     const fieldText =
-        fieldIsInInlineMode(currentField) && currentField.innerHTML.endsWith("<br>")
+        fieldContainsInlineContent(currentField) &&
+        currentField.innerHTML.endsWith("<br>")
             ? // trim trailing <br>
               currentField.innerHTML.slice(0, -4)
             : currentField.innerHTML;
@@ -466,7 +467,7 @@ function createField(
     field.addEventListener("oncut", onCutOrCopy);
     field.innerHTML = content;
 
-    if (fieldIsInInlineMode(field)) {
+    if (fieldContainsInlineContent(field)) {
         field.appendChild(document.createElement("br"));
     }
 

--- a/qt/aqt/data/web/js/editor.ts
+++ b/qt/aqt/data/web/js/editor.ts
@@ -118,7 +118,14 @@ function nodeIsText(node: Node): node is Text {
 }
 
 function nodeIsInline(node: Node): boolean {
-    return nodeIsText(node) || nodeIsBRElement(node) || window.getComputedStyle(node as Element).getPropertyValue("display").startsWith("inline");
+    return (
+        nodeIsText(node) ||
+        nodeIsBRElement(node) ||
+        window
+            .getComputedStyle(node as Element)
+            .getPropertyValue("display")
+            .startsWith("inline")
+    );
 }
 
 function inListItem(): boolean {
@@ -308,10 +315,11 @@ function saveField(type: "blur" | "key"): void {
         return;
     }
 
-    const fieldText = fieldIsInInlineMode(currentField) && currentField.innerHTML.endsWith("<br>")
-        // trim trailing <br>
-        ? currentField.innerHTML.slice(0, -4)
-        : currentField.innerHTML
+    const fieldText =
+        fieldIsInInlineMode(currentField) && currentField.innerHTML.endsWith("<br>")
+            ? // trim trailing <br>
+              currentField.innerHTML.slice(0, -4)
+            : currentField.innerHTML;
 
     pycmd(`${type}:${currentFieldOrdinal()}:${currentNoteId}:${fieldText}`);
 }
@@ -387,7 +395,12 @@ function onCutOrCopy(): boolean {
     return true;
 }
 
-function createField(index: number, label: string, color: string, content: string): [HTMLDivElement, HTMLDivElement] {
+function createField(
+    index: number,
+    label: string,
+    color: string,
+    content: string
+): [HTMLDivElement, HTMLDivElement] {
     const name = document.createElement("div");
     name.id = `name${index}`;
     name.className = "fname";
@@ -426,11 +439,11 @@ function setFields(fields: [string, string][]): void {
         .getComputedStyle(document.documentElement)
         .getPropertyValue("--text-fg");
 
-    const elements = fields.flatMap(
-        ([name, fieldcontent], index: number) => createField(index, name, color, fieldcontent)
-    )
+    const elements = fields.flatMap(([name, fieldcontent], index: number) =>
+        createField(index, name, color, fieldcontent)
+    );
 
-    const fieldsContainer = document.getElementById("fields")
+    const fieldsContainer = document.getElementById("fields");
     // can be replaced with ParentNode.replaceChildren in Chrome 86+
     while (fieldsContainer.firstChild) {
         fieldsContainer.removeChild(fieldsContainer.firstChild);

--- a/qt/aqt/data/web/js/tsconfig.json
+++ b/qt/aqt/data/web/js/tsconfig.json
@@ -2,7 +2,7 @@
     "compilerOptions": {
         "target": "es6",
         "module": "commonjs",
-        "lib": ["es6", "dom", "dom.iterable"],
+        "lib": ["es2019", "dom", "dom.iterable"],
         "strict": true,
         "noImplicitAny": false,
         "strictNullChecks": false,


### PR DESCRIPTION
I tried out the 2.1.39Beta1 released, and unfortunately noticed a bug in the editor, with the behavior of `<br>`. That occurs, when you have an empty field, you add some content `Content`, now using "Ctrl-Shift-X" will show `Content`. If you create a newline and remove it again, and use "Ctrl-Shift-X" again, you will see that it now reads `Content<br>`. The only way to get rid of this `<br>` will be now to remove it in the HTML editor.

This to some degree already existed in previous versions, in a different form: The field would read `Content`, but clicking "Ctrl-Shift-X" would reveal `<div>Content</div>`, causing the same problem.

I had to think a bit about how to solve this once and for all, and also what it even means to solve it. I came to the following conclusion: Sometimes fields have a role in the template, which is more akin to inline elements, whereas sometimes you want them to fulfil a role more akin to block elements.

For example, in the picture below, the fields "left" and "left_back" are more inline in nature, whereas "bottom_back" is more like a block element.

![Screenshot 2021-01-26 at 23 13 50](https://user-images.githubusercontent.com/7188844/105918728-b7042480-6034-11eb-90e9-d2226ee8a70d.png)

The user doesn't have to make a conscious decision here, but he will make it unconsciously by what he fills into the field. If he puts in a block element like a list, it can only be used as a block. If he only puts in text, or inline elements like `span`, or `i`/`a`/`u` it can be used as both inline, or as a block.

The contenteditable element treats its content more like it's a block by default, and especially in our case because the editor fields are `div`s. To make it suitable to being an inline element, we have to modify it, and this modification is stripping away *one* trailing `<br>` if there is one. For example, if the user text field shows:

```
This is the first line of content
<empty line>
```

What we would expect from it is `This is the first line of content<br>`, however what's actually in the div is `This is the first line of content<br><br>`. In the template, this will not generate what the user expects, as he might use it in an inline fashion, and expects it to have one trailing newline. So we have to modify it, before we send it to Python via `pycmd("key/blur:...")`.

However in block scenarios, we don't want to strip them away. E.g. `<ul><li>Item 1</li><li>Item2</li></ul><br><br>` renders two full newlines after the unordered list. Stripping away one `<br>` would change the content. However in this case we can detect that `ul` is a block element, and leave it intact.

The list of inline elements is taken [from here](https://developer.mozilla.org/en-US/docs/Web/HTML/Inline_elements).

This also contains some other changes like:
1. Don't use table for editor fields anymore, but use a flatter layout.
2. Don't create fields as one big chunk of HTML, but prefer `createElement`. This avoids losing type safety.
3. Avoid using jQuery in some cases.
4. Instead of tables and clearfix, use flex (just like topbars). Here we also have the caveat of not being able to use the `gap` property again, so we resort to margins.