### PR TITLE
Sample deck

### DIFF
--- a/ftl/core/sample-deck.ftl
+++ b/ftl/core/sample-deck.ftl
@@ -1,0 +1,28 @@
+### Text used in the sample deck.
+
+shall-create-sample-deck = Welcome to Anki, a flashcard program that uses spaced repetition to let you study in the most efficient way! Do you want Anki to create a sample deck with some introductory information?
+created-sample-deck = The sample deck has been created. Click its name “Anki Basics” to begin learning about Anki.
+could-not-create-sample-deck = A deck of the name “Anki Basics” already exists. You must delete or rename it before you can create the Anki sample deck.
+# Must be a valid deck name.
+sample-deck-name = Anki Basics
+sample-notetype-name = Anki Basics
+sample-template-name = Card 1
+sample-field-question = Question
+sample-field-answer = Answer
+sample-field-details = Details
+sample-field-manual = Manual section
+
+## Flashcard text for the sample deck.
+
+sample-question-card = What is a <b>card</b> in Anki?
+sample-answer-card = A question and answer pair.
+sample-details-card = Just like a paper flashcard with a question on one side and the answer on the back. You're looking straight at one!
+sample-question-deck = What is a <b>deck</b> in Anki?
+sample-answer-deck = A group of cards sharing certain settings and usually studied together.
+sample-details-deck = For example right now, you're studying the “Anki Basics” deck. Decks can also contain other decks.
+sample-question-note = What is a <b>note</b> in Anki?
+sample-answer-note = A collection of related pieces of information from which Anki creates your flashcards.
+sample-details-note = With paper flashcards, you would write each card individually, even if some of them share certain content. In Anki, you only have to enter information once. You can then tell Anki how many and what kind of cards you want to be created from it.
+sample-question-field = What is a <b>field</b> in Anki?
+sample-answer-field = A piece of information belonging to a note.
+sample-details-field = For example, the note from which this card was created has four fields: a question, an answer, some additional information and a link to the manual.

--- a/ftl/qt/qt-misc.ftl
+++ b/ftl/qt/qt-misc.ftl
@@ -14,6 +14,7 @@ qt-misc-closing = Closing...
 qt-misc-configure-interface-language-and-options = Configure interface language and options
 qt-misc-copy-to-clipboard = Copy to Clipboard
 qt-misc-create-filtered-deck = Create Filtered Deck...
+qt-misc-create-sample-deck = Create Anki Basics Deck
 qt-misc-debug-console = Debug Console
 qt-misc-deck-will-be-imported-when-a = Deck will be imported when a profile is opened.
 qt-misc-default = Default

--- a/qt/aqt/forms/main.ui
+++ b/qt/aqt/forms/main.ui
@@ -46,7 +46,7 @@
      <x>0</x>
      <y>0</y>
      <width>667</width>
-     <height>22</height>
+     <height>21</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuHelp">
@@ -81,6 +81,7 @@
     </property>
     <addaction name="actionStudyDeck"/>
     <addaction name="actionCreateFiltered"/>
+    <addaction name="actionCreateSampleDeck"/>
     <addaction name="separator"/>
     <addaction name="actionFullDatabaseCheck"/>
     <addaction name="actionCheckMediaDatabase"/>
@@ -235,6 +236,11 @@
    </property>
    <property name="shortcut">
     <string notr="true">Ctrl+Shift+A</string>
+   </property>
+  </action>
+  <action name="actionCreateSampleDeck">
+   <property name="text">
+    <string>QT_MISC_CREATE_SAMPLE_DECK</string>
    </property>
   </action>
  </widget>

--- a/qt/aqt/main.py
+++ b/qt/aqt/main.py
@@ -398,6 +398,13 @@ class AnkiQt(QMainWindow):
         self.activateWindow()
         self.raise_()
 
+        if "showWelcome" not in self.pm.profile or self.pm.profile["showWelcome"]:
+            if askUser(tr(TR.SHALL_CREATE_SAMPLE_DECK)):
+                self.pm.profile["showWelcome"] = True
+                self.onCreateSampleDeck()
+            else:
+                self.pm.profile["showWelcome"] = False
+
         # import pending?
         if self.pendingImport:
             if self._isAddon(self.pendingImport):
@@ -1091,6 +1098,16 @@ title="%s" %s>%s</button>""" % (
 
     def onDocumentation(self):
         openHelp("")
+
+    def onCreateSampleDeck(self):
+        try:
+            self.col.backend.create_sample_deck()
+        except Exception:
+            showInfo(tr(TR.COULD_NOT_CREATE_SAMPLE_DECK))
+        else:
+            self.reset()
+            showInfo(tr(TR.CREATED_SAMPLE_DECK))
+            self.pm.profile["showWelcome"] = False
 
     # Importing & exporting
     ##########################################################################

--- a/qt/aqt/main.py
+++ b/qt/aqt/main.py
@@ -1192,6 +1192,7 @@ title="%s" %s>%s</button>""" % (
         qconnect(m.actionDonate.triggered, self.onDonate)
         qconnect(m.actionStudyDeck.triggered, self.onStudyDeck)
         qconnect(m.actionCreateFiltered.triggered, self.onCram)
+        qconnect(m.actionCreateSampleDeck.triggered, self.onCreateSampleDeck)
         qconnect(m.actionEmptyCards.triggered, self.onEmptyCards)
         qconnect(m.actionNoteTypes.triggered, self.onNoteTypes)
 

--- a/rslib/backend.proto
+++ b/rslib/backend.proto
@@ -138,6 +138,7 @@ service BackendService {
   rpc GetDeckNames(GetDeckNamesIn) returns (DeckNames);
   rpc NewDeckLegacy(Bool) returns (Json);
   rpc RemoveDeck(DeckID) returns (Empty);
+  rpc CreateSampleDeck(Empty) returns (Empty);
 
   // deck config
 

--- a/rslib/src/backend/mod.rs
+++ b/rslib/src/backend/mod.rs
@@ -792,6 +792,11 @@ impl BackendService for Backend {
             .map(Into::into)
     }
 
+    fn create_sample_deck(&self, _input: Empty) -> BackendResult<Empty> {
+        self.with_col(|col| col.create_sample_deck())
+            .map(Into::into)
+    }
+
     // deck config
     //----------------------------------------------------
 

--- a/rslib/src/decks/mod.rs
+++ b/rslib/src/decks/mod.rs
@@ -17,6 +17,7 @@ use crate::{
     types::Usn,
 };
 mod counts;
+mod sample;
 mod schema11;
 mod tree;
 pub(crate) use counts::DueCounts;

--- a/rslib/src/decks/sample.rs
+++ b/rslib/src/decks/sample.rs
@@ -1,0 +1,120 @@
+use super::Deck;
+use crate::{
+    collection::Collection,
+    err::{AnkiError, Result},
+    i18n::TR,
+    notes::Note,
+    notetype::{CardGenContext, NoteType},
+};
+
+impl Collection {
+    pub fn create_sample_deck(&mut self) -> Result<()> {
+        let deck_name = self.i18n.tr(TR::SampleDeckName).to_string();
+        let nt_name = self.i18n.tr(TR::SampleNotetypeName).to_string();
+        if self.get_deck_id(&deck_name)? != None || self.get_notetype_by_name(&nt_name)? != None {
+            return Err(AnkiError::Existing);
+        }
+        let mut deck = Deck::new_normal();
+        deck.name = deck_name;
+        let mut nt = self.sample_notetype(&nt_name);
+        self.state.deck_cache.clear();
+        self.transact(None, |col| {
+            let usn = col.usn()?;
+
+            col.prepare_deck_for_update(&mut deck, usn)?;
+            col.storage.add_deck(&mut deck)?;
+
+            nt.set_modified(usn);
+            nt.prepare_for_adding()?;
+            col.storage.add_new_notetype(&mut nt)?;
+
+            let did = col.get_deck_id(&deck.name)?.ok_or(AnkiError::NotFound)?;
+            let col_nt = col
+                .get_notetype_by_name(&nt_name)?
+                .ok_or(AnkiError::NotFound)?;
+            let ctx = CardGenContext::new(&col_nt, usn);
+
+            for mut note in col.sample_notes(&col_nt)? {
+                note.prepare_for_update(&col_nt, true)?;
+                note.set_modified(usn);
+                col.storage.add_note(&mut note)?;
+                col.generate_cards_for_new_note(&ctx, &note, did)?;
+            }
+
+            Ok(())
+        })
+    }
+
+    fn sample_notetype(&self, nt_name: &str) -> NoteType {
+        let mut nt = NoteType::default();
+        nt.name = nt_name.to_string();
+        let question = self.i18n.tr(TR::SampleFieldQuestion);
+        let answer = self.i18n.tr(TR::SampleFieldAnswer);
+        let details = self.i18n.tr(TR::SampleFieldDetails);
+        let manual = self.i18n.tr(TR::SampleFieldManual);
+        let front = format!("<div class=question>{{{{{}}}}}</div>", question);
+        let back = format!(
+            "{{{{FrontSide}}}}
+    <hr id=answer>
+
+    <div class=answer>{{{{{}}}}}</div>
+    <div class=details>{{{{{}}}}}</div>
+    <a href=https://docs.ankiweb.net/#/{{{{{}}}}}></a>",
+            answer, details, manual
+        );
+        nt.add_field(question);
+        nt.add_field(answer);
+        nt.add_field(details);
+        nt.add_field(manual);
+        nt.add_template(self.i18n.tr(TR::SampleTemplateName), front, back);
+        nt
+    }
+
+    fn sample_notes(&self, nt: &NoteType) -> Result<Vec<Note>> {
+        Ok(vec![
+            sample_note(
+                nt,
+                &self.i18n.tr(TR::SampleQuestionCard),
+                &self.i18n.tr(TR::SampleAnswerCard),
+                &self.i18n.tr(TR::SampleDetailsCard),
+                "getting-started?id=cards",
+            )?,
+            sample_note(
+                nt,
+                &self.i18n.tr(TR::SampleQuestionDeck),
+                &self.i18n.tr(TR::SampleAnswerDeck),
+                &self.i18n.tr(TR::SampleDetailsDeck),
+                "getting-started?id=decks",
+            )?,
+            sample_note(
+                nt,
+                &self.i18n.tr(TR::SampleQuestionNote),
+                &self.i18n.tr(TR::SampleAnswerNote),
+                &self.i18n.tr(TR::SampleDetailsNote),
+                "getting-started?id=notes-amp-fields",
+            )?,
+            sample_note(
+                nt,
+                &self.i18n.tr(TR::SampleQuestionField),
+                &self.i18n.tr(TR::SampleAnswerField),
+                &self.i18n.tr(TR::SampleDetailsField),
+                "getting-started?id=notes-amp-fields",
+            )?,
+        ])
+    }
+}
+
+fn sample_note(
+    nt: &NoteType,
+    question: &str,
+    answer: &str,
+    details: &str,
+    manual: &str,
+) -> Result<Note> {
+    let mut note = Note::new(nt);
+    note.set_field(0, question)?;
+    note.set_field(1, answer)?;
+    note.set_field(2, details)?;
+    note.set_field(3, manual)?;
+    Ok(note)
+}


### PR DESCRIPTION
The goal is to provide a sample deck to new users so they can start discovering and learning about Anki immediately. As of yet, new users and those upgrading from a prior release will be shown a brief welcome message with the option to create the sample deck. The deck itself will then be created on the backend using fluent translations.

There is still a lot of work to be done (definitely nothing for 2.1.39) but I'd like to know whether you approve of this feature and the general direction of its implementation.