### PR TITLE
Make search for clozes in editor unsusceptible to catastrophic backtracking

### DIFF
--- a/qt/aqt/editor.py
+++ b/qt/aqt/editor.py
@@ -675,7 +675,7 @@ class Editor:
 
     def _onCloze(self):
         # check that the model is set up for cloze deletion
-        if not re.search("{{(.*:)*cloze:", self.note.model()["tmpls"][0]["qfmt"]):
+        if not re.search("{{([^:]+?:)*?cloze:", self.note.model()["tmpls"][0]["qfmt"]):
             if self.addMode:
                 tooltip(tr(TR.EDITING_WARNING_CLOZE_DELETIONS_WILL_NOT_WORK))
             else:


### PR DESCRIPTION
This is actually unrelated to the newest version, but something I noticed with a note type template of mine, which has a section like this:

```js
{a:"ㄚ",ai:"ㄞ",an:"ㄢ",ang:"ㄤ",ao:"ㄠ",ba:"ㄅㄚ",bai:"ㄅㄞ",ban:"ㄅㄢ",bang:"ㄅㄤ",bao:"ㄅㄠ",bei:"ㄅㄟ",ben:"ㄅㄣ",
beng:"ㄅㄥ",bi:"ㄅㄧ",bian:"ㄅㄧㄢ",biao:"ㄅㄧㄠ",bie:"ㄅㄧㄝ",bin:"ㄅㄧㄣ",bing:"ㄅㄧㄥ",bo:"ㄅㄛ",bu:"ㄅㄨ",
ca:"ㄘㄚ",cai:"ㄘㄞ",can:"ㄘㄢ",cang:"ㄘㄤ",cao:"ㄘㄠ",ce:"ㄘㄜ",cei:"ㄘㄟ",cen:"ㄘㄣ",ceng:"ㄘㄥ",cha:"ㄔㄚ",
chai:"ㄔㄞ",chan:"ㄔㄢ",chang:"ㄔㄤ",chao:"ㄔㄠ",che:"ㄔㄜ",chen:"ㄔㄣ",cheng:"ㄔㄥ",chi:"ㄔ",chong:"ㄔㄨㄥ",
chou:"ㄔㄡ",chu:"ㄔㄨ",chua:"ㄔㄨㄚ",chuai:"ㄔㄨㄞ",chuan:"ㄔㄨㄢ",chuang:"ㄔㄨㄤ",chui:"ㄔㄨㄟ",
chun:"ㄔㄨㄣ",chuo:"ㄔㄨㄛ",ci:"ㄘ",cong:"ㄘㄨㄥ",cou:"ㄘㄡ",cu:"ㄘㄨ",cuan:"ㄘㄨ",...
```

This makes it target to the regex for searching for clozes, because it's an eager search. Making it lazy and non-matching for `:` turns this regex search from at least 5 minutes to instant.