### PR TITLE
Implement editor as Web Component

### DIFF
--- a/qt/aqt/data/web/css/editable.scss
+++ b/qt/aqt/data/web/css/editable.scss
@@ -1,4 +1,4 @@
-editing-area {
+anki-editable {
     display: block;
     overflow-wrap: break-word;
     overflow: auto;

--- a/qt/aqt/data/web/css/editing-area.scss
+++ b/qt/aqt/data/web/css/editing-area.scss
@@ -9,3 +9,11 @@ editing-area {
         white-space: pre;
     }
 }
+
+img.drawing {
+    zoom: 50%;
+
+    .nightMode & {
+        filter: unquote("invert() hue-rotate(180deg)");
+    }
+}

--- a/qt/aqt/data/web/css/editing-area.scss
+++ b/qt/aqt/data/web/css/editing-area.scss
@@ -1,0 +1,11 @@
+editing-area {
+    display: block;
+    overflow-wrap: break-word;
+    overflow: auto;
+    padding: 5px;
+
+    &:empty::after {
+        content: "\a";
+        white-space: pre;
+    }
+}

--- a/qt/aqt/data/web/css/editor.scss
+++ b/qt/aqt/data/web/css/editor.scss
@@ -1,6 +1,10 @@
 /* Copyright: Ankitects Pty Ltd and contributors
  * License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html */
 
+html {
+    background: var(--bg-color);
+}
+
 #fields {
     display: flex;
     flex-direction: column;
@@ -22,6 +26,10 @@
 .field {
     border: 1px solid var(--border);
     background: var(--frame-bg);
+
+    &.dupe {
+        background: var(--flag1-bg);
+    }
 }
 
 .fname {
@@ -46,6 +54,8 @@ body {
     top: 0;
     left: 0;
     padding: 2px;
+
+    background: var(--bg-color);
 }
 
 .topbuts > * {
@@ -113,12 +123,20 @@ button.highlighted {
     }
 }
 
-.dupe {
-    background: var(--flag1-bg);
-}
+#dupes {
+    position: sticky;
+    bottom: 0;
 
-#dupes a {
-    color: var(--link);
+    text-align: center;
+    background-color: var(--bg-color);
+
+    &.is-inactive {
+        display: none;
+    }
+
+    a {
+        color: var(--link);
+    }
 }
 
 .drawing {

--- a/qt/aqt/data/web/css/editor.scss
+++ b/qt/aqt/data/web/css/editor.scss
@@ -10,7 +10,7 @@ html {
     flex-direction: column;
     margin: 5px;
 
-    & > * {
+    & > *, & > * > * {
         margin: 1px 0;
 
         &:first-child {
@@ -35,10 +35,6 @@ html {
 .fname {
     vertical-align: middle;
     padding: 0;
-}
-
-img {
-    max-width: 90%;
 }
 
 body {
@@ -141,11 +137,4 @@ button.highlighted {
     a {
         color: var(--link);
     }
-}
-
-.drawing {
-    zoom: 50%;
-}
-.nightMode img.drawing {
-    filter: unquote("invert() hue-rotate(180deg)");
 }

--- a/qt/aqt/data/web/css/editor.scss
+++ b/qt/aqt/data/web/css/editor.scss
@@ -22,14 +22,6 @@
 .field {
     border: 1px solid var(--border);
     background: var(--frame-bg);
-    padding: 5px;
-    overflow-wrap: break-word;
-    overflow: auto;
-
-    &:empty::after {
-        content: "\A";
-        white-space: pre;
-    }
 }
 
 .fname {

--- a/qt/aqt/data/web/css/editor.scss
+++ b/qt/aqt/data/web/css/editor.scss
@@ -119,7 +119,11 @@ button.highlighted {
     }
 
     #topbutsright & {
-        border-bottom: 3px solid #000;
+        border-bottom: 3px solid black;
+    }
+
+    .nightMode #topbutsright & {
+        border-bottom: 3px solid white;
     }
 }
 

--- a/qt/aqt/data/web/js/editor.ts
+++ b/qt/aqt/data/web/js/editor.ts
@@ -353,9 +353,7 @@ function saveField(type: "blur" | "key"): void {
         return;
     }
 
-    pycmd(
-        `${type}:${currentField.ord}:${currentNoteId}:${currentField.fieldHTML}`
-    );
+    pycmd(`${type}:${currentField.ord}:${currentNoteId}:${currentField.fieldHTML}`);
 }
 
 function wrappedExceptForWhitespace(text: string, front: string, back: string): string {
@@ -459,18 +457,18 @@ class EditingContainer extends HTMLDivElement {
         const rootStyle = document.createElement("link");
         rootStyle.setAttribute("rel", "stylesheet");
         rootStyle.setAttribute("href", "./_anki/css/editing-area.css");
-        this.shadowRoot.appendChild(rootStyle)
+        this.shadowRoot.appendChild(rootStyle);
 
         this.baseStyle = document.createElement("style");
         this.baseStyle.setAttribute("rel", "stylesheet");
-        this.shadowRoot.appendChild(this.baseStyle)
+        this.shadowRoot.appendChild(this.baseStyle);
 
         this.editingArea = document.createElement("editing-area") as EditingArea;
         this.shadowRoot.appendChild(this.editingArea);
     }
 
     static get observedAttributes(): string[] {
-        return ['ord'];
+        return ["ord"];
     }
 
     get ord(): number {
@@ -557,7 +555,7 @@ class EditorField extends HTMLDivElement {
         super();
         this.labelContainer = document.createElement("div");
         this.labelContainer.className = "fname";
-        this.appendChild(this.labelContainer)
+        this.appendChild(this.labelContainer);
 
         this.label = document.createElement("span");
         this.label.className = "fieldname";
@@ -570,7 +568,7 @@ class EditorField extends HTMLDivElement {
     }
 
     static get observedAttributes(): string[] {
-        return ['ord'];
+        return ["ord"];
     }
 
     attributeChangedCallback(name: string, _oldValue: string, newValue: string): void {
@@ -600,7 +598,9 @@ function adjustFieldAmount(amount: number): void {
     const fieldsContainer = document.getElementById("fields");
 
     while (fieldsContainer.childElementCount < amount) {
-        const newField = document.createElement("div", { is: "editor-field" }) as EditorField;
+        const newField = document.createElement("div", {
+            is: "editor-field",
+        }) as EditorField;
         newField.ord = fieldsContainer.childElementCount;
         fieldsContainer.appendChild(newField);
     }
@@ -610,15 +610,14 @@ function adjustFieldAmount(amount: number): void {
     }
 }
 
-function forField<T>(
+function forEditorField<T>(
     values: T[],
-    func: (value: T, field: EditorField, index: number) => void
+    func: (field: EditorField, value: T) => void
 ): void {
-    const fieldContainer = document.getElementById("fields");
-    const fields = [...fieldContainer.children] as EditorField[];
-
-    for (const [index, field] of fields.entries()) {
-        func(values[index], field, index);
+    const fields = document.getElementById("fields").children;
+    for (let i = 0; i < fields.length; i++) {
+        const field = fields[i] as EditorField;
+        func(field, values[i]);
     }
 }
 
@@ -630,7 +629,7 @@ function setFields(fields: [string, string][]): void {
         .getPropertyValue("--text-fg");
 
     adjustFieldAmount(fields.length);
-    forField(fields, ([name, fieldContent], field) =>
+    forEditorField(fields, (field, [name, fieldContent]) =>
         field.initialize(name, color, fieldContent)
     );
 
@@ -638,7 +637,7 @@ function setFields(fields: [string, string][]): void {
 }
 
 function setBackgrounds(cols: ("dupe" | "")[]) {
-    forField(cols, (value, field) =>
+    forEditorField(cols, (field, value) =>
         field.editingContainer.classList.toggle("dupe", value === "dupe")
     );
     document
@@ -647,7 +646,7 @@ function setBackgrounds(cols: ("dupe" | "")[]) {
 }
 
 function setFonts(fonts: [string, number, boolean][]): void {
-    forField(fonts, ([fontFamily, fontSize, isRtl], field) => {
+    forEditorField(fonts, (field, [fontFamily, fontSize, isRtl]) => {
         field.setBaseStyling(fontFamily, `${fontSize}px`, isRtl ? "rtl" : "ltr");
     });
 }

--- a/qt/aqt/data/web/js/editor.ts
+++ b/qt/aqt/data/web/js/editor.ts
@@ -467,10 +467,6 @@ class EditingContainer extends HTMLDivElement {
         this.shadowRoot.appendChild(this.editingArea);
     }
 
-    static get observedAttributes(): string[] {
-        return ["ord"];
-    }
-
     get ord(): number {
         return Number(this.getAttribute("ord"));
     }

--- a/qt/aqt/data/web/js/editor.ts
+++ b/qt/aqt/data/web/js/editor.ts
@@ -334,7 +334,7 @@ function onBlur(): void {
     }
 }
 
-function fieldContainsInlineContent(field: Element): boolean {
+function containsInlineContent(field: Element): boolean {
     if (field.childNodes.length === 0) {
         // for now, for all practical purposes, empty fields are in block mode
         return false;
@@ -444,13 +444,13 @@ class EditingArea extends HTMLElement {
     set fieldHTML(content: string) {
         this.innerHTML = content;
 
-        if (fieldContainsInlineContent(this)) {
+        if (containsInlineContent(this)) {
             this.appendChild(document.createElement("br"));
         }
     }
 
     get fieldHTML(): string {
-        return fieldContainsInlineContent(this) && this.innerHTML.endsWith("<br>")
+        return containsInlineContent(this) && this.innerHTML.endsWith("<br>")
             ? this.innerHTML.slice(0, -4) // trim trailing <br>
             : this.innerHTML;
     }

--- a/qt/aqt/data/web/js/editor.ts
+++ b/qt/aqt/data/web/js/editor.ts
@@ -559,12 +559,15 @@ function adjustFieldAmount(amount: number): void {
     }
 }
 
-function forField<T>(values: T[], func: (value: T, field: EditorField, index: number) => void): void {
+function forField<T>(
+    values: T[],
+    func: (value: T, field: EditorField, index: number) => void
+): void {
     const fieldContainer = document.getElementById("fields");
     const fields = [...fieldContainer.children] as EditorField[];
 
     for (const [index, field] of fields.entries()) {
-        func(values[index], field, index)
+        func(values[index], field, index);
     }
 }
 
@@ -576,13 +579,20 @@ function setFields(fields: [string, string][]): void {
         .getPropertyValue("--text-fg");
 
     adjustFieldAmount(fields.length);
-    forField(fields, ([name, fieldContent], field, index) => field.initialize(index, name, color, fieldContent));
+    forField(fields, ([name, fieldContent], field, index) =>
+        field.initialize(index, name, color, fieldContent)
+    );
 
     maybeDisableButtons();
 }
 
-function setBackgrounds(cols: "dupe"[]) {
-    forField(cols, (value, field) => field.classList.toggle("dupe", value === "dupe"));
+function setBackgrounds(cols: ("dupe" | "")[]) {
+    forField(cols, (value, field) =>
+        field.editingContainer.classList.toggle("dupe", value === "dupe")
+    );
+    document
+        .querySelector("#dupes")
+        .classList.toggle("is-inactive", !cols.includes("dupe"));
 }
 
 function setFonts(fonts: [string, number, boolean][]): void {
@@ -593,14 +603,6 @@ function setFonts(fonts: [string, number, boolean][]): void {
 
 function setNoteId(id: number): void {
     currentNoteId = id;
-}
-
-function showDupes(): void {
-    $("#dupes").show();
-}
-
-function hideDupes(): void {
-    $("#dupes").hide();
 }
 
 let pasteHTML = function (

--- a/qt/aqt/data/web/js/editor.ts
+++ b/qt/aqt/data/web/js/editor.ts
@@ -19,7 +19,7 @@ String.prototype.format = function (...args: string[]): string {
 };
 
 function setFGButton(col: string): void {
-    $("#forecolor")[0].style.backgroundColor = col;
+    document.getElementById("forecolor").style.backgroundColor = col;
 }
 
 function saveNow(keepFocus: boolean): void {
@@ -33,7 +33,7 @@ function saveNow(keepFocus: boolean): void {
         saveField("key");
     } else {
         // triggers onBlur, which saves
-        currentField.blur();
+        currentField.blurEditingArea();
     }
 }
 
@@ -52,7 +52,7 @@ interface Selection {
 function onKey(evt: KeyboardEvent): void {
     // esc clears focus, allowing dialog to close
     if (evt.code === "Escape") {
-        currentField.blur();
+        currentField.blurEditingArea();
         return;
     }
 
@@ -279,10 +279,11 @@ function onFocus(evt: FocusEvent): void {
 }
 
 function focusField(n: number): void {
-    if (n === null) {
-        return;
+    const field = document.getElementById(`f${n}`) as EditingContainer;
+
+    if (field) {
+        field.focusEditingArea();
     }
-    $(`#f${n}`).focus();
 }
 
 function focusIfField(x: number, y: number): boolean {
@@ -290,7 +291,7 @@ function focusIfField(x: number, y: number): boolean {
     for (let i = 0; i < elements.length; i++) {
         let elem = elements[i] as EditingContainer;
         if (elem.classList.contains("field")) {
-            elem.focus();
+            elem.focusEditingArea();
             // the focus event may not fire if the window is not active, so make sure
             // the current field is set
             currentField = elem;
@@ -502,6 +503,14 @@ class EditingContainer extends HTMLDivElement {
 
     getSelection(): Selection {
         return this.editingShadow.getSelection();
+    }
+
+    focusEditingArea(): void {
+        this.editingArea.focus();
+    }
+
+    blurEditingArea(): void {
+        this.editingArea.blur();
     }
 
     set fieldHTML(content: string) {

--- a/qt/aqt/data/web/js/editor.ts
+++ b/qt/aqt/data/web/js/editor.ts
@@ -434,10 +434,6 @@ class EditingArea extends HTMLElement {
         this.setAttribute("contenteditable", "true");
     }
 
-    initialize(index: number): void {
-        this.className = `editor-field-${index}`;
-    }
-
     set fieldHTML(content: string) {
         this.innerHTML = content;
 
@@ -496,14 +492,12 @@ class EditingContainer extends HTMLDivElement {
             0
         );
 
-        this.editingArea = this.editingShadow.appendChild(
-            document.createElement("editing-area")
-        ) as EditingArea;
+        this.editingArea = document.createElement("editing-area") as EditingArea;
+        this.editingArea.id = `editor-field-${this.id.match(/\d+$/)[0]}`;
+        this.editingShadow.appendChild(this.editingArea);
     }
 
-    initialize(index: number, color: string, content: string): void {
-        this.id = `f${index}`;
-        this.editingArea.initialize(index);
+    initialize(color: string, content: string): void {
         this.setBaseColor(color);
         this.editingArea.fieldHTML = content;
     }
@@ -553,21 +547,25 @@ class EditorField extends HTMLDivElement {
     editingContainer: EditingContainer;
 
     connectedCallback(): void {
+        const index = Array.prototype.indexOf.call(this.parentNode.children, this);
+
         this.labelContainer = this.appendChild(document.createElement("div"));
         this.labelContainer.className = "fname";
+        this.labelContainer.id = `name${index}`;
 
         this.label = this.labelContainer.appendChild(document.createElement("span"));
         this.label.className = "fieldname";
 
-        this.editingContainer = this.appendChild(
-            document.createElement("div", { is: "editing-container" })
-        ) as EditingContainer;
+        this.editingContainer = document.createElement("div", {
+            is: "editing-container",
+        }) as EditingContainer;
+        this.editingContainer.id = `f${index}`;
+        this.appendChild(this.editingContainer);
     }
 
-    initialize(index: number, label: string, color: string, content: string): void {
-        this.labelContainer.id = `name${index}`;
+    initialize(label: string, color: string, content: string): void {
         this.label.innerText = label;
-        this.editingContainer.initialize(index, color, content);
+        this.editingContainer.initialize(color, content);
     }
 
     setBaseStyling(fontFamily: string, fontSize: string, direction: string): void {
@@ -611,8 +609,8 @@ function setFields(fields: [string, string][]): void {
         .getPropertyValue("--text-fg");
 
     adjustFieldAmount(fields.length);
-    forField(fields, ([name, fieldContent], field, index) =>
-        field.initialize(index, name, color, fieldContent)
+    forField(fields, ([name, fieldContent], field) =>
+        field.initialize(name, color, fieldContent)
     );
 
     maybeDisableButtons();

--- a/qt/aqt/data/web/js/editor.ts
+++ b/qt/aqt/data/web/js/editor.ts
@@ -424,10 +424,6 @@ function onCutOrCopy(): boolean {
 }
 
 class EditingArea extends HTMLElement {
-    connectedCallback() {
-        this.setAttribute("contenteditable", "");
-    }
-
     set fieldHTML(content: string) {
         this.innerHTML = content;
 
@@ -440,6 +436,10 @@ class EditingArea extends HTMLElement {
         return containsInlineContent(this) && this.innerHTML.endsWith("<br>")
             ? this.innerHTML.slice(0, -4) // trim trailing <br>
             : this.innerHTML;
+    }
+
+    connectedCallback() {
+        this.setAttribute("contenteditable", "");
     }
 }
 
@@ -469,6 +469,14 @@ class EditingContainer extends HTMLDivElement {
 
     get ord(): number {
         return Number(this.getAttribute("ord"));
+    }
+
+    set fieldHTML(content: string) {
+        this.editingArea.fieldHTML = content;
+    }
+
+    get fieldHTML(): string {
+        return this.editingArea.fieldHTML;
     }
 
     connectedCallback(): void {
@@ -530,14 +538,6 @@ class EditingContainer extends HTMLDivElement {
     blurEditingArea(): void {
         this.editingArea.blur();
     }
-
-    set fieldHTML(content: string) {
-        this.editingArea.fieldHTML = content;
-    }
-
-    get fieldHTML(): string {
-        return this.editingArea.fieldHTML;
-    }
 }
 
 customElements.define("editing-container", EditingContainer, { extends: "div" });
@@ -567,15 +567,15 @@ class EditorField extends HTMLDivElement {
         return ["ord"];
     }
 
+    set ord(n: number) {
+        this.setAttribute("ord", String(n));
+    }
+
     attributeChangedCallback(name: string, _oldValue: string, newValue: string): void {
         switch (name) {
             case "ord":
                 this.editingContainer.setAttribute("ord", newValue);
         }
-    }
-
-    set ord(n: number) {
-        this.setAttribute("ord", String(n));
     }
 
     initialize(label: string, color: string, content: string): void {

--- a/qt/aqt/data/web/js/editor.ts
+++ b/qt/aqt/data/web/js/editor.ts
@@ -505,15 +505,7 @@ class EditingContainer extends HTMLDivElement {
         this.addEventListener("oncut", onCutOrCopy);
 
         const baseStyleSheet = this.baseStyle.sheet as CSSStyleSheet;
-        baseStyleSheet.insertRule(
-            `editing-area {
-            font-family: initial;
-            font-size: initial;
-            direction: initial;
-            color: initial;
-        }`,
-            0
-        );
+        baseStyleSheet.insertRule("editing-area {}", 0);
     }
 
     disconnectedCallback(): void {

--- a/qt/aqt/data/web/js/editor.ts
+++ b/qt/aqt/data/web/js/editor.ts
@@ -86,7 +86,7 @@ function onKey(evt: KeyboardEvent): void {
 function onKeyUp(evt: KeyboardEvent): void {
     // Avoid div element on remove
     if (evt.code === "Enter" || evt.code === "Backspace") {
-        const anchor = window.getSelection().anchorNode;
+        const anchor = currentField.getSelection().anchorNode;
 
         if (
             nodeIsElement(anchor) &&
@@ -190,7 +190,7 @@ function insertNewline(): void {
     // differently. so in such cases we note the height has not
     // changed and insert an extra newline.
 
-    const r = window.getSelection().getRangeAt(0);
+    const r = currentField.getSelection().getRangeAt(0);
     if (!r.collapsed) {
         // delete any currently selected text first, making
         // sure the delete is undoable
@@ -206,7 +206,7 @@ function insertNewline(): void {
 
 // is the cursor in an environment that respects whitespace?
 function inPreEnvironment(): boolean {
-    const anchor = window.getSelection().anchorNode;
+    const anchor = currentField.getSelection().anchorNode;
     const n = nodeIsElement(anchor) ? anchor : anchor.parentElement;
 
     return window.getComputedStyle(n).whiteSpace.startsWith("pre");
@@ -310,7 +310,7 @@ function caretToEnd(): void {
     const r = document.createRange();
     r.selectNodeContents(currentField);
     r.collapse(false);
-    const s = document.getSelection();
+    const s = currentField.getSelection();
     s.removeAllRanges();
     s.addRange(r);
 }
@@ -401,7 +401,7 @@ function wrapIntoText(front: string, back: string): void {
 }
 
 function wrapInternal(front: string, back: string, plainText: boolean): void {
-    const s = window.getSelection();
+    const s = currentField.getSelection();
     let r = s.getRangeAt(0);
     const content = r.cloneContents();
     const span = document.createElement("span");

--- a/qt/aqt/data/web/js/editor.ts
+++ b/qt/aqt/data/web/js/editor.ts
@@ -2,8 +2,8 @@
  * License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html */
 
 let currentField: EditingContainer | null = null;
-let changeTimer = null;
-let currentNoteId = null;
+let changeTimer: number | null = null;
+let currentNoteId: number | null = null;
 
 declare interface String {
     format(...args: string[]): string;
@@ -254,6 +254,7 @@ function onFocus(evt: FocusEvent): void {
         // anki window refocused; current element unchanged
         return;
     }
+    elem.focusEditingArea();
     currentField = elem;
     pycmd(`focus:${currentFieldOrdinal()}`);
     enableButtons();
@@ -307,12 +308,12 @@ function onPaste(): void {
 }
 
 function caretToEnd(): void {
-    const r = document.createRange();
-    r.selectNodeContents(currentField);
-    r.collapse(false);
-    const s = currentField.getSelection();
-    s.removeAllRanges();
-    s.addRange(r);
+    const range = document.createRange();
+    range.selectNodeContents(currentField.editingArea);
+    range.collapse(false);
+    const selection = currentField.getSelection();
+    selection.removeAllRanges();
+    selection.addRange(range);
 }
 
 function onBlur(): void {

--- a/qt/aqt/data/web/js/editor.ts
+++ b/qt/aqt/data/web/js/editor.ts
@@ -430,16 +430,6 @@ class EditingArea extends HTMLElement {
         this.setAttribute("contenteditable", "");
     }
 
-    static get observedAttributes(): string[] {
-        return ['ord'];
-    }
-
-    attributeChangedCallback(name: string, _oldValue: string, newValue: string): void {
-        switch (name) {
-            case "ord": this.id = `editor-field-${newValue}`;
-        }
-    }
-
     set fieldHTML(content: string) {
         this.innerHTML = content;
 
@@ -481,13 +471,6 @@ class EditingContainer extends HTMLDivElement {
 
     static get observedAttributes(): string[] {
         return ['ord'];
-    }
-
-    attributeChangedCallback(name: string, _oldValue: string, newValue: string): void {
-        switch (name) {
-            case "ord":
-                this.id = `f${newValue}`;
-        }
     }
 
     get ord(): number {

--- a/qt/aqt/data/web/js/editor.ts
+++ b/qt/aqt/data/web/js/editor.ts
@@ -433,8 +433,8 @@ class EditingArea extends HTMLElement {
         this.setAttribute("contenteditable", "true");
     }
 
-    initialize(color: string): void {
-        this.style.color = color;
+    initialize(index: number): void {
+        this.className = `editor-field-${index}`;
     }
 
     set fieldHTML(content: string) {
@@ -491,6 +491,7 @@ class EditingContainer extends HTMLDivElement {
             font-family: initial;
             font-size: initial;
             direction: initial;
+            color: initial;
         }`,
             0
         );
@@ -507,8 +508,14 @@ class EditingContainer extends HTMLDivElement {
 
     initialize(index: number, color: string, content: string): void {
         this.id = `f${index}`;
-        this.editingArea.initialize(color);
+        this.editingArea.initialize(index);
+        this.setBaseColor(color);
         this.editingArea.fieldHTML = content;
+    }
+
+    setBaseColor(color: string): void {
+        const firstRule = this.baseStylesheet.cssRules[0] as CSSStyleRule;
+        firstRule.style.color = color;
     }
 
     setBaseStyling(fontFamily: string, fontSize: string, direction: string): void {

--- a/qt/aqt/data/web/js/editor.ts
+++ b/qt/aqt/data/web/js/editor.ts
@@ -460,7 +460,6 @@ class EditingContainer extends HTMLDivElement {
     editingArea: EditingArea;
 
     baseStylesheet: CSSStyleSheet;
-    userStyle: HTMLStyleElement;
 
     connectedCallback(): void {
         this.className = "field";
@@ -497,11 +496,6 @@ class EditingContainer extends HTMLDivElement {
             0
         );
 
-        this.userStyle = this.editingShadow.appendChild(
-            document.createElement("style")
-        );
-        this.userStyle.setAttribute("rel", "stylesheet");
-
         this.editingArea = this.editingShadow.appendChild(
             document.createElement("editing-area")
         ) as EditingArea;
@@ -524,11 +518,6 @@ class EditingContainer extends HTMLDivElement {
         firstRule.style.fontFamily = fontFamily;
         firstRule.style.fontSize = fontSize;
         firstRule.style.direction = direction;
-    }
-
-    setUserStyling(css: HTMLStyleElement): void {
-        this.userStyle.parentNode.replaceChild(css, this.userStyle);
-        this.userStyle = css;
     }
 
     isRightToLeft(): boolean {
@@ -583,10 +572,6 @@ class EditorField extends HTMLDivElement {
 
     setBaseStyling(fontFamily: string, fontSize: string, direction: string): void {
         this.editingContainer.setBaseStyling(fontFamily, fontSize, direction);
-    }
-
-    setUserStyling(css: HTMLStyleElement): void {
-        this.editingContainer.setUserStyling(css);
     }
 }
 
@@ -645,16 +630,6 @@ function setBackgrounds(cols: ("dupe" | "")[]) {
 function setFonts(fonts: [string, number, boolean][]): void {
     forField(fonts, ([fontFamily, fontSize, isRtl], field) => {
         field.setBaseStyling(fontFamily, `${fontSize}px`, isRtl ? "rtl" : "ltr");
-    });
-}
-
-function setUserStyling(css: string): void {
-    const userStyle = document.createElement("style");
-    userStyle.setAttribute("rel", "stylesheet");
-    userStyle.innerHTML = css;
-
-    forField([], (_, field) => {
-        field.setUserStyling(userStyle.cloneNode(true) as HTMLStyleElement);
     });
 }
 

--- a/qt/aqt/editor.py
+++ b/qt/aqt/editor.py
@@ -504,7 +504,7 @@ class Editor:
                 self.web.setFocus()
             gui_hooks.editor_did_load_note(self)
 
-        js = "setFields(%s); setFonts(%s); focusField(%s); setNoteId(%s)" % (
+        js = "setFields(%s); setFonts(%s); focusField(%s); setNoteId(%s);" % (
             json.dumps(data),
             json.dumps(self.fonts()),
             json.dumps(focusTo),

--- a/qt/aqt/editor.py
+++ b/qt/aqt/editor.py
@@ -73,8 +73,9 @@ audio = (
 
 _html = """
 <style>
-html { background: %s; }
-#topbutsOuter { background: %s; }
+:root {
+    --bg-color: %s;
+}
 </style>
 <div>
     <div id="topbutsOuter">
@@ -82,11 +83,9 @@ html { background: %s; }
     </div>
     <div id="fields">
     </div>
-</div>
-<div id="dupes" style="display:none;">
-    <a href="#" onclick="pycmd('dupes');return false;">
-%s
-    </a>
+    <div id="dupes" class="is-inactive">
+        <a href="#" onclick="pycmd('dupes');return false;">%s</a>
+    </div>
 </div>
 """
 
@@ -219,7 +218,7 @@ class Editor:
         bgcol = self.mw.app.palette().window().color().name()  # type: ignore
         # then load page
         self.web.stdHtml(
-            _html % (bgcol, bgcol, topbuts, tr(TR.EDITING_SHOW_DUPLICATES)),
+            _html % (bgcol, topbuts, tr(TR.EDITING_SHOW_DUPLICATES)),
             css=["css/editor.css"],
             js=["js/vendor/jquery.min.js", "js/editor.js"],
             context=self,
@@ -534,9 +533,7 @@ class Editor:
         err = self.note.dupeOrEmpty()
         if err == 2:
             cols[0] = "dupe"
-            self.web.eval("showDupes();")
-        else:
-            self.web.eval("hideDupes();")
+
         self.web.eval("setBackgrounds(%s);" % json.dumps(cols))
 
     def showDupes(self):

--- a/qt/aqt/editor.py
+++ b/qt/aqt/editor.py
@@ -504,10 +504,9 @@ class Editor:
                 self.web.setFocus()
             gui_hooks.editor_did_load_note(self)
 
-        js = "setFields(%s); setFonts(%s); setUserStyling(%s); focusField(%s); setNoteId(%s)" % (
+        js = "setFields(%s); setFonts(%s); focusField(%s); setNoteId(%s)" % (
             json.dumps(data),
             json.dumps(self.fonts()),
-            json.dumps(self.note.model()["css"]),
             json.dumps(focusTo),
             json.dumps(self.note.id),
         )

--- a/qt/aqt/editor.py
+++ b/qt/aqt/editor.py
@@ -504,9 +504,10 @@ class Editor:
                 self.web.setFocus()
             gui_hooks.editor_did_load_note(self)
 
-        js = "setFields(%s); setFonts(%s); focusField(%s); setNoteId(%s)" % (
+        js = "setFields(%s); setFonts(%s); setUserStyling(%s); focusField(%s); setNoteId(%s)" % (
             json.dumps(data),
             json.dumps(self.fonts()),
+            json.dumps(self.note.model()["css"]),
             json.dumps(focusTo),
             json.dumps(self.note.id),
         )


### PR DESCRIPTION
Implements the editor fields as web components, putting the main editing area inside of a shadow root.
This isolates the HTML in the editing area from the rest of the editor. For this new editing area, I created a new file `editing-area.scss`. What this also means, is that the CSS from the editor cannot affect the editing area anymore, which allows us for more possibilities going forward.

This allows for a cool feature, I already implemented: Python now instantiates the editor with the CSS from the note type. So if the user defines some general CSS, for example `b { color: red }`, then this CSS will also translate to the editor. This will make the editor fields look more like how they will end up looking in the reviewer.
This is somewhat implemented in several add-ons, like [this one](https://ankiweb.net/shared/info/1215991469), or [this one](https://ankiweb.net/shared/info/1899278645), which I currently maintain.

The editing area is now also wrapped in a custom-named `<editing-area>`. This means that rogue `</div>`s won't close the editing area anymore, like [what happened here](https://forums.ankiweb.net/t/words-bugging-when-i-search-and-replace/6916/5).

Other features:
1.  I implemented is avoiding rebuilding the editor fields, but adjust the amount of editor fields via `adjustAmountOfFields`, and then update their contents, which will avoid blinking when `saveNow` is executed.
2. The `#dupes` section is now sticky, and centered, making it stand out a bit more. Having worked with note types with a lot of fields for some time now, I somewhat forgot it even existed.
3. The highlight for buttons in dark mode is now white (which was black for, being very hard to see).