### PR TITLE
Make sticky topbar have a positive z-index

### DIFF
--- a/qt/aqt/data/web/css/editor.scss
+++ b/qt/aqt/data/web/css/editor.scss
@@ -53,6 +53,7 @@ body {
     position: sticky;
     top: 0;
     left: 0;
+    z-index: 5;
     padding: 2px;
 }
 


### PR DESCRIPTION
A typical way to style an icon would be like this:

```
i.icon {
    display: inline-block;
    width: 14px;
    height: 14px;
    margin-right: 3px;
    background-image: url(../icons/open.png);
    background-size: cover;
    background-repeat: no-repeat;
    background-origin: content-box;
}
```

However if you use an element with this styling now inside the editor fields, it will show through the topbar, because it is defined later than the topbar. Giving the topbar a higher z-index resolves this.