### PR TITLE
NF: add AGPL licence missing in some file

### DIFF
--- a/rslib/BUILD.bazel
+++ b/rslib/BUILD.bazel
@@ -1,3 +1,6 @@
+# Copyright: Ankitects Pty Ltd and contributors
+# License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
+
 load("@rules_proto//proto:defs.bzl", "proto_library")
 load("@io_bazel_rules_rust//rust:rust.bzl", "rust_binary", "rust_library", "rust_test")
 load("@io_bazel_rules_rust//cargo:cargo_build_script.bzl", "cargo_build_script")

--- a/rslib/backend.proto
+++ b/rslib/backend.proto
@@ -1,3 +1,5 @@
+// Copyright: Ankitects Pty Ltd and contributors
+// License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 syntax = "proto3";
 
 package BackendProto;

--- a/rslib/build/main.rs
+++ b/rslib/build/main.rs
@@ -1,3 +1,6 @@
+// Copyright: Ankitects Pty Ltd and contributors
+// License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
+
 pub mod mergeftl;
 pub mod protobuf;
 

--- a/rslib/build/mergeftl.rs
+++ b/rslib/build/mergeftl.rs
@@ -1,3 +1,6 @@
+// Copyright: Ankitects Pty Ltd and contributors
+// License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
+
 use fluent_syntax::ast::Entry;
 use fluent_syntax::parser::Parser;
 use std::path::Path;

--- a/rslib/build/protobuf.rs
+++ b/rslib/build/protobuf.rs
@@ -1,3 +1,6 @@
+// Copyright: Ankitects Pty Ltd and contributors
+// License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
+
 use std::path::PathBuf;
 use std::{env, fmt::Write};
 

--- a/rslib/build/write_fluent_proto.rs
+++ b/rslib/build/write_fluent_proto.rs
@@ -1,3 +1,6 @@
+// Copyright: Ankitects Pty Ltd and contributors
+// License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
+
 include!("mergeftl.rs");
 
 fn main() {

--- a/rslib/cargo/BUILD.bazel
+++ b/rslib/cargo/BUILD.bazel
@@ -1,3 +1,6 @@
+# Copyright: Ankitects Pty Ltd and contributors
+# License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
+
 """
 @generated
 cargo-raze generated Bazel file.

--- a/rslib/clang_format.bzl
+++ b/rslib/clang_format.bzl
@@ -1,3 +1,6 @@
+# Copyright: Ankitects Pty Ltd and contributors
+# License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
+
 """
 Exposes a clang-format binary for formatting protobuf.
 """

--- a/rslib/proto_format.py
+++ b/rslib/proto_format.py
@@ -1,3 +1,6 @@
+# Copyright: Ankitects Pty Ltd and contributors
+# License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
+
 import sys, subprocess, os, difflib
 
 clang_format = sys.argv[1]

--- a/rslib/rustfmt.bzl
+++ b/rslib/rustfmt.bzl
@@ -1,3 +1,6 @@
+# Copyright: Ankitects Pty Ltd and contributors
+# License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
+
 def _rustfmt_impl(ctx):
     toolchain = ctx.toolchains["@io_bazel_rules_rust//rust:toolchain"]
     script_name = ctx.label.name + "_script"

--- a/rslib/src/backend_proto.rs
+++ b/rslib/src/backend_proto.rs
@@ -1,1 +1,4 @@
+// Copyright: Ankitects Pty Ltd and contributors
+// License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
+
 include!(concat!(env!("OUT_DIR"), "/backend_proto.rs"));

--- a/rslib/src/fluent_proto.rs
+++ b/rslib/src/fluent_proto.rs
@@ -1,1 +1,4 @@
+// Copyright: Ankitects Pty Ltd and contributors
+// License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
+
 include!(concat!(env!("OUT_DIR"), "/fluent_proto.rs"));

--- a/rslib/src/search/mod.rs
+++ b/rslib/src/search/mod.rs
@@ -1,3 +1,6 @@
+// Copyright: Ankitects Pty Ltd and contributors
+// License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
+
 mod cards;
 mod notes;
 mod parser;

--- a/rslib/src/stats/card_stats.html
+++ b/rslib/src/stats/card_stats.html
@@ -1,6 +1,3 @@
-<!-- Copyright: Ankitects Pty Ltd and contributors
--- License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html -->
-
 <table class="card-stats" width="100%">
   {% for row in stats %}
   <tr>

--- a/rslib/src/stats/card_stats.html
+++ b/rslib/src/stats/card_stats.html
@@ -1,3 +1,6 @@
+<!-- Copyright: Ankitects Pty Ltd and contributors
+-- License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html -->
+
 <table class="card-stats" width="100%">
   {% for row in stats %}
   <tr>


### PR DESCRIPTION
I noticed it when I looked at some files now used in AnkiDroid, wanting to be sure we clearly indicate that we have
AGPLv3 code linked in the app