### PR TITLE
Fix ease graph building wrong query omitting ease edge cases

### DIFF
--- a/ts/graphs/ease.ts
+++ b/ts/graphs/ease.ts
@@ -38,7 +38,7 @@ function makeQuery(start: number, end: number): string {
     }
 
     const fromQuery = `"prop:ease>=${start / 100}"`;
-    const tillQuery = `"prop:ease<${end / 100}"`;
+    const tillQuery = `"prop:ease<${(end + 1) / 100}"`;
 
     return `${fromQuery} AND ${tillQuery}`;
 }


### PR DESCRIPTION
E.g. search for `"prop:ease>=2.5" AND "prop:ease<2.55"` instead of `"prop:ease>=2.5" AND "prop:ease<2.54"`.

Previously cards with ease ending in 4 or 9, like 254% or 259%, wouldn't be included anywhere. Being quite rare, I hadn't noticed it until now.