### PR TITLE
Coerce ease graph min to 130 if applicable

### DIFF
--- a/ts/graphs/intervals.ts
+++ b/ts/graphs/intervals.ts
@@ -122,7 +122,6 @@ export function prepareIntervalData(
     const desiredBars = Math.min(70, xMax! - xMin!);
 
     const prescale = scaleLinear().domain([xMin!, xMax!]);
-
     const scale = scaleLinear().domain(
         (niceNecessary ? prescale.nice() : prescale).domain().map(increment)
     );


### PR DESCRIPTION
Right now the ease graph often starts at 120, once again because of using `.nice()`.

This PR will coerce the graph to start at 130, if applicable, by which I mean:

* it won't change the graph, if it wants to start at 100, with ticks at every 50.
* it would change the graph, if it starts at 120, with ticks at every 10.