### PR TITLE
Cleanup after #955

### DIFF
--- a/pylib/anki/collection.py
+++ b/pylib/anki/collection.py
@@ -29,7 +29,6 @@ from anki.models import ModelManager
 from anki.notes import Note
 from anki.rsbackend import (  # pylint: disable=unused-import
     TR,
-    BackendNoteTypeID,
     ConcatSeparator,
     DBError,
     FormatTimeSpanContext,

--- a/pylib/anki/rsbackend.py
+++ b/pylib/anki/rsbackend.py
@@ -50,7 +50,6 @@ TagTreeNode = pb.TagTreeNode
 NoteType = pb.NoteType
 DeckTreeNode = pb.DeckTreeNode
 StockNoteType = pb.StockNoteType
-BackendNoteTypeID = pb.NoteTypeID
 ConcatSeparator = pb.ConcatenateSearchesIn.Separator
 SyncAuth = pb.SyncAuth
 SyncOutput = pb.SyncCollectionOut

--- a/qt/aqt/sidebar.py
+++ b/qt/aqt/sidebar.py
@@ -461,12 +461,14 @@ class SidebarTreeView(QTreeView):
         item = SidebarItem(
             tr(TR.BROWSING_WHOLE_COLLECTION),
             ":/icons/collection.svg",
+            self._filter_func(SearchTerm(whole_collection=True)),
             item_type=SidebarItemType.COLLECTION,
         )
         root.addChild(item)
         item = SidebarItem(
             tr(TR.BROWSING_CURRENT_DECK),
             ":/icons/deck.svg",
+            self._filter_func(SearchTerm(current_deck=True)),
             item_type=SidebarItemType.CURRENT_DECK,
         )
         root.addChild(item)


### PR DESCRIPTION
Here are two things I found.

Also, in the light of the newfound protobuf rules (at least to me it was news), it might be worth to reconsider the enum for argumentless SearchTerms. At the moment, we call the filter with `SearchTerm(current_deck=True)`. If we put them in an enum (Other, Preset, Named, NoArgs...) again, we could use `SearchTerm(other=SearchTerm.CURRENT_DECK)` which is longer, but more intuitive than assigning an inconsequential variable.
I hate to bring it up again, but since you said it's important to get the public interface right, I wanted to have at least pointed it out.
If you think that would be an improvement, I would see to it.