### PR TITLE
Remove protobuf filters whole_col and current_deck

### DIFF
--- a/qt/aqt/browser.py
+++ b/qt/aqt/browser.py
@@ -609,7 +609,7 @@ class Browser(QMainWindow):
             tr(TR.BROWSING_SEARCH_BAR_HINT)
         )
         self.form.searchEdit.addItems(self.mw.pm.profile["searchHistory"])
-        self.search_for(self.col.build_search_string(SearchTerm(current_deck=True)), "")
+        self.search_for(self.col.build_search_string(SearchTerm(deck="current")), "")
         self.form.searchEdit.setFocus()
 
     # search triggered by user

--- a/qt/aqt/sidebar.py
+++ b/qt/aqt/sidebar.py
@@ -462,14 +462,14 @@ class SidebarTreeView(QTreeView):
         item = SidebarItem(
             tr(TR.BROWSING_WHOLE_COLLECTION),
             ":/icons/collection.svg",
-            self._filter_func(SearchTerm(whole_collection=True)),
+            self._filter_func(),
             item_type=SidebarItemType.COLLECTION,
         )
         root.addChild(item)
         item = SidebarItem(
             tr(TR.BROWSING_CURRENT_DECK),
             ":/icons/deck.svg",
-            self._filter_func(SearchTerm(current_deck=True)),
+            self._filter_func(SearchTerm(deck="current")),
             item_type=SidebarItemType.CURRENT_DECK,
         )
         root.addChild(item)

--- a/rslib/backend.proto
+++ b/rslib/backend.proto
@@ -811,11 +811,9 @@ message SearchTerm {
     Rated rated = 8;
     uint32 added_in_days = 9;
     int32 due_in_days = 10;
-    bool whole_collection = 11;
-    bool current_deck = 12;
-    Flag flag = 13;
-    CardState card_state = 14;
-    IdList nids = 15;
+    Flag flag = 11;
+    CardState card_state = 12;
+    IdList nids = 13;
   }
 }
 


### PR DESCRIPTION
I opted to cheat. Feels a bit like surrender. 🏳️ 
Anyway, we can use that `build_search_string` already defaults to whole collection when called with no args which should be intuitive enough.
We have to handle the unwrapping different, too, because we lack the default option now, but that's actually an improvement in my opinion.