### PR TITLE
Expand sidebar match trees one level

### DIFF
--- a/pylib/anki/tags.py
+++ b/pylib/anki/tags.py
@@ -68,9 +68,9 @@ class TagManager:
         res = self.col.db.list(query)
         return list(set(self.split(" ".join(res))))
 
-    def set_collapsed(self, tag: str, collapsed: bool) -> None:
-        "Set browser collapse state for tag, registering the tag if missing."
-        self.col._backend.set_tag_collapsed(name=tag, collapsed=collapsed)
+    def set_expanded(self, tag: str, expanded: bool) -> None:
+        "Set browser expansion state for tag, registering the tag if missing."
+        self.col._backend.set_tag_expanded(name=tag, expanded=expanded)
 
     # Bulk addition/removal from notes
     #############################################################

--- a/pylib/anki/tags.py
+++ b/pylib/anki/tags.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 import pprint
 import re
-from typing import Collection, List, Match, Optional, Sequence, Tuple
+from typing import Collection, List, Match, Optional, Sequence
 
 import anki  # pylint: disable=unused-import
 import anki._backend.backend_pb2 as _pb
@@ -28,18 +28,14 @@ class TagManager:
     def __init__(self, col: anki.collection.Collection) -> None:
         self.col = col.weakref()
 
-    # all tags
+    # legacy add-on code expects a List return type
     def all(self) -> List[str]:
-        return [t.name for t in self.col._backend.all_tags()]
+        return list(self.col._backend.all_tags())
 
     def __repr__(self) -> str:
         d = dict(self.__dict__)
         del d["col"]
         return f"{super().__repr__()} {pprint.pformat(d, width=300)}"
-
-    # # List of (tag, usn)
-    def allItems(self) -> List[Tuple[str, int]]:
-        return [(t.name, t.usn) for t in self.col._backend.all_tags()]
 
     def tree(self) -> TagTreeNode:
         return self.col._backend.tag_tree()

--- a/qt/aqt/browser.py
+++ b/qt/aqt/browser.py
@@ -914,6 +914,8 @@ QTableView {{ gridline-color: {grid} }}
         l = QVBoxLayout()
         l.addWidget(searchBar)
         l.addWidget(self.sidebar)
+        l.setContentsMargins(0, 0, 0, 0)
+        l.setSpacing(0)
         w = QWidget()
         w.setLayout(l)
         dw.setWidget(w)

--- a/qt/aqt/sidebar.py
+++ b/qt/aqt/sidebar.py
@@ -149,8 +149,8 @@ class SidebarModel(QAbstractItemModel):
     def item_for_index(self, idx: QModelIndex) -> SidebarItem:
         return idx.internalPointer()
 
-    def search(self, text: str) -> None:
-        self.root.search(text.lower())
+    def search(self, text: str) -> bool:
+        return self.root.search(text.lower())
 
     # Qt API
     ######################################################################
@@ -349,6 +349,7 @@ class SidebarTreeView(QTreeView):
         self.mw.taskman.run_in_background(self._root_tree, on_done)
 
     def search_for(self, text: str) -> None:
+        self.showColumn(0)
         if not text.strip():
             self.current_search = None
             self.refresh()
@@ -357,7 +358,7 @@ class SidebarTreeView(QTreeView):
         self.current_search = text
         # start from a collapsed state, as it's faster
         self.collapseAll()
-        self.model().search(text)
+        self.setColumnHidden(0, not self.model().search(text))
         expand_where_necessary(self.model(), self, searching=True)
 
     def drawRow(

--- a/qt/aqt/sidebar.py
+++ b/qt/aqt/sidebar.py
@@ -548,7 +548,7 @@ class SidebarTreeView(QTreeView):
                     icon,
                     self._filter_func(SearchTerm(tag=head + node.name)),
                     toggle_expand(),
-                    not node.collapsed,
+                    node.expanded,
                     item_type=SidebarItemType.TAG,
                     full_name=head + node.name,
                 )

--- a/qt/aqt/sidebar.py
+++ b/qt/aqt/sidebar.py
@@ -539,8 +539,8 @@ class SidebarTreeView(QTreeView):
 
                 def toggle_expand() -> Callable[[bool], None]:
                     full_name = head + node.name  # pylint: disable=cell-var-from-loop
-                    return lambda expanded: self.mw.col.tags.set_collapsed(
-                        full_name, not expanded
+                    return lambda expanded: self.mw.col.tags.set_expanded(
+                        full_name, expanded
                     )
 
                 item = SidebarItem(

--- a/qt/aqt/sidebar.py
+++ b/qt/aqt/sidebar.py
@@ -55,6 +55,8 @@ class SidebarItemType(Enum):
     TEMPLATE = 8
     SAVED_SEARCH_ROOT = 9
     DECK_ROOT = 10
+    NOTETYPE_ROOT = 11
+    TAG_ROOT = 12
 
 
 #  used by an add-on hook
@@ -113,10 +115,11 @@ class SidebarItem:
             if self._search_matches_child:
                 return True
             # if search matches top level, expand children one level
-            # FIXME: add types for other roots
             return self._search_matches_self and self.item_type in (
                 SidebarItemType.SAVED_SEARCH_ROOT,
                 SidebarItemType.DECK_ROOT,
+                SidebarItemType.NOTETYPE_ROOT,
+                SidebarItemType.TAG_ROOT,
             )
 
     def is_highlighted(self) -> bool:
@@ -558,6 +561,7 @@ class SidebarTreeView(QTreeView):
             name=TR.BROWSING_SIDEBAR_TAGS,
             icon=icon,
             collapse_key=ConfigBoolKey.COLLAPSE_TAGS,
+            type=SidebarItemType.TAG_ROOT,
         )
         render(root, tree.children)
 
@@ -604,6 +608,7 @@ class SidebarTreeView(QTreeView):
             name=TR.BROWSING_SIDEBAR_NOTETYPES,
             icon=icon,
             collapse_key=ConfigBoolKey.COLLAPSE_NOTETYPES,
+            type=SidebarItemType.NOTETYPE_ROOT,
         )
 
         for nt in sorted(self.col.models.all(), key=lambda nt: nt["name"].lower()):

--- a/rslib/backend.proto
+++ b/rslib/backend.proto
@@ -865,7 +865,7 @@ message TagTreeNode {
   string name = 1;
   repeated TagTreeNode children = 2;
   uint32 level = 3;
-  bool collapsed = 4;
+  bool expanded = 4;
 }
 
 message SetConfigJsonIn {

--- a/rslib/backend.proto
+++ b/rslib/backend.proto
@@ -41,6 +41,10 @@ message Bool {
   bool val = 1;
 }
 
+message StringList {
+  repeated string vals = 1;
+}
+
 // IDs used in RPC calls
 ///////////////////////////////////////////////////////////
 
@@ -212,7 +216,7 @@ service BackendService {
   // tags
 
   rpc ClearUnusedTags(Empty) returns (Empty);
-  rpc AllTags(Empty) returns (AllTagsOut);
+  rpc AllTags(Empty) returns (StringList);
   rpc SetTagCollapsed(SetTagCollapsedIn) returns (Empty);
   rpc ClearTag(String) returns (Empty);
   rpc TagTree(Empty) returns (TagTreeNode);
@@ -842,19 +846,9 @@ message AddOrUpdateDeckConfigLegacyIn {
   bool preserve_usn_and_mtime = 2;
 }
 
-message AllTagsOut {
-  repeated Tag tags = 1;
-}
-
 message SetTagCollapsedIn {
   string name = 1;
   bool collapsed = 2;
-}
-
-message Tag {
-  string name = 1;
-  sint32 usn = 2;
-  bool collapsed = 3;
 }
 
 message GetChangedTagsOut {

--- a/rslib/backend.proto
+++ b/rslib/backend.proto
@@ -217,7 +217,7 @@ service BackendService {
 
   rpc ClearUnusedTags(Empty) returns (Empty);
   rpc AllTags(Empty) returns (StringList);
-  rpc SetTagCollapsed(SetTagCollapsedIn) returns (Empty);
+  rpc SetTagExpanded(SetTagExpandedIn) returns (Empty);
   rpc ClearTag(String) returns (Empty);
   rpc TagTree(Empty) returns (TagTreeNode);
 
@@ -846,9 +846,9 @@ message AddOrUpdateDeckConfigLegacyIn {
   bool preserve_usn_and_mtime = 2;
 }
 
-message SetTagCollapsedIn {
+message SetTagExpandedIn {
   string name = 1;
-  bool collapsed = 2;
+  bool expanded = 2;
 }
 
 message GetChangedTagsOut {

--- a/rslib/src/backend/mod.rs
+++ b/rslib/src/backend/mod.rs
@@ -1399,16 +1399,17 @@ impl BackendService for Backend {
     // tags
     //-------------------------------------------------------------------
 
-    fn all_tags(&self, _input: Empty) -> BackendResult<pb::AllTagsOut> {
-        let tags: Vec<pb::Tag> = self.with_col(|col| {
-            Ok(col
-                .storage
-                .all_tags()?
-                .into_iter()
-                .map(|t| t.into())
-                .collect())
-        })?;
-        Ok(pb::AllTagsOut { tags })
+    fn all_tags(&self, _input: Empty) -> BackendResult<pb::StringList> {
+        Ok(pb::StringList {
+            vals: self.with_col(|col| {
+                Ok(col
+                    .storage
+                    .all_tags()?
+                    .into_iter()
+                    .map(|t| t.name)
+                    .collect())
+            })?,
+        })
     }
 
     fn set_tag_collapsed(&self, input: pb::SetTagCollapsedIn) -> BackendResult<pb::Empty> {

--- a/rslib/src/backend/mod.rs
+++ b/rslib/src/backend/mod.rs
@@ -1412,10 +1412,10 @@ impl BackendService for Backend {
         })
     }
 
-    fn set_tag_collapsed(&self, input: pb::SetTagCollapsedIn) -> BackendResult<pb::Empty> {
+    fn set_tag_expanded(&self, input: pb::SetTagExpandedIn) -> BackendResult<pb::Empty> {
         self.with_col(|col| {
             col.transact(None, |col| {
-                col.set_tag_collapsed(&input.name, input.collapsed)?;
+                col.set_tag_expanded(&input.name, input.expanded)?;
                 Ok(().into())
             })
         })

--- a/rslib/src/dbcheck.rs
+++ b/rslib/src/dbcheck.rs
@@ -242,7 +242,7 @@ impl Collection {
         let usn = self.usn()?;
         let stamp = TimestampMillis::now();
 
-        let collapsed_tags = self.storage.collapsed_tags()?;
+        let expanded_tags = self.storage.expanded_tags()?;
         self.storage.clear_tags()?;
 
         let total_notes = self.storage.total_notes()?;
@@ -296,7 +296,7 @@ impl Collection {
 
         // the note rebuilding process took care of adding tags back, so we just need
         // to ensure to restore the collapse state
-        self.storage.restore_collapsed_tags(&collapsed_tags)?;
+        self.storage.restore_expanded_tags(&expanded_tags)?;
 
         // if the collection is empty and the user has deleted all note types, ensure at least
         // one note type exists
@@ -646,7 +646,7 @@ mod test {
         note.tags.push("two".into());
         col.add_note(&mut note, DeckID(1))?;
 
-        col.set_tag_collapsed("two", true)?;
+        col.set_tag_collapsed("one", false)?;
 
         col.check_database(progress_fn)?;
 

--- a/rslib/src/dbcheck.rs
+++ b/rslib/src/dbcheck.rs
@@ -646,12 +646,12 @@ mod test {
         note.tags.push("two".into());
         col.add_note(&mut note, DeckID(1))?;
 
-        col.set_tag_collapsed("one", false)?;
+        col.set_tag_expanded("one", true)?;
 
         col.check_database(progress_fn)?;
 
-        assert_eq!(col.storage.get_tag("one")?.unwrap().collapsed, false);
-        assert_eq!(col.storage.get_tag("two")?.unwrap().collapsed, true);
+        assert_eq!(col.storage.get_tag("one")?.unwrap().expanded, true);
+        assert_eq!(col.storage.get_tag("two")?.unwrap().expanded, false);
 
         Ok(())
     }

--- a/rslib/src/decks/mod.rs
+++ b/rslib/src/decks/mod.rs
@@ -45,7 +45,11 @@ impl Deck {
             name: "".into(),
             mtime_secs: TimestampSecs(0),
             usn: Usn(0),
-            common: DeckCommon::default(),
+            common: DeckCommon {
+                study_collapsed: true,
+                browser_collapsed: true,
+                ..Default::default()
+            },
             kind: DeckKind::Normal(norm),
         }
     }

--- a/rslib/src/filtered.rs
+++ b/rslib/src/filtered.rs
@@ -133,7 +133,11 @@ impl Deck {
             name: "".into(),
             mtime_secs: TimestampSecs(0),
             usn: Usn(0),
-            common: DeckCommon::default(),
+            common: DeckCommon {
+                study_collapsed: true,
+                browser_collapsed: true,
+                ..Default::default()
+            },
             kind: DeckKind::Filtered(filt),
         }
     }

--- a/rslib/src/storage/tag/mod.rs
+++ b/rslib/src/storage/tag/mod.rs
@@ -24,17 +24,17 @@ impl SqliteStorage {
             .collect()
     }
 
-    pub(crate) fn collapsed_tags(&self) -> Result<Vec<String>> {
+    pub(crate) fn expanded_tags(&self) -> Result<Vec<String>> {
         self.db
-            .prepare_cached("select tag from tags where collapsed = true")?
+            .prepare_cached("select tag from tags where collapsed = false")?
             .query_and_then(NO_PARAMS, |r| r.get::<_, String>(0).map_err(Into::into))?
             .collect::<Result<Vec<_>>>()
     }
 
-    pub(crate) fn restore_collapsed_tags(&self, tags: &[String]) -> Result<()> {
+    pub(crate) fn restore_expanded_tags(&self, tags: &[String]) -> Result<()> {
         let mut stmt = self
             .db
-            .prepare_cached("update tags set collapsed = true where tag = ?")?;
+            .prepare_cached("update tags set collapsed = false where tag = ?")?;
         for tag in tags {
             stmt.execute(&[tag])?;
         }

--- a/rslib/src/storage/tag/mod.rs
+++ b/rslib/src/storage/tag/mod.rs
@@ -11,7 +11,7 @@ fn row_to_tag(row: &Row) -> Result<Tag> {
     Ok(Tag {
         name: row.get(0)?,
         usn: row.get(1)?,
-        collapsed: row.get(2)?,
+        expanded: !row.get(2)?,
     })
 }
 
@@ -52,7 +52,7 @@ impl SqliteStorage {
     pub(crate) fn register_tag(&self, tag: &Tag) -> Result<()> {
         self.db
             .prepare_cached(include_str!("add.sql"))?
-            .execute(params![tag.name, tag.usn, tag.collapsed])?;
+            .execute(params![tag.name, tag.usn, !tag.expanded])?;
         Ok(())
     }
 

--- a/rslib/src/storage/upgrades/mod.rs
+++ b/rslib/src/storage/upgrades/mod.rs
@@ -35,6 +35,10 @@ impl SqliteStorage {
             self.upgrade_tags_to_schema17()?;
             self.db.execute_batch("update col set ver = 17")?;
         }
+        // fixme: on the next schema upgrade, change _collapsed to _expanded
+        // in DeckCommon and invert existing values, so that we can avoid
+        // serializing the values in the default case, and use
+        // DeckCommon::default() in new_normal() and new_filtered()
 
         Ok(())
     }

--- a/rslib/src/tags.rs
+++ b/rslib/src/tags.rs
@@ -46,7 +46,7 @@ impl Tag {
         Tag {
             name,
             usn,
-            collapsed: false,
+            collapsed: true,
         }
     }
 }

--- a/rslib/src/tags.rs
+++ b/rslib/src/tags.rs
@@ -2,7 +2,7 @@
 // License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
 use crate::{
-    backend_proto::{Tag as TagProto, TagTreeNode},
+    backend_proto::TagTreeNode,
     collection::Collection,
     err::{AnkiError, Result},
     notes::{NoteID, TransformNoteOutput},
@@ -19,26 +19,6 @@ pub struct Tag {
     pub name: String,
     pub usn: Usn,
     pub collapsed: bool,
-}
-
-impl From<Tag> for TagProto {
-    fn from(t: Tag) -> Self {
-        TagProto {
-            name: t.name,
-            usn: t.usn.0,
-            collapsed: t.collapsed,
-        }
-    }
-}
-
-impl From<TagProto> for Tag {
-    fn from(t: TagProto) -> Self {
-        Tag {
-            name: t.name,
-            usn: Usn(t.usn),
-            collapsed: t.collapsed,
-        }
-    }
 }
 
 impl Tag {


### PR DESCRIPTION
See comments under https://github.com/ankitects/anki/commit/132bb5ff365ccac00b9d4ac8ba7690bddd49c9b6 for context.

This expands match trees one level while including all items under them in collapsed state:

![image](https://user-images.githubusercontent.com/41397710/106485829-109ba180-64c2-11eb-8e2d-9457c39ee9c9.png)


Regarding apps with a similar interface, I can think of some examples:

1. There is a thing in Visual Studio called Object Browser that has a hierarchical interface.
![visual-studio-object-browser-1](https://user-images.githubusercontent.com/41397710/106486070-50628900-64c2-11eb-8bcf-39e1545ff279.png)
Searching for "Program" shows a collapsed, partially flattened tree.
![visual-studio-object-browser-2](https://user-images.githubusercontent.com/41397710/106486084-548ea680-64c2-11eb-859f-f6d304cd5fea.png)

2. Another example is an app called [TreeSize](https://www.jam-software.com/treesize_free) for visualizing disk usage.
Searching for "bar" here shows the match trees collaped, with all files/folders under matches included, obviously.
![treesize-1](https://user-images.githubusercontent.com/41397710/106487267-8bb18780-64c3-11eb-9718-9672502441a4.png)

Personally, I now think it makes more sense to include all items under matches, even if that means making the search a bit slower.
The approach taken by Visual Studio may result in a less cluttered interface but I guess it will be more complex to implement.
This PR takes a similar approach to TreeSize's, with the difference that match trees are expanded one level.

What do you think about only expanding matched section roots, while keeping other matches collapsed?

if anyone has got any suggestions, please share them here.