### PR TITLE
Update setFirstWeekday with new .on() type signature

### DIFF
--- a/ts/graphs/calendar.ts
+++ b/ts/graphs/calendar.ts
@@ -196,7 +196,7 @@ export function renderCalendar(
                 d
             )
         )
-        .on("click", setFirstDayOfWeek);
+        .on("click", (_event: MouseEvent, d: number) => setFirstDayOfWeek(d));
 
     svg.select("g.days")
         .selectAll("rect")


### PR DESCRIPTION
This addresses the bug with setting the first weekday you reported you reported [here](https://github.com/ankitects/anki/commit/6bf38236b917e0df3d0e25affbdadf30b5726083#commitcomment-46734739).
The new update for d3 changed the type signature for `.on()`, which before was

```js
.on("event", (this, data, index) => void);
```

with `this` being optional, and now changed to:

```js
.on("event", (Event, data) => void);
```