### PR TITLE
Use lang="scss" in CardCounts

### DIFF
--- a/ts/graphs/CardCounts.svelte
+++ b/ts/graphs/CardCounts.svelte
@@ -33,7 +33,7 @@
     const total = i18n.tr(i18n.TR.STATISTICS_COUNTS_TOTAL_CARDS);
 </script>
 
-<style>
+<style lang="scss">
     svg {
         transition: opacity 1s;
     }
@@ -47,10 +47,10 @@
         display: flex;
         flex-direction: column;
         justify-content: center;
-    }
 
-    .counts-table td {
-        white-space: nowrap;
+        td {
+            white-space: nowrap;
+        }
     }
 
     table {


### PR DESCRIPTION
A tiny example of using `lang="scss"` in Svelte. Should only be merged, after https://github.com/ankitects/rules_svelte/pull/1 was merged and updated here.

Is confirmed to work locally.