### PR TITLE
Move reviewer to ts/reviewer

### DIFF
--- a/qt/aqt/data/web/css/BUILD.bazel
+++ b/qt/aqt/data/web/css/BUILD.bazel
@@ -26,12 +26,21 @@ copy_files_into_group(
     package = "//ts/editor",
 )
 
+copy_files_into_group(
+    name = "reviewer",
+    srcs = [
+        "reviewer.css",
+    ],
+    package = "//ts/reviewer",
+)
+
 filegroup(
     name = "css",
     srcs = [
         "core.css",
         "css_local",
         "editor",
+        "reviewer",
     ],
     visibility = ["//qt:__subpackages__"],
 )

--- a/qt/aqt/data/web/js/BUILD.bazel
+++ b/qt/aqt/data/web/js/BUILD.bazel
@@ -38,11 +38,20 @@ copy_files_into_group(
     package = "//ts/editor",
 )
 
+copy_files_into_group(
+    name = "reviewer",
+    srcs = [
+        "reviewer.js",
+    ],
+    package = "//ts/reviewer",
+)
+
 filegroup(
     name = "js",
     srcs = [
         "aqt_es5",
         "editor",
+        "reviewer",
         "mathjax.js",
         "//qt/aqt/data/web/js/vendor",
     ],

--- a/ts/editor/editor.scss
+++ b/ts/editor/editor.scss
@@ -10,7 +10,8 @@ html {
     flex-direction: column;
     margin: 5px;
 
-    & > *, & > * > * {
+    & > *,
+    & > * > * {
         margin: 1px 0;
 
         &:first-child {

--- a/ts/reviewer/BUILD.bazel
+++ b/ts/reviewer/BUILD.bazel
@@ -5,19 +5,13 @@ load("//ts:prettier.bzl", "prettier_test")
 load("//ts:eslint.bzl", "eslint_test")
 
 sass_binary(
-    name = "editor_css",
-    src = "editor.scss",
-    visibility = ["//visibility:public"],
-)
-
-sass_binary(
-    name = "editable_css",
-    src = "editable.scss",
+    name = "reviewer_css",
+    src = "reviewer.scss",
     visibility = ["//visibility:public"],
 )
 
 ts_library(
-    name = "editor_ts",
+    name = "reviewer_ts",
     srcs = glob(["*.ts"]),
     tsconfig = "//qt/aqt/data/web/js:tsconfig.json",
     deps = [
@@ -26,7 +20,7 @@ ts_library(
 )
 
 rollup_bundle(
-    name = "editor",
+    name = "reviewer",
     config_file = "//ts:rollup.aqt.config.js",
     entry_point = "index.ts",
     format = "iife",
@@ -35,7 +29,7 @@ rollup_bundle(
     sourcemap = "false",
     visibility = ["//visibility:public"],
     deps = [
-        "editor_ts",
+        "reviewer_ts",
         "@npm//@rollup/plugin-commonjs",
         "@npm//@rollup/plugin-node-resolve",
         "@npm//rollup-plugin-terser",

--- a/ts/reviewer/index.ts
+++ b/ts/reviewer/index.ts
@@ -1,6 +1,8 @@
 /* Copyright: Ankitects Pty Ltd and contributors
  * License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html */
 
+import { bridgeCommand } from "./lib";
+
 declare var MathJax: any;
 
 type Callback = () => void | Promise<void>;
@@ -29,7 +31,7 @@ function _queueAction(action: Callback): void {
     _updatingQueue = _updatingQueue.then(action);
 }
 
-async function _updateQA(
+export async function _updateQA(
     html: string,
     fadeTime: number,
     onupdate: Callback,
@@ -78,7 +80,7 @@ async function _updateQA(
     await _runHook(onShownHook);
 }
 
-function _showQuestion(q: string, bodyclass: string): void {
+export function _showQuestion(q: string, bodyclass: string): void {
     _queueAction(() =>
         _updateQA(
             q,
@@ -100,7 +102,7 @@ function _showQuestion(q: string, bodyclass: string): void {
     );
 }
 
-function _showAnswer(a: string, bodyclass: string): void {
+export function _showAnswer(a: string, bodyclass: string): void {
     _queueAction(() =>
         _updateQA(
             a,
@@ -129,7 +131,7 @@ const _flagColours = {
     4: "#77aaff",
 };
 
-function _drawFlag(flag: 0 | 1 | 2 | 3 | 4): void {
+export function _drawFlag(flag: 0 | 1 | 2 | 3 | 4): void {
     var elem = $("#_flag");
     if (flag === 0) {
         elem.hide();
@@ -139,7 +141,7 @@ function _drawFlag(flag: 0 | 1 | 2 | 3 | 4): void {
     elem.css("color", _flagColours[flag]);
 }
 
-function _drawMark(mark: boolean): void {
+export function _drawMark(mark: boolean): void {
     var elem = $("#_mark");
     if (!mark) {
         elem.hide();
@@ -148,13 +150,13 @@ function _drawMark(mark: boolean): void {
     }
 }
 
-function _typeAnsPress(): void {
+export function _typeAnsPress(): void {
     if ((window.event as KeyboardEvent).keyCode === 13) {
-        pycmd("ans");
+        bridgeCommand("ans");
     }
 }
 
-function _emulateMobile(enabled: boolean): void {
+export function _emulateMobile(enabled: boolean): void {
     const list = document.documentElement.classList;
     if (enabled) {
         list.add("mobile");

--- a/ts/reviewer/lib.ts
+++ b/ts/reviewer/lib.ts
@@ -1,0 +1,9 @@
+declare global {
+    interface Window {
+        bridgeCommand<T>(command: string, callback?: (value: T) => void): void;
+    }
+}
+
+export function bridgeCommand<T>(command: string, callback?: (value: T) => void): void {
+    window.bridgeCommand<T>(command, callback);
+}

--- a/ts/reviewer/reviewer.scss
+++ b/ts/reviewer/reviewer.scss
@@ -88,7 +88,9 @@ img {
     }
 }
 
-.drawing { zoom: 50%; }
+.drawing {
+    zoom: 50%;
+}
 .nightMode img.drawing {
-    filter: unquote("invert(1) hue-rotate(180deg)")
+    filter: unquote("invert(1) hue-rotate(180deg)");
 }


### PR DESCRIPTION
This will move `data/web/js/reviewer.ts` and `data/web/css/reviewer.scss` to `/ts/reviewer`.

The motivation here is the following:
Previewer will also display the card to the user, so it would be nice, if it could reuse the code that Reviewer uses. So the first step is moving reviewer to `ts`. In the Previewer PR, I will split off the "displaying" functionality of Reviewer into another directory, probably `ts/cardDisplayer`, which can then be imported by both Reviewer and Previewer.