### PR TITLE
Refactor "currentField" concept for editor, export for add-on developers

### DIFF
--- a/ts/editor/changeTimer.ts
+++ b/ts/editor/changeTimer.ts
@@ -1,0 +1,47 @@
+import type { EditingArea } from ".";
+
+import { getCurrentField } from ".";
+import { bridgeCommand } from "./lib";
+import { getNoteId } from "./noteId";
+import { updateButtonState } from "./toolbar";
+
+let changeTimer: number | null = null;
+
+export function triggerChangeTimer(currentField: EditingArea): void {
+    clearChangeTimer();
+    changeTimer = setTimeout(function () {
+        updateButtonState();
+        saveField(currentField, "key");
+    }, 600);
+}
+
+function clearChangeTimer(): void {
+    if (changeTimer) {
+        clearTimeout(changeTimer);
+        changeTimer = null;
+    }
+}
+
+export function saveField(currentField: EditingArea, type: "blur" | "key"): void {
+    clearChangeTimer();
+    bridgeCommand(
+        `${type}:${currentField.ord}:${getNoteId()}:${currentField.fieldHTML}`
+    );
+}
+
+export function saveNow(keepFocus: boolean): void {
+    const currentField = getCurrentField();
+
+    if (!currentField) {
+        return;
+    }
+
+    clearChangeTimer();
+
+    if (keepFocus) {
+        saveField(currentField, "key");
+    } else {
+        // triggers onBlur, which saves
+        currentField.blurEditable();
+    }
+}

--- a/ts/editor/editor.scss
+++ b/ts/editor/editor.scss
@@ -56,15 +56,19 @@ body {
     background: var(--bg-color);
 }
 
-.topbuts > * {
-    margin: 0 1px;
+.topbuts {
+    margin-bottom: 2px;
 
-    &:first-child {
-        margin-left: 0;
-    }
+    & > * {
+        margin: 0 1px;
 
-    &:last-child {
-        margin-right: 0;
+        &:first-child {
+            margin-left: 0;
+        }
+
+        &:last-child {
+            margin-right: 0;
+        }
     }
 }
 

--- a/ts/editor/editor.scss
+++ b/ts/editor/editor.scss
@@ -10,7 +10,8 @@ html {
     flex-direction: column;
     margin: 5px;
 
-    & > *, & > * > * {
+    & > *,
+    & > * > * {
         margin: 1px 0;
 
         &:first-child {

--- a/ts/editor/focusHandlers.ts
+++ b/ts/editor/focusHandlers.ts
@@ -1,0 +1,60 @@
+import type { EditingArea } from ".";
+
+import { bridgeCommand } from "./lib";
+import { enableButtons, disableButtons } from "./toolbar";
+import { saveField } from "./changeTimer";
+
+function isElementInViewport(element: Element): boolean {
+    const rect = element.getBoundingClientRect();
+
+    return (
+        rect.top >= 0 &&
+        rect.left >= 0 &&
+        rect.bottom <= (window.innerHeight || document.documentElement.clientHeight) &&
+        rect.right <= (window.innerWidth || document.documentElement.clientWidth)
+    );
+}
+
+function caretToEnd(currentField: EditingArea): void {
+    const range = document.createRange();
+    range.selectNodeContents(currentField.editable);
+    range.collapse(false);
+    const selection = currentField.getSelection();
+    selection.removeAllRanges();
+    selection.addRange(range);
+}
+
+// For distinguishing focus by refocusing window from deliberate focus
+let previousActiveElement: EditingArea | null = null;
+
+export function onFocus(evt: FocusEvent): void {
+    const currentField = evt.currentTarget as EditingArea;
+
+    if (currentField === previousActiveElement) {
+        return;
+    }
+
+    currentField.focusEditable();
+    bridgeCommand(`focus:${currentField.ord}`);
+    enableButtons();
+    // do this twice so that there's no flicker on newer versions
+    caretToEnd(currentField);
+    // scroll if bottom of element off the screen
+    if (!isElementInViewport(currentField)) {
+        currentField.scrollIntoView(false /* alignToBottom */);
+    }
+}
+
+export function onBlur(evt: FocusEvent): void {
+    const currentField = evt.currentTarget as EditingArea;
+
+    if (currentField === previousActiveElement) {
+        // other widget or window focused; current field unchanged
+        saveField(currentField, "key");
+        previousActiveElement = currentField;
+    } else {
+        saveField(currentField, "blur");
+        disableButtons();
+        previousActiveElement = null;
+    }
+}

--- a/ts/editor/htmlFilter.ts
+++ b/ts/editor/htmlFilter.ts
@@ -1,6 +1,6 @@
 import { nodeIsElement } from "./helpers";
 
-export let filterHTML = function (
+export function filterHTML(
     html: string,
     internal: boolean,
     extendedMode: boolean
@@ -21,7 +21,7 @@ export let filterHTML = function (
     }
     outHtml = outHtml.trim();
     return outHtml;
-};
+}
 
 let allowedTagsBasic = {};
 let allowedTagsExtended = {};

--- a/ts/editor/index.ts
+++ b/ts/editor/index.ts
@@ -138,6 +138,7 @@ export class EditingArea extends HTMLDivElement {
         this.addEventListener("paste", onPaste);
         this.addEventListener("copy", onCutOrCopy);
         this.addEventListener("oncut", onCutOrCopy);
+        this.addEventListener("click", updateButtonState);
 
         const baseStyleSheet = this.baseStyle.sheet as CSSStyleSheet;
         baseStyleSheet.insertRule("anki-editable {}", 0);
@@ -152,6 +153,7 @@ export class EditingArea extends HTMLDivElement {
         this.removeEventListener("paste", onPaste);
         this.removeEventListener("copy", onCutOrCopy);
         this.removeEventListener("oncut", onCutOrCopy);
+        this.removeEventListener("click", updateButtonState);
     }
 
     initialize(color: string, content: string): void {

--- a/ts/editor/index.ts
+++ b/ts/editor/index.ts
@@ -11,6 +11,7 @@ import { onFocus, onBlur } from "./focusHandlers";
 
 export { setNoteId, getNoteId } from "./noteId";
 export { preventButtonFocus, toggleEditorButton, setFGButton } from "./toolbar";
+export { saveNow } from "./changeTimer";
 
 declare global {
     interface Selection {

--- a/ts/editor/index.ts
+++ b/ts/editor/index.ts
@@ -207,7 +207,7 @@ export class EditingArea extends HTMLDivElement {
 
 customElements.define("anki-editing-area", EditingArea, { extends: "div" });
 
-class EditorField extends HTMLDivElement {
+export class EditorField extends HTMLDivElement {
     labelContainer: HTMLDivElement;
     label: HTMLSpanElement;
     editingArea: EditingArea;

--- a/ts/editor/index.ts
+++ b/ts/editor/index.ts
@@ -151,7 +151,7 @@ export class EditingArea extends HTMLDivElement {
         this.addEventListener("paste", onPaste);
         this.addEventListener("copy", onCutOrCopy);
         this.addEventListener("oncut", onCutOrCopy);
-        this.addEventListener("click", updateButtonState);
+        this.addEventListener("mouseup", updateButtonState);
 
         const baseStyleSheet = this.baseStyle.sheet as CSSStyleSheet;
         baseStyleSheet.insertRule("anki-editable {}", 0);
@@ -166,7 +166,7 @@ export class EditingArea extends HTMLDivElement {
         this.removeEventListener("paste", onPaste);
         this.removeEventListener("copy", onCutOrCopy);
         this.removeEventListener("oncut", onCutOrCopy);
-        this.removeEventListener("click", updateButtonState);
+        this.removeEventListener("mouseup", updateButtonState);
     }
 
     initialize(color: string, content: string): void {

--- a/ts/editor/index.ts
+++ b/ts/editor/index.ts
@@ -18,6 +18,14 @@ declare global {
     }
 }
 
+export function getCurrentField(): EditingArea | null {
+    return currentField;
+}
+
+export function getCurrentNoteId(): number | null {
+    return currentNoteId;
+}
+
 export function setFGButton(col: string): void {
     document.getElementById("forecolor").style.backgroundColor = col;
 }

--- a/ts/editor/inputHandlers.ts
+++ b/ts/editor/inputHandlers.ts
@@ -1,0 +1,76 @@
+import { EditingArea } from ".";
+import { nodeIsElement } from "./helpers";
+import { triggerChangeTimer } from "./changeTimer";
+
+function inListItem(currentField: EditingArea): boolean {
+    const anchor = currentField.getSelection()!.anchorNode!;
+
+    let inList = false;
+    let n = nodeIsElement(anchor) ? anchor : anchor.parentElement;
+    while (n) {
+        inList = inList || window.getComputedStyle(n).display == "list-item";
+        n = n.parentElement;
+    }
+
+    return inList;
+}
+
+export function onInput(event: Event): void {
+    // make sure IME changes get saved
+    triggerChangeTimer(event.currentTarget as EditingArea);
+}
+
+export function onKey(evt: KeyboardEvent): void {
+    const currentField = evt.currentTarget as EditingArea;
+
+    // esc clears focus, allowing dialog to close
+    if (evt.code === "Escape") {
+        currentField.blurEditable();
+        return;
+    }
+
+    // prefer <br> instead of <div></div>
+    if (evt.code === "Enter" && !inListItem(currentField)) {
+        evt.preventDefault();
+        document.execCommand("insertLineBreak");
+    }
+
+    // // fix Ctrl+right/left handling in RTL fields
+    if (currentField.isRightToLeft()) {
+        const selection = currentField.getSelection();
+        const granularity = evt.ctrlKey ? "word" : "character";
+        const alter = evt.shiftKey ? "extend" : "move";
+
+        switch (evt.code) {
+            case "ArrowRight":
+                selection.modify(alter, "right", granularity);
+                evt.preventDefault();
+                return;
+            case "ArrowLeft":
+                selection.modify(alter, "left", granularity);
+                evt.preventDefault();
+                return;
+        }
+    }
+
+    triggerChangeTimer(currentField);
+}
+
+export function onKeyUp(evt: KeyboardEvent): void {
+    const currentField = evt.currentTarget as EditingArea;
+
+    // Avoid div element on remove
+    if (evt.code === "Enter" || evt.code === "Backspace") {
+        const anchor = currentField.getSelection().anchorNode as Node;
+
+        if (
+            nodeIsElement(anchor) &&
+            anchor.tagName === "DIV" &&
+            !(anchor instanceof EditingArea) &&
+            anchor.childElementCount === 1 &&
+            anchor.children[0].tagName === "BR"
+        ) {
+            anchor.replaceWith(anchor.children[0]);
+        }
+    }
+}

--- a/ts/editor/noteId.ts
+++ b/ts/editor/noteId.ts
@@ -1,0 +1,9 @@
+let currentNoteId: number | null = null;
+
+export function setNoteId(id: number): void {
+    currentNoteId = id;
+}
+
+export function getNoteId(): number | null {
+    return currentNoteId;
+}

--- a/ts/editor/toolbar.ts
+++ b/ts/editor/toolbar.ts
@@ -1,0 +1,46 @@
+import { EditingArea } from ".";
+
+export function updateButtonState(): void {
+    const buts = ["bold", "italic", "underline", "superscript", "subscript"];
+    for (const name of buts) {
+        const elem = document.querySelector(`#${name}`) as HTMLElement;
+        elem.classList.toggle("highlighted", document.queryCommandState(name));
+    }
+
+    // fixme: forecolor
+    //    'col': document.queryCommandValue("forecolor")
+}
+
+export function preventButtonFocus(): void {
+    for (const element of document.querySelectorAll("button.linkb")) {
+        element.addEventListener("mousedown", (evt: Event) => {
+            evt.preventDefault();
+        });
+    }
+}
+
+export function disableButtons(): void {
+    $("button.linkb:not(.perm)").prop("disabled", true);
+}
+
+export function enableButtons(): void {
+    $("button.linkb").prop("disabled", false);
+}
+
+// disable the buttons if a field is not currently focused
+export function maybeDisableButtons(): void {
+    if (document.activeElement instanceof EditingArea) {
+        enableButtons();
+    } else {
+        disableButtons();
+    }
+}
+
+export function setFGButton(col: string): void {
+    document.getElementById("forecolor")!.style.backgroundColor = col;
+}
+
+export function toggleEditorButton(buttonid: string): void {
+    const button = $(buttonid)[0];
+    button.classList.toggle("highlighted");
+}

--- a/ts/editor/wrap.ts
+++ b/ts/editor/wrap.ts
@@ -5,11 +5,19 @@ function wrappedExceptForWhitespace(text: string, front: string, back: string): 
     return match[1] + front + match[2] + back + match[3];
 }
 
+function moveCursorPastPostfix(selection: Selection, postfix: string): void {
+    const range = selection.getRangeAt(0);
+    range.setStart(range.startContainer, range.startOffset - postfix.length);
+    range.collapse(true);
+    selection.removeAllRanges();
+    selection.addRange(range);
+}
+
 function wrapInternal(front: string, back: string, plainText: boolean): void {
     const currentField = getCurrentField()!;
-    const s = currentField.getSelection();
-    let r = s.getRangeAt(0);
-    const content = r.cloneContents();
+    const selection = currentField.getSelection();
+    const range = selection.getRangeAt(0);
+    const content = range.cloneContents();
     const span = document.createElement("span");
     span.appendChild(content);
 
@@ -22,12 +30,7 @@ function wrapInternal(front: string, back: string, plainText: boolean): void {
     }
 
     if (!span.innerHTML) {
-        // run with an empty selection; move cursor back past postfix
-        r = s.getRangeAt(0);
-        r.setStart(r.startContainer, r.startOffset - back.length);
-        r.collapse(true);
-        s.removeAllRanges();
-        s.addRange(r);
+        moveCursorPastPostfix(selection, back);
     }
 }
 

--- a/ts/editor/wrap.ts
+++ b/ts/editor/wrap.ts
@@ -1,0 +1,41 @@
+import { getCurrentField, setFormat } from ".";
+
+function wrappedExceptForWhitespace(text: string, front: string, back: string): string {
+    const match = text.match(/^(\s*)([^]*?)(\s*)$/)!;
+    return match[1] + front + match[2] + back + match[3];
+}
+
+function wrapInternal(front: string, back: string, plainText: boolean): void {
+    const currentField = getCurrentField()!;
+    const s = currentField.getSelection();
+    let r = s.getRangeAt(0);
+    const content = r.cloneContents();
+    const span = document.createElement("span");
+    span.appendChild(content);
+
+    if (plainText) {
+        const new_ = wrappedExceptForWhitespace(span.innerText, front, back);
+        setFormat("inserttext", new_);
+    } else {
+        const new_ = wrappedExceptForWhitespace(span.innerHTML, front, back);
+        setFormat("inserthtml", new_);
+    }
+
+    if (!span.innerHTML) {
+        // run with an empty selection; move cursor back past postfix
+        r = s.getRangeAt(0);
+        r.setStart(r.startContainer, r.startOffset - back.length);
+        r.collapse(true);
+        s.removeAllRanges();
+        s.addRange(r);
+    }
+}
+
+export function wrap(front: string, back: string): void {
+    wrapInternal(front, back, false);
+}
+
+/* currently unused */
+export function wrapIntoText(front: string, back: string): void {
+    wrapInternal(front, back, true);
+}


### PR DESCRIPTION
I started porting my editor add-ons for Anki 2.1.41 beta, and I realized, that there was one big omission in the new visible editor API, which is an easy way to get the current field.

However I didn't want to simple export a way to access `currentField`, because I always thought it's kind of an anti-pattern to have this kind of global variable available, that all functions access. The event handlers wouldn't even need it, as they have access to `event.currentTarget`, which is guaranteed to be of type `EditingArea`, as well.

So this turned out to be a bigger refactoring PR, with the main goal, to remove the global `currentField`.

Other changes include:
* For cases, where there is no easily accessible "currentField" via an `Event` interface e.g. `wrap`, or `pasteHTML`, there is a new exported function `getCurrentField`, which utilizes `document.activeElement`, which will also return `EditingArea`, if the focus is inside the contenteditable, as anything else would be hidden within the shadow root.
* I tried to put global variables into their own files, so that only functions that absolute require them have them in their scope, this includes:
  1. The old `currentField`, is now `previousActiveElement`, and is in `focusHandlers.ts`
  2. `currentNoteId` is accessible for add-ons via `getNoteId`, and is in file `noteId.ts`
  3. `changeTimer` is in the file `changeTimer.ts`
* I rewrote the logic for scrolling the currentField into view, utilizing `scrollIntoView`, and `scrollBy`
* I put a 2px margin between the the button rows, which is noticeable when they wrap. Before this, they would touch each other, now there's a small gap.
* When clicking on text, which has bold, italic, or underline applied to them, it would not highlight the button. Now it does, by calling `updateButtonState` upon `mouseup`.