### PR TITLE
Note.ephemeral_card() fix

### DIFF
--- a/pylib/anki/notes.py
+++ b/pylib/anki/notes.py
@@ -78,7 +78,11 @@ class Note:
         return joinFields(self.fields)
 
     def ephemeral_card(
-        self, ord: int = 0, *, fill_empty: bool = False
+        self,
+        ord: int = 0,
+        *,
+        custom_note_type: NoteType = None,
+        fill_empty: bool = False,
     ) -> anki.cards.Card:
         card = anki.cards.Card(self.col)
         card.ord = ord
@@ -86,7 +90,11 @@ class Note:
 
         model = self.model()
         template = copy.copy(
-            model["tmpls"][ord] if model["type"] == MODEL_STD else model["tmpls"][0]
+            custom_note_type or (
+                model["tmpls"][ord]
+                if model["type"] == MODEL_STD
+                else model["tmpls"][0]
+            )
         )
         # may differ in cloze case
         template["ord"] = card.ord

--- a/pylib/anki/notes.py
+++ b/pylib/anki/notes.py
@@ -11,7 +11,7 @@ import anki  # pylint: disable=unused-import
 import anki._backend.backend_pb2 as _pb
 from anki import hooks
 from anki.consts import MODEL_STD
-from anki.models import NoteType
+from anki.models import NoteType, Template
 from anki.utils import joinFields
 
 
@@ -82,18 +82,18 @@ class Note:
         ord: int = 0,
         *,
         custom_note_type: NoteType = None,
+        custom_template: Template = None,
         fill_empty: bool = False,
     ) -> anki.cards.Card:
         card = anki.cards.Card(self.col)
         card.ord = ord
         card.did = 1
 
-        model = self.model()
+        model = custom_note_type or self.model()
         template = copy.copy(
-            custom_note_type or (
-                model["tmpls"][ord]
-                if model["type"] == MODEL_STD
-                else model["tmpls"][0]
+            custom_template
+            or (
+                model["tmpls"][ord] if model["type"] == MODEL_STD else model["tmpls"][0]
             )
         )
         # may differ in cloze case

--- a/qt/aqt/clayout.py
+++ b/qt/aqt/clayout.py
@@ -474,7 +474,11 @@ class CardLayout(QDialog):
     def _renderPreview(self) -> None:
         self.cancelPreviewTimer()
 
-        c = self.rendered_card = self.ephemeral_card_for_rendering()
+        c = self.rendered_card = self.note.ephemeral_card(
+            self.ord,
+            custom_note_type=self.current_template(),
+            fill_empty=self.fill_empty_action_toggled,
+        )
 
         ti = self.maybeTextInput
 
@@ -534,24 +538,6 @@ class CardLayout(QDialog):
         else:
             repl = answerRepl
         return re.sub(r"\[\[type:.+?\]\]", repl, txt)
-
-    def ephemeral_card_for_rendering(self) -> Card:
-        card = Card(self.col)
-        card.ord = self.ord
-        card.did = 1
-        template = copy.copy(self.current_template())
-        # may differ in cloze case
-        template["ord"] = card.ord
-        output = TemplateRenderContext.from_card_layout(
-            self.note,
-            card,
-            notetype=self.model,
-            template=template,
-            fill_empty=self.fill_empty_action_toggled,
-        ).render()
-        card.set_render_output(output)
-        card._note = self.note
-        return card
 
     # Card operations
     ######################################################################

--- a/qt/aqt/clayout.py
+++ b/qt/aqt/clayout.py
@@ -476,7 +476,8 @@ class CardLayout(QDialog):
 
         c = self.rendered_card = self.note.ephemeral_card(
             self.ord,
-            custom_note_type=self.current_template(),
+            custom_note_type=self.model,
+            custom_template=self.current_template(),
             fill_empty=self.fill_empty_action_toggled,
         )
 

--- a/qt/aqt/clayout.py
+++ b/qt/aqt/clayout.py
@@ -1,18 +1,15 @@
 # Copyright: Ankitects Pty Ltd and contributors
 # License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
-import copy
 import json
 import re
 from concurrent.futures import Future
 from typing import Any, Dict, List, Match, Optional
 
 import aqt
-from anki.cards import Card
 from anki.consts import *
 from anki.errors import TemplateError
 from anki.lang import without_unicode_isolation
 from anki.notes import Note
-from anki.template import TemplateRenderContext
 from aqt import AnkiQt, gui_hooks
 from aqt.forms.browserdisp import Ui_Dialog
 from aqt.qt import *


### PR DESCRIPTION
This is a fix for what you mentioned [here](https://github.com/ankitects/anki/commit/6e9dfefb24e42d8f4367e0a7fb98e6af0030de64#commitcomment-47036672).

Now you can pass in both a custom note type, and a custom template for rendering. Really should have noticed it the first time around.