### PR TITLE
Add missing preconditions for browser search in filtered deck options

### DIFF
--- a/qt/aqt/dyndeckconf.py
+++ b/qt/aqt/dyndeckconf.py
@@ -152,7 +152,26 @@ class DeckConf(QDialog):
 
     def _on_search_button(self, line: QLineEdit) -> None:
         try:
-            search = self.mw.col.build_search_string(line.text())
+            node = self.mw.col.group_searches(
+                line.text(),
+                SearchNode(
+                    negated=SearchNode(card_state=SearchNode.CARD_STATE_SUSPENDED)
+                ),
+                SearchNode(negated=SearchNode(card_state=SearchNode.CARD_STATE_BURIED)),
+                SearchNode(negated=SearchNode(deck="filtered")),
+            )
+
+            if self.mw.col.schedVer() == 1:
+                search = self.mw.col.join_searches(
+                    node,
+                    SearchNode(
+                        negated=SearchNode(card_state=SearchNode.CARD_STATE_LEARN)
+                    ),
+                    "AND",
+                )
+            else:
+                search = self.mw.col.build_search_string(node)
+
         except InvalidInput as err:
             line.setFocus()
             line.selectAll()


### PR DESCRIPTION
I believe browser search should match the parameters used to create the filtered deck, as in [move_cards_matching_term](https://github.com/ankitects/anki/blob/d2c580033b9b59c3a8f5e0e25649ba90fc0b5784/rslib/src/filtered.rs#L226).
