### PR TITLE
Add max-width: 100% to editable.scss

### DIFF
--- a/ts/editor/editable.scss
+++ b/ts/editor/editable.scss
@@ -10,10 +10,14 @@ anki-editable {
     }
 }
 
-img.drawing {
-    zoom: 50%;
+img {
+    max-width: 100%;
 
-    .nightMode & {
-        filter: unquote("invert() hue-rotate(180deg)");
+    &.drawing {
+        zoom: 50%;
+
+        .nightMode & {
+            filter: unquote("invert() hue-rotate(180deg)");
+        }
     }
 }

--- a/ts/editor/editable.scss
+++ b/ts/editor/editable.scss
@@ -2,7 +2,7 @@ anki-editable {
     display: block;
     overflow-wrap: break-word;
     overflow: auto;
-    padding: 5px;
+    padding: 6px;
 
     &:empty::after {
         content: "\a";


### PR DESCRIPTION
This was mentioned [here](https://forums.ankiweb.net/t/anki-2-1-41-beta/7305/46?u=hengiesel).
I removed it, because I didn't know of its effect in the editor fields.

Instead of `max-width: 90%`, I set it to `max-width: 100%`. For a sufficiently vertical pictures, both 90% and 100% will make the picture occupy too much space.

It would be nice to add a dynamic `max-width` [range bar](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/range) to Anki for users to adjust the image width, however that would most likely mean, that we would have to overwrite the context menu.