### PR TITLE
Shortcuts to preview clozes in card layout screen

### DIFF
--- a/qt/aqt/clayout.py
+++ b/qt/aqt/clayout.py
@@ -187,6 +187,12 @@ class CardLayout(QDialog):
             self,
             activated=self.tform.style_button.click,
         )
+        for i in range(min(len(self.cloze_numbers), 9)):
+            QShortcut(  # type: ignore
+                QKeySequence(f"Alt+{i+1}"),
+                self,
+                activated=lambda n=i: self.pform.cloze_number_combo.setCurrentIndex(n),
+            )
 
     # Main area setup
     ##########################################################################


### PR DESCRIPTION
This assigns the Alt+{number} shortcuts to to select cloze cards.

I remember reading something similar discussed in the forum (along with changing the Ctrl+{n} shortcuts to Ctrl+tab), but I can't find the thread now...