### PR TITLE
change _on_click_current to _on_click_index

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -35,7 +35,7 @@ zjosua <zjosua@hotmail.com>
 Arthur Milchior <arthur@milchior.fr>
 Yngve Hoiseth <yngve@hoiseth.net>
 Ijgnd
-Yoonchae Lee
+Yoonchae Lee <bluegreenmagick@gmail.com>
 Evandro Coan <github.com/evandrocoan>
 Alan Du <alanhdu@gmail.com>
 Yuchen Lei <lyc@xuming.studio>

--- a/qt/aqt/sidebar.py
+++ b/qt/aqt/sidebar.py
@@ -442,11 +442,13 @@ class SidebarTreeView(QTreeView):
     def mouseReleaseEvent(self, event: QMouseEvent) -> None:
         super().mouseReleaseEvent(event)
         if event.button() == Qt.LeftButton:
-            self._on_click_current()
+            idx = self.indexAt(event.pos())
+            self._on_click_index(idx)
 
     def keyPressEvent(self, event: QKeyEvent) -> None:
         if event.key() in (Qt.Key_Return, Qt.Key_Enter):
-            self._on_click_current()
+            idx = self.currentIndex()
+            self._on_click_index(idx)
         else:
             super().keyPressEvent(event)
 
@@ -516,8 +518,7 @@ class SidebarTreeView(QTreeView):
         self.browser.editor.saveNow(on_save)
         return True
 
-    def _on_click_current(self) -> None:
-        idx = self.currentIndex()
+    def _on_click_index(self, idx: QModelIndex) -> None:
         if item := self.model().item_for_index(idx):
             if item.on_click:
                 item.on_click()


### PR DESCRIPTION
This PR fixes a bug where clicking on the blank space below sidebar items would still trigger currently selected item's click event. 

This is most noticeable when you have `Saved Searches` selected(clicked). clicking anywhere not an item would trigger the click event, which in turn triggers the context menu event.

As `_on_click_current` is supposed to be an internal method and it's a brand new method, removing it shouldn't affect any add-ons. 