### PR TITLE
Source graphs.js as library in the HTML head

### DIFF
--- a/ts/graphs/graphs.html
+++ b/ts/graphs/graphs.html
@@ -4,30 +4,31 @@
         <meta charset="utf-8" />
         <meta name="viewport" id="viewport" content="width=device-width" />
         <link href="graphs.css" rel="stylesheet" />
+        <script src="../js/vendor/protobuf.min.js"></script>
+        <script src="graphs.js"></script>
     </head>
     <body>
         <div id="main"></div>
+
+        <script>
+            anki.graphs(
+                document.getElementById("main"),
+                [
+                    anki.TodayStats,
+                    anki.FutureDue,
+                    anki.CalendarGraph,
+                    anki.ReviewsGraph,
+                    anki.CardCounts,
+                    anki.IntervalsGraph,
+                    anki.EaseGraph,
+                    anki.HourGraph,
+                    anki.ButtonsGraph,
+                    anki.AddedGraph,
+                ],
+                {
+                    controller: anki.RangeBox,
+                }
+            );
+        </script>
     </body>
-    <script src="../js/vendor/protobuf.min.js"></script>
-    <script src="graphs.js"></script>
-    <script>
-        anki.graphs(
-            document.getElementById("main"),
-            [
-                anki.TodayStats,
-                anki.FutureDue,
-                anki.CalendarGraph,
-                anki.ReviewsGraph,
-                anki.CardCounts,
-                anki.IntervalsGraph,
-                anki.EaseGraph,
-                anki.HourGraph,
-                anki.ButtonsGraph,
-                anki.AddedGraph,
-            ],
-            {
-                controller: anki.RangeBox,
-            }
-        );
-    </script>
 </html>

--- a/ts/graphs/tooltip.ts
+++ b/ts/graphs/tooltip.ts
@@ -3,11 +3,24 @@
 
 import throttle from "lodash.throttle";
 
-const tooltipDiv: HTMLDivElement = document.createElement("div");
-tooltipDiv.className = "graph-tooltip";
-document.body.appendChild(tooltipDiv);
+function getOrCreateTooltipDiv(): HTMLDivElement {
+    const existingTooltip = document.getElementById("graphTooltip") as HTMLDivElement;
+
+    if (existingTooltip) {
+        return existingTooltip;
+    }
+
+    const tooltipDiv: HTMLDivElement = document.createElement("div");
+    tooltipDiv.id = "graphTooltip";
+    tooltipDiv.className = "graph-tooltip";
+    document.body.appendChild(tooltipDiv);
+
+    return tooltipDiv
+}
 
 function showTooltipInner(msg: string, x: number, y: number): void {
+    const tooltipDiv = getOrCreateTooltipDiv();
+
     tooltipDiv.innerHTML = msg;
 
     // move tooltip away from edge as user approaches right side
@@ -26,6 +39,8 @@ function showTooltipInner(msg: string, x: number, y: number): void {
 export const showTooltip = throttle(showTooltipInner, 16);
 
 export function hideTooltip(): void {
+    const tooltipDiv = getOrCreateTooltipDiv();
+
     showTooltip.cancel();
     tooltipDiv.style.opacity = "0";
 }

--- a/ts/graphs/tooltip.ts
+++ b/ts/graphs/tooltip.ts
@@ -15,7 +15,7 @@ function getOrCreateTooltipDiv(): HTMLDivElement {
     tooltipDiv.className = "graph-tooltip";
     document.body.appendChild(tooltipDiv);
 
-    return tooltipDiv
+    return tooltipDiv;
 }
 
 function showTooltipInner(msg: string, x: number, y: number): void {


### PR DESCRIPTION
This is a small change that was required, to make `graphs.js` as a library that can be sourced in the HTML head.

Functionally, there will be no difference, but it allows for more flexibility with the library.
I gotta admit, my motivation here is also personal. I wrote an add-on which allows you to include the graphs section into other web views, and it works quite well:

![image](https://user-images.githubusercontent.com/7188844/108719572-05b3ba00-7520-11eb-89ae-7c5d721e989a.png)

I also have a question concerning your view on the future of Anki. Svelte does allow for both client-side, and server-side rendering. Right now, Anki only utilises client-side rendering. If it were to stay that way, we could consider using the [Custom Elements API](https://svelte.dev/docs#Custom_element_API) from Svelte to truly encapsulate graphs component, and make them reusable. Right now, global CSS will affect the svelte components, and the graphs page even specifically uses that feature. I think moving to encapsulated components would also be beneficial for the future, once more components move to Svelte.
