### PR TITLE
Remove logic for pulling editor field into view

### DIFF
--- a/ts/editor/focusHandlers.ts
+++ b/ts/editor/focusHandlers.ts
@@ -31,7 +31,7 @@ export function onFocus(evt: FocusEvent): void {
     const previousFocus = evt.relatedTarget as EditingArea;
 
     if (previousFocus === previousActiveElement || !previousFocus) {
-        focusField(currentField)
+        focusField(currentField);
     }
 }
 

--- a/ts/editor/index.ts
+++ b/ts/editor/index.ts
@@ -5,7 +5,7 @@ import { nodeIsInline } from "./helpers";
 import { bridgeCommand } from "./lib";
 import { saveField } from "./changeTimer";
 import { filterHTML } from "./htmlFilter";
-import { updateButtonState, maybeDisableButtons } from "./toolbar";
+import { updateButtonState } from "./toolbar";
 import { onInput, onKey, onKeyUp } from "./inputHandlers";
 import { onFocus, onBlur } from "./focusHandlers";
 
@@ -298,8 +298,6 @@ export function setFields(fields: [string, string][]): void {
     forEditorField(fields, (field, [name, fieldContent]) =>
         field.initialize(name, color, fieldContent)
     );
-
-    maybeDisableButtons();
 }
 
 export function setBackgrounds(cols: ("dupe" | "")[]) {

--- a/ts/editor/toolbar.ts
+++ b/ts/editor/toolbar.ts
@@ -1,8 +1,6 @@
 /* Copyright: Ankitects Pty Ltd and contributors
  * License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html */
 
-import { EditingArea } from ".";
-
 export function updateButtonState(): void {
     const buts = ["bold", "italic", "underline", "superscript", "subscript"];
     for (const name of buts) {
@@ -28,15 +26,6 @@ export function disableButtons(): void {
 
 export function enableButtons(): void {
     $("button.linkb").prop("disabled", false);
-}
-
-// disable the buttons if a field is not currently focused
-export function maybeDisableButtons(): void {
-    if (document.activeElement instanceof EditingArea) {
-        enableButtons();
-    } else {
-        disableButtons();
-    }
 }
 
 export function setFGButton(col: string): void {


### PR DESCRIPTION
There's a bug in current beta concerning this.
In the browser, if you select a note, and select its field, select another note, then select the first field again, it will not enable the toolbar buttons.
This bug is not exclusive to the browser though, it's just easier to reproduce.

The whole issue here is the refocusing. When clicking away from a window, and clicking on a editor field again, we get two scenarios:
1. User clicks on the same editor field, in which case we get one `FocusEvent`, from `null` to previous/new focus.
2. User clicks on a different editor field, in which case we get two `FocusEvent`, one focusing from `null` to the previous focus, and one from previous focus to new focus.

There is no way to distinguish the `FocusEvent` of scenario one, with the first `FocusEvent` from scenario two. So we always have to err on one side. Previously I erred on not focusing. This new version errs on the side of focusing, which will make sure the toolbar buttons activate, but it makes it impossible to use the "scroll field into view" code, because it will be activated for the "refocus" first event of scenario two as well. Even though it was nice, I also don't think it's that valuable. A focus change by clicking tab will still move the window, so it was only used, when the user clicked an editor field barely in view.

I also researched a bit what explains this weird behavior, and surprisingly it's not Qt specific, it's just how browser engines work. When clicking on an inactive browser window, it will also refocus the previous focus first.

Closes hgiesel/anki_collapsible_fields#6