### PR TITLE
Clickable hint in dyndeck dialogue for unmovable cards

### DIFF
--- a/ftl/core/decks.ftl
+++ b/ftl/core/decks.ftl
@@ -31,6 +31,7 @@ decks-reschedule-cards-based-on-my-answers = Reschedule cards based on my answer
 decks-study = Study
 decks-study-deck = Study Deck
 decks-the-provided-search-did-not-match = The provided search did not match any cards. Would you like to revise it?
+decks-unmovable-cards = Some cards may be excluded despite matching the search.
 decks-it-has-card =
     { $count ->
         [one] It has { $count } card.

--- a/qt/aqt/dyndeckconf.py
+++ b/qt/aqt/dyndeckconf.py
@@ -185,12 +185,12 @@ class DeckConf(QDialog):
         else:
             aqt.dialogs.open("Browser", self.mw, search=(search,))
 
-    def _second_filter(self) -> Tuple[str]:
+    def _second_filter(self) -> Tuple[str, ...]:
         if self.form.secondFilter.isChecked():
             return (self.form.search_2.text(),)
         return ()
 
-    def _learning_search_node(self) -> Tuple[SearchNode]:
+    def _learning_search_node(self) -> Tuple[SearchNode, ...]:
         """Return a search node that matches learning cards if the old scheduler is enabled.
         If it's a rebuild, exclude cards from this filtered deck as those will be reset.
         """

--- a/qt/aqt/dyndeckconf.py
+++ b/qt/aqt/dyndeckconf.py
@@ -40,12 +40,13 @@ class DeckConf(QDialog):
 
         QDialog.__init__(self, mw)
         self.mw = mw
+        self.col = self.mw.col
         self.did: Optional[int] = None
         self.form = aqt.forms.dyndconf.Ui_Dialog()
         self.form.setupUi(self)
         self.mw.checkpoint(tr(TR.ACTIONS_OPTIONS))
         self.initialSetup()
-        self.old_deck = self.mw.col.decks.current()
+        self.old_deck = self.col.decks.current()
 
         if deck and deck["dyn"]:
             # modify existing dyn deck
@@ -83,7 +84,7 @@ class DeckConf(QDialog):
             without_unicode_isolation(tr(TR.ACTIONS_OPTIONS_FOR, val=self.deck["name"]))
         )
         self.form.buttonBox.button(QDialogButtonBox.Ok).setText(label)
-        if self.mw.col.schedVer() == 1:
+        if self.col.schedVer() == 1:
             self.form.secondFilter.setVisible(False)
         restoreGeom(self, "dyndeckconf")
 
@@ -100,23 +101,23 @@ class DeckConf(QDialog):
 
     def new_dyn_deck(self) -> None:
         suffix: int = 1
-        while self.mw.col.decks.id_for_name(
+        while self.col.decks.id_for_name(
             without_unicode_isolation(tr(TR.QT_MISC_FILTERED_DECK, val=suffix))
         ):
             suffix += 1
         name: str = without_unicode_isolation(tr(TR.QT_MISC_FILTERED_DECK, val=suffix))
-        self.did = self.mw.col.decks.new_filtered(name)
-        self.deck = self.mw.col.decks.current()
+        self.did = self.col.decks.new_filtered(name)
+        self.deck = self.col.decks.current()
 
     def set_default_searches(self, deck_name: str) -> None:
         self.form.search.setText(
-            self.mw.col.build_search_string(
+            self.col.build_search_string(
                 SearchNode(deck=deck_name),
                 SearchNode(card_state=SearchNode.CARD_STATE_DUE),
             )
         )
         self.form.search_2.setText(
-            self.mw.col.build_search_string(
+            self.col.build_search_string(
                 SearchNode(deck=deck_name),
                 SearchNode(card_state=SearchNode.CARD_STATE_NEW),
             )
@@ -152,7 +153,7 @@ class DeckConf(QDialog):
 
     def _on_search_button(self, line: QLineEdit) -> None:
         try:
-            search = self.mw.col.build_search_string(line.text())
+            search = self.col.build_search_string(line.text())
         except InvalidInput as err:
             line.setFocus()
             line.selectAll()
@@ -162,7 +163,7 @@ class DeckConf(QDialog):
 
     def _onReschedToggled(self, _state: int) -> None:
         self.form.previewDelayWidget.setVisible(
-            not self.form.resched.isChecked() and self.mw.col.schedVer() > 1
+            not self.form.resched.isChecked() and self.col.schedVer() > 1
         )
 
     def loadConf(self, deck: Optional[Deck] = None) -> None:
@@ -175,7 +176,7 @@ class DeckConf(QDialog):
         search, limit, order = d["terms"][0]
         f.search.setText(search)
 
-        if self.mw.col.schedVer() == 1:
+        if self.col.schedVer() == 1:
             if d["delays"]:
                 f.steps.setText(self.listToUser(d["delays"]))
                 f.stepsOn.setChecked(True)
@@ -205,35 +206,36 @@ class DeckConf(QDialog):
         d = self.deck
 
         if f.name.text() and d["name"] != f.name.text():
-            self.mw.col.decks.rename(d, f.name.text())
+            self.col.decks.rename(d, f.name.text())
             gui_hooks.sidebar_should_refresh_decks()
 
         d["resched"] = f.resched.isChecked()
         d["delays"] = None
 
-        if self.mw.col.schedVer() == 1 and f.stepsOn.isChecked():
+        if self.col.schedVer() == 1 and f.stepsOn.isChecked():
             steps = self.userToList(f.steps)
             if steps:
                 d["delays"] = steps
             else:
                 d["delays"] = None
 
-        search = self.mw.col.build_search_string(f.search.text())
+        search = self.col.build_search_string(f.search.text())
         terms = [[search, f.limit.value(), f.order.currentIndex()]]
 
         if f.secondFilter.isChecked():
-            search_2 = self.mw.col.build_search_string(f.search_2.text())
+            search_2 = self.col.build_search_string(f.search_2.text())
             terms.append([search_2, f.limit_2.value(), f.order_2.currentIndex()])
 
         d["terms"] = terms
         d["previewDelay"] = f.previewDelay.value()
 
-        self.mw.col.decks.save(d)
+        self.col.decks.save(d)
 
     def reject(self) -> None:
         if self.did:
-            self.mw.col.decks.rem(self.did)
-            self.mw.col.decks.select(self.old_deck["id"])
+            self.col.decks.rem(self.did)
+            self.col.decks.select(self.old_deck["id"])
+            self.mw.reset()
         saveGeom(self, "dyndeckconf")
         QDialog.reject(self)
         aqt.dialogs.markClosed("DynDeckConfDialog")
@@ -246,7 +248,7 @@ class DeckConf(QDialog):
         except DeckRenameError as err:
             showWarning(err.description)
         else:
-            if not self.mw.col.sched.rebuild_filtered_deck(self.deck["id"]):
+            if not self.col.sched.rebuild_filtered_deck(self.deck["id"]):
                 if askUser(tr(TR.DECKS_THE_PROVIDED_SEARCH_DID_NOT_MATCH)):
                     return
             saveGeom(self, "dyndeckconf")

--- a/qt/aqt/dyndeckconf.py
+++ b/qt/aqt/dyndeckconf.py
@@ -71,10 +71,13 @@ class DeckConf(QDialog):
         qconnect(self.form.search_button.clicked, self.on_search_button)
         qconnect(self.form.search_button_2.clicked, self.on_search_button_2)
         qconnect(self.form.hint_button.clicked, self.on_hint_button)
-        color = theme_manager.color(colors.LINK)
+        blue = theme_manager.color(colors.LINK)
+        grey = theme_manager.color(colors.DISABLED)
         self.setStyleSheet(
-            f"""QPushButton[flat=true] {{ text-align: left; color: {color}; padding: 0; border: 0 }}
-            QPushButton[flat=true]:hover {{ text-decoration: underline }}"""
+            f"""QPushButton[label] {{ padding: 0; border: 0 }}
+            QPushButton[label]:hover {{ text-decoration: underline }}
+            QPushButton[label="search"] {{ text-align: left; color: {blue} }}
+            QPushButton[label="hint"] {{ text-align: right; color: {grey} }}"""
         )
         disable_help_button(self)
         self.setWindowModality(Qt.WindowModal)

--- a/qt/aqt/forms/dyndconf.ui
+++ b/qt/aqt/forms/dyndconf.ui
@@ -251,6 +251,25 @@
     </widget>
    </item>
    <item>
+    <widget class="QPushButton" name="hint_button">
+     <property name="focusPolicy">
+      <enum>Qt::NoFocus</enum>
+     </property>
+     <property name="toolTip">
+      <string>SEARCH_VIEW_IN_BROWSER</string>
+     </property>
+     <property name="text">
+      <string>DECKS_UNMOVABLE_CARDS</string>
+     </property>
+     <property name="autoDefault">
+      <bool>false</bool>
+     </property>
+     <property name="flat">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>

--- a/qt/aqt/forms/dyndconf.ui
+++ b/qt/aqt/forms/dyndconf.ui
@@ -79,6 +79,9 @@
         <property name="flat">
          <bool>true</bool>
         </property>
+        <property name="label" stdset="0">
+         <string notr="true">search</string>
+        </property>
        </widget>
       </item>
       <item row="1" column="2" colspan="4">
@@ -142,6 +145,9 @@
         </property>
         <property name="flat">
          <bool>true</bool>
+        </property>
+        <property name="label" stdset="0">
+         <string notr="true">search</string>
         </property>
        </widget>
       </item>
@@ -266,6 +272,9 @@
      </property>
      <property name="flat">
       <bool>true</bool>
+     </property>
+     <property name="label" stdset="0">
+      <string notr="true">hint</string>
      </property>
     </widget>
    </item>


### PR DESCRIPTION
This is a slighty different approach than #1020 as it shows unmovable cards matching the filter(s) instead of the eligible cards. I tried to take into account all of our reasoning and catch every case where a card is not movable. What do you reckon, @dae and @abdnh?

On a related note, we need to handle the case where the browser modifies the deck that is currently opened in a dyndeck dialogue. In the worst case, the deck is deleted and Anki has to be closed via the OS because the modal dyndeck dialogue cannot be exited.
Also, it's a bit weird to see the new filtered deck in the browser (or in the main window if it somehow gets resetted) while the dialogue is still open. When I reworked dyndeckconf, I kept the workaround of creating the new deck on setup because it's convenient for loading the default dyndeck settings. But now that concurrent usage of this dialogue and other parts of Anki is getting more common, it would be much nicer if the new deck wasn't created until the user had really hit `Build`.