### PR TITLE
Sticky icons in the editor window

### DIFF
--- a/qt/aqt/data/web/css/BUILD.bazel
+++ b/qt/aqt/data/web/css/BUILD.bazel
@@ -32,6 +32,7 @@ filegroup(
         "core.css",
         "css_local",
         "editor",
+        "//qt/aqt/data/web/css/vendor",
     ],
     visibility = ["//qt:__subpackages__"],
 )

--- a/qt/aqt/data/web/css/vendor/BUILD.bazel
+++ b/qt/aqt/data/web/css/vendor/BUILD.bazel
@@ -1,0 +1,20 @@
+load("//ts:vendor.bzl", "copy_bootstrap_css", "copy_bootstrap_icons")
+
+copy_bootstrap_css(name = "bootstrap")
+
+copy_bootstrap_icons(name = "bootstrap-icons")
+
+files = [
+    "bootstrap",
+    "bootstrap-icons",
+]
+
+directories = []
+
+filegroup(
+    name = "vendor",
+    srcs = glob(["*.css"]) +
+           ["//qt/aqt/data/web/css/vendor:{}".format(file) for file in files] +
+           ["//qt/aqt/data/web/css/vendor/{}".format(dir) for dir in directories],
+    visibility = ["//qt:__subpackages__"],
+)

--- a/qt/aqt/data/web/js/vendor/BUILD.bazel
+++ b/qt/aqt/data/web/js/vendor/BUILD.bazel
@@ -1,4 +1,12 @@
-load("//ts:vendor.bzl", "copy_css_browser_selector", "copy_jquery", "copy_jquery_ui", "copy_protobufjs")
+load(
+    "//ts:vendor.bzl",
+    "copy_css_browser_selector",
+    "copy_jquery",
+    "copy_jquery_ui",
+    "copy_protobufjs",
+    "copy_bootstrap_js",
+    "copy_popperjs",
+)
 
 copy_jquery(name = "jquery")
 
@@ -8,11 +16,17 @@ copy_protobufjs(name = "protobufjs")
 
 copy_css_browser_selector(name = "css-browser-selector")
 
+copy_bootstrap_js(name = "bootstrap")
+
+copy_popperjs(name = "popperjs")
+
 files = [
     "jquery",
     "jquery-ui",
     "protobufjs",
     "css-browser-selector",
+    "bootstrap",
+    "popperjs",
 ]
 
 directories = [

--- a/qt/aqt/data/web/js/vendor/BUILD.bazel
+++ b/qt/aqt/data/web/js/vendor/BUILD.bazel
@@ -5,7 +5,6 @@ load(
     "copy_jquery_ui",
     "copy_protobufjs",
     "copy_bootstrap_js",
-    "copy_popperjs",
 )
 
 copy_jquery(name = "jquery")
@@ -18,15 +17,12 @@ copy_css_browser_selector(name = "css-browser-selector")
 
 copy_bootstrap_js(name = "bootstrap")
 
-copy_popperjs(name = "popperjs")
-
 files = [
     "jquery",
     "jquery-ui",
     "protobufjs",
     "css-browser-selector",
     "bootstrap",
-    "popperjs",
 ]
 
 directories = [

--- a/qt/aqt/editor.py
+++ b/qt/aqt/editor.py
@@ -179,7 +179,7 @@ class Editor:
                 "colour",
                 tr(TR.EDITING_SET_FOREGROUND_COLOUR_F7),
                 """
-<span id="forecolor" class="topbut topbut--rounded" style="background: #000"></span>
+<span id="forecolor" class="topbut rounded" style="background: #000"></span>
 """,
             ),
             self._addButton(
@@ -187,7 +187,7 @@ class Editor:
                 "changeCol",
                 tr(TR.EDITING_CHANGE_COLOUR_F8),
                 """
-<span class="topbut topbut--rounded rainbow"></span>
+<span class="topbut rounded rainbow"></span>
 """,
             ),
             self._addButton(
@@ -315,7 +315,7 @@ class Editor:
                 iconstr = self.resourceToData(icon)
             else:
                 iconstr = f"/_anki/imgs/{icon}.png"
-            imgelm = f"""<img class=topbut src="{iconstr}">"""
+            imgelm = f"""<img class="topbut" src="{iconstr}">"""
         else:
             imgelm = ""
         if label or not imgelm:
@@ -334,7 +334,7 @@ class Editor:
         if rightside:
             class_ = "linkb"
         else:
-            class_ = ""
+            class_ = "rounded"
         if not disables:
             class_ += " perm"
         return """<button tabindex=-1

--- a/qt/aqt/editor.py
+++ b/qt/aqt/editor.py
@@ -179,19 +179,16 @@ class Editor:
                 "colour",
                 tr(TR.EDITING_SET_FOREGROUND_COLOUR_F7),
                 """
-<div id="forecolor"
-     style="display: inline-block; background: #000; border-radius: 5px;"
-     class="topbut"
->""",
+<span id="forecolor" class="topbut topbut--rounded" style="background: #000"></span>
+"""
             ),
             self._addButton(
                 None,
                 "changeCol",
                 tr(TR.EDITING_CHANGE_COLOUR_F8),
                 """
-<div style="display: inline-block; border-radius: 5px;"
-     class="topbut rainbow"
->""",
+<span class="topbut topbut--rounded rainbow"></span>
+"""
             ),
             self._addButton(
                 "text_cloze", "cloze", tr(TR.EDITING_CLOZE_DELETION_CTRLANDSHIFTANDC)
@@ -321,7 +318,7 @@ class Editor:
         else:
             imgelm = ""
         if label or not imgelm:
-            labelelm = f"""<span class=blabel>{label or cmd}</span>"""
+            labelelm = label or cmd
         else:
             labelelm = ""
         if id:

--- a/qt/aqt/editor.py
+++ b/qt/aqt/editor.py
@@ -221,6 +221,7 @@ class Editor:
             _html % (bgcol, topbuts, tr(TR.EDITING_SHOW_DUPLICATES)),
             css=[
                 "css/vendor/bootstrap.min.css",
+                "css/vendor/bootstrap-icons.css",
                 "css/editor.css",
             ],
             js=[

--- a/qt/aqt/editor.py
+++ b/qt/aqt/editor.py
@@ -429,7 +429,7 @@ class Editor:
     # JS->Python bridge
     ######################################################################
 
-    def onBridgeCmd(self, cmd: str) -> None:
+    def onBridgeCmd(self, cmd: str) -> Any:
         if not self.note:
             # shutdown
             return

--- a/qt/aqt/editor.py
+++ b/qt/aqt/editor.py
@@ -477,7 +477,10 @@ class Editor:
             ord = int(num)
 
             fld = self.note.model()["flds"][ord]
-            fld["sticky"] = not fld["sticky"]
+            new_state = not fld["sticky"]
+            fld["sticky"] = new_state
+
+            return new_state
 
     def mungeHTML(self, txt: str) -> str:
         return gui_hooks.editor_will_munge_html(txt, self)

--- a/qt/aqt/editor.py
+++ b/qt/aqt/editor.py
@@ -222,8 +222,15 @@ class Editor:
         # then load page
         self.web.stdHtml(
             _html % (bgcol, topbuts, tr(TR.EDITING_SHOW_DUPLICATES)),
-            css=["css/editor.css"],
-            js=["js/vendor/jquery.min.js", "js/editor.js"],
+            css=[
+                "css/vendor/bootstrap.min.css",
+                "css/editor.css",
+            ],
+            js=[
+                "js/vendor/jquery.min.js",
+                "js/vendor/bootstrap.bundle.min.js",
+                "js/editor.js",
+            ],
             context=self,
         )
         self.web.eval("preventButtonFocus();")

--- a/qt/aqt/editor.py
+++ b/qt/aqt/editor.py
@@ -433,6 +433,7 @@ class Editor:
         if not self.note:
             # shutdown
             return
+
         # focus lost or key/button pressed?
         if cmd.startswith("blur") or cmd.startswith("key"):
             (type, ord_str, nid_str, txt) = cmd.split(":", 3)
@@ -462,17 +463,14 @@ class Editor:
             else:
                 gui_hooks.editor_did_fire_typing_timer(self.note)
                 self.checkValid()
+
         # focused into field?
         elif cmd.startswith("focus"):
             (type, num) = cmd.split(":", 1)
             self.currentField = int(num)
             gui_hooks.editor_did_focus_field(self.note, self.currentField)
-        elif cmd in self._links:
-            self._links[cmd](self)
-        else:
-            print("uncaught cmd", cmd)
 
-        if cmd.startswith("toggleSticky"):
+        elif cmd.startswith("toggleSticky"):
             (type, num) = cmd.split(":", 1)
             ord = int(num)
 
@@ -481,6 +479,12 @@ class Editor:
             fld["sticky"] = new_state
 
             return new_state
+
+        elif cmd in self._links:
+            self._links[cmd](self)
+
+        else:
+            print("uncaught cmd", cmd)
 
     def mungeHTML(self, txt: str) -> str:
         return gui_hooks.editor_will_munge_html(txt, self)

--- a/qt/aqt/editor.py
+++ b/qt/aqt/editor.py
@@ -29,7 +29,6 @@ from anki.utils import checksum, isLin, isWin, namedtmp
 from aqt import AnkiQt, colors, gui_hooks
 from aqt.main import ResetReason
 from aqt.qt import *
-from aqt.schema_change_tracker import ChangeTracker
 from aqt.sound import av_player
 from aqt.theme import theme_manager
 from aqt.utils import (
@@ -479,9 +478,6 @@ class Editor:
 
             fld = self.note.model()["flds"][ord]
             fld["sticky"] = not fld["sticky"]
-
-            change_tracker = ChangeTracker(self.mw)
-            change_tracker.mark_basic()
 
     def mungeHTML(self, txt: str) -> str:
         return gui_hooks.editor_will_munge_html(txt, self)

--- a/ts/editor/changeTimer.ts
+++ b/ts/editor/changeTimer.ts
@@ -1,7 +1,7 @@
 /* Copyright: Ankitects Pty Ltd and contributors
  * License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html */
 
-import type { EditingArea } from ".";
+import type { EditingArea } from "./editingArea";
 
 import { getCurrentField } from ".";
 import { bridgeCommand } from "./lib";

--- a/ts/editor/editable.ts
+++ b/ts/editor/editable.ts
@@ -1,0 +1,36 @@
+import { nodeIsInline } from "./helpers";
+
+function containsInlineContent(field: Element): boolean {
+    if (field.childNodes.length === 0) {
+        // for now, for all practical purposes, empty fields are in block mode
+        return false;
+    }
+
+    for (const child of field.children) {
+        if (!nodeIsInline(child)) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+export class Editable extends HTMLElement {
+    set fieldHTML(content: string) {
+        this.innerHTML = content;
+
+        if (containsInlineContent(this)) {
+            this.appendChild(document.createElement("br"));
+        }
+    }
+
+    get fieldHTML(): string {
+        return containsInlineContent(this) && this.innerHTML.endsWith("<br>")
+            ? this.innerHTML.slice(0, -4) // trim trailing <br>
+            : this.innerHTML;
+    }
+
+    connectedCallback() {
+        this.setAttribute("contenteditable", "");
+    }
+}

--- a/ts/editor/editingArea.ts
+++ b/ts/editor/editingArea.ts
@@ -10,9 +10,8 @@ function onPaste(evt: ClipboardEvent): void {
     evt.preventDefault();
 }
 
-function onCutOrCopy(): boolean {
+function onCutOrCopy(): void {
     bridgeCommand("cutOrCopy");
-    return true;
 }
 
 export class EditingArea extends HTMLDivElement {

--- a/ts/editor/editingArea.ts
+++ b/ts/editor/editingArea.ts
@@ -1,0 +1,115 @@
+import type { Editable } from "./editable";
+
+import { bridgeCommand } from "./lib";
+import { onInput, onKey, onKeyUp } from "./inputHandlers";
+import { onFocus, onBlur } from "./focusHandlers";
+import { updateButtonState } from "./toolbar";
+
+function onPaste(evt: ClipboardEvent): void {
+    bridgeCommand("paste");
+    evt.preventDefault();
+}
+
+function onCutOrCopy(): boolean {
+    bridgeCommand("cutOrCopy");
+    return true;
+}
+
+export class EditingArea extends HTMLDivElement {
+    editable: Editable;
+    baseStyle: HTMLStyleElement;
+
+    constructor() {
+        super();
+        this.attachShadow({ mode: "open" });
+        this.className = "field";
+
+        const rootStyle = document.createElement("link");
+        rootStyle.setAttribute("rel", "stylesheet");
+        rootStyle.setAttribute("href", "./_anki/css/editable.css");
+        this.shadowRoot!.appendChild(rootStyle);
+
+        this.baseStyle = document.createElement("style");
+        this.baseStyle.setAttribute("rel", "stylesheet");
+        this.shadowRoot!.appendChild(this.baseStyle);
+
+        this.editable = document.createElement("anki-editable") as Editable;
+        this.shadowRoot!.appendChild(this.editable);
+    }
+
+    get ord(): number {
+        return Number(this.getAttribute("ord"));
+    }
+
+    set fieldHTML(content: string) {
+        this.editable.fieldHTML = content;
+    }
+
+    get fieldHTML(): string {
+        return this.editable.fieldHTML;
+    }
+
+    connectedCallback(): void {
+        this.addEventListener("keydown", onKey);
+        this.addEventListener("keyup", onKeyUp);
+        this.addEventListener("input", onInput);
+        this.addEventListener("focus", onFocus);
+        this.addEventListener("blur", onBlur);
+        this.addEventListener("paste", onPaste);
+        this.addEventListener("copy", onCutOrCopy);
+        this.addEventListener("oncut", onCutOrCopy);
+        this.addEventListener("mouseup", updateButtonState);
+
+        const baseStyleSheet = this.baseStyle.sheet as CSSStyleSheet;
+        baseStyleSheet.insertRule("anki-editable {}", 0);
+    }
+
+    disconnectedCallback(): void {
+        this.removeEventListener("keydown", onKey);
+        this.removeEventListener("keyup", onKeyUp);
+        this.removeEventListener("input", onInput);
+        this.removeEventListener("focus", onFocus);
+        this.removeEventListener("blur", onBlur);
+        this.removeEventListener("paste", onPaste);
+        this.removeEventListener("copy", onCutOrCopy);
+        this.removeEventListener("oncut", onCutOrCopy);
+        this.removeEventListener("mouseup", updateButtonState);
+    }
+
+    initialize(color: string, content: string): void {
+        this.setBaseColor(color);
+        this.editable.fieldHTML = content;
+    }
+
+    setBaseColor(color: string): void {
+        const styleSheet = this.baseStyle.sheet as CSSStyleSheet;
+        const firstRule = styleSheet.cssRules[0] as CSSStyleRule;
+        firstRule.style.color = color;
+    }
+
+    setBaseStyling(fontFamily: string, fontSize: string, direction: string): void {
+        const styleSheet = this.baseStyle.sheet as CSSStyleSheet;
+        const firstRule = styleSheet.cssRules[0] as CSSStyleRule;
+        firstRule.style.fontFamily = fontFamily;
+        firstRule.style.fontSize = fontSize;
+        firstRule.style.direction = direction;
+    }
+
+    isRightToLeft(): boolean {
+        const styleSheet = this.baseStyle.sheet as CSSStyleSheet;
+        const firstRule = styleSheet.cssRules[0] as CSSStyleRule;
+        return firstRule.style.direction === "rtl";
+    }
+
+    getSelection(): Selection {
+        return this.shadowRoot!.getSelection()!;
+    }
+
+    focusEditable(): void {
+        this.editable.focus();
+    }
+
+    blurEditable(): void {
+        this.editable.blur();
+    }
+}

--- a/ts/editor/editor.scss
+++ b/ts/editor/editor.scss
@@ -1,8 +1,8 @@
 /* Copyright: Ankitects Pty Ltd and contributors
  * License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html */
 
-html {
-    background: var(--bg-color);
+body {
+    background-color: var(--bg-color);
 }
 
 #fields {

--- a/ts/editor/editor.scss
+++ b/ts/editor/editor.scss
@@ -56,9 +56,15 @@ body {
 }
 
 .topbut {
+    display: inline-block;
     width: 16px;
     height: 16px;
     margin-top: 4px;
+    vertical-align: -.125em;
+}
+
+.topbut--rounded {
+    border-radius: 5px;
 }
 
 .rainbow {

--- a/ts/editor/editor.scss
+++ b/ts/editor/editor.scss
@@ -105,10 +105,11 @@ button.highlighted {
 
     #topbutsright & {
         border-bottom: 3px solid black;
-    }
+        border-radius: 3px;
 
-    .nightMode #topbutsright & {
-        border-bottom: 3px solid white;
+        .nightMode & {
+            border-bottom-color: white;
+        }
     }
 }
 

--- a/ts/editor/editor.scss
+++ b/ts/editor/editor.scss
@@ -9,19 +9,6 @@ body {
     display: flex;
     flex-direction: column;
     margin: 5px;
-
-    & > *,
-    & > * > * {
-        margin: 1px 0;
-
-        &:first-child {
-            margin-top: 0;
-        }
-
-        &:last-child {
-            margin-bottom: 0;
-        }
-    }
 }
 
 .field {
@@ -36,10 +23,6 @@ body {
 .fname {
     vertical-align: middle;
     padding: 0;
-}
-
-body {
-    margin: 0;
 }
 
 #topbutsOuter {

--- a/ts/editor/editor.scss
+++ b/ts/editor/editor.scss
@@ -143,8 +143,4 @@ button.highlighted {
     .nightMode & {
         color: var(--bs-light);
     }
-
-    &.is-active {
-        color: var(--bs-danger);
-    }
 }

--- a/ts/editor/editor.scss
+++ b/ts/editor/editor.scss
@@ -135,3 +135,15 @@ button.highlighted {
         color: var(--link);
     }
 }
+
+.sticky-icon {
+    color: var(--bs-dark);
+
+    .nightMode & {
+        color: var(--bs-light);
+    }
+
+    &.is-active {
+        color: var(--bs-danger);
+    }
+}

--- a/ts/editor/editor.scss
+++ b/ts/editor/editor.scss
@@ -2,6 +2,7 @@
  * License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html */
 
 body {
+    color: var(--text-fg);
     background-color: var(--bg-color);
 }
 
@@ -61,7 +62,7 @@ body {
     width: 16px;
     height: 16px;
     margin-top: 4px;
-    vertical-align: -.125em;
+    vertical-align: -0.125em;
 }
 
 .topbut--rounded {

--- a/ts/editor/editor.scss
+++ b/ts/editor/editor.scss
@@ -133,10 +133,15 @@ button.highlighted {
     }
 }
 
-.sticky-icon {
-    color: var(--bs-dark);
+.icon {
+    cursor: pointer;
+    color: var(--text-fg);
 
-    .nightMode & {
-        color: var(--bs-light);
+    &.is-inactive::before {
+        opacity: 0.1;
+    }
+
+    &.icon--hover::before {
+        opacity: 0.5;
     }
 }

--- a/ts/editor/editor.scss
+++ b/ts/editor/editor.scss
@@ -65,10 +65,6 @@ body {
     vertical-align: -0.125em;
 }
 
-.topbut--rounded {
-    border-radius: 5px;
-}
-
 .rainbow {
     background-image: -webkit-gradient(
         linear,

--- a/ts/editor/editor.scss
+++ b/ts/editor/editor.scss
@@ -37,6 +37,7 @@ body {
     padding: 2px;
 
     background: var(--bg-color);
+    font-size: 13px;
 }
 
 .topbuts {

--- a/ts/editor/editorField.ts
+++ b/ts/editor/editorField.ts
@@ -1,0 +1,45 @@
+import type { EditingArea } from "./editingArea";
+import type { LabelContainer } from "./labelContainer";
+
+export class EditorField extends HTMLDivElement {
+    labelContainer: LabelContainer;
+    editingArea: EditingArea;
+
+    constructor() {
+        super();
+        this.labelContainer = document.createElement("div", {
+            is: "anki-label-container",
+        }) as LabelContainer;
+        this.appendChild(this.labelContainer);
+
+        this.editingArea = document.createElement("div", {
+            is: "anki-editing-area",
+        }) as EditingArea;
+        this.appendChild(this.editingArea);
+    }
+
+    static get observedAttributes(): string[] {
+        return ["ord"];
+    }
+
+    set ord(n: number) {
+        this.setAttribute("ord", String(n));
+    }
+
+    attributeChangedCallback(name: string, _oldValue: string, newValue: string): void {
+        switch (name) {
+            case "ord":
+                this.editingArea.setAttribute("ord", newValue);
+                this.labelContainer.setAttribute("ord", newValue);
+        }
+    }
+
+    initialize(label: string, color: string, content: string): void {
+        this.labelContainer.initialize(label);
+        this.editingArea.initialize(color, content);
+    }
+
+    setBaseStyling(fontFamily: string, fontSize: string, direction: string): void {
+        this.editingArea.setBaseStyling(fontFamily, fontSize, direction);
+    }
+}

--- a/ts/editor/focusHandlers.ts
+++ b/ts/editor/focusHandlers.ts
@@ -1,11 +1,11 @@
 /* Copyright: Ankitects Pty Ltd and contributors
  * License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html */
 
-import type { EditingArea } from ".";
+import type { EditingArea } from "./editingArea";
 
+import { saveField } from "./changeTimer";
 import { bridgeCommand } from "./lib";
 import { enableButtons, disableButtons } from "./toolbar";
-import { saveField } from "./changeTimer";
 
 export function onFocus(evt: FocusEvent): void {
     const currentField = evt.currentTarget as EditingArea;

--- a/ts/editor/helpers.ts
+++ b/ts/editor/helpers.ts
@@ -1,7 +1,7 @@
 /* Copyright: Ankitects Pty Ltd and contributors
  * License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html */
 
-import type { EditingArea } from ".";
+import type { EditingArea } from "./editingArea";
 
 export function nodeIsElement(node: Node): node is Element {
     return node.nodeType === Node.ELEMENT_NODE;

--- a/ts/editor/index.ts
+++ b/ts/editor/index.ts
@@ -115,7 +115,7 @@ export function setFields(fields: [string, string][]): void {
     );
 }
 
-export function setBackgrounds(cols: ("dupe" | "")[]) {
+export function setBackgrounds(cols: ("dupe" | "")[]): void {
     forEditorField(cols, (field, value) =>
         field.editingArea.classList.toggle("dupe", value === "dupe")
     );

--- a/ts/editor/index.ts
+++ b/ts/editor/index.ts
@@ -212,8 +212,8 @@ export class EditingArea extends HTMLDivElement {
 customElements.define("anki-editing-area", EditingArea, { extends: "div" });
 
 export class LabelContainer extends HTMLDivElement {
-    sticky: HTMLSpanElement
-    label: HTMLSpanElement
+    sticky: HTMLSpanElement;
+    label: HTMLSpanElement;
 
     constructor() {
         super();
@@ -221,6 +221,7 @@ export class LabelContainer extends HTMLDivElement {
 
         this.sticky = document.createElement("span");
         this.sticky.className = "bi bi-pin-angle-fill me-1 sticky-icon";
+        this.sticky.hidden = true;
         this.appendChild(this.sticky);
 
         this.label = document.createElement("span");
@@ -242,8 +243,15 @@ export class LabelContainer extends HTMLDivElement {
         this.label.innerText = labelName;
     }
 
+    activateSticky(initialState: boolean): void {
+        this.sticky.classList.toggle("is-active", initialState);
+        this.sticky.hidden = false;
+    }
+
     toggleSticky(): void {
-        this.sticky.classList.toggle('is-active');
+        bridgeCommand(`toggleSticky:${this.getAttribute("ord")}`, () => {
+            this.sticky.classList.toggle("is-active");
+        });
     }
 }
 
@@ -278,6 +286,7 @@ export class EditorField extends HTMLDivElement {
         switch (name) {
             case "ord":
                 this.editingArea.setAttribute("ord", newValue);
+                this.labelContainer.setAttribute("ord", newValue);
         }
     }
 
@@ -350,6 +359,12 @@ export function setBackgrounds(cols: ("dupe" | "")[]) {
 export function setFonts(fonts: [string, number, boolean][]): void {
     forEditorField(fonts, (field, [fontFamily, fontSize, isRtl]) => {
         field.setBaseStyling(fontFamily, `${fontSize}px`, isRtl ? "rtl" : "ltr");
+    });
+}
+
+export function setSticky(stickies: boolean[]): void {
+    forEditorField(stickies, (field, isSticky) => {
+        field.labelContainer.activateSticky(isSticky);
     });
 }
 

--- a/ts/editor/index.ts
+++ b/ts/editor/index.ts
@@ -211,20 +211,54 @@ export class EditingArea extends HTMLDivElement {
 
 customElements.define("anki-editing-area", EditingArea, { extends: "div" });
 
+export class LabelContainer extends HTMLDivElement {
+    sticky: HTMLSpanElement
+    label: HTMLSpanElement
+
+    constructor() {
+        super();
+        this.className = "d-flex";
+
+        this.sticky = document.createElement("span");
+        this.sticky.className = "bi bi-pin-angle-fill me-1 sticky-icon";
+        this.appendChild(this.sticky);
+
+        this.label = document.createElement("span");
+        this.label.className = "fieldname";
+        this.appendChild(this.label);
+
+        this.toggleSticky = this.toggleSticky.bind(this);
+    }
+
+    connectedCallback(): void {
+        this.sticky.addEventListener("click", this.toggleSticky);
+    }
+
+    disconnectedCallback(): void {
+        this.sticky.removeEventListener("click", this.toggleSticky);
+    }
+
+    initialize(labelName: string): void {
+        this.label.innerText = labelName;
+    }
+
+    toggleSticky(): void {
+        this.sticky.classList.toggle('is-active');
+    }
+}
+
+customElements.define("anki-label-container", LabelContainer, { extends: "div" });
+
 export class EditorField extends HTMLDivElement {
-    labelContainer: HTMLDivElement;
-    label: HTMLSpanElement;
+    labelContainer: LabelContainer;
     editingArea: EditingArea;
 
     constructor() {
         super();
-        this.labelContainer = document.createElement("div");
-        this.labelContainer.className = "fname";
+        this.labelContainer = document.createElement("div", {
+            is: "anki-label-container",
+        }) as LabelContainer;
         this.appendChild(this.labelContainer);
-
-        this.label = document.createElement("span");
-        this.label.className = "fieldname";
-        this.labelContainer.appendChild(this.label);
 
         this.editingArea = document.createElement("div", {
             is: "anki-editing-area",
@@ -248,7 +282,7 @@ export class EditorField extends HTMLDivElement {
     }
 
     initialize(label: string, color: string, content: string): void {
-        this.label.innerText = label;
+        this.labelContainer.initialize(label);
         this.editingArea.initialize(color, content);
     }
 

--- a/ts/editor/index.ts
+++ b/ts/editor/index.ts
@@ -1,13 +1,15 @@
 /* Copyright: Ankitects Pty Ltd and contributors
  * License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html */
 
-import { nodeIsInline, caretToEnd } from "./helpers";
-import { bridgeCommand } from "./lib";
+import { caretToEnd } from "./helpers";
 import { saveField } from "./changeTimer";
 import { filterHTML } from "./htmlFilter";
 import { updateButtonState } from "./toolbar";
-import { onInput, onKey, onKeyUp } from "./inputHandlers";
-import { onFocus, onBlur } from "./focusHandlers";
+
+import { EditorField } from "./editorField";
+import { LabelContainer } from "./labelContainer";
+import { EditingArea } from "./editingArea";
+import { Editable } from "./editable";
 
 export { setNoteId, getNoteId } from "./noteId";
 export { preventButtonFocus, toggleEditorButton, setFGButton } from "./toolbar";
@@ -22,6 +24,11 @@ declare global {
         getRangeAt(n: number): Range;
     }
 }
+
+customElements.define("anki-editable", Editable);
+customElements.define("anki-editing-area", EditingArea, { extends: "div" });
+customElements.define("anki-label-container", LabelContainer, { extends: "div" });
+customElements.define("anki-editor-field", EditorField, { extends: "div" });
 
 export function getCurrentField(): EditingArea | null {
     return document.activeElement instanceof EditingArea
@@ -62,245 +69,6 @@ export function pasteHTML(
         setFormat("inserthtml", html);
     }
 }
-
-function onPaste(evt: ClipboardEvent): void {
-    bridgeCommand("paste");
-    evt.preventDefault();
-}
-
-function onCutOrCopy(): boolean {
-    bridgeCommand("cutOrCopy");
-    return true;
-}
-
-function containsInlineContent(field: Element): boolean {
-    if (field.childNodes.length === 0) {
-        // for now, for all practical purposes, empty fields are in block mode
-        return false;
-    }
-
-    for (const child of field.children) {
-        if (!nodeIsInline(child)) {
-            return false;
-        }
-    }
-
-    return true;
-}
-
-class Editable extends HTMLElement {
-    set fieldHTML(content: string) {
-        this.innerHTML = content;
-
-        if (containsInlineContent(this)) {
-            this.appendChild(document.createElement("br"));
-        }
-    }
-
-    get fieldHTML(): string {
-        return containsInlineContent(this) && this.innerHTML.endsWith("<br>")
-            ? this.innerHTML.slice(0, -4) // trim trailing <br>
-            : this.innerHTML;
-    }
-
-    connectedCallback() {
-        this.setAttribute("contenteditable", "");
-    }
-}
-
-customElements.define("anki-editable", Editable);
-
-export class EditingArea extends HTMLDivElement {
-    editable: Editable;
-    baseStyle: HTMLStyleElement;
-
-    constructor() {
-        super();
-        this.attachShadow({ mode: "open" });
-        this.className = "field";
-
-        const rootStyle = document.createElement("link");
-        rootStyle.setAttribute("rel", "stylesheet");
-        rootStyle.setAttribute("href", "./_anki/css/editable.css");
-        this.shadowRoot!.appendChild(rootStyle);
-
-        this.baseStyle = document.createElement("style");
-        this.baseStyle.setAttribute("rel", "stylesheet");
-        this.shadowRoot!.appendChild(this.baseStyle);
-
-        this.editable = document.createElement("anki-editable") as Editable;
-        this.shadowRoot!.appendChild(this.editable);
-    }
-
-    get ord(): number {
-        return Number(this.getAttribute("ord"));
-    }
-
-    set fieldHTML(content: string) {
-        this.editable.fieldHTML = content;
-    }
-
-    get fieldHTML(): string {
-        return this.editable.fieldHTML;
-    }
-
-    connectedCallback(): void {
-        this.addEventListener("keydown", onKey);
-        this.addEventListener("keyup", onKeyUp);
-        this.addEventListener("input", onInput);
-        this.addEventListener("focus", onFocus);
-        this.addEventListener("blur", onBlur);
-        this.addEventListener("paste", onPaste);
-        this.addEventListener("copy", onCutOrCopy);
-        this.addEventListener("oncut", onCutOrCopy);
-        this.addEventListener("mouseup", updateButtonState);
-
-        const baseStyleSheet = this.baseStyle.sheet as CSSStyleSheet;
-        baseStyleSheet.insertRule("anki-editable {}", 0);
-    }
-
-    disconnectedCallback(): void {
-        this.removeEventListener("keydown", onKey);
-        this.removeEventListener("keyup", onKeyUp);
-        this.removeEventListener("input", onInput);
-        this.removeEventListener("focus", onFocus);
-        this.removeEventListener("blur", onBlur);
-        this.removeEventListener("paste", onPaste);
-        this.removeEventListener("copy", onCutOrCopy);
-        this.removeEventListener("oncut", onCutOrCopy);
-        this.removeEventListener("mouseup", updateButtonState);
-    }
-
-    initialize(color: string, content: string): void {
-        this.setBaseColor(color);
-        this.editable.fieldHTML = content;
-    }
-
-    setBaseColor(color: string): void {
-        const styleSheet = this.baseStyle.sheet as CSSStyleSheet;
-        const firstRule = styleSheet.cssRules[0] as CSSStyleRule;
-        firstRule.style.color = color;
-    }
-
-    setBaseStyling(fontFamily: string, fontSize: string, direction: string): void {
-        const styleSheet = this.baseStyle.sheet as CSSStyleSheet;
-        const firstRule = styleSheet.cssRules[0] as CSSStyleRule;
-        firstRule.style.fontFamily = fontFamily;
-        firstRule.style.fontSize = fontSize;
-        firstRule.style.direction = direction;
-    }
-
-    isRightToLeft(): boolean {
-        const styleSheet = this.baseStyle.sheet as CSSStyleSheet;
-        const firstRule = styleSheet.cssRules[0] as CSSStyleRule;
-        return firstRule.style.direction === "rtl";
-    }
-
-    getSelection(): Selection {
-        return this.shadowRoot!.getSelection()!;
-    }
-
-    focusEditable(): void {
-        this.editable.focus();
-    }
-
-    blurEditable(): void {
-        this.editable.blur();
-    }
-}
-
-customElements.define("anki-editing-area", EditingArea, { extends: "div" });
-
-export class LabelContainer extends HTMLDivElement {
-    sticky: HTMLSpanElement;
-    label: HTMLSpanElement;
-
-    constructor() {
-        super();
-        this.className = "d-flex";
-
-        this.sticky = document.createElement("span");
-        this.sticky.className = "bi bi-pin-angle-fill me-1 sticky-icon";
-        this.sticky.hidden = true;
-        this.appendChild(this.sticky);
-
-        this.label = document.createElement("span");
-        this.label.className = "fieldname";
-        this.appendChild(this.label);
-
-        this.toggleSticky = this.toggleSticky.bind(this);
-    }
-
-    connectedCallback(): void {
-        this.sticky.addEventListener("click", this.toggleSticky);
-    }
-
-    disconnectedCallback(): void {
-        this.sticky.removeEventListener("click", this.toggleSticky);
-    }
-
-    initialize(labelName: string): void {
-        this.label.innerText = labelName;
-    }
-
-    activateSticky(initialState: boolean): void {
-        this.sticky.classList.toggle("is-active", initialState);
-        this.sticky.hidden = false;
-    }
-
-    toggleSticky(): void {
-        bridgeCommand(`toggleSticky:${this.getAttribute("ord")}`, () => {
-            this.sticky.classList.toggle("is-active");
-        });
-    }
-}
-
-customElements.define("anki-label-container", LabelContainer, { extends: "div" });
-
-export class EditorField extends HTMLDivElement {
-    labelContainer: LabelContainer;
-    editingArea: EditingArea;
-
-    constructor() {
-        super();
-        this.labelContainer = document.createElement("div", {
-            is: "anki-label-container",
-        }) as LabelContainer;
-        this.appendChild(this.labelContainer);
-
-        this.editingArea = document.createElement("div", {
-            is: "anki-editing-area",
-        }) as EditingArea;
-        this.appendChild(this.editingArea);
-    }
-
-    static get observedAttributes(): string[] {
-        return ["ord"];
-    }
-
-    set ord(n: number) {
-        this.setAttribute("ord", String(n));
-    }
-
-    attributeChangedCallback(name: string, _oldValue: string, newValue: string): void {
-        switch (name) {
-            case "ord":
-                this.editingArea.setAttribute("ord", newValue);
-                this.labelContainer.setAttribute("ord", newValue);
-        }
-    }
-
-    initialize(label: string, color: string, content: string): void {
-        this.labelContainer.initialize(label);
-        this.editingArea.initialize(color, content);
-    }
-
-    setBaseStyling(fontFamily: string, fontSize: string, direction: string): void {
-        this.editingArea.setBaseStyling(fontFamily, fontSize, direction);
-    }
-}
-
-customElements.define("anki-editor-field", EditorField, { extends: "div" });
 
 function adjustFieldAmount(amount: number): void {
     const fieldsContainer = document.getElementById("fields")!;

--- a/ts/editor/inputHandlers.ts
+++ b/ts/editor/inputHandlers.ts
@@ -1,7 +1,7 @@
 /* Copyright: Ankitects Pty Ltd and contributors
  * License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html */
 
-import { EditingArea } from ".";
+import { EditingArea } from "./editingArea";
 import { caretToEnd, nodeIsElement } from "./helpers";
 import { triggerChangeTimer } from "./changeTimer";
 import { updateButtonState } from "./toolbar";

--- a/ts/editor/labelContainer.ts
+++ b/ts/editor/labelContainer.ts
@@ -24,7 +24,7 @@ export class LabelContainer extends HTMLDivElement {
         this.appendChild(this.label);
 
         this.sticky = document.createElement("span");
-        this.sticky.className = "bi me-1 bi-sticky icon";
+        this.sticky.className = "bi me-1 bi-pin-angle icon";
         this.sticky.hidden = true;
         this.appendChild(this.sticky);
 

--- a/ts/editor/labelContainer.ts
+++ b/ts/editor/labelContainer.ts
@@ -9,7 +9,7 @@ export class LabelContainer extends HTMLDivElement {
         this.className = "d-flex";
 
         this.sticky = document.createElement("span");
-        this.sticky.className = "bi bi-pin-angle-fill me-1 sticky-icon";
+        this.sticky.className = "bi me-1 sticky-icon";
         this.sticky.hidden = true;
         this.appendChild(this.sticky);
 
@@ -32,14 +32,22 @@ export class LabelContainer extends HTMLDivElement {
         this.label.innerText = labelName;
     }
 
+    setSticky(state: boolean): void {
+        this.sticky.classList.toggle("bi-lock-fill", state);
+        this.sticky.classList.toggle("bi-unlock-fill", !state);
+    }
+
     activateSticky(initialState: boolean): void {
-        this.sticky.classList.toggle("is-active", initialState);
+        this.setSticky(initialState);
         this.sticky.hidden = false;
     }
 
     toggleSticky(): void {
-        bridgeCommand(`toggleSticky:${this.getAttribute("ord")}`, () => {
-            this.sticky.classList.toggle("is-active");
-        });
+        bridgeCommand(
+            `toggleSticky:${this.getAttribute("ord")}`,
+            (newState: boolean): void => {
+                this.setSticky(newState);
+            }
+        );
     }
 }

--- a/ts/editor/labelContainer.ts
+++ b/ts/editor/labelContainer.ts
@@ -1,5 +1,16 @@
 import { bridgeCommand } from "./lib";
 
+
+function removeHoverIcon(evt: Event): void {
+    const icon = evt.currentTarget as HTMLElement;
+    icon.classList.remove("icon--hover")
+}
+
+function hoverIcon(evt: Event): void {
+    const icon = evt.currentTarget as HTMLElement;
+    icon.classList.add("icon--hover");
+}
+
 export class LabelContainer extends HTMLDivElement {
     sticky: HTMLSpanElement;
     label: HTMLSpanElement;
@@ -13,7 +24,7 @@ export class LabelContainer extends HTMLDivElement {
         this.appendChild(this.label);
 
         this.sticky = document.createElement("span");
-        this.sticky.className = "bi me-1 sticky-icon";
+        this.sticky.className = "bi me-1 bi-sticky icon";
         this.sticky.hidden = true;
         this.appendChild(this.sticky);
 
@@ -22,10 +33,14 @@ export class LabelContainer extends HTMLDivElement {
 
     connectedCallback(): void {
         this.sticky.addEventListener("click", this.toggleSticky);
+        this.sticky.addEventListener("mouseenter", hoverIcon);
+        this.sticky.addEventListener("mouseleave", removeHoverIcon);
     }
 
     disconnectedCallback(): void {
         this.sticky.removeEventListener("click", this.toggleSticky);
+        this.sticky.removeEventListener("mouseenter", hoverIcon);
+        this.sticky.removeEventListener("mouseleave", removeHoverIcon);
     }
 
     initialize(labelName: string): void {
@@ -33,8 +48,7 @@ export class LabelContainer extends HTMLDivElement {
     }
 
     setSticky(state: boolean): void {
-        this.sticky.classList.toggle("bi-pin-angle-fill", state);
-        this.sticky.classList.toggle("bi-pin-angle", !state);
+        this.sticky.classList.toggle("is-inactive", state);
     }
 
     activateSticky(initialState: boolean): void {
@@ -42,12 +56,13 @@ export class LabelContainer extends HTMLDivElement {
         this.sticky.hidden = false;
     }
 
-    toggleSticky(): void {
+    toggleSticky(evt: Event): void {
         bridgeCommand(
             `toggleSticky:${this.getAttribute("ord")}`,
             (newState: boolean): void => {
                 this.setSticky(newState);
             }
         );
+        removeHoverIcon(evt);
     }
 }

--- a/ts/editor/labelContainer.ts
+++ b/ts/editor/labelContainer.ts
@@ -1,9 +1,8 @@
 import { bridgeCommand } from "./lib";
 
-
 function removeHoverIcon(evt: Event): void {
     const icon = evt.currentTarget as HTMLElement;
-    icon.classList.remove("icon--hover")
+    icon.classList.remove("icon--hover");
 }
 
 function hoverIcon(evt: Event): void {

--- a/ts/editor/labelContainer.ts
+++ b/ts/editor/labelContainer.ts
@@ -6,16 +6,16 @@ export class LabelContainer extends HTMLDivElement {
 
     constructor() {
         super();
-        this.className = "d-flex";
+        this.className = "d-flex justify-content-between";
+
+        this.label = document.createElement("span");
+        this.label.className = "fieldname";
+        this.appendChild(this.label);
 
         this.sticky = document.createElement("span");
         this.sticky.className = "bi me-1 sticky-icon";
         this.sticky.hidden = true;
         this.appendChild(this.sticky);
-
-        this.label = document.createElement("span");
-        this.label.className = "fieldname";
-        this.appendChild(this.label);
 
         this.toggleSticky = this.toggleSticky.bind(this);
     }

--- a/ts/editor/labelContainer.ts
+++ b/ts/editor/labelContainer.ts
@@ -47,7 +47,7 @@ export class LabelContainer extends HTMLDivElement {
     }
 
     setSticky(state: boolean): void {
-        this.sticky.classList.toggle("is-inactive", state);
+        this.sticky.classList.toggle("is-inactive", !state);
     }
 
     activateSticky(initialState: boolean): void {

--- a/ts/editor/labelContainer.ts
+++ b/ts/editor/labelContainer.ts
@@ -33,8 +33,8 @@ export class LabelContainer extends HTMLDivElement {
     }
 
     setSticky(state: boolean): void {
-        this.sticky.classList.toggle("bi-lock-fill", state);
-        this.sticky.classList.toggle("bi-unlock-fill", !state);
+        this.sticky.classList.toggle("bi-pin-angle-fill", state);
+        this.sticky.classList.toggle("bi-pin-angle", !state);
     }
 
     activateSticky(initialState: boolean): void {

--- a/ts/editor/labelContainer.ts
+++ b/ts/editor/labelContainer.ts
@@ -1,0 +1,45 @@
+import { bridgeCommand } from "./lib";
+
+export class LabelContainer extends HTMLDivElement {
+    sticky: HTMLSpanElement;
+    label: HTMLSpanElement;
+
+    constructor() {
+        super();
+        this.className = "d-flex";
+
+        this.sticky = document.createElement("span");
+        this.sticky.className = "bi bi-pin-angle-fill me-1 sticky-icon";
+        this.sticky.hidden = true;
+        this.appendChild(this.sticky);
+
+        this.label = document.createElement("span");
+        this.label.className = "fieldname";
+        this.appendChild(this.label);
+
+        this.toggleSticky = this.toggleSticky.bind(this);
+    }
+
+    connectedCallback(): void {
+        this.sticky.addEventListener("click", this.toggleSticky);
+    }
+
+    disconnectedCallback(): void {
+        this.sticky.removeEventListener("click", this.toggleSticky);
+    }
+
+    initialize(labelName: string): void {
+        this.label.innerText = labelName;
+    }
+
+    activateSticky(initialState: boolean): void {
+        this.sticky.classList.toggle("is-active", initialState);
+        this.sticky.hidden = false;
+    }
+
+    toggleSticky(): void {
+        bridgeCommand(`toggleSticky:${this.getAttribute("ord")}`, () => {
+            this.sticky.classList.toggle("is-active");
+        });
+    }
+}

--- a/ts/licenses.json
+++ b/ts/licenses.json
@@ -7,6 +7,14 @@
         "path": "node_modules/@fluent/bundle",
         "licenseFile": "node_modules/@fluent/bundle/README.md"
     },
+    "@popperjs/core@2.8.6": {
+        "licenses": "MIT",
+        "repository": "https://github.com/popperjs/popper-core",
+        "publisher": "Federico Zivolo",
+        "email": "federico.zivolo@gmail.com",
+        "path": "node_modules/@popperjs/core",
+        "licenseFile": "node_modules/@popperjs/core/LICENSE.md"
+    },
     "@protobufjs/aspromise@1.1.2": {
         "licenses": "BSD-3-Clause",
         "repository": "https://github.com/dcodeIO/protobuf.js",
@@ -98,6 +106,21 @@
         "repository": "https://github.com/DefinitelyTyped/DefinitelyTyped",
         "path": "node_modules/protobufjs/node_modules/@types/node",
         "licenseFile": "node_modules/protobufjs/node_modules/@types/node/LICENSE"
+    },
+    "bootstrap-icons@1.4.0": {
+        "licenses": "MIT",
+        "repository": "https://github.com/twbs/icons",
+        "publisher": "mdo",
+        "path": "node_modules/bootstrap-icons",
+        "licenseFile": "node_modules/bootstrap-icons/LICENSE.md"
+    },
+    "bootstrap@5.0.0-beta2": {
+        "licenses": "MIT",
+        "repository": "https://github.com/twbs/bootstrap",
+        "publisher": "The Bootstrap Authors",
+        "url": "https://github.com/twbs/bootstrap/graphs/contributors",
+        "path": "node_modules/bootstrap",
+        "licenseFile": "node_modules/bootstrap/LICENSE"
     },
     "commander@2.20.3": {
         "licenses": "MIT",

--- a/ts/licenses.json
+++ b/ts/licenses.json
@@ -7,14 +7,6 @@
         "path": "node_modules/@fluent/bundle",
         "licenseFile": "node_modules/@fluent/bundle/README.md"
     },
-    "@popperjs/core@2.8.6": {
-        "licenses": "MIT",
-        "repository": "https://github.com/popperjs/popper-core",
-        "publisher": "Federico Zivolo",
-        "email": "federico.zivolo@gmail.com",
-        "path": "node_modules/@popperjs/core",
-        "licenseFile": "node_modules/@popperjs/core/LICENSE.md"
-    },
     "@protobufjs/aspromise@1.1.2": {
         "licenses": "BSD-3-Clause",
         "repository": "https://github.com/dcodeIO/protobuf.js",

--- a/ts/package.json
+++ b/ts/package.json
@@ -50,7 +50,6 @@
     },
     "dependencies": {
         "@fluent/bundle": "^0.15.1",
-        "@popperjs/core": "^2.8.6",
         "bootstrap": "^5.0.0-beta2",
         "bootstrap-icons": "^1.4.0",
         "css-browser-selector": "^0.6.5",

--- a/ts/package.json
+++ b/ts/package.json
@@ -50,6 +50,9 @@
     },
     "dependencies": {
         "@fluent/bundle": "^0.15.1",
+        "@popperjs/core": "^2.8.6",
+        "bootstrap": "^5.0.0-beta2",
+        "bootstrap-icons": "^1.4.0",
         "css-browser-selector": "^0.6.5",
         "d3": "^6.5.0",
         "intl-pluralrules": "^1.2.2",

--- a/ts/sass/_buttons.scss
+++ b/ts/sass/_buttons.scss
@@ -7,49 +7,51 @@ $fusion-button-border: #646464;
 $fusion-button-base-bg: #454545;
 
 .isWin {
-  button {
-    font-size: 12px;
-  }
+    button {
+        font-size: 12px;
+    }
 }
 
 .isMac {
-  button {
-    font-size: 13px;
-  }
+    button {
+        font-size: 13px;
+    }
 }
 
 .isLin {
-  button {
-    font-size: 14px;
+    button {
+        font-size: 14px;
 
-    -webkit-appearance: none;
-    border-radius: 3px;
-    padding: 5px;
-    border: 1px solid var(--border);
-  }
+        -webkit-appearance: none;
+        border-radius: 3px;
+        padding: 5px;
+        border: 1px solid var(--border);
+    }
 }
 
 .nightMode {
-  button {
-    -webkit-appearance: none;
-    color: var(--text-fg);
+    button {
+        -webkit-appearance: none;
+        color: var(--text-fg);
 
-    /* match the fusion button gradient */
-    background: linear-gradient(0deg,
+        /* match the fusion button gradient */
+        background: linear-gradient(
+            0deg,
             $fusion-button-gradient-start 0%,
-            $fusion-button-gradient-end 100%);
-    box-shadow: 0 0 3px $fusion-button-outline;
-    border: 1px solid $fusion-button-border;
+            $fusion-button-gradient-end 100%
+        );
+        box-shadow: 0 0 3px $fusion-button-outline;
+        border: 1px solid $fusion-button-border;
 
-    border-radius: 2px;
-    padding: 10px;
-    padding-top: 3px;
-    padding-bottom: 3px;
-  }
+        border-radius: 2px;
+        padding: 10px;
+        padding-top: 3px;
+        padding-bottom: 3px;
+    }
 
-  button:hover {
-    background: $fusion-button-hover-bg;
-  }
+    button:hover {
+        background: $fusion-button-hover-bg;
+    }
 }
 
 /* imitate standard macOS dark mode buttons */

--- a/ts/sass/scrollbar.scss
+++ b/ts/sass/scrollbar.scss
@@ -5,28 +5,28 @@
 @use 'buttons';
 
 @mixin night-mode {
-  &::-webkit-scrollbar {
-    background: var(--window-bg);
+    &::-webkit-scrollbar {
+        background: var(--window-bg);
 
-    &:horizontal {
-      height: 12px;
+        &:horizontal {
+            height: 12px;
+        }
+
+        &:vertical {
+            width: 12px;
+        }
     }
 
-    &:vertical {
-      width: 12px;
-    }
-  }
+    &::-webkit-scrollbar-thumb {
+        background: buttons.$fusion-button-hover-bg;
+        border-radius: 8px;
 
-  &::-webkit-scrollbar-thumb {
-    background: buttons.$fusion-button-hover-bg;
-    border-radius: 8px;
+        &:horizontal {
+            min-width: 50px;
+        }
 
-    &:horizontal {
-      min-width: 50px;
+        &:vertical {
+            min-height: 50px;
+        }
     }
-
-    &:vertical {
-      min-height: 50px;
-    }
-  }
 }

--- a/ts/vendor.bzl
+++ b/ts/vendor.bzl
@@ -94,3 +94,49 @@ def copy_css_browser_selector(name = "css-browser-selector", visibility = ["//vi
         ],
         visibility = visibility,
     )
+
+def copy_bootstrap_js(name = "bootstrap-js", visibility = ["//visibility:public"]):
+    vendor_js_lib(
+        name = name,
+        pkg = _pkg_from_name(name),
+        include = [
+            "dist/js/bootstrap.bundle.min.js",
+        ],
+        strip_prefix = "dist/js/",
+        visibility = visibility,
+    )
+
+def copy_bootstrap_css(name = "bootstrap-css", visibility = ["//visibility:public"]):
+    vendor_js_lib(
+        name = name,
+        pkg = _pkg_from_name(name),
+        include = [
+            "dist/css/bootstrap.min.css",
+        ],
+        strip_prefix = "dist/css/",
+        visibility = visibility,
+    )
+
+def copy_bootstrap_icons(name = "bootstrap-icons", visibility = ["//visibility:public"]):
+    vendor_js_lib(
+        name = name,
+        pkg = _pkg_from_name(name),
+        include = [
+            "font/bootstrap-icons.css",
+            "font/fonts/bootstrap-icons.woff",
+            "font/fonts/bootstrap-icons.woff2",
+        ],
+        strip_prefix = "font/",
+        visibility = visibility,
+    )
+
+def copy_popperjs(name = "popperjs", visibility = ["//visibility:public"]):
+    vendor_js_lib(
+        name = name,
+        pkg = "@npm//@popperjs/core:core__files",
+        include = [
+            "external/npm/node_modules/@popperjs/core/dist/umd/popper.min.js",
+        ],
+        strip_prefix = "external/npm/node_modules/@popperjs/core/dist/umd/",
+        visibility = visibility,
+    )

--- a/ts/vendor.bzl
+++ b/ts/vendor.bzl
@@ -129,14 +129,3 @@ def copy_bootstrap_icons(name = "bootstrap-icons", visibility = ["//visibility:p
         strip_prefix = "font/",
         visibility = visibility,
     )
-
-def copy_popperjs(name = "popperjs", visibility = ["//visibility:public"]):
-    vendor_js_lib(
-        name = name,
-        pkg = "@npm//@popperjs/core:core__files",
-        include = [
-            "external/npm/node_modules/@popperjs/core/dist/umd/popper.min.js",
-        ],
-        strip_prefix = "external/npm/node_modules/@popperjs/core/dist/umd/",
-        visibility = visibility,
-    )

--- a/ts/yarn.lock
+++ b/ts/yarn.lock
@@ -53,6 +53,11 @@
   resolved "https://registry.yarnpkg.com/@fluent/bundle/-/bundle-0.15.1.tgz#95d3b9f836ac138b6ee8480ef8d0547dd59195b1"
   integrity sha512-uhDGjpEwTMBNxYMSXyjXFBG5LY7dqoNatle6mnghu5lFOrf0JyblY/Y0al2GzDKFuYbtOSbJvUkxzjtYX3odkw==
 
+"@popperjs/core@^2.8.6":
+  version "2.8.6"
+  resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.8.6.tgz#ad75ebe8dbecfa145af3c7e4d0ae98016458d005"
+  integrity sha512-1oXH2bAFXz9SttE1v/0Jp+2ZVePsPEAPGIuPKrmljWZcS3FPBEn2Q4WcANozZC0YiCjTWOF55k0g6rbSZS39ew==
+
 "@protobufjs/aspromise@^1.1.1", "@protobufjs/aspromise@^1.1.2":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@protobufjs/aspromise/-/aspromise-1.1.2.tgz#9b8b0cc663d669a7d8f6f5d0893a14d348f30fbf"
@@ -698,6 +703,16 @@ bluebird@^3.7.2:
   version "3.7.2"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.2.tgz#9f229c15be272454ffa973ace0dbee79a1b0c36f"
   integrity sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==
+
+bootstrap-icons@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/bootstrap-icons/-/bootstrap-icons-1.4.0.tgz#ea08e2c8bc1535576ad267312cca9ee84ea73343"
+  integrity sha512-EynaOv/G/X/sQgPUqkdLJoxPrWk73wwsVjVR3cDNYO0jMS58poq7DOC2CraBWlBt1AberEmt0blfw4ony2/ZIg==
+
+bootstrap@^5.0.0-beta2:
+  version "5.0.0-beta2"
+  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-5.0.0-beta2.tgz#ab1504a12807fa58e5e41408e35fcea42461e84b"
+  integrity sha512-e+uPbPHqTQWKyCX435uVlOmgH9tUt0xtjvyOC7knhKgOS643BrQKuTo+KecGpPV7qlmOyZgCfaM4xxPWtDEN/g==
 
 brace-expansion@^1.1.7:
   version "1.1.11"

--- a/ts/yarn.lock
+++ b/ts/yarn.lock
@@ -53,11 +53,6 @@
   resolved "https://registry.yarnpkg.com/@fluent/bundle/-/bundle-0.15.1.tgz#95d3b9f836ac138b6ee8480ef8d0547dd59195b1"
   integrity sha512-uhDGjpEwTMBNxYMSXyjXFBG5LY7dqoNatle6mnghu5lFOrf0JyblY/Y0al2GzDKFuYbtOSbJvUkxzjtYX3odkw==
 
-"@popperjs/core@^2.8.6":
-  version "2.8.6"
-  resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.8.6.tgz#ad75ebe8dbecfa145af3c7e4d0ae98016458d005"
-  integrity sha512-1oXH2bAFXz9SttE1v/0Jp+2ZVePsPEAPGIuPKrmljWZcS3FPBEn2Q4WcANozZC0YiCjTWOF55k0g6rbSZS39ew==
-
 "@protobufjs/aspromise@^1.1.1", "@protobufjs/aspromise@^1.1.2":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@protobufjs/aspromise/-/aspromise-1.1.2.tgz#9b8b0cc663d669a7d8f6f5d0893a14d348f30fbf"


### PR DESCRIPTION
This PR will add sticky / frozen / pinned buttons directly into the Editor window.

 The biggest point of contention imo are the icons. I've included the [Bootstrap icons](https://icons.getbootstrap.com/?), because I've already used them in Previewer PR. Looking at the icons in `/qt/aqt/data/web/imgs`, Bootstrap icons contain equivalents for all of them except the superscript and subscript icons.

Alternatives would be:
1. Create icons ourselves.
2. [Font Awesome](https://fontawesome.com/icons?d=gallery&p=2&m=free) offers a wide selection of free icons as well, certainly more than the Bootstrap icons. It would contain equivalents for all icons in `/qt/aqt/data/web/imgs`. Font Awesome has both a free and a paid pro tier.

Other small changes this PR includes:
1. Split up `/ts/editor/index.ts` into four files
2. I had to make some changes to `editor.scss`, as well as the button generation code in `editor.py` to make it behave well with Bootstraps CSS
3. I reworked the code for updating the buttons states a little bit. Now, all buttons will be unhighlighted on blur.
4. I removed all last uses of jQuery from `/ts/editor`. It could now technically removed from `editor.py` without breaking it. Interestingly, on the initial load of the editor, loading jQuery takes 3-4 times as long as Bootstrap. However I've left it in for addon backwards compatibility.

This PR does not entirely cover the functionality of my add-on, as there are no shortcuts associated with toggling the sticky/frozen status of fields. Anki has so far no configuration settings for shortcuts, so I wouldn't want to add this. At the same time, I don't think the default shortcuts of Ze Frozen Fields (F9 and Shift+F9) are that good, that I would want to have them directly in Anki.

My suggestion here would be that we don't add any built-in shortcuts, and I can transform my "Ze Frozen Fields" add-on to something like "Sticky Fields Shortcuts", to offer the functionality for those who want it.