### PR TITLE
Choose addon to update

### DIFF
--- a/ftl/qt/addons.ftl
+++ b/ftl/qt/addons.ftl
@@ -64,3 +64,4 @@ addons-delete-the-numd-selected-addon =
         [one] Delete the { $count } selected add-on?
        *[other] Delete the { $count } selected add-ons?
     }
+addons-choose-update-window-title = Update Add-ons

--- a/qt/aqt/addons.py
+++ b/qt/aqt/addons.py
@@ -1180,33 +1180,33 @@ class ChooseAddonsToUpdateList(QListWidget):
             item.setData(self.ADDON_ID_ROLE, addon_id)
         self.refresh_header_check_state()
 
+    def bool_to_check(self, check_bool: bool) -> Qt.CheckState:
+        if check_bool:
+            return Qt.Checked
+        else:
+            return Qt.Unchecked
+
+    def checked(self, item: QListWidgetItem) -> bool:
+        return item.checkState() == Qt.Checked
+
     def on_click(self, item: QListWidgetItem) -> None:
         if item == self.header_item:
             return
-        if item.checkState() == Qt.Checked:
-            self.check_item(item, Qt.Unchecked)
-        else:
-            self.check_item(item, Qt.Checked)
+        checked = self.checked(item)
+        self.check_item(item, self.bool_to_check(not checked))
         self.refresh_header_check_state()
 
     def on_check(self, item: QListWidgetItem) -> None:
         if self.ignore_check_evt:
             return
         if item == self.header_item:
-            if item.checkState() == Qt.Checked:
-                check = Qt.Checked
-            else:
-                check = Qt.Unchecked
-            self.header_checked(check)
+            self.header_checked(item.checkState())
 
     def on_double_click(self, item: QListWidgetItem) -> None:
         if item == self.header_item:
-            if item.checkState() == Qt.Checked:
-                check = Qt.Unchecked
-            else:
-                check = Qt.Checked
-            self.check_item(self.header_item, check)
-            self.header_checked(check)
+            checked = self.checked(item)
+            self.check_item(self.header_item, self.bool_to_check(not checked))
+            self.header_checked(self.bool_to_check(not checked))
 
     def check_item(self, item: QListWidgetItem, check: Qt.CheckState) -> None:
         "call item.setCheckState without triggering on_check"
@@ -1221,7 +1221,7 @@ class ChooseAddonsToUpdateList(QListWidget):
     def refresh_header_check_state(self) -> None:
         for i in range(1, self.count()):
             item = self.item(i)
-            if item.checkState() == Qt.Unchecked:
+            if not self.checked(item):
                 self.check_item(self.header_item, Qt.Unchecked)
                 return
         self.check_item(self.header_item, Qt.Checked)
@@ -1230,7 +1230,7 @@ class ChooseAddonsToUpdateList(QListWidget):
         addon_ids = []
         for i in range(1, self.count()):
             item = self.item(i)
-            if item.checkState() == Qt.Checked:
+            if self.checked(item):
                 addon_id = item.data(self.ADDON_ID_ROLE)
                 addon_ids.append(addon_id)
         return addon_ids
@@ -1240,8 +1240,7 @@ class ChooseAddonsToUpdateList(QListWidget):
             item = self.item(i)
             addon_id = item.data(self.ADDON_ID_ROLE)
             addon_meta = self.mgr.addon_meta(str(addon_id))
-            checked = item.checkState() == Qt.Checked
-            addon_meta.update_enabled = checked
+            addon_meta.update_enabled = self.checked(item)
             self.mgr.write_addon_meta(addon_meta)
 
 

--- a/qt/aqt/addons.py
+++ b/qt/aqt/addons.py
@@ -1152,9 +1152,11 @@ class ChooseAddonsToUpdateList(QListWidget):
         )
         self.ignore_check_evt = False
         self.setup()
+        self.setContextMenuPolicy(Qt.CustomContextMenu)
         qconnect(self.itemClicked, self.on_click)
         qconnect(self.itemChanged, self.on_check)
         qconnect(self.itemDoubleClicked, self.on_double_click)
+        qconnect(self.customContextMenuRequested, self.on_context_menu)
 
     def setup(self) -> None:
         header_item = QListWidgetItem("", self)
@@ -1207,6 +1209,14 @@ class ChooseAddonsToUpdateList(QListWidget):
             checked = self.checked(item)
             self.check_item(self.header_item, self.bool_to_check(not checked))
             self.header_checked(self.bool_to_check(not checked))
+
+    def on_context_menu(self, point: QPoint) -> None:
+        item = self.itemAt(point)
+        addon_id = item.data(self.ADDON_ID_ROLE)
+        m = QMenu()
+        a = m.addAction(tr(TR.ADDONS_VIEW_ADDON_PAGE))
+        qconnect(a.triggered, lambda _: openLink(f"{aqt.appShared}info/{addon_id}"))
+        m.exec_(QCursor.pos())
 
     def check_item(self, item: QListWidgetItem, check: Qt.CheckState) -> None:
         "call item.setCheckState without triggering on_check"

--- a/qt/aqt/main.py
+++ b/qt/aqt/main.py
@@ -848,7 +848,10 @@ title="%s" %s>%s</button>""" % (
 
         if elap > 86_400:
             check_and_prompt_for_updates(
-                self, self.addonManager, self.on_updates_installed
+                self,
+                self.addonManager,
+                self.on_updates_installed,
+                requested_by_user=False,
             )
             self.pm.set_last_addon_update_check(intTime())
 


### PR DESCRIPTION
<img src="https://user-images.githubusercontent.com/50060875/109752033-02f14d00-7c23-11eb-809b-df2d8d2c1d7b.png" height="200px"><img src="https://user-images.githubusercontent.com/50060875/109752086-17354a00-7c23-11eb-9c3c-1b847aba397f.png" height="200px">

This is a continuation of #668 

I've addressed the 4 points you suggested:
* Addon update specific widget instead of generic
* The checkbox state is remembered using `AddonMeta.update_enabled`
* For daily update checks, whether the window is showed is determined by whether `update_enabled` is `False` for all update-able addons. Users will have to deselect all addons for this window to not show up every day. I'm not quite sure if it is the best solution - if you have a better idea, I'd be happy to edit.
* You can open the AnkiWeb addon page via context menu. 
* Show update date. I experimented with QTreeWidget or QTableWidget to render the update date in seperate columns, but they all seem to add a lot more complexity to create a checkable list-like widget. As long as only update date is showed, I think it should be fine to just seperate them with whitespaces.
