### PR TITLE
Import Dialog: Do not change delimiter if cancel button is pressed

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -75,6 +75,7 @@ Meredith Derecho <meredithderecho@gmail.com>
 Daniel Wallgren <github.com/wallgrenen>
 Kerrick Staley <kerrick@kerrickstaley.com>
 Maksim Abramchuk <maximabramchuck@gmail.com>
+Benjamin Kulnik <benjamin.kulnik@student.tuwien.ac.at>
 
 ********************
 

--- a/qt/aqt/importing.py
+++ b/qt/aqt/importing.py
@@ -10,8 +10,6 @@ import zipfile
 from concurrent.futures import Future
 from typing import Any, Dict, Optional
 
-from qt.aqt.utils import getText
-
 import anki.importing as importing
 import aqt.deckchooser
 import aqt.forms
@@ -25,7 +23,7 @@ from aqt.utils import (
     askUser,
     disable_help_button,
     getFile,
-    getOnlyText,
+    getText,
     openHelp,
     showInfo,
     showText,


### PR DESCRIPTION
## What?

In the current version of Anki (v2.1.40) the default delimiter is removed and replaced by TAB, even if the "cancel" button is clicked. Usually canceling an operation should not make any changes therefore I assume this is not intended behavior. 

![Video showing the bug](https://user-images.githubusercontent.com/16613048/110015433-23ed9700-7d24-11eb-9305-fa781568c56d.mp4)

## How to reproduce

Select `Import File`, select e.g. a CSV file and click the `Fields separated  by` button. A modal dialog should open. Close the modal dialog using `Cancel`. The preselected delimiter (Semicolon) is replaced by TAB.

## Fix

I made a minor change where the result of the modal dialog is checked and only if it the OK button pressed the delimiter is updated. 




