### PR TITLE
Do not execute caretToEnd when Alt-tabbing back to application

### DIFF
--- a/ts/editor/focusHandlers.ts
+++ b/ts/editor/focusHandlers.ts
@@ -20,7 +20,6 @@ function focusField(field: EditingArea) {
     field.focusEditable();
     bridgeCommand(`focus:${field.ord}`);
     enableButtons();
-    caretToEnd(field);
 }
 
 // For distinguishing focus by refocusing window from deliberate focus
@@ -31,10 +30,14 @@ export function onFocus(evt: FocusEvent): void {
     const previousFocus = evt.relatedTarget as EditingArea;
 
     if (
-        previousFocus === previousActiveElement ||
-        !(previousFocus instanceof EditingArea)
+        !(previousFocus instanceof EditingArea) ||
+        previousFocus === previousActiveElement
     ) {
         focusField(currentField);
+
+        if (previousFocus) {
+            caretToEnd(currentField);
+        }
     }
 }
 


### PR DESCRIPTION
Closes #1054.

This is very much related to #1037, and might even be a regression from it, even though I did not test it.
It also works with the fact, that when you refocus a window, the first `FocusEvent` has `relatedTarget === null`.

The fix solves the problem when you Alt-tab back to the application. I wouldn't know any other way to trigger this behavior, because otherwise you'd click on the window to reactivate it, in which case the clicking sets the new focus anyway.