### PR TITLE
Fix focus handling by moving caretToEnd logic

### DIFF
--- a/ts/editor/changeTimer.ts
+++ b/ts/editor/changeTimer.ts
@@ -6,16 +6,12 @@ import type { EditingArea } from ".";
 import { getCurrentField } from ".";
 import { bridgeCommand } from "./lib";
 import { getNoteId } from "./noteId";
-import { updateButtonState } from "./toolbar";
 
 let changeTimer: number | null = null;
 
 export function triggerChangeTimer(currentField: EditingArea): void {
     clearChangeTimer();
-    changeTimer = setTimeout(function () {
-        updateButtonState();
-        saveField(currentField, "key");
-    }, 600);
+    changeTimer = setTimeout(() => saveField(currentField, "key"), 600);
 }
 
 function clearChangeTimer(): void {

--- a/ts/editor/focusHandlers.ts
+++ b/ts/editor/focusHandlers.ts
@@ -1,55 +1,23 @@
 /* Copyright: Ankitects Pty Ltd and contributors
  * License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html */
 
-import { EditingArea } from ".";
+import type { EditingArea } from ".";
 
 import { bridgeCommand } from "./lib";
 import { enableButtons, disableButtons } from "./toolbar";
 import { saveField } from "./changeTimer";
 
-function caretToEnd(currentField: EditingArea): void {
-    const range = document.createRange();
-    range.selectNodeContents(currentField.editable);
-    range.collapse(false);
-    const selection = currentField.getSelection();
-    selection.removeAllRanges();
-    selection.addRange(range);
-}
-
-function focusField(field: EditingArea, moveCaretToEnd: boolean): void {
-    field.focusEditable();
-    bridgeCommand(`focus:${field.ord}`);
-
-    if (moveCaretToEnd) {
-        caretToEnd(field);
-    }
-
-    enableButtons();
-}
-
-// For distinguishing focus by refocusing window from deliberate focus
-let previousActiveElement: EditingArea | null = null;
-
 export function onFocus(evt: FocusEvent): void {
     const currentField = evt.currentTarget as EditingArea;
-    const previousFocus = evt.relatedTarget as EditingArea;
-
-    if (
-        !(previousFocus instanceof EditingArea) ||
-        previousFocus === previousActiveElement
-    ) {
-        const moveCaretToEnd =
-            Boolean(previousFocus) || !Boolean(previousActiveElement);
-
-        focusField(currentField, moveCaretToEnd);
-    }
+    currentField.focusEditable();
+    bridgeCommand(`focus:${currentField.ord}`);
+    enableButtons();
 }
 
 export function onBlur(evt: FocusEvent): void {
     const previousFocus = evt.currentTarget as EditingArea;
+    const currentFieldUnchanged = previousFocus === document.activeElement;
 
-    saveField(previousFocus, previousFocus === document.activeElement ? "key" : "blur");
-    // other widget or window focused; current field unchanged
-    previousActiveElement = previousFocus;
+    saveField(previousFocus, currentFieldUnchanged ? "key" : "blur");
     disableButtons();
 }

--- a/ts/editor/focusHandlers.ts
+++ b/ts/editor/focusHandlers.ts
@@ -16,9 +16,14 @@ function caretToEnd(currentField: EditingArea): void {
     selection.addRange(range);
 }
 
-function focusField(field: EditingArea) {
+function focusField(field: EditingArea, moveCaretToEnd: boolean): void {
     field.focusEditable();
     bridgeCommand(`focus:${field.ord}`);
+
+    if (moveCaretToEnd) {
+        caretToEnd(field);
+    }
+
     enableButtons();
 }
 
@@ -33,11 +38,10 @@ export function onFocus(evt: FocusEvent): void {
         !(previousFocus instanceof EditingArea) ||
         previousFocus === previousActiveElement
     ) {
-        focusField(currentField);
+        const moveCaretToEnd =
+            Boolean(previousFocus) || !Boolean(previousActiveElement);
 
-        if (previousFocus) {
-            caretToEnd(currentField);
-        }
+        focusField(currentField, moveCaretToEnd);
     }
 }
 

--- a/ts/editor/helpers.ts
+++ b/ts/editor/helpers.ts
@@ -1,6 +1,8 @@
 /* Copyright: Ankitects Pty Ltd and contributors
  * License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html */
 
+import type { EditingArea } from ".";
+
 export function nodeIsElement(node: Node): node is Element {
     return node.nodeType === Node.ELEMENT_NODE;
 }
@@ -65,4 +67,13 @@ const INLINE_TAGS = [
 
 export function nodeIsInline(node: Node): boolean {
     return !nodeIsElement(node) || INLINE_TAGS.includes(node.tagName);
+}
+
+export function caretToEnd(currentField: EditingArea): void {
+    const range = document.createRange();
+    range.selectNodeContents(currentField.editable);
+    range.collapse(false);
+    const selection = currentField.getSelection();
+    selection.removeAllRanges();
+    selection.addRange(range);
 }

--- a/ts/editor/index.ts
+++ b/ts/editor/index.ts
@@ -1,7 +1,7 @@
 /* Copyright: Ankitects Pty Ltd and contributors
  * License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html */
 
-import { nodeIsInline } from "./helpers";
+import { nodeIsInline, caretToEnd } from "./helpers";
 import { bridgeCommand } from "./lib";
 import { saveField } from "./changeTimer";
 import { filterHTML } from "./htmlFilter";
@@ -34,6 +34,8 @@ export function focusField(n: number): void {
 
     if (field) {
         field.editingArea.focusEditable();
+        caretToEnd(field.editingArea);
+        updateButtonState();
     }
 }
 

--- a/ts/editor/inputHandlers.ts
+++ b/ts/editor/inputHandlers.ts
@@ -2,8 +2,9 @@
  * License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html */
 
 import { EditingArea } from ".";
-import { nodeIsElement } from "./helpers";
+import { caretToEnd, nodeIsElement } from "./helpers";
 import { triggerChangeTimer } from "./changeTimer";
+import { updateButtonState } from "./toolbar";
 
 function inListItem(currentField: EditingArea): boolean {
     const anchor = currentField.getSelection()!.anchorNode!;
@@ -21,6 +22,7 @@ function inListItem(currentField: EditingArea): boolean {
 export function onInput(event: Event): void {
     // make sure IME changes get saved
     triggerChangeTimer(event.currentTarget as EditingArea);
+    updateButtonState();
 }
 
 export function onKey(evt: KeyboardEvent): void {
@@ -58,6 +60,18 @@ export function onKey(evt: KeyboardEvent): void {
 
     triggerChangeTimer(currentField);
 }
+
+globalThis.addEventListener("keydown", (evt: KeyboardEvent) => {
+    if (evt.code === "Tab") {
+        globalThis.addEventListener("focusin", (evt: FocusEvent) => {
+            const newFocusTarget = evt.target;
+            if (newFocusTarget instanceof EditingArea) {
+                caretToEnd(newFocusTarget);
+                updateButtonState();
+            }
+        }, { once: true })
+    }
+})
 
 export function onKeyUp(evt: KeyboardEvent): void {
     const currentField = evt.currentTarget as EditingArea;

--- a/ts/editor/toolbar.ts
+++ b/ts/editor/toolbar.ts
@@ -1,15 +1,23 @@
 /* Copyright: Ankitects Pty Ltd and contributors
  * License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html */
 
+const highlightButtons = ["bold", "italic", "underline", "superscript", "subscript"];
+
 export function updateButtonState(): void {
-    const buts = ["bold", "italic", "underline", "superscript", "subscript"];
-    for (const name of buts) {
+    for (const name of highlightButtons) {
         const elem = document.querySelector(`#${name}`) as HTMLElement;
         elem.classList.toggle("highlighted", document.queryCommandState(name));
     }
 
     // fixme: forecolor
     //    'col': document.queryCommandValue("forecolor")
+}
+
+function clearButtonHighlight(): void {
+    for (const name of highlightButtons) {
+        const elem = document.querySelector(`#${name}`) as HTMLElement;
+        elem.classList.remove("highlighted");
+    }
 }
 
 export function preventButtonFocus(): void {
@@ -20,19 +28,34 @@ export function preventButtonFocus(): void {
     }
 }
 
-export function disableButtons(): void {
-    $("button.linkb:not(.perm)").prop("disabled", true);
+export function enableButtons(): void {
+    const buttons = document.querySelectorAll(
+        "button.linkb"
+    ) as NodeListOf<HTMLButtonElement>;
+    buttons.forEach((elem: HTMLButtonElement): void => {
+        elem.disabled = false;
+    });
+    updateButtonState();
 }
 
-export function enableButtons(): void {
-    $("button.linkb").prop("disabled", false);
+export function disableButtons(): void {
+    const buttons = document.querySelectorAll(
+        "button.linkb:not(.perm)"
+    ) as NodeListOf<HTMLButtonElement>;
+    buttons.forEach((elem: HTMLButtonElement): void => {
+        elem.disabled = true;
+    });
+    clearButtonHighlight();
 }
 
 export function setFGButton(col: string): void {
     document.getElementById("forecolor")!.style.backgroundColor = col;
 }
 
-export function toggleEditorButton(buttonid: string): void {
-    const button = $(buttonid)[0];
+export function toggleEditorButton(buttonOrId: string | HTMLElement): void {
+    const button =
+        typeof buttonOrId === "string"
+            ? (document.getElementById(buttonOrId) as HTMLElement)
+            : buttonOrId;
     button.classList.toggle("highlighted");
 }


### PR DESCRIPTION
Ok, let's hope this will be the last focus handling PR...

I think one way we made it unnecessarily complicated for us, was that we executed `caretToEnd` from the focus handler, even though it's not really connected to focusing. As I see it, we have two situations where we want to move the caret to the end of the field:

1. When we programmatically focus a field (e.g. on opening the editor)
2. When changing focus via Tab

I've moved `caretToEnd` out of `onFocus`, and moved it to these two places. This also allows us to vastly simplify `onFocus`.