### PR TITLE
Strip HTML comments from external pastes

### DIFF
--- a/ts/editor/htmlFilter.ts
+++ b/ts/editor/htmlFilter.ts
@@ -132,13 +132,17 @@ let filterInternalNode = function (elem: Element) {
 
 // filtering from external sources
 let filterNode = function (node: Node, extendedMode: boolean): void {
+    if (node.nodeType === Node.COMMENT_NODE) {
+        node.parentNode.removeChild(node);
+        return;
+    }
     if (!nodeIsElement(node)) {
         return;
     }
 
     // descend first, and take a copy of the child nodes as the loop will skip
     // elements due to node modifications otherwise
-    for (const child of [...node.children]) {
+    for (const child of [...node.childNodes]) {
         filterNode(child, extendedMode);
     }
 


### PR DESCRIPTION
Fixes a regression caused by https://github.com/ankitects/anki/commit/150de7a683348198183166ddda5791eb5ff6bc28

This is especially annoying on Windows with the `<!--StartFragment --><!--EndFragment -->` thingy getting inserted in every HTML paste.

I suspect the code previously used to also strip many non-text nodes like CDATA sections, but I didn't bother with those here.