### PR TITLE
Clicking the expander icon should not trigger click event

### DIFF
--- a/qt/aqt/sidebar.py
+++ b/qt/aqt/sidebar.py
@@ -443,7 +443,8 @@ class SidebarTreeView(QTreeView):
         super().mouseReleaseEvent(event)
         if event.button() == Qt.LeftButton:
             idx = self.indexAt(event.pos())
-            self._on_click_index(idx)
+            if idx == self.currentIndex():
+                self._on_click_index(idx)
 
     def keyPressEvent(self, event: QKeyEvent) -> None:
         if event.key() in (Qt.Key_Return, Qt.Key_Enter):


### PR DESCRIPTION
Fixes #1059

Uses the fact that `currentIndex` does not change when expander triangle icon is clicked. I *think* 1) clicking the expander icon and 2) clicking outside the sidebar item, are the only cases where `currentIndex` is different from sidebar item on mouse position.


I've also considered some other solutions:
* Use `currentChanged` for the searches. The search is done only when currentIndex is changed, not when the items are clicked. A drawback is that you can't re-click the selected item to re-trigger the search and update the notes list.
* Check if expander icon was clicked by mouse position. Qt does this by calling `itemDecorationAt`, but the method is not exposed. It is non-trivial to calculate if mouse position is on the icon.