### PR TITLE
Fix regex error formatting and search error escaping

### DIFF
--- a/rslib/src/err.rs
+++ b/rslib/src/err.rs
@@ -158,7 +158,7 @@ impl AnkiError {
                     SearchErrorKind::InvalidPropOperator(ctx) => i18n
                         .trn(TR::SearchInvalidPropOperator, tr_strs!["val"=>(ctx)])
                         .into(),
-                    SearchErrorKind::Regex(text) => text.into(),
+                    SearchErrorKind::Regex(text) => format!("<pre>`{}`</pre>", text.replace('`', "'")).into(),
                     SearchErrorKind::Other(Some(info)) => info.into(),
                     SearchErrorKind::Other(None) => i18n.tr(TR::SearchInvalidOther),
                     SearchErrorKind::InvalidNumber { provided, context } => i18n

--- a/rslib/src/err.rs
+++ b/rslib/src/err.rs
@@ -139,20 +139,20 @@ impl AnkiError {
                     SearchErrorKind::UnknownEscape(ctx) => i18n
                         .trn(
                             TR::SearchUnknownEscape,
-                            tr_strs!["val"=>(htmlescape::encode_minimal(ctx))],
+                            tr_strs!["val"=>(ctx.replace('`', "'"))],
                         )
                         .into(),
                     SearchErrorKind::InvalidState(state) => i18n
                         .trn(
                             TR::SearchInvalidArgument,
-                            tr_strs!("term" => "is:", "argument" => state),
+                            tr_strs!("term" => "is:", "argument" => state.replace('`', "'")),
                         )
                         .into(),
                     SearchErrorKind::InvalidFlag => i18n.tr(TR::SearchInvalidFlag),
                     SearchErrorKind::InvalidPropProperty(prop) => i18n
                         .trn(
                             TR::SearchInvalidArgument,
-                            tr_strs!("term" => "prop:", "argument" => prop),
+                            tr_strs!("term" => "prop:", "argument" => prop.replace('`', "'")),
                         )
                         .into(),
                     SearchErrorKind::InvalidPropOperator(ctx) => i18n
@@ -164,31 +164,31 @@ impl AnkiError {
                     SearchErrorKind::InvalidNumber { provided, context } => i18n
                         .trn(
                             TR::SearchInvalidNumber,
-                            tr_strs!["provided"=>provided, "context"=>context],
+                            tr_strs!["provided"=>provided.replace('`', "'"), "context"=>context.replace('`', "'")],
                         )
                         .into(),
                     SearchErrorKind::InvalidWholeNumber { provided, context } => i18n
                         .trn(
                             TR::SearchInvalidWholeNumber,
-                            tr_strs!["provided"=>provided, "context"=>context],
+                            tr_strs!["provided"=>provided.replace('`', "'"), "context"=>context.replace('`', "'")],
                         )
                         .into(),
                     SearchErrorKind::InvalidPositiveWholeNumber { provided, context } => i18n
                         .trn(
                             TR::SearchInvalidPositiveWholeNumber,
-                            tr_strs!["provided"=>provided, "context"=>context],
+                            tr_strs!["provided"=>provided.replace('`', "'"), "context"=>context.replace('`', "'")],
                         )
                         .into(),
                     SearchErrorKind::InvalidNegativeWholeNumber { provided, context } => i18n
                         .trn(
                             TR::SearchInvalidNegativeWholeNumber,
-                            tr_strs!["provided"=>provided, "context"=>context],
+                            tr_strs!["provided"=>provided.replace('`', "'"), "context"=>context.replace('`', "'")],
                         )
                         .into(),
                     SearchErrorKind::InvalidAnswerButton { provided, context } => i18n
                         .trn(
                             TR::SearchInvalidAnswerButton,
-                            tr_strs!["provided"=>provided, "context"=>context],
+                            tr_strs!["provided"=>provided.replace('`', "'"), "context"=>context.replace('`', "'")],
                         )
                         .into(),
                 };


### PR DESCRIPTION
1. Reported here: https://forums.ankiweb.net/t/potential-bug-with-escape-sequences-on-regex/8260
9686cd99 assimilated the regex error into the Markdown-formatted search error breaking the plaintext error message from the regex crate. (As far as I recall, it wasn't properly displayed before, either, because no monospace font was used.)
2. Either `htmlescape::encode_minimal()` was used or Markdown wasn't escaped at all. Since there is no clean way to escape Markdown, I used a hack. But I think it's pretty good compared with the alternatives.