### PR TITLE
Emptying field lead to proper message

### DIFF
--- a/rslib/src/notetype/mod.rs
+++ b/rslib/src/notetype/mod.rs
@@ -329,14 +329,7 @@ impl NoteType {
     }
 
     fn fix_field_names(&mut self) -> Result<()> {
-        for mut f in &mut self.fields {
-            NoteField::fix_name(&mut f);
-            if f.name.is_empty() {
-                return Err(AnkiError::invalid_input("Empty field name"));
-            }
-        }
-
-        Ok(())
+        self.fields.iter_mut().try_for_each(NoteField::fix_name)
     }
 
     fn fix_template_names(&mut self) -> Result<()> {

--- a/rslib/src/notetype/mod.rs
+++ b/rslib/src/notetype/mod.rs
@@ -333,14 +333,9 @@ impl NoteType {
     }
 
     fn fix_template_names(&mut self) -> Result<()> {
-        for mut t in &mut self.templates {
-            CardTemplate::fix_name(&mut t);
-            if t.name.is_empty() {
-                return Err(AnkiError::invalid_input("Empty template name"));
-            }
-        }
-
-        Ok(())
+        self.templates
+            .iter_mut()
+            .try_for_each(CardTemplate::fix_name)
     }
 
     /// Find the field index of the provided field name.


### PR DESCRIPTION
This solve the following bug:

I have a note type with a field named "/" in a note type called Algebra
Today, I wanted to change a card type of algebra. However, when I tried to save, I got an error message stating that there was an empty field name. This made no sens, A quick search show that no field name is actually empty. Reading the code, I understood that "/" was stripped, leading to an empty field name, but the error message made no sens. So this correct that.

Similar correction is made to the template name

