### PR TITLE
update _onRowChanged

### DIFF
--- a/qt/aqt/browser.py
+++ b/qt/aqt/browser.py
@@ -735,7 +735,7 @@ class Browser(QMainWindow):
             show_invalid_search_error(err)
         if not self.model.cards:
             # no row change will fire
-            self._onRowChanged(None, None)
+            self.onRowChanged(None, None)
 
     def update_history(self) -> None:
         sh = self.mw.pm.profile["searchHistory"]


### PR DESCRIPTION
_onRowChanged was removed in https://github.com/ankitects/anki/commit/6bbd1e615b0e53ec1cb8abf31bcbd4b5587b636d

```
Caught exception:
Traceback (most recent call last):
  File "/home/zjosua/.cache/bazel/_bazel_zjosua/1c79c7ac51bf6692c8fc3f9a9a4ef48a/execroot/net_ankiweb_anki/bazel-out/k8-fastbuild/bin/qt/runanki.runfiles/net_ankiweb_anki/qt/aqt/main.py", line 1261, in onBrowse
    aqt.dialogs.open("Browser", self, card=self.reviewer.card)
  File "/home/zjosua/.cache/bazel/_bazel_zjosua/1c79c7ac51bf6692c8fc3f9a9a4ef48a/execroot/net_ankiweb_anki/bazel-out/k8-fastbuild/bin/qt/runanki.runfiles/net_ankiweb_anki/qt/aqt/__init__.py", line 101, in open
    instance = creator(*args, **kwargs)
  File "/home/zjosua/.cache/bazel/_bazel_zjosua/1c79c7ac51bf6692c8fc3f9a9a4ef48a/execroot/net_ankiweb_anki/bazel-out/k8-fastbuild/bin/qt/runanki.runfiles/net_ankiweb_anki/qt/aqt/browser.py", line 500, in __init__
    self.setupSearch(card, search)
  File "/home/zjosua/.cache/bazel/_bazel_zjosua/1c79c7ac51bf6692c8fc3f9a9a4ef48a/execroot/net_ankiweb_anki/bazel-out/k8-fastbuild/bin/qt/runanki.runfiles/net_ankiweb_anki/qt/aqt/browser.py", line 698, in setupSearch
    self.search_for(
  File "/home/zjosua/.cache/bazel/_bazel_zjosua/1c79c7ac51bf6692c8fc3f9a9a4ef48a/execroot/net_ankiweb_anki/bazel-out/k8-fastbuild/bin/qt/runanki.runfiles/net_ankiweb_anki/qt/aqt/browser.py", line 724, in search_for
    self.search()
  File "/home/zjosua/.cache/bazel/_bazel_zjosua/1c79c7ac51bf6692c8fc3f9a9a4ef48a/execroot/net_ankiweb_anki/bazel-out/k8-fastbuild/bin/qt/runanki.runfiles/net_ankiweb_anki/qt/aqt/browser.py", line 738, in search
    self._onRowChanged(None, None)
AttributeError: 'Browser' object has no attribute '_onRowChanged'
```