### PR TITLE
Add an exception that allows add-ons to abort early

### DIFF
--- a/qt/aqt/addons.py
+++ b/qt/aqt/addons.py
@@ -46,6 +46,10 @@ from aqt.utils import (
 )
 
 
+class AbortAddonImport(Exception):
+    """Add-ons may raise this exception to abort their import"""
+
+
 @dataclass
 class InstallOk:
     name: str
@@ -211,6 +215,8 @@ class AddonManager:
             self.dirty = True
             try:
                 __import__(addon.dir_name)
+            except AbortAddonImport:
+                pass
             except:
                 showWarning(
                     tr(


### PR DESCRIPTION
I've been dealing with quite a few add-on incompatibilities lately, and realized it could be quite helpful to a have a convenient way for add-ons to abort their execution early.

For instance, some of my add-ons are currently unsupported on Anki 2.1.41+, but have updates pending in the coming weeks that should add support. To bridge that gap, rather than updating the max version and thus permanently disabling the add-ons / having to create a new branch in the future, I was thinking of pushing an update that soft-disables the add-on (to prevent exceptions from being raised), and perhaps then presents users with a quick info message once to let them know that a proper fix is coming.

Another good use case I could see for exiting early are compatibility issues not covered by the manifest system, e.g. OS-specific add-ons in case of packaged binaries, more complex add-on interactions scenarios, etc.

Basically: I think that having a way for add-ons to graciously exit early could be beneficial in a lot of scenarios.

To take a quick look at the current situation, right now add-ons that want to abort their execution have to follow a pattern similar to this:

e.g. in `__init__.py`

```python

def initialize_addon():
    if EXIT_CONDITION:
        # show an info dialog, etc.
        return
    ...

initialize_addon()
```

For add-ons that undergo longer initialization procedures, this is a bit awkward both because of the indentation needed and the limited scope of any variables initialized in the initialization function.

To address this, the changes in this commit introduce `AbortAddonImport`, an exception that add-ons may raise at will to abort their execution graciously, e.g.:


```python
from aqt.addons import AbortAddonImport

if EXIT_CONDITION:
     raise AbortAddonImport()

# initialization steps
```

