### PR TITLE
Add hooks to the filtered deck dialog

### DIFF
--- a/qt/aqt/filtered_deck.py
+++ b/qt/aqt/filtered_deck.py
@@ -9,8 +9,7 @@ from anki.decks import DeckDict, DeckID, FilteredDeckConfig
 from anki.errors import SearchError
 from anki.lang import without_unicode_isolation
 from anki.scheduler import FilteredDeckForUpdate
-from aqt import AnkiQt, colors
-from aqt import gui_hooks
+from aqt import AnkiQt, colors, gui_hooks
 from aqt.qt import *
 from aqt.scheduling_ops import add_or_update_filtered_deck
 from aqt.theme import theme_manager

--- a/qt/aqt/filtered_deck.py
+++ b/qt/aqt/filtered_deck.py
@@ -303,7 +303,9 @@ class FilteredDeckConfigDialog(QDialog):
             return
 
         def success(out: OpChangesWithID) -> None:
-            gui_hooks.filtered_deck_dialog_did_add_or_update_deck(self, self.deck)
+            gui_hooks.filtered_deck_dialog_did_add_or_update_deck(
+                self, self.deck, out.id
+            )
             saveGeom(self, self.GEOMETRY_KEY)
             aqt.dialogs.markClosed(self.DIALOG_KEY)
             QDialog.accept(self)

--- a/qt/aqt/filtered_deck.py
+++ b/qt/aqt/filtered_deck.py
@@ -10,6 +10,7 @@ from anki.errors import SearchError
 from anki.lang import without_unicode_isolation
 from anki.scheduler import FilteredDeckForUpdate
 from aqt import AnkiQt, colors
+from aqt import gui_hooks
 from aqt.qt import *
 from aqt.scheduling_ops import add_or_update_filtered_deck
 from aqt.theme import theme_manager
@@ -156,6 +157,8 @@ class FilteredDeckConfigDialog(QDialog):
             without_unicode_isolation(tr(TR.ACTIONS_OPTIONS_FOR, val=self.deck.name))
         )
 
+        gui_hooks.filtered_deck_dialog_did_load_deck(self, deck)
+
     def reopen(
         self,
         _mw: AnkiQt,
@@ -300,9 +303,12 @@ class FilteredDeckConfigDialog(QDialog):
             return
 
         def success(out: OpChangesWithCount) -> None:
+            gui_hooks.filtered_deck_dialog_did_add_or_update_deck(self, self.deck)
             saveGeom(self, self.GEOMETRY_KEY)
             aqt.dialogs.markClosed(self.DIALOG_KEY)
             QDialog.accept(self)
+
+        gui_hooks.filtered_deck_dialog_will_add_or_update_deck(self, self.deck)
 
         add_or_update_filtered_deck(mw=self.mw, deck=self.deck, success=success)
 

--- a/qt/aqt/filtered_deck.py
+++ b/qt/aqt/filtered_deck.py
@@ -4,7 +4,7 @@
 from typing import List, Optional, Tuple
 
 import aqt
-from anki.collection import OpChangesWithCount, SearchNode
+from anki.collection import OpChangesWithID, SearchNode
 from anki.decks import DeckDict, DeckID, FilteredDeckConfig
 from anki.errors import SearchError
 from anki.lang import without_unicode_isolation
@@ -302,7 +302,7 @@ class FilteredDeckConfigDialog(QDialog):
         if not self._update_deck():
             return
 
-        def success(out: OpChangesWithCount) -> None:
+        def success(out: OpChangesWithID) -> None:
             gui_hooks.filtered_deck_dialog_did_add_or_update_deck(self, self.deck)
             saveGeom(self, self.GEOMETRY_KEY)
             aqt.dialogs.markClosed(self.DIALOG_KEY)

--- a/qt/tools/genhooks_gui.py
+++ b/qt/tools/genhooks_gui.py
@@ -284,6 +284,32 @@ hooks = [
         ],
         doc="Called before config group is renamed",
     ),
+    # Filtered deck options
+    ###################
+    Hook(
+        name="filtered_deck_dialog_did_load_deck",
+        args=[
+            "filtered_deck_dialog: aqt.filtered_deck.FilteredDeckConfigDialog",
+            "filtered_deck: anki.scheduler.FilteredDeckForUpdate",
+        ],
+        doc="Allows updating widget state once the filtered deck config is loaded",
+    ),
+    Hook(
+        name="filtered_deck_dialog_will_add_or_update_deck",
+        args=[
+            "filtered_deck_dialog: aqt.filtered_deck.FilteredDeckConfigDialog",
+            "filtered_deck: anki.scheduler.FilteredDeckForUpdate",
+        ],
+        doc="Allows modifying the filtered deck config object before it is written",
+    ),
+    Hook(
+        name="filtered_deck_dialog_did_add_or_update_deck",
+        args=[
+            "filtered_deck_dialog: aqt.filtered_deck.FilteredDeckConfigDialog",
+            "filtered_deck: anki.scheduler.FilteredDeckForUpdate",
+        ],
+        doc="Allows performing changes after a filtered deck has been added or updated",
+    ),
     # Browser
     ###################
     Hook(

--- a/qt/tools/genhooks_gui.py
+++ b/qt/tools/genhooks_gui.py
@@ -307,6 +307,7 @@ hooks = [
         args=[
             "filtered_deck_dialog: aqt.filtered_deck.FilteredDeckConfigDialog",
             "filtered_deck: anki.scheduler.FilteredDeckForUpdate",
+            "deck_id: int",
         ],
         doc="Allows performing changes after a filtered deck has been added or updated",
     ),


### PR DESCRIPTION
Inspired by #458, adds a number of hooks that allow add-ons to conveniently extend the filtered deck dialog with their own widgets and filtered-deck-specific state.

My use case for this is to allow users to configure add-ons like Speed Focus Mode or Exam Notifier on a filtered deck basis, which is a frequent feature request I've seen.

**A few notes**:

- I wasn't  too keen on the length of the hook names, but couldn't think of a good way to make them shorter without making them less semantic
- I tried to limit the number of hooks as best possible and adapt them to the needs of the filtered deck dialog, which is why they aren't fully in sync with the deck config hooks.
- Ideally we wouldn't have both `filtered_deck_dialog_will_add_or_update_deck` and `filtered_deck_dialog_did_add_or_update_deck`, but this seemed like the only way to me to allow add-ons to both modify config options passed to the backend via `FilteredDeckForUpdate` objects, and the classic config options that still reside in the deck's dictionary (and are commonly used by add-ons to store deck-specific add-on data)

**Proof of concept**

```python
from PyQt5.QtWidgets import QLineEdit

from anki.scheduler import FilteredDeckForUpdate
from aqt import gui_hooks, mw
from aqt.filtered_deck import FilteredDeckConfigDialog

CONFIG_KEY = "my_line_edit"


def on_filtered_deck_dialog_did_load_deck(
    filtered_deck_dialog: FilteredDeckConfigDialog, filtered_deck: FilteredDeckForUpdate
):

    form = filtered_deck_dialog.form
    layout = form.verticalLayout

    my_line_edit = QLineEdit(filtered_deck_dialog)
    form.my_line_edit = my_line_edit  # type: ignore
    layout.insertWidget(layout.count() - 1, my_line_edit)

    if filtered_deck.id:
        deck_config_dict = mw.col.decks.get(filtered_deck.id)
        text = deck_config_dict.get(CONFIG_KEY, "")
    else:
        text = ""

    my_line_edit.setText(text)


def on_filtered_deck_dialog_did_add_or_update_deck(
    filtered_deck_dialog: FilteredDeckConfigDialog,
    filtered_deck: FilteredDeckForUpdate,
    deck_id: int,
):
    my_line_edit: QLineEdit = filtered_deck_dialog.form.my_line_edit  # type: ignore

    deck_config_dict = mw.col.decks.get(deck_id)
    deck_config_dict[CONFIG_KEY] = my_line_edit.text()

    mw.col.decks.save(deck_config_dict)


gui_hooks.filtered_deck_dialog_did_load_deck.append(
    on_filtered_deck_dialog_did_load_deck
)
gui_hooks.filtered_deck_dialog_did_add_or_update_deck.append(
    on_filtered_deck_dialog_did_add_or_update_deck
)

```

----

BTW, I don't want to derail this PR too much, but I assume you're planning on switching to a custom DTO for regular decks as well, right? (dropping `DeckDict`, etc.). If so, it would be really cool if that object had a field for add-on data, as using the deck config dict for add-on specific data has become a common pattern in add-on design over the years (although probably never really sanctioned or recommended). That's the approach I went with in the PoC above for instance and what I would be planning to do for Speed Focus Mode, etc.

And in that case, perhaps it would also make sense to add a custom field to `FilteredDeckForUpdate`, which would eliminate the need for the slightly awkward `filtered_deck_dialog_did_add_or_update_deck` hook.