### PR TITLE
Fix extraneous whitespaces from strip_html_for_tts

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -76,6 +76,7 @@ Daniel Wallgren <github.com/wallgrenen>
 Kerrick Staley <kerrick@kerrickstaley.com>
 Maksim Abramchuk <maximabramchuck@gmail.com>
 Benjamin Kulnik <benjamin.kulnik@student.tuwien.ac.at>
+Shaun Ren <shaun.ren@linux.com>
 
 ********************
 


### PR DESCRIPTION
This PR fixes a bug in `strip_html_for_tts`.

The function `strip_html_for_tts` currently adds extraneous whitespaces for tags such as `<b>` and `<i>`, causing the generated TTS audio to be incorrect.