### PR TITLE
Use svg-loader to load svgs directly into ts packages

### DIFF
--- a/qt/aqt/data/web/css/vendor/BUILD.bazel
+++ b/qt/aqt/data/web/css/vendor/BUILD.bazel
@@ -1,12 +1,9 @@
-load("//ts:vendor.bzl", "copy_bootstrap_css", "copy_bootstrap_icons")
+load("//ts:vendor.bzl", "copy_bootstrap_css")
 
 copy_bootstrap_css(name = "bootstrap")
 
-copy_bootstrap_icons(name = "bootstrap-icons")
-
 files = [
     "bootstrap",
-    "bootstrap-icons",
 ]
 
 directories = []

--- a/qt/aqt/editor.py
+++ b/qt/aqt/editor.py
@@ -234,7 +234,6 @@ class Editor:
             _html % (bgcol, topbuts, tr.editing_show_duplicates()),
             css=[
                 "css/vendor/bootstrap.min.css",
-                "css/vendor/bootstrap-icons.css",
                 "css/editor.css",
             ],
             js=[

--- a/ts/BUILD.bazel
+++ b/ts/BUILD.bazel
@@ -1,5 +1,6 @@
 load("//ts:prettier.bzl", "prettier", "prettier_test")
 load("//ts:sql_format.bzl", "sql_format_setup")
+load("@npm//@bazel/typescript:index.bzl", "ts_library")
 
 prettier()
 
@@ -12,6 +13,12 @@ prettier_test(
 )
 
 sql_format_setup()
+
+ts_library(
+    name = "image_module_support",
+    srcs = ["images.d.ts"],
+    visibility = ["//visibility:public"],
+)
 
 # Exported files
 #################

--- a/ts/editor/BUILD.bazel
+++ b/ts/editor/BUILD.bazel
@@ -2,7 +2,7 @@ load("@npm//@bazel/typescript:index.bzl", "ts_library")
 load("//ts:prettier.bzl", "prettier_test")
 load("//ts:eslint.bzl", "eslint_test")
 load("//ts:esbuild.bzl", "esbuild")
-load("//ts:vendor.bzl", "vendor_js_lib", "pkg_from_name")
+load("//ts:vendor.bzl", "copy_bootstrap_icons")
 load("@io_bazel_rules_sass//:defs.bzl", "sass_binary")
 
 sass_binary(
@@ -27,14 +27,9 @@ ts_library(
     ],
 )
 
-vendor_js_lib(
+copy_bootstrap_icons(
     name = "bootstrap-icons",
-    pkg = pkg_from_name("bootstrap-icons"),
-    include = [
-        "icons/pin-angle.svg",
-    ],
-    strip_prefix = "icons/",
-    visibility = ["//visibility:public"],
+    icons = ["pin-angle.svg"],
 )
 
 esbuild(

--- a/ts/editor/BUILD.bazel
+++ b/ts/editor/BUILD.bazel
@@ -22,6 +22,7 @@ ts_library(
     srcs = glob(["*.ts"]),
     tsconfig = "//ts:tsconfig.json",
     deps = [
+        "//ts:image_module_support",
         "//ts/html-filter",
     ],
 )

--- a/ts/editor/BUILD.bazel
+++ b/ts/editor/BUILD.bazel
@@ -2,6 +2,7 @@ load("@npm//@bazel/typescript:index.bzl", "ts_library")
 load("//ts:prettier.bzl", "prettier_test")
 load("//ts:eslint.bzl", "eslint_test")
 load("//ts:esbuild.bzl", "esbuild")
+load("//ts:vendor.bzl", "vendor_js_lib", "pkg_from_name")
 load("@io_bazel_rules_sass//:defs.bzl", "sass_binary")
 
 sass_binary(
@@ -25,12 +26,23 @@ ts_library(
     ],
 )
 
+vendor_js_lib(
+    name = "bootstrap-icons",
+    pkg = pkg_from_name("bootstrap-icons"),
+    include = [
+        "icons/pin-angle.svg",
+    ],
+    strip_prefix = "icons/",
+    visibility = ["//visibility:public"],
+)
+
 esbuild(
     name = "editor",
     entry_point = "index_wrapper.ts",
     visibility = ["//visibility:public"],
     deps = [
         "editor_ts",
+        "bootstrap-icons",
     ],
 )
 

--- a/ts/editor/editor.scss
+++ b/ts/editor/editor.scss
@@ -133,15 +133,18 @@ button.highlighted {
     }
 }
 
-.icon {
-    cursor: pointer;
-    color: var(--text-fg);
+.icon > svg {
+    fill: var(--text-fg);
+}
 
-    &.is-inactive::before {
+.pin-icon {
+    cursor: pointer;
+
+    &.is-inactive {
         opacity: 0.1;
     }
 
-    &.icon--hover::before {
+    &.icon--hover {
         opacity: 0.5;
     }
 }

--- a/ts/editor/labelContainer.ts
+++ b/ts/editor/labelContainer.ts
@@ -1,4 +1,5 @@
 import { bridgeCommand } from "./lib";
+// import pinIcon from "./pin-angle.svg";
 
 function removeHoverIcon(evt: Event): void {
     const icon = evt.currentTarget as HTMLElement;

--- a/ts/editor/labelContainer.ts
+++ b/ts/editor/labelContainer.ts
@@ -1,5 +1,5 @@
 import { bridgeCommand } from "./lib";
-// import pinIcon from "./pin-angle.svg";
+import pinIcon from "./pin-angle.svg";
 
 function removeHoverIcon(evt: Event): void {
     const icon = evt.currentTarget as HTMLElement;
@@ -24,7 +24,8 @@ export class LabelContainer extends HTMLDivElement {
         this.appendChild(this.label);
 
         this.sticky = document.createElement("span");
-        this.sticky.className = "bi me-1 bi-pin-angle icon";
+        this.sticky.className = "icon pin-icon me-1";
+        this.sticky.innerHTML = pinIcon;
         this.sticky.hidden = true;
         this.appendChild(this.sticky);
 

--- a/ts/esbuild/upstream.bzl
+++ b/ts/esbuild/upstream.bzl
@@ -66,6 +66,7 @@ def _esbuild_impl(ctx):
     args.add_joined(["--platform", ctx.attr.platform], join_with = "=")
     args.add_joined(["--target", ctx.attr.target], join_with = "=")
     args.add_joined(["--log-level", "info"], join_with = "=")
+    args.add_joined(["--loader", ".svg=text"], join_with = ":")
     args.add_joined(["--metafile", metafile.path], join_with = "=")
     args.add_all(ctx.attr.define, format_each = "--define:%s")
     args.add_all(ctx.attr.external, format_each = "--external:%s")

--- a/ts/images.d.ts
+++ b/ts/images.d.ts
@@ -1,0 +1,1 @@
+declare module "*.svg";

--- a/ts/vendor.bzl
+++ b/ts/vendor.bzl
@@ -116,16 +116,3 @@ def copy_bootstrap_css(name = "bootstrap-css", visibility = ["//visibility:publi
         strip_prefix = "dist/css/",
         visibility = visibility,
     )
-
-def copy_bootstrap_icons(name = "bootstrap-icons", visibility = ["//visibility:public"]):
-    vendor_js_lib(
-        name = name,
-        pkg = _pkg_from_name(name),
-        include = [
-            "font/bootstrap-icons.css",
-            "font/fonts/bootstrap-icons.woff",
-            "font/fonts/bootstrap-icons.woff2",
-        ],
-        strip_prefix = "font/",
-        visibility = visibility,
-    )

--- a/ts/vendor.bzl
+++ b/ts/vendor.bzl
@@ -26,7 +26,7 @@ vendor_js_lib = rule(
     },
 )
 
-def _pkg_from_name(name):
+def pkg_from_name(name):
     return "@npm//{0}:{0}__files".format(name)
 
 #
@@ -37,7 +37,7 @@ def _pkg_from_name(name):
 def copy_jquery(name = "jquery", visibility = ["//visibility:public"]):
     vendor_js_lib(
         name = name,
-        pkg = _pkg_from_name(name),
+        pkg = pkg_from_name(name),
         include = [
             "dist/jquery.min.js",
         ],
@@ -48,7 +48,7 @@ def copy_jquery(name = "jquery", visibility = ["//visibility:public"]):
 def copy_jquery_ui(name = "jquery-ui", visibility = ["//visibility:public"]):
     vendor_js_lib(
         name = name,
-        pkg = _pkg_from_name("jquery-ui-dist"),
+        pkg = pkg_from_name("jquery-ui-dist"),
         base = "external/npm/node_modules/jquery-ui-dist/",
         include = [
             "jquery-ui.min.js",
@@ -59,7 +59,7 @@ def copy_jquery_ui(name = "jquery-ui", visibility = ["//visibility:public"]):
 def copy_protobufjs(name = "protobufjs", visibility = ["//visibility:public"]):
     vendor_js_lib(
         name = name,
-        pkg = _pkg_from_name(name),
+        pkg = pkg_from_name(name),
         include = [
             "dist/protobuf.min.js",
         ],
@@ -70,7 +70,7 @@ def copy_protobufjs(name = "protobufjs", visibility = ["//visibility:public"]):
 def copy_mathjax(name = "mathjax", visibility = ["//visibility:public"]):
     vendor_js_lib(
         name = name,
-        pkg = _pkg_from_name(name),
+        pkg = pkg_from_name(name),
         include = [
             "es5/tex-chtml.js",
             "es5/input/tex/extensions",
@@ -88,7 +88,7 @@ def copy_mathjax(name = "mathjax", visibility = ["//visibility:public"]):
 def copy_css_browser_selector(name = "css-browser-selector", visibility = ["//visibility:public"]):
     vendor_js_lib(
         name = name,
-        pkg = _pkg_from_name(name),
+        pkg = pkg_from_name(name),
         include = [
             "css_browser_selector.min.js",
         ],
@@ -98,7 +98,7 @@ def copy_css_browser_selector(name = "css-browser-selector", visibility = ["//vi
 def copy_bootstrap_js(name = "bootstrap-js", visibility = ["//visibility:public"]):
     vendor_js_lib(
         name = name,
-        pkg = _pkg_from_name(name),
+        pkg = pkg_from_name(name),
         include = [
             "dist/js/bootstrap.bundle.min.js",
         ],
@@ -109,7 +109,7 @@ def copy_bootstrap_js(name = "bootstrap-js", visibility = ["//visibility:public"
 def copy_bootstrap_css(name = "bootstrap-css", visibility = ["//visibility:public"]):
     vendor_js_lib(
         name = name,
-        pkg = _pkg_from_name(name),
+        pkg = pkg_from_name(name),
         include = [
             "dist/css/bootstrap.min.css",
         ],

--- a/ts/vendor.bzl
+++ b/ts/vendor.bzl
@@ -26,7 +26,7 @@ vendor_js_lib = rule(
     },
 )
 
-def pkg_from_name(name):
+def _pkg_from_name(name):
     return "@npm//{0}:{0}__files".format(name)
 
 #
@@ -37,7 +37,7 @@ def pkg_from_name(name):
 def copy_jquery(name = "jquery", visibility = ["//visibility:public"]):
     vendor_js_lib(
         name = name,
-        pkg = pkg_from_name(name),
+        pkg = _pkg_from_name(name),
         include = [
             "dist/jquery.min.js",
         ],
@@ -48,7 +48,7 @@ def copy_jquery(name = "jquery", visibility = ["//visibility:public"]):
 def copy_jquery_ui(name = "jquery-ui", visibility = ["//visibility:public"]):
     vendor_js_lib(
         name = name,
-        pkg = pkg_from_name("jquery-ui-dist"),
+        pkg = _pkg_from_name("jquery-ui-dist"),
         base = "external/npm/node_modules/jquery-ui-dist/",
         include = [
             "jquery-ui.min.js",
@@ -59,7 +59,7 @@ def copy_jquery_ui(name = "jquery-ui", visibility = ["//visibility:public"]):
 def copy_protobufjs(name = "protobufjs", visibility = ["//visibility:public"]):
     vendor_js_lib(
         name = name,
-        pkg = pkg_from_name(name),
+        pkg = _pkg_from_name(name),
         include = [
             "dist/protobuf.min.js",
         ],
@@ -70,7 +70,7 @@ def copy_protobufjs(name = "protobufjs", visibility = ["//visibility:public"]):
 def copy_mathjax(name = "mathjax", visibility = ["//visibility:public"]):
     vendor_js_lib(
         name = name,
-        pkg = pkg_from_name(name),
+        pkg = _pkg_from_name(name),
         include = [
             "es5/tex-chtml.js",
             "es5/input/tex/extensions",
@@ -88,7 +88,7 @@ def copy_mathjax(name = "mathjax", visibility = ["//visibility:public"]):
 def copy_css_browser_selector(name = "css-browser-selector", visibility = ["//visibility:public"]):
     vendor_js_lib(
         name = name,
-        pkg = pkg_from_name(name),
+        pkg = _pkg_from_name(name),
         include = [
             "css_browser_selector.min.js",
         ],
@@ -98,7 +98,7 @@ def copy_css_browser_selector(name = "css-browser-selector", visibility = ["//vi
 def copy_bootstrap_js(name = "bootstrap-js", visibility = ["//visibility:public"]):
     vendor_js_lib(
         name = name,
-        pkg = pkg_from_name(name),
+        pkg = _pkg_from_name(name),
         include = [
             "dist/js/bootstrap.bundle.min.js",
         ],
@@ -109,10 +109,19 @@ def copy_bootstrap_js(name = "bootstrap-js", visibility = ["//visibility:public"
 def copy_bootstrap_css(name = "bootstrap-css", visibility = ["//visibility:public"]):
     vendor_js_lib(
         name = name,
-        pkg = pkg_from_name(name),
+        pkg = _pkg_from_name(name),
         include = [
             "dist/css/bootstrap.min.css",
         ],
         strip_prefix = "dist/css/",
+        visibility = visibility,
+    )
+
+def copy_bootstrap_icons(name = "bootstrap-icons", icons = [], visibility = ["//visibility:public"]):
+    vendor_js_lib(
+        name = name,
+        pkg = _pkg_from_name(name),
+        include = ["icons/{}".format(icon) for icon in icons],
+        strip_prefix = "icons/",
         visibility = visibility,
     )


### PR DESCRIPTION
Currently we load the bootstrap icons as a library over `<head>`.

That seems kinda wasteful, as we certainly won't need _all_ of the icons. It would be better if we could more easily _pick and choose_ from icons / iconssets.

Esbuild offers support for [importing files as text](https://esbuild.github.io/content-types/#text). This way we could use inline svgs instead of the icon fonts provided by bootstrap-icons. Using inline svgs also [seems to be the better way to use icons](https://www.lambdatest.com/blog/its-2019-lets-end-the-debate-on-icon-fonts-vs-svg-icons/).

I've somewhat tried, but I already have many hours of unfruitful Bazel tinkering behind me, so I want to get straight to you with this idea, and if you think it's a good one, any pointers. 