### PR TITLE
NF: add an extra option to search card to return one by note

### DIFF
--- a/pylib/anki/collection.py
+++ b/pylib/anki/collection.py
@@ -495,6 +495,7 @@ class Collection:
         query: str,
         order: Union[bool, str, BuiltinSort.Kind.V] = False,
         reverse: bool = False,
+        one_by_note: bool = False,
     ) -> Sequence[CardId]:
         """Return card ids matching the provided search.
 
@@ -526,7 +527,10 @@ class Collection:
                 builtin=_pb.SortOrder.Builtin(kind=order, reverse=reverse)
             )
         return [
-            CardId(id) for id in self._backend.search_cards(search=query, order=mode)
+            CardId(id)
+            for id in self._backend.search_cards(
+                search=query, order=mode, one_by_note=one_by_note
+            )
         ]
 
     def find_notes(self, *terms: Union[str, SearchNode]) -> Sequence[NoteId]:

--- a/rslib/backend.proto
+++ b/rslib/backend.proto
@@ -798,6 +798,7 @@ message OpenCollectionIn {
 message SearchCardsIn {
   string search = 1;
   SortOrder order = 2;
+  bool one_by_note = 3;
 }
 
 message SearchCardsOut {

--- a/rslib/src/backend/search/mod.rs
+++ b/rslib/src/backend/search/mod.rs
@@ -27,7 +27,8 @@ impl SearchService for Backend {
     fn search_cards(&self, input: pb::SearchCardsIn) -> Result<pb::SearchCardsOut> {
         self.with_col(|col| {
             let order = input.order.unwrap_or_default().value.into();
-            let cids = col.search_cards(&input.search, order)?;
+            let one_by_note = input.one_by_note;
+            let cids = col.search_cards(&input.search, order, one_by_note)?;
             Ok(pb::SearchCardsOut {
                 card_ids: cids.into_iter().map(|v| v.0).collect(),
             })

--- a/rslib/src/dbcheck.rs
+++ b/rslib/src/dbcheck.rs
@@ -487,7 +487,7 @@ mod test {
         col.add_note(&mut note, DeckId(1))?;
 
         // duplicate ordinals
-        let cid = col.search_cards("", SortMode::NoOrder)?[0];
+        let cid = col.search_cards("", SortMode::NoOrder, false)?[0];
         let mut card = col.storage.get_card(cid)?.unwrap();
         card.id.0 += 1;
         col.storage.add_card(&mut card)?;
@@ -506,7 +506,7 @@ mod test {
         );
 
         // missing templates
-        let cid = col.search_cards("", SortMode::NoOrder)?[0];
+        let cid = col.search_cards("", SortMode::NoOrder, false)?[0];
         let mut card = col.storage.get_card(cid)?.unwrap();
         card.id.0 += 1;
         card.template_idx = 10;

--- a/rslib/src/decks/mod.rs
+++ b/rslib/src/decks/mod.rs
@@ -839,7 +839,7 @@ mod test {
         let nt = col.get_notetype_by_name("Basic")?.unwrap();
         let mut note = nt.new_note();
         col.add_note(&mut note, default.id)?;
-        assert_ne!(col.search_cards("", SortMode::NoOrder)?, vec![]);
+        assert_ne!(col.search_cards("", SortMode::NoOrder, false)?, vec![]);
 
         // add a subdeck
         let _ = col.get_or_create_normal_deck("one::two::three")?;
@@ -852,7 +852,7 @@ mod test {
         assert_eq!(sorted_names(&col), vec!["default", "Default+"]);
 
         // and the cards it contained should have been removed
-        assert_eq!(col.search_cards("", SortMode::NoOrder)?, vec![]);
+        assert_eq!(col.search_cards("", SortMode::NoOrder, false)?, vec![]);
 
         Ok(())
     }

--- a/rslib/src/notes/mod.rs
+++ b/rslib/src/notes/mod.rs
@@ -647,12 +647,17 @@ mod test {
         col.add_note(&mut note, DeckId(1))?;
         assert_eq!(note.fields[0], "\u{6f22}");
         // non-normalized searches should be converted
-        assert_eq!(col.search_cards("\u{fa47}", SortMode::NoOrder)?.len(), 1);
         assert_eq!(
-            col.search_cards("front:\u{fa47}", SortMode::NoOrder)?.len(),
+            col.search_cards("\u{fa47}", SortMode::NoOrder, false)?
+                .len(),
             1
         );
-        let cids = col.search_cards("", SortMode::NoOrder)?;
+        assert_eq!(
+            col.search_cards("front:\u{fa47}", SortMode::NoOrder, false)?
+                .len(),
+            1
+        );
+        let cids = col.search_cards("", SortMode::NoOrder, false)?;
         col.remove_cards_and_orphaned_notes(&cids)?;
 
         // if normalization turned off, note text is entered as-is
@@ -662,9 +667,17 @@ mod test {
         col.add_note(&mut note, DeckId(1))?;
         assert_eq!(note.fields[0], "\u{fa47}");
         // normalized searches won't match
-        assert_eq!(col.search_cards("\u{6f22}", SortMode::NoOrder)?.len(), 0);
+        assert_eq!(
+            col.search_cards("\u{6f22}", SortMode::NoOrder, false)?
+                .len(),
+            0
+        );
         // but original characters will
-        assert_eq!(col.search_cards("\u{fa47}", SortMode::NoOrder)?.len(), 1);
+        assert_eq!(
+            col.search_cards("\u{fa47}", SortMode::NoOrder, false)?
+                .len(),
+            1
+        );
 
         Ok(())
     }
@@ -678,7 +691,7 @@ mod test {
 
         let assert_initial = |col: &mut Collection| -> Result<()> {
             assert_eq!(col.search_notes("")?.len(), 0);
-            assert_eq!(col.search_cards("", SortMode::NoOrder)?.len(), 0);
+            assert_eq!(col.search_cards("", SortMode::NoOrder, false)?.len(), 0);
             assert_eq!(
                 col.storage.db_scalar::<u32>("select count() from graves")?,
                 0
@@ -689,7 +702,7 @@ mod test {
 
         let assert_after_add = |col: &mut Collection| -> Result<()> {
             assert_eq!(col.search_notes("")?.len(), 1);
-            assert_eq!(col.search_cards("", SortMode::NoOrder)?.len(), 2);
+            assert_eq!(col.search_cards("", SortMode::NoOrder, false)?.len(), 2);
             assert_eq!(
                 col.storage.db_scalar::<u32>("select count() from graves")?,
                 0
@@ -716,7 +729,7 @@ mod test {
 
         let assert_after_remove = |col: &mut Collection| -> Result<()> {
             assert_eq!(col.search_notes("")?.len(), 0);
-            assert_eq!(col.search_cards("", SortMode::NoOrder)?.len(), 0);
+            assert_eq!(col.search_cards("", SortMode::NoOrder, false)?.len(), 0);
             // 1 note + 2 cards
             assert_eq!(
                 col.storage.db_scalar::<u32>("select count() from graves")?,

--- a/rslib/src/notetype/schemachange.rs
+++ b/rslib/src/notetype/schemachange.rs
@@ -257,7 +257,7 @@ mod test {
         col.add_note(&mut note, DeckId(1))?;
 
         assert_eq!(
-            col.search_cards(&format!("nid:{}", note.id), SortMode::NoOrder)
+            col.search_cards(&format!("nid:{}", note.id), SortMode::NoOrder, false)
                 .unwrap()
                 .len(),
             1
@@ -268,7 +268,7 @@ mod test {
         col.update_notetype(&mut nt, false)?;
 
         assert_eq!(
-            col.search_cards(&format!("nid:{}", note.id), SortMode::NoOrder)
+            col.search_cards(&format!("nid:{}", note.id), SortMode::NoOrder, false)
                 .unwrap()
                 .len(),
             2

--- a/rslib/src/scheduler/bury_and_suspend.rs
+++ b/rslib/src/scheduler/bury_and_suspend.rs
@@ -166,7 +166,7 @@ mod test {
         col.add_card(&mut card).unwrap();
         let assert_count = |col: &mut Collection, cnt| {
             assert_eq!(
-                col.search_cards("is:buried", SortMode::NoOrder)
+                col.search_cards("is:buried", SortMode::NoOrder, false)
                     .unwrap()
                     .len(),
                 cnt

--- a/rslib/src/scheduler/new.rs
+++ b/rslib/src/scheduler/new.rs
@@ -169,7 +169,7 @@ impl Collection {
     /// This creates a transaction - we probably want to split it out
     /// in the future if calling it as part of a deck options update.
     pub fn sort_deck(&mut self, deck: DeckId, random: bool) -> Result<OpOutput<usize>> {
-        let cids = self.search_cards(&format!("did:{} is:new", deck), SortMode::NoOrder)?;
+        let cids = self.search_cards(&format!("did:{} is:new", deck), SortMode::NoOrder, false)?;
         let order = if random {
             NewCardSortOrder::Random
         } else {

--- a/rslib/src/search/cards.rs
+++ b/rslib/src/search/cards.rs
@@ -60,12 +60,18 @@ impl SortKind {
 }
 
 impl Collection {
-    pub fn search_cards(&mut self, search: &str, mut mode: SortMode) -> Result<Vec<CardId>> {
+    pub fn search_cards(
+        &mut self,
+        search: &str,
+        mut mode: SortMode,
+        one_by_note: bool,
+    ) -> Result<Vec<CardId>> {
         let top_node = Node::Group(parse(search)?);
         self.resolve_config_sort(&mut mode);
         let writer = SqlWriter::new(self);
 
-        let (mut sql, args) = writer.build_cards_query(&top_node, mode.required_table())?;
+        let (mut sql, args) =
+            writer.build_cards_query(&top_node, mode.required_table(), one_by_note)?;
         self.add_order(&mut sql, mode)?;
 
         let mut stmt = self.storage.db.prepare(&sql)?;
@@ -105,7 +111,7 @@ impl Collection {
         let writer = SqlWriter::new(self);
         let want_order = mode != SortMode::NoOrder;
 
-        let (mut sql, args) = writer.build_cards_query(&top_node, mode.required_table())?;
+        let (mut sql, args) = writer.build_cards_query(&top_node, mode.required_table(), false)?;
         self.add_order(&mut sql, mode)?;
 
         if want_order {

--- a/rslib/src/stats/card.rs
+++ b/rslib/src/stats/card.rs
@@ -267,7 +267,7 @@ mod test {
         let mut note = nt.new_note();
         col.add_note(&mut note, DeckId(1))?;
 
-        let cid = col.search_cards("", SortMode::NoOrder)?[0];
+        let cid = col.search_cards("", SortMode::NoOrder, false)?[0];
         let _report = col.card_stats(cid)?;
         //println!("report {}", report);
 

--- a/rslib/src/sync/mod.rs
+++ b/rslib/src/sync/mod.rs
@@ -1435,7 +1435,7 @@ mod test {
         let deckid = deck.id;
         let dconfid = dconf.id;
         let noteid = note.id;
-        let cardid = col1.search_cards(&format!("nid:{}", note.id), SortMode::NoOrder)?[0];
+        let cardid = col1.search_cards(&format!("nid:{}", note.id), SortMode::NoOrder, false)?[0];
         let revlogid = RevlogId(123);
 
         let compare_sides = |col1: &mut Collection, col2: &mut Collection| -> Result<()> {


### PR DESCRIPTION
This PR's goal is to allow add-on 797076357 to be quick again. It became impossible when search moved to rust. 

I believe it would be a nice feature to get natively, so that you can check all notes, fields, tags, without having to go through all cards. But this would require also a UI change, and the PR do not contain it (It would be far harder work and I would not do this kind of thing without discussion first. I'm okay with loosing this work, not UI work.) However, right now, this PR do not do any change visible to the user, it just add an optional boolean to some function and a protobuf input.

In my opinion, it would also be useful for AnkiDroid. Browser is limited by the size of the screen, so avoiding duplicate entry for a single note may help the UX. And since ankidroid will move to rust, we can't just add it on our java