### PR TITLE
Fix ResourceWarning in openFolder() on Windows

### DIFF
--- a/qt/aqt/utils.py
+++ b/qt/aqt/utils.py
@@ -688,7 +688,7 @@ def mungeQA(col: Collection, txt: str) -> str:
 
 def openFolder(path: str) -> None:
     if isWin:
-        subprocess.Popen(["explorer", f"file://{path}"])
+        subprocess.run(["explorer", f"file://{path}"], check=False)
     else:
         with noBundledLibs():
             QDesktopServices.openUrl(QUrl(f"file://{path}"))


### PR DESCRIPTION
subprocess.Popen emits ResourceWarning in the destructor if the status of the process was not read starting from Python 3.6 (with an error message like `ResourceWarning: subprocess 23296 is still running`), but this was not being triggered in Anki until recently, maybe after [this change](https://github.com/ankitects/anki/commit/57d7e3e2ab37ef3b5d2c1eef3509fc42fcfe0f2e) in memory management in Anki.
Fix/avoid the issue by using subprocess.run() instead, which takes care of that. Using run() is also recommended for simple cases like this in the docs.

`check=False` is because explorer always returns a non-zero exit code for some reason (at least on my system).