### PR TITLE
Remove jQuery reviewer-bottom.ts and overview.ts

### DIFF
--- a/qt/aqt/data/web/js/overview.ts
+++ b/qt/aqt/data/web/js/overview.ts
@@ -1,6 +1,0 @@
-/* Copyright: Ankitects Pty Ltd and contributors
- * License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html */
-
-$(function () {
-    $("#study").focus();
-});

--- a/qt/aqt/data/web/js/reviewer-bottom.ts
+++ b/qt/aqt/data/web/js/reviewer-bottom.ts
@@ -4,8 +4,7 @@
 var time: number; // set in python code
 
 let maxTime = 0;
-$(function () {
-    $("#ansbut").focus();
+document.addEventListener("DOMContentLoaded", () => {
     updateTime();
     setInterval(function () {
         time += 1;
@@ -13,35 +12,33 @@ $(function () {
     }, 1000);
 });
 
-let updateTime = function () {
-    let timeNode = $("#time");
-    if (!maxTime) {
-        timeNode.text("");
+function updateTime(): void {
+    const timeNode = document.getElementById("time");
+    if (maxTime === 0) {
+        timeNode.textContent = "";
         return;
     }
     time = Math.min(maxTime, time);
     const m = Math.floor(time / 60);
     const s = time % 60;
-    let sStr = s.toString();
-    if (s < 10) {
-        sStr = "0" + s;
-    }
-    if (maxTime === time) {
-        timeNode.html("<font color=red>" + m + ":" + sStr + "</font>");
-    } else {
-        timeNode.text(m + ":" + sStr);
-    }
-};
+    const sStr = String(s).padStart(2, "0");
+    const timeString = `${m}:${sStr}`;
 
-function showQuestion(txt, maxTime_) {
-    // much faster than jquery's .html()
-    $("#middle")[0].innerHTML = txt;
+    if (maxTime === time) {
+        timeNode.innerHTML = `<font color=red>${timeString}</font>`;
+    } else {
+        timeNode.textContent = timeString;
+    }
+}
+
+function showQuestion(txt: string, maxTime_: number): void {
+    showAnswer(txt);
     time = 0;
     maxTime = maxTime_;
 }
 
-function showAnswer(txt) {
-    $("#middle")[0].innerHTML = txt;
+function showAnswer(txt: string): void {
+    document.getElementById("middle").innerHTML = txt;
 }
 
 function selectedAnswerButton() {

--- a/qt/aqt/overview.py
+++ b/qt/aqt/overview.py
@@ -187,7 +187,7 @@ class Overview:
         self.web.stdHtml(
             self._body % content.__dict__,
             css=["css/overview.css"],
-            js=["js/vendor/jquery.min.js", "js/overview.js"],
+            js=["js/vendor/jquery.min.js"],
             context=self,
         )
 


### PR DESCRIPTION
Just like #1119.

`overview.ts` was not even necessary, as the `#study` button is focused through the `autofocus` property.