### PR TITLE
Remove unnecessary exports from sass/BUILD.bazel

### DIFF
--- a/ts/sass/BUILD.bazel
+++ b/ts/sass/BUILD.bazel
@@ -45,6 +45,6 @@ sass_library(
 
 # qt package extracts colours from source file
 exports_files(
-    ["_vars.scss"] + glob(["*.scss"], exclude = ["_*.scss"]),
-    visibility = ["//qt:__subpackages__", "//ts:__subpackages__"],
+    ["_vars.scss"],
+    visibility = ["//qt:__subpackages__"],
 )


### PR DESCRIPTION
I think these were just part of an unsuccessful experiment.
Partially reverses cfb9ed267f.