### PR TITLE
Editor Preferences and Editor Data

### DIFF
--- a/pylib/anki/_backend/genbackend.py
+++ b/pylib/anki/_backend/genbackend.py
@@ -37,7 +37,7 @@ LABEL_REPEATED = 3
 SKIP_UNROLL_INPUT = {"TranslateString", "SetPreferences", "UpdateDeckConfigs"}
 SKIP_UNROLL_OUTPUT = {"GetPreferences"}
 
-SKIP_DECODE = {"Graphs", "GetGraphPreferences"}
+SKIP_DECODE = {"Graphs", "GetGraphPreferences", "EditorData", "GetEditorPreferences"}
 
 
 def python_type(field):

--- a/pylib/anki/collection.py
+++ b/pylib/anki/collection.py
@@ -801,6 +801,18 @@ class Collection:
     def set_config_string(self, key: Config.String.Key.V, value: str) -> None:
         self._backend.set_config_string(key=key, value=value)
 
+    # Editor
+    ##########################################################################
+
+    def editor_data(self) -> bytes:
+        return self._backend.editor_data()
+
+    def get_editor_preferences(self) -> bytes:
+        return self._backend.get_editor_preferences()
+
+    def set_editor_preferences(self, prefs: EditorPreferences) -> None:
+        self._backend.set_editor_preferences(input=prefs)
+
     # Stats
     ##########################################################################
 
@@ -829,15 +841,6 @@ table.review-log {{ {revlog_style} }}
 
     def studied_today(self) -> str:
         return self._backend.studied_today()
-
-    def editor_data(self) -> bytes:
-        return self._backend.editor_data()
-
-    def get_editor_preferences(self) -> bytes:
-        return self._backend.get_editor_preferences()
-
-    def set_editor_preferences(self, prefs: EditorPreferences) -> None:
-        self._backend.set_editor_preferences(input=prefs)
 
     def graph_data(self, search: str, days: int) -> bytes:
         return self._backend.graphs(search=search, days=days)

--- a/pylib/anki/collection.py
+++ b/pylib/anki/collection.py
@@ -11,6 +11,7 @@ import anki._backend.backend_pb2 as _pb
 SearchNode = _pb.SearchNode
 Progress = _pb.Progress
 EmptyCardsReport = _pb.EmptyCardsReport
+EditorPreferences = _pb.EditorPreferences
 GraphPreferences = _pb.GraphPreferences
 Preferences = _pb.Preferences
 UndoStatus = _pb.UndoStatus
@@ -828,6 +829,15 @@ table.review-log {{ {revlog_style} }}
 
     def studied_today(self) -> str:
         return self._backend.studied_today()
+
+    def editor_data(self) -> bytes:
+        return self._backend.editor_data()
+
+    def get_editor_preferences(self) -> bytes:
+        return self._backend.get_editor_preferences()
+
+    def set_editor_preferences(self, prefs: EditorPreferences) -> None:
+        self._backend.set_editor_preferences(input=prefs)
 
     def graph_data(self, search: str, days: int) -> bytes:
         return self._backend.graphs(search=search, days=days)

--- a/qt/aqt/mediasrv.py
+++ b/qt/aqt/mediasrv.py
@@ -20,7 +20,7 @@ from waitress.server import create_server
 
 import aqt
 from anki import hooks
-from anki.collection import GraphPreferences, OpChanges
+from anki.collection import EditorPreferences, GraphPreferences, OpChanges
 from anki.decks import UpdateDeckConfigs
 from anki.utils import devMode, from_json_bytes
 from aqt.operations.deck import update_deck_configs
@@ -254,6 +254,21 @@ def _redirectWebExports(path: str) -> Tuple[str, str]:
     return aqt.mw.col.media.dir(), path
 
 
+def editor_data() -> bytes:
+    args = from_json_bytes(request.data)
+    return aqt.mw.col.editor_data()
+
+
+def editor_preferences() -> bytes:
+    return aqt.mw.col.get_editor_preferences()
+
+
+def set_editor_preferences() -> None:
+    prefs = EditorPreferences()
+    prefs.ParseFromString(request.data)
+    aqt.mw.col.set_editor_preferences(prefs)
+
+
 def graph_data() -> bytes:
     args = from_json_bytes(request.data)
     return aqt.mw.col.graph_data(search=args["search"], days=args["days"])
@@ -306,12 +321,14 @@ def update_deck_configs_request() -> bytes:
 
 
 post_handlers = {
+    "editorData": editor_data,
+    "editorPreferences": editor_preferences,
+    "setEditorPreferences": set_editor_preferences,
     "graphData": graph_data,
     "graphPreferences": graph_preferences,
     "setGraphPreferences": set_graph_preferences,
     "deckConfigsForUpdate": deck_configs_for_update,
     "updateDeckConfigs": update_deck_configs_request,
-    # pylint: disable=unnecessary-lambda
     "i18nResources": i18n_resources,
     "congratsInfo": congrats_info,
 }

--- a/rslib/backend.proto
+++ b/rslib/backend.proto
@@ -108,6 +108,7 @@ enum ServiceIndex {
   SERVICE_INDEX_I18N = 12;
   SERVICE_INDEX_COLLECTION = 13;
   SERVICE_INDEX_CARDS = 14;
+  SERVICE_INDEX_EDITOR = 15;
 }
 
 service SchedulingService {
@@ -230,6 +231,12 @@ service DeckConfigService {
   rpc RemoveDeckConfig(DeckConfigId) returns (Empty);
   rpc GetDeckConfigsForUpdate(DeckId) returns (DeckConfigsForUpdate);
   rpc UpdateDeckConfigs(UpdateDeckConfigsIn) returns (OpChanges);
+}
+
+service EditorService {
+  rpc EditorData(EditorIn) returns (EditorOut);
+  rpc GetEditorPreferences(Empty) returns (EditorPreferences);
+  rpc SetEditorPreferences(EditorPreferences) returns (Empty);
 }
 
 service TagsService {
@@ -1266,6 +1273,15 @@ message ExtendLimitsIn {
 message CountsForDeckTodayOut {
   int32 new = 1;
   int32 review = 2;
+}
+
+message EditorIn {
+}
+
+message EditorOut {
+}
+
+message EditorPreferences {
 }
 
 message GraphsIn {

--- a/rslib/backend.proto
+++ b/rslib/backend.proto
@@ -1281,7 +1281,9 @@ message EditorIn {
 message EditorOut {
 }
 
+
 message EditorPreferences {
+  repeated uint32 favorite_colors = 1;
 }
 
 message GraphsIn {

--- a/rslib/src/backend/editor.rs
+++ b/rslib/src/backend/editor.rs
@@ -1,0 +1,21 @@
+// Copyright: Ankitects Pty Ltd and contributors
+// License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
+
+use super::Backend;
+pub(super) use crate::backend_proto::editor_service::Service as EditorService;
+use crate::{backend_proto as pb, prelude::*};
+
+impl EditorService for Backend {
+    fn editor_data(&self, input: pb::EditorIn) -> Result<pb::EditorOut> {
+        self.with_col(|col| col.editor_data(input))
+    }
+
+    fn get_editor_preferences(&self, _input: pb::Empty) -> Result<pb::EditorPreferences> {
+        self.with_col(|col| Ok(col.get_editor_preferences()))
+    }
+
+    fn set_editor_preferences(&self, input: pb::EditorPreferences) -> Result<pb::Empty> {
+        self.with_col(|col| col.set_editor_preferences(input))
+            .map(Into::into)
+    }
+}

--- a/rslib/src/backend/mod.rs
+++ b/rslib/src/backend/mod.rs
@@ -12,6 +12,7 @@ mod config;
 mod dbproxy;
 mod deckconfig;
 mod decks;
+mod editor;
 mod error;
 mod generic;
 mod i18n;
@@ -43,6 +44,7 @@ use self::{
     config::ConfigService,
     deckconfig::DeckConfigService,
     decks::DecksService,
+    editor::EditorService,
     i18n::I18nService,
     media::MediaService,
     notes::NotesService,
@@ -119,6 +121,7 @@ impl Backend {
             .and_then(|service| match service {
                 pb::ServiceIndex::Scheduling => SchedulingService::run_method(self, method, input),
                 pb::ServiceIndex::Decks => DecksService::run_method(self, method, input),
+                pb::ServiceIndex::Editor => EditorService::run_method(self, method, input),
                 pb::ServiceIndex::Notes => NotesService::run_method(self, method, input),
                 pb::ServiceIndex::Notetypes => NotetypesService::run_method(self, method, input),
                 pb::ServiceIndex::Config => ConfigService::run_method(self, method, input),

--- a/rslib/src/config/mod.rs
+++ b/rslib/src/config/mod.rs
@@ -40,6 +40,7 @@ impl ConfigEntry {
 #[strum(serialize_all = "camelCase")]
 pub(crate) enum ConfigKey {
     CreationOffset,
+    FavoriteColors,
     FirstDayOfWeek,
     LocalOffset,
     Rollover,
@@ -206,6 +207,16 @@ impl Collection {
 
     pub(crate) fn set_new_review_mix(&mut self, mix: NewReviewMix) -> Result<()> {
         self.set_config(ConfigKey::NewReviewMix, &(mix as u8))
+            .map(|_| ())
+    }
+
+    pub(crate) fn get_favorite_colors(&self) -> [u32; 8] {
+        self.get_config_optional(ConfigKey::FavoriteColors)
+            .unwrap_or([0xffffffff; 8])
+    }
+
+    pub(crate) fn set_favorite_colors(&mut self, colors: [u32; 8]) -> Result<()> {
+        self.set_config(ConfigKey::FavoriteColors, &colors)
             .map(|_| ())
     }
 

--- a/rslib/src/editor.rs
+++ b/rslib/src/editor.rs
@@ -1,0 +1,18 @@
+// Copyright: Ankitects Pty Ltd and contributors
+// License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
+
+use crate::{backend_proto as pb, prelude::*};
+
+impl Collection {
+    pub(crate) fn editor_data(&mut self, _input: pb::EditorIn) -> Result<pb::EditorOut> {
+        Ok(pb::EditorOut {})
+    }
+
+    pub(crate) fn get_editor_preferences(&self) -> pb::EditorPreferences {
+        pb::EditorPreferences {}
+    }
+
+    pub(crate) fn set_editor_preferences(&mut self, _prefs: pb::EditorPreferences) -> Result<()> {
+        Ok(())
+    }
+}

--- a/rslib/src/editor.rs
+++ b/rslib/src/editor.rs
@@ -2,6 +2,7 @@
 // License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
 use crate::{backend_proto as pb, prelude::*};
+use std::convert::*;
 
 impl Collection {
     pub(crate) fn editor_data(&mut self, _input: pb::EditorIn) -> Result<pb::EditorOut> {
@@ -9,10 +10,22 @@ impl Collection {
     }
 
     pub(crate) fn get_editor_preferences(&self) -> pb::EditorPreferences {
-        pb::EditorPreferences {}
+        pb::EditorPreferences {
+            favorite_colors: self.get_favorite_colors().to_vec(),
+        }
     }
 
-    pub(crate) fn set_editor_preferences(&mut self, _prefs: pb::EditorPreferences) -> Result<()> {
+    pub(crate) fn set_editor_preferences(&mut self, prefs: pb::EditorPreferences) -> Result<()> {
+        let colors = <[u32; 8]>::from(FavoriteColors(prefs.favorite_colors));
+        self.set_favorite_colors(colors)?;
         Ok(())
+    }
+}
+
+struct FavoriteColors(Vec<u32>);
+
+impl From<FavoriteColors> for [u32; 8] {
+    fn from(v: FavoriteColors) -> Self {
+        v.0.try_into().unwrap_or_else(|_| [0xffffffff; 8])
     }
 }

--- a/rslib/src/lib.rs
+++ b/rslib/src/lib.rs
@@ -14,6 +14,7 @@ pub mod config;
 pub mod dbcheck;
 pub mod deckconf;
 pub mod decks;
+pub mod editor;
 pub mod error;
 pub mod findreplace;
 pub mod i18n;

--- a/ts/editor/BUILD.bazel
+++ b/ts/editor/BUILD.bazel
@@ -26,6 +26,9 @@ ts_library(
     deps = [
         "//ts:image_module_support",
         "//ts/html-filter",
+        "//ts/lib",
+        "//ts/lib:backend_proto",
+        "//ts/sveltelib",
     ],
 )
 
@@ -36,17 +39,26 @@ copy_bootstrap_icons(
 
 esbuild(
     name = "editor",
+    srcs = [
+        "//ts:protobuf-shim.js",
+    ],
     args = [
         "--loader:.svg=text",
+        "--inject:$(location //ts:protobuf-shim.js)",
         "--resolve-extensions=.mjs,.js",
         "--log-level=warning",
     ],
     entry_point = "index_wrapper.ts",
+    external = [
+        "protobufjs/light",
+    ],
     visibility = ["//visibility:public"],
     deps = [
         "base_css",
         ":bootstrap-icons",
         ":editor_ts",
+        "//ts/lib",
+        "//ts/sveltelib",
     ],
 )
 

--- a/ts/editor/index.ts
+++ b/ts/editor/index.ts
@@ -10,6 +10,7 @@ import { EditorField } from "./editorField";
 import { LabelContainer } from "./labelContainer";
 import { EditingArea } from "./editingArea";
 import { Editable } from "./editable";
+import { preferences, data } from "./preferences";
 
 export { setNoteId, getNoteId } from "./noteId";
 export { saveNow } from "./changeTimer";
@@ -162,3 +163,5 @@ export function setFormat(cmd: string, arg?: any, nosave: boolean = false): void
         editorToolbar.updateActiveButtons();
     }
 }
+
+preferences.then((prefs) => data.then((editorData) => console.log(prefs, editorData)));

--- a/ts/editor/preferences.ts
+++ b/ts/editor/preferences.ts
@@ -1,0 +1,40 @@
+// Copyright: Ankitects Pty Ltd and contributors
+// License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
+
+import type { PreferenceRaw, PreferencePayload } from "sveltelib/preferences";
+import pb from "anki/backend_proto";
+import { postRequest } from "anki/postrequest";
+import { getPreferences } from "sveltelib/preferences";
+
+async function getEditorData(): Promise<pb.BackendProto.EditorOut> {
+    return pb.BackendProto.EditorOut.decode(
+        await postRequest("/_anki/editorData", JSON.stringify({}))
+    );
+}
+
+async function getEditorPreferences(): Promise<pb.BackendProto.EditorPreferences> {
+    return pb.BackendProto.EditorPreferences.decode(
+        await postRequest("/_anki/editorPreferences", JSON.stringify({}))
+    );
+}
+
+async function setEditorPreferences(
+    prefs: PreferencePayload<pb.BackendProto.EditorPreferences>
+): Promise<void> {
+    await postRequest(
+        "/_anki/setEditorPreferences",
+        pb.BackendProto.EditorPreferences.encode(prefs).finish()
+    );
+}
+
+export const preferences = getPreferences(
+    getEditorPreferences,
+    setEditorPreferences,
+    pb.BackendProto.EditorPreferences.toObject.bind(
+        pb.BackendProto.EditorPreferences
+    ) as (
+        preferences: pb.BackendProto.EditorPreferences,
+        options: { defaults: boolean }
+    ) => PreferenceRaw<pb.BackendProto.EditorPreferences>
+);
+export const data = getEditorData();


### PR DESCRIPTION
This is a WIP for having `EditorPreferences` and `EditorData` for the editor webview, similar to `GraphPreferences`, and `GraphData`.

I'm not entirely sure, whether `EditorData` makes sense, maybe it should be renamed to `NoteData`, which could at some point contain all the field data, and could also be both get/set. At the first level (for this PR), it could contain the information whether a note supports clozes.

Regarding `EditorPreferences`, I've noticed that there's already `EditingPreferences` which is used in editor.py. I've gathered, that it that is more useful for notetype/note independent editing settings however. `EditorPreferences` could contain the colors for the new ColorPicker, however I'd do this in another PR.

What do you think about the suggestions?