### PR TITLE
Editor Toolbar cleanup

### DIFF
--- a/qt/aqt/addcards.py
+++ b/qt/aqt/addcards.py
@@ -68,21 +68,31 @@ class AddCards(QDialog):
 
             editor.web.eval(
                 f"""
-const notetypeChooser = editorToolbar.labelButton({{
-    label: `Choose note type`,
-    onClick: () => bridgeCommand("choosenotetype"),
-    disables: false,
+const notetypeChooser = editorToolbar.withLabel({{
+    label: `{tr.notetypes_type()}`,
+    className: "flex-grow-1",
+    button: editorToolbar.labelButton({{
+        label: `Choose note type`,
+        className: "flex-grow-1",
+        onClick: () => bridgeCommand("choosenotetype"),
+        disables: false,
+    }})
 }});
 
-const deckChooser = editorToolbar.labelButton({{
-    label: `Choose deck`,
-    onClick: () => bridgeCommand("choosedeck"),
-    disables: false,
+const deckChooser = editorToolbar.withLabel({{
+    label: `{tr.decks_deck()}`,
+    className: "flex-grow-1",
+    button: editorToolbar.labelButton({{
+        label: `Choose deck`,
+        className: "flex-grow-1",
+        onClick: () => bridgeCommand("choosedeck"),
+        disables: false,
+    }})
 }});
 
 $editorToolbar.insertButton(editorToolbar.buttonGroup({{
     id: "choosers",
-    fullWidth: true,
+    className: "flex-basis-100",
     items: [notetypeChooser, deckChooser],
 }}), 0);
 """

--- a/qt/aqt/addcards.py
+++ b/qt/aqt/addcards.py
@@ -58,49 +58,7 @@ class AddCards(QDialog):
         self.show()
 
     def setupEditor(self) -> None:
-        def add_choosers(editor: Editor) -> None:
-            editor._links[
-                "choosenotetype"
-            ] = lambda _editor: self.show_notetype_selector()
-            editor._links[
-                "choosedeck"
-            ] = lambda _editor: self.deck_chooser.choose_deck()
-
-            editor.web.eval(
-                f"""
-const notetypeChooser = editorToolbar.withLabel({{
-    label: `{tr.notetypes_type()}`,
-    className: "flex-grow-1",
-    button: editorToolbar.labelButton({{
-        label: `Choose note type`,
-        className: "flex-grow-1",
-        onClick: () => bridgeCommand("choosenotetype"),
-        disables: false,
-    }})
-}});
-
-const deckChooser = editorToolbar.withLabel({{
-    label: `{tr.decks_deck()}`,
-    className: "flex-grow-1",
-    button: editorToolbar.labelButton({{
-        label: `Choose deck`,
-        className: "flex-grow-1",
-        onClick: () => bridgeCommand("choosedeck"),
-        disables: false,
-    }})
-}});
-
-$editorToolbar.insertButton(editorToolbar.buttonGroup({{
-    id: "choosers",
-    className: "flex-basis-100",
-    items: [notetypeChooser, deckChooser],
-}}), 0);
-"""
-            )
-
-        gui_hooks.editor_did_init.append(add_choosers)
         self.editor = aqt.editor.Editor(self.mw, self.form.fieldsArea, self, True)
-        gui_hooks.editor_did_init.remove(add_choosers)
 
     def setup_choosers(self) -> None:
         defaults = self.col.defaults_for_adding(

--- a/qt/aqt/addcards.py
+++ b/qt/aqt/addcards.py
@@ -13,7 +13,6 @@ from anki.notes import DuplicateOrEmptyResult, Note, NoteId
 from anki.utils import htmlToTextLine, isMac
 from aqt import AnkiQt, gui_hooks
 from aqt.deckchooser import DeckChooser
-from aqt.editor import Editor
 from aqt.notetypechooser import NotetypeChooser
 from aqt.operations.note import add_note
 from aqt.qt import *

--- a/qt/aqt/browser/browser.py
+++ b/qt/aqt/browser/browser.py
@@ -391,7 +391,7 @@ $editorToolbar.addButton(editorToolbar.labelButton({{
     tooltip: `{tr.browsing_preview_selected_card(val=shortcut(preview_shortcut))}`,
     onClick: () => bridgeCommand("preview"),
     disables: false,
-}}), "notetype");
+}}), "notetype", -1);
 """
             )
 

--- a/qt/aqt/browser/browser.py
+++ b/qt/aqt/browser/browser.py
@@ -386,13 +386,12 @@ class Browser(QMainWindow):
             editor._links["preview"] = lambda _editor: self.onTogglePreview()
             editor.web.eval(
                 f"""
-$editorToolbar.addButton({{
-    component: editorToolbar.LabelButton,
+$editorToolbar.addButton(editorToolbar.labelButton({{
     label: `{tr.actions_preview()}`,
     tooltip: `{tr.browsing_preview_selected_card(val=shortcut(preview_shortcut))}`,
     onClick: () => bridgeCommand("preview"),
     disables: false,
-}}, "notetype");
+}}), "notetype");
 """
             )
 

--- a/qt/aqt/editor.py
+++ b/qt/aqt/editor.py
@@ -175,7 +175,7 @@ class Editor:
             f"""
 $editorToolbar.addButtonGroup({{
   id: "addons",
-  buttons: [ {righttopbtns_defs} ]
+  items: [ {righttopbtns_defs} ]
 }});
 """
             if righttopbtns_defs

--- a/qt/aqt/editor.py
+++ b/qt/aqt/editor.py
@@ -173,10 +173,10 @@ class Editor:
         )
         righttopbtns_js = (
             f"""
-$editorToolbar.addButtonGroup({{
+$editorToolbar.addButtonGroup(editorToolbar.buttonGroup({{
   id: "addons",
   items: [ {righttopbtns_defs} ]
-}});
+}}));
 """
             if righttopbtns_defs
             else ""

--- a/qt/aqt/editor.py
+++ b/qt/aqt/editor.py
@@ -155,7 +155,7 @@ class Editor:
         gui_hooks.editor_did_init_left_buttons(lefttopbtns, self)
 
         lefttopbtns_defs = [
-            f"$editorToolbar.addButton({{ component: editorToolbar.RawButton, html: `{button}` }}, 'notetype');"
+            f"$editorToolbar.addButton(editorToolbar.rawButton({{ html: `{button}` }}), 'notetype');"
             for button in lefttopbtns
         ]
         lefttopbtns_js = "\n".join(lefttopbtns_defs)
@@ -167,7 +167,7 @@ class Editor:
 
         righttopbtns_defs = "\n".join(
             [
-                f"{{ component: editorToolbar.RawButton, html: `{button}` }},"
+                f"editorToolbar.rawButton({{ html: `{button}` }}),"
                 for button in righttopbtns
             ]
         )
@@ -1277,13 +1277,9 @@ gui_hooks.editor_will_munge_html.append(reverse_url_quoting)
 
 def set_cloze_button(editor: Editor) -> None:
     if editor.note.model()["type"] == MODEL_CLOZE:
-        editor.web.eval(
-            'document.getElementById("editorToolbar").showButton("template", "cloze"); '
-        )
+        editor.web.eval('$editorToolbar.showButton("template", "cloze"); ')
     else:
-        editor.web.eval(
-            'document.getElementById("editorToolbar").hideButton("template", "cloze"); '
-        )
+        editor.web.eval('$editorToolbar.hideButton("template", "cloze"); ')
 
 
 gui_hooks.editor_did_load_note.append(set_cloze_button)

--- a/qt/aqt/editor.py
+++ b/qt/aqt/editor.py
@@ -155,7 +155,7 @@ class Editor:
         gui_hooks.editor_did_init_left_buttons(lefttopbtns, self)
 
         lefttopbtns_defs = [
-            f"$editorToolbar.addButton(editorToolbar.rawButton({{ html: `{button}` }}), 'notetype');"
+            f"$editorToolbar.addButton(editorToolbar.rawButton({{ html: `{button}` }}), 'notetype', -1);"
             for button in lefttopbtns
         ]
         lefttopbtns_js = "\n".join(lefttopbtns_defs)
@@ -173,10 +173,10 @@ class Editor:
         )
         righttopbtns_js = (
             f"""
-$editorToolbar.addButtonGroup(editorToolbar.buttonGroup({{
+$editorToolbar.addButton(editorToolbar.buttonGroup({{
   id: "addons",
   items: [ {righttopbtns_defs} ]
-}}));
+}}), -1);
 """
             if righttopbtns_defs
             else ""

--- a/ts/editor-toolbar/ButtonDropdown.d.ts
+++ b/ts/editor-toolbar/ButtonDropdown.d.ts
@@ -5,5 +5,5 @@ import type { ToolbarItem } from "./types";
 export interface ButtonDropdownProps {
     id: string;
     className?: string;
-    buttons: ToolbarItem[];
+    items: ToolbarItem[];
 }

--- a/ts/editor-toolbar/ButtonDropdown.svelte
+++ b/ts/editor-toolbar/ButtonDropdown.svelte
@@ -13,7 +13,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         return `dropdown-menu btn-dropdown-menu py-1 mb-0 ${className}`;
     }
 
-    export let buttons: ToolbarItem[];
+    export let items: ToolbarItem[];
 </script>
 
 <style>
@@ -24,4 +24,4 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     }
 </style>
 
-<ButtonGroup {id} className={extendClassName(className)} {buttons} />
+<ButtonGroup {id} className={extendClassName(className)} {items} />

--- a/ts/editor-toolbar/ButtonDropdown.svelte
+++ b/ts/editor-toolbar/ButtonDropdown.svelte
@@ -10,7 +10,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     export let className = "";
 
     function extendClassName(className: string): string {
-        return `dropdown-menu btn-dropdown-menu py-1 mb-0 ${className}`;
+        return `dropdown-menu btn-dropdown-menu ${className}`;
     }
 
     export let items: ToolbarItem[];
@@ -21,6 +21,10 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         display: none;
         background-color: var(--window-bg);
         border-color: var(--medium-border);
+    }
+
+    :global(ul.btn-dropdown-menu.show) {
+        display: flex;
     }
 </style>
 

--- a/ts/editor-toolbar/ButtonGroup.d.ts
+++ b/ts/editor-toolbar/ButtonGroup.d.ts
@@ -6,4 +6,5 @@ export interface ButtonGroupProps {
     id: string;
     className?: string;
     items: ToolbarItem[];
+    fullWidth?: boolean;
 }

--- a/ts/editor-toolbar/ButtonGroup.d.ts
+++ b/ts/editor-toolbar/ButtonGroup.d.ts
@@ -5,5 +5,5 @@ import type { ToolbarItem } from "./types";
 export interface ButtonGroupProps {
     id: string;
     className?: string;
-    buttons: ToolbarItem[];
+    items: ToolbarItem[];
 }

--- a/ts/editor-toolbar/ButtonGroup.svelte
+++ b/ts/editor-toolbar/ButtonGroup.svelte
@@ -27,7 +27,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         overflow-y: auto;
 
         padding-inline-start: 0;
-        margin: 0 0 calc(var(--toolbar-size) / 10);
+        margin: 0 calc(var(--toolbar-size) / 8) calc(var(--toolbar-size) / 8) 0;
 
         &.border-overlap-group {
             :global(button),
@@ -35,10 +35,17 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
                 margin-left: -1px;
             }
         }
+
+        &.gap-group {
+            :global(button),
+            :global(select) {
+                margin-left: 1px;
+            }
+        }
     }
 
     li {
-        display: inline-block;
+        display: contents;
 
         > :global(button),
         > :global(select) {
@@ -65,17 +72,17 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
                 border-bottom-right-radius: calc(var(--toolbar-size) / 7.5);
             }
         }
-
-        &.gap-item:not(:nth-child(1)) {
-            margin-left: 1px;
-        }
     }
 </style>
 
-<ul {id} class={className} class:border-overlap-group={!nightMode}>
+<ul
+    {id}
+    class={className}
+    class:border-overlap-group={!nightMode}
+    class:gap-group={nightMode}>
     {#each items as button}
         {#if !button.hidden}
-            <li class:gap-item={nightMode}>
+            <li>
                 <svelte:component this={button.component} {...filterHidden(button)} />
             </li>
         {/if}

--- a/ts/editor-toolbar/ButtonGroup.svelte
+++ b/ts/editor-toolbar/ButtonGroup.svelte
@@ -26,8 +26,8 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         flex-wrap: var(--toolbar-wrap);
         overflow-y: auto;
 
-        padding-inline-start: 0;
-        margin: 0 calc(var(--toolbar-size) / 8) calc(var(--toolbar-size) / 8) 0;
+        padding: calc(var(--toolbar-size) / 10);
+        margin: 0;
 
         &.border-overlap-group {
             :global(button),
@@ -53,19 +53,14 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         }
 
         &:nth-child(1) {
-            margin-left: calc(var(--toolbar-size) / 7.5);
-
             > :global(button),
             > :global(select) {
-                /* default 0.25rem */
                 border-top-left-radius: calc(var(--toolbar-size) / 7.5);
                 border-bottom-left-radius: calc(var(--toolbar-size) / 7.5);
             }
         }
 
         &:nth-last-child(1) {
-            margin-right: calc(var(--toolbar-size) / 7.5);
-
             > :global(button),
             > :global(select) {
                 border-top-right-radius: calc(var(--toolbar-size) / 7.5);

--- a/ts/editor-toolbar/ButtonGroup.svelte
+++ b/ts/editor-toolbar/ButtonGroup.svelte
@@ -9,7 +9,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
     export let id: string | undefined = undefined;
     export let className = "";
-    export let buttons: ToolbarItem[];
+    export let items: ToolbarItem[];
 
     function filterHidden({ hidden = false, ...props }) {
         return props;
@@ -73,7 +73,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 </style>
 
 <ul {id} class={className} class:border-overlap-group={!nightMode}>
-    {#each buttons as button}
+    {#each items as button}
         {#if !button.hidden}
             <li class:gap-item={nightMode}>
                 <svelte:component this={button.component} {...filterHidden(button)} />

--- a/ts/editor-toolbar/ButtonGroup.svelte
+++ b/ts/editor-toolbar/ButtonGroup.svelte
@@ -28,12 +28,12 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
         padding-inline-start: 0;
         margin: 0 0 calc(var(--toolbar-size) / 10);
-    }
 
-    .border-overlap-group {
-        :global(button),
-        :global(select) {
-            margin-left: -1px;
+        &.border-overlap-group {
+            :global(button),
+            :global(select) {
+                margin-left: -1px;
+            }
         }
     }
 

--- a/ts/editor-toolbar/DropdownMenu.d.ts
+++ b/ts/editor-toolbar/DropdownMenu.d.ts
@@ -4,5 +4,5 @@ import type { ToolbarItem } from "./types";
 
 export interface DropdownMenuProps {
     id: string;
-    menuItems: ToolbarItem[];
+    items: ToolbarItem[];
 }

--- a/ts/editor-toolbar/DropdownMenu.svelte
+++ b/ts/editor-toolbar/DropdownMenu.svelte
@@ -3,7 +3,7 @@ Copyright: Ankitects Pty Ltd and contributors
 License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 -->
 <script lang="typescript">
-    import type { DynamicSvelteComponent } from "sveltelib/dynamicComponent";
+    import type { ToolbarItem } from "./types";
     import { getContext } from "svelte";
     import { nightModeKey } from "./contextKeys";
 

--- a/ts/editor-toolbar/DropdownMenu.svelte
+++ b/ts/editor-toolbar/DropdownMenu.svelte
@@ -8,7 +8,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     import { nightModeKey } from "./contextKeys";
 
     export let id: string;
-    export let menuItems: DynamicSvelteComponent[];
+    export let items: ToolbarItem[];
 
     const nightMode = getContext<boolean>(nightModeKey);
 </script>
@@ -27,7 +27,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 </style>
 
 <ul {id} class="dropdown-menu" class:night-mode={nightMode}>
-    {#each menuItems as menuItem}
+    {#each items as menuItem}
         <li>
             <svelte:component this={menuItem.component} {...menuItem} />
         </li>

--- a/ts/editor-toolbar/EditorToolbar.svelte
+++ b/ts/editor-toolbar/EditorToolbar.svelte
@@ -19,16 +19,14 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
 <script lang="typescript">
     import type { Readable } from "svelte/store";
-    import type { ToolbarItem } from "./types";
+    import type { ToolbarItem, IterableToolbarItem } from "./types";
     import { setContext } from "svelte";
     import { disabledKey, nightModeKey } from "./contextKeys";
 
     import ButtonGroup from "./ButtonGroup.svelte";
     import type { ButtonGroupProps } from "./ButtonGroup";
 
-    export let buttons: Readable<
-        (ToolbarItem<typeof ButtonGroup> & ButtonGroupProps)[]
-    >;
+    export let buttons: Readable<IterableToolbarItem>[];
     export let menus: Readable<ToolbarItem[]>;
 
     $: _buttons = $buttons;
@@ -77,5 +75,5 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 </div>
 
 <nav {style}>
-    <ButtonGroup buttons={_buttons} className="mt-0" />
+    <ButtonGroup items={_buttons} className="mt-0" />
 </nav>

--- a/ts/editor-toolbar/EditorToolbar.svelte
+++ b/ts/editor-toolbar/EditorToolbar.svelte
@@ -24,7 +24,6 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     import { disabledKey, nightModeKey } from "./contextKeys";
 
     import ButtonGroup from "./ButtonGroup.svelte";
-    import type { ButtonGroupProps } from "./ButtonGroup";
 
     export let buttons: Readable<IterableToolbarItem>[];
     export let menus: Readable<ToolbarItem[]>;

--- a/ts/editor-toolbar/EditorToolbar.svelte
+++ b/ts/editor-toolbar/EditorToolbar.svelte
@@ -25,7 +25,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
     import ButtonGroup from "./ButtonGroup.svelte";
 
-    export let buttons: Readable<IterableToolbarItem>[];
+    export let buttons: Readable<IterableToolbarItem[]>;
     export let menus: Readable<ToolbarItem[]>;
 
     $: _buttons = $buttons;

--- a/ts/editor-toolbar/EditorToolbar.svelte
+++ b/ts/editor-toolbar/EditorToolbar.svelte
@@ -54,17 +54,6 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
         background: var(--bg-color);
         border-bottom: 1px solid var(--border);
-
-        /* Remove outermost marigns */
-        & > :global(ul) {
-            & > :global(li:nth-child(1)) {
-                margin-left: 0;
-            }
-
-            & > :global(li:nth-last-child(1)) {
-                margin-right: 0;
-            }
-        }
     }
 </style>
 
@@ -75,5 +64,5 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 </div>
 
 <nav {style}>
-    <ButtonGroup items={_buttons} className="mt-0" />
+    <ButtonGroup items={_buttons} className="p-0 mb-1" />
 </nav>

--- a/ts/editor-toolbar/SelectButton.d.ts
+++ b/ts/editor-toolbar/SelectButton.d.ts
@@ -1,7 +1,5 @@
 // Copyright: Ankitects Pty Ltd and contributors
 // License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
-import type { ToolbarItem } from "./types";
-
 export interface Option {
     label: string;
     value: string;
@@ -12,7 +10,6 @@ export interface SelectButtonProps {
     id: string;
     className?: string;
     tooltip?: string;
-    buttons: ToolbarItem[];
     disables: boolean;
     options: Option[];
 }

--- a/ts/editor-toolbar/SelectButton.d.ts
+++ b/ts/editor-toolbar/SelectButton.d.ts
@@ -1,0 +1,18 @@
+// Copyright: Ankitects Pty Ltd and contributors
+// License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
+import type { ToolbarItem } from "./types";
+
+export interface Option {
+    label: string;
+    value: string;
+    selected: boolean;
+}
+
+export interface SelectButtonProps {
+    id: string;
+    className?: string;
+    tooltip?: string;
+    buttons: ToolbarItem[];
+    disables: boolean;
+    options: Option[];
+}

--- a/ts/editor-toolbar/SelectButton.svelte
+++ b/ts/editor-toolbar/SelectButton.svelte
@@ -4,15 +4,10 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 -->
 <script lang="typescript">
     import type { Readable } from "svelte/store";
+    import type { Option } from "./SelectButton";
     import { onMount, createEventDispatcher, getContext } from "svelte";
     import { disabledKey } from "./contextKeys";
     import SelectOption from "./SelectOption.svelte";
-
-    interface Option {
-        label: string;
-        value: string;
-        selected: boolean;
-    }
 
     export let id: string;
     export let className = "";

--- a/ts/editor-toolbar/WithLabel.d.ts
+++ b/ts/editor-toolbar/WithLabel.d.ts
@@ -1,0 +1,8 @@
+// Copyright: Ankitects Pty Ltd and contributors
+// License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
+import type { ToolbarItem } from "./types";
+
+export interface WithLabelProps {
+    button: ToolbarItem;
+    label: string;
+}

--- a/ts/editor-toolbar/WithLabel.d.ts
+++ b/ts/editor-toolbar/WithLabel.d.ts
@@ -3,6 +3,9 @@
 import type { ToolbarItem } from "./types";
 
 export interface WithLabelProps {
+    id?: string;
+    className?: string;
+
     button: ToolbarItem;
     label: string;
 }

--- a/ts/editor-toolbar/WithLabel.svelte
+++ b/ts/editor-toolbar/WithLabel.svelte
@@ -1,0 +1,22 @@
+<!--
+Copyright: Ankitects Pty Ltd and contributors
+License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
+-->
+<script lang="typescript">
+    import type { DynamicSvelteComponent } from "sveltelib/dynamicComponent";
+    import type { ToolbarItem } from "./types";
+    import type { Modifier } from "lib/shortcuts";
+
+    import { onDestroy } from "svelte";
+    import { registerShortcut, getPlatformString } from "lib/shortcuts";
+
+    export let button: ToolbarItem;
+    export let label: string;
+</script>
+
+<!-- svelte-ignore a11y-label-has-associated-control -->
+
+<label>
+    {label}
+    <svelte:component this={button.component} {...button} />
+</label>

--- a/ts/editor-toolbar/WithLabel.svelte
+++ b/ts/editor-toolbar/WithLabel.svelte
@@ -3,20 +3,25 @@ Copyright: Ankitects Pty Ltd and contributors
 License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 -->
 <script lang="typescript">
-    import type { DynamicSvelteComponent } from "sveltelib/dynamicComponent";
     import type { ToolbarItem } from "./types";
-    import type { Modifier } from "lib/shortcuts";
 
-    import { onDestroy } from "svelte";
-    import { registerShortcut, getPlatformString } from "lib/shortcuts";
+    export let id: string;
+    export let className = "";
 
-    export let button: ToolbarItem;
     export let label: string;
+    export let button: ToolbarItem;
 </script>
+
+<style lang="scss">
+    label {
+        display: flex;
+        padding: 0 calc(var(--toolbar-size) / 10);
+    }
+</style>
 
 <!-- svelte-ignore a11y-label-has-associated-control -->
 
-<label>
-    {label}
+<label {id} class={className}>
+    <span class="me-1">{label}</span>
     <svelte:component this={button.component} {...button} />
 </label>

--- a/ts/editor-toolbar/dynamicComponents.ts
+++ b/ts/editor-toolbar/dynamicComponents.ts
@@ -26,6 +26,9 @@ import type { WithDropdownMenuProps } from "./WithDropdownMenu";
 import WithShortcut from "./WithShortcut.svelte";
 import type { WithShortcutProps } from "./WithShortcut";
 
+import WithLabel from "./WithLabel.svelte";
+import type { WithLabelProps } from "./WithLabel";
+
 import { dynamicComponent } from "sveltelib/dynamicComponent";
 
 export const rawButton = dynamicComponent<typeof RawButton, { html: string }>(
@@ -71,3 +74,5 @@ export const withDropdownMenu = dynamicComponent<
 export const withShortcut = dynamicComponent<typeof WithShortcut, WithShortcutProps>(
     WithShortcut
 );
+
+export const withLabel = dynamicComponent<typeof WithLabel, WithLabelProps>(WithLabel);

--- a/ts/editor-toolbar/dynamicComponents.ts
+++ b/ts/editor-toolbar/dynamicComponents.ts
@@ -1,5 +1,6 @@
 // Copyright: Ankitects Pty Ltd and contributors
 // License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
+import RawButton from "./RawButton.svelte";
 import LabelButton from "./LabelButton.svelte";
 import type { LabelButtonProps } from "./LabelButton";
 import IconButton from "./IconButton.svelte";
@@ -8,6 +9,8 @@ import CommandIconButton from "./CommandIconButton.svelte";
 import type { CommandIconButtonProps } from "./CommandIconButton";
 import ColorPicker from "./ColorPicker.svelte";
 import type { ColorPickerProps } from "./ColorPicker";
+import SelectButton from "./SelectButton.svelte";
+import type { SelectButtonProps } from "./SelectButton";
 import ButtonGroup from "./ButtonGroup.svelte";
 import type { ButtonGroupProps } from "./ButtonGroup";
 
@@ -25,6 +28,9 @@ import type { WithShortcutProps } from "./WithShortcut";
 
 import { dynamicComponent } from "sveltelib/dynamicComponent";
 
+export const rawButton = dynamicComponent<typeof RawButton, { html: string }>(
+    RawButton
+);
 export const labelButton = dynamicComponent<typeof LabelButton, LabelButtonProps>(
     LabelButton
 );
@@ -37,6 +43,9 @@ export const commandIconButton = dynamicComponent<
 >(CommandIconButton);
 export const colorPicker = dynamicComponent<typeof ColorPicker, ColorPickerProps>(
     ColorPicker
+);
+export const selectButton = dynamicComponent<typeof SelectButton, SelectButtonProps>(
+    SelectButton
 );
 
 export const buttonGroup = dynamicComponent<typeof ButtonGroup, ButtonGroupProps>(

--- a/ts/editor-toolbar/hideable.ts
+++ b/ts/editor-toolbar/hideable.ts
@@ -4,14 +4,17 @@ interface Hideable {
     hidden?: boolean;
 }
 
-export function showComponent(component: Hideable): void {
+export function showComponent<T extends Hideable>(component: T): T {
     component.hidden = false;
+    return component;
 }
 
-export function hideComponent(component: Hideable): void {
+export function hideComponent<T extends Hideable>(component: T): T {
     component.hidden = true;
+    return component;
 }
 
-export function toggleComponent(component: Hideable): void {
+export function toggleComponent<T extends Hideable>(component: T): T {
     component.hidden = !component.hidden;
+    return component;
 }

--- a/ts/editor-toolbar/hideable.ts
+++ b/ts/editor-toolbar/hideable.ts
@@ -1,0 +1,17 @@
+// Copyright: Ankitects Pty Ltd and contributors
+// License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
+interface Hideable {
+    hidden?: boolean;
+}
+
+export function showComponent(component: Hideable): void {
+    component.hidden = false;
+}
+
+export function hideComponent(component: Hideable): void {
+    component.hidden = true;
+}
+
+export function toggleComponent(component: Hideable): void {
+    component.hidden = !component.hidden;
+}

--- a/ts/editor-toolbar/identifiable.ts
+++ b/ts/editor-toolbar/identifiable.ts
@@ -39,11 +39,8 @@ export function insert<T extends Identifiable>(
     const index = normalize(iterable, idOrIndex);
 
     if (index >= 0) {
-        iterable.items = [
-            ...iterable.items.slice(0, index),
-            value,
-            ...iterable.items.slice(index),
-        ];
+        iterable.items = iterable.items.slice();
+        iterable.items.splice(index, 0, value);
     }
 
     return iterable;
@@ -57,11 +54,8 @@ export function add<T extends Identifiable>(
     const index = normalize(iterable, idOrIndex);
 
     if (index >= 0) {
-        iterable.items = [
-            ...iterable.items.slice(0, index + 1),
-            value,
-            ...iterable.items.slice(index + 1),
-        ];
+        iterable.items = iterable.items.slice();
+        iterable.items.splice(index + 1, 0, value);
     }
 
     return iterable;

--- a/ts/editor-toolbar/identifiable.ts
+++ b/ts/editor-toolbar/identifiable.ts
@@ -8,11 +8,19 @@ function normalize<T extends Identifiable>(
     values: T[],
     idOrIndex: string | number
 ): number {
+    let normalizedIndex: number;
+
     if (typeof idOrIndex === "string") {
-        return values.findIndex((value) => value.id === idOrIndex);
-    } else {
-        return idOrIndex >= values.length ? -1 : idOrIndex;
+        normalizedIndex = values.findIndex((value) => value.id === idOrIndex);
     }
+    else if (idOrIndex < 0) {
+        normalizedIndex = values.length + idOrIndex;
+    }
+    else {
+        normalizedIndex = idOrIndex;
+    }
+
+    return normalizedIndex >= values.length ? -1 : normalizedIndex;
 }
 
 export function search<T extends Identifiable>(

--- a/ts/editor-toolbar/identifiable.ts
+++ b/ts/editor-toolbar/identifiable.ts
@@ -1,6 +1,6 @@
 // Copyright: Ankitects Pty Ltd and contributors
 // License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
-export interface Identifiable {
+interface Identifiable {
     id?: string;
 }
 

--- a/ts/editor-toolbar/identifiable.ts
+++ b/ts/editor-toolbar/identifiable.ts
@@ -12,11 +12,9 @@ function normalize<T extends Identifiable>(
 
     if (typeof idOrIndex === "string") {
         normalizedIndex = values.findIndex((value) => value.id === idOrIndex);
-    }
-    else if (idOrIndex < 0) {
+    } else if (idOrIndex < 0) {
         normalizedIndex = values.length + idOrIndex;
-    }
-    else {
+    } else {
         normalizedIndex = idOrIndex;
     }
 

--- a/ts/editor-toolbar/index.ts
+++ b/ts/editor-toolbar/index.ts
@@ -134,7 +134,7 @@ export class EditorToolbar extends HTMLElement {
         button: string | number
     ): void {
         this.updateButtonGroup((foundGroup) => {
-            const foundButton = search(foundGroup.buttons, button);
+            const foundButton = search(foundGroup.items, button);
 
             if (foundButton) {
                 update(foundButton);
@@ -160,8 +160,8 @@ export class EditorToolbar extends HTMLElement {
         button: string | number = 0
     ): void {
         this.updateButtonGroup((component) => {
-            component.buttons = insert(
-                component.buttons as (ToolbarItem & Identifiable)[],
+            component.items = insert(
+                component.items as (ToolbarItem & Identifiable)[],
                 newButton,
                 button
             );
@@ -174,8 +174,8 @@ export class EditorToolbar extends HTMLElement {
         button: string | number = -1
     ): void {
         this.updateButtonGroup((component) => {
-            component.buttons = add(
-                component.buttons as (ToolbarItem & Identifiable)[],
+            component.items = add(
+                component.items as (ToolbarItem & Identifiable)[],
                 newButton,
                 button
             );

--- a/ts/editor-toolbar/types.ts
+++ b/ts/editor-toolbar/types.ts
@@ -3,8 +3,15 @@
 import type { DynamicSvelteComponent } from "sveltelib/dynamicComponent";
 import type { SvelteComponentDev } from "svelte/internal";
 
-interface ToolbarItem<T extends typeof SvelteComponentDev = typeof SvelteComponentDev>
-    extends DynamicSvelteComponent<T> {
+export interface ToolbarItem<
+    T extends typeof SvelteComponentDev = typeof SvelteComponentDev
+> extends DynamicSvelteComponent<T> {
     id?: string;
     hidden?: boolean;
+}
+
+export interface IterableToolbarItem<
+    T extends typeof SvelteComponentDev = typeof SvelteComponentDev
+> extends ToolbarItem<T> {
+    items: ToolbarItem[];
 }

--- a/ts/editor/addons.ts
+++ b/ts/editor/addons.ts
@@ -9,10 +9,12 @@ import {
     iconButton,
     commandIconButton,
     selectButton,
+
     dropdownMenu,
     dropdownItem,
     buttonDropdown,
     withDropdownMenu,
+    withLabel,
 } from "editor-toolbar/dynamicComponents";
 
 export const editorToolbar: Record<
@@ -30,4 +32,5 @@ export const editorToolbar: Record<
     dropdownItem,
     buttonDropdown,
     withDropdownMenu,
+    withLabel,
 };

--- a/ts/editor/addons.ts
+++ b/ts/editor/addons.ts
@@ -3,6 +3,7 @@
 import type { DynamicSvelteComponent } from "sveltelib/dynamicComponent";
 
 import {
+    buttonGroup,
     rawButton,
     labelButton,
     iconButton,
@@ -18,6 +19,7 @@ export const editorToolbar: Record<
     string,
     (props: Record<string, unknown>) => DynamicSvelteComponent
 > = {
+    buttonGroup,
     rawButton,
     labelButton,
     iconButton,

--- a/ts/editor/addons.ts
+++ b/ts/editor/addons.ts
@@ -9,7 +9,6 @@ import {
     iconButton,
     commandIconButton,
     selectButton,
-
     dropdownMenu,
     dropdownItem,
     buttonDropdown,

--- a/ts/editor/addons.ts
+++ b/ts/editor/addons.ts
@@ -1,24 +1,31 @@
 // Copyright: Ankitects Pty Ltd and contributors
 // License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
-import { default as RawButton } from "editor-toolbar/RawButton.svelte";
-import { default as LabelButton } from "editor-toolbar/LabelButton.svelte";
-import { default as IconButton } from "editor-toolbar/IconButton.svelte";
-import { default as CommandIconButton } from "editor-toolbar/CommandIconButton.svelte";
-import { default as SelectButton } from "editor-toolbar/SelectButton.svelte";
+import type { DynamicSvelteComponent } from "sveltelib/dynamicComponent";
 
-import { default as DropdownMenu } from "editor-toolbar/DropdownMenu.svelte";
-import { default as DropdownItem } from "editor-toolbar/DropdownItem.svelte";
-import { default as ButtonDropdown } from "editor-toolbar/DropdownMenu.svelte";
-import { default as WithDropdownMenu } from "editor-toolbar/WithDropdownMenu.svelte";
+import {
+    rawButton,
+    labelButton,
+    iconButton,
+    commandIconButton,
+    selectButton,
+    dropdownMenu,
+    dropdownItem,
+    buttonDropdown,
+    withDropdownMenu,
+} from "editor-toolbar/dynamicComponents";
 
-export const editorToolbar = {
-    RawButton,
-    LabelButton,
-    IconButton,
-    CommandIconButton,
-    SelectButton,
-    DropdownMenu,
-    DropdownItem,
-    ButtonDropdown,
-    WithDropdownMenu,
+export const editorToolbar: Record<
+    string,
+    (props: Record<string, unknown>) => DynamicSvelteComponent
+> = {
+    rawButton,
+    labelButton,
+    iconButton,
+    commandIconButton,
+    selectButton,
+
+    dropdownMenu,
+    dropdownItem,
+    buttonDropdown,
+    withDropdownMenu,
 };

--- a/ts/editor/cloze.ts
+++ b/ts/editor/cloze.ts
@@ -1,8 +1,6 @@
 // Copyright: Ankitects Pty Ltd and contributors
 // License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
-import type WithShortcut from "editor-toolbar/WithShortcut.svelte";
-import type { WithShortcutProps } from "editor-toolbar/WithShortcut";
-import type { DynamicSvelteComponent } from "sveltelib/dynamicComponent";
+import type { ToolbarItem } from "editor-toolbar/types";
 
 import * as tr from "lib/i18n";
 import { iconButton, withShortcut } from "editor-toolbar/dynamicComponents";
@@ -40,8 +38,7 @@ function onCloze(event: KeyboardEvent | MouseEvent): void {
     wrap(`{{c${highestCloze}::`, "}}");
 }
 
-export function getClozeButton(): DynamicSvelteComponent<typeof WithShortcut> &
-    WithShortcutProps {
+export function getClozeButton(): ToolbarItem {
     return withShortcut({
         id: "cloze",
         shortcut: "Control+Shift+KeyC",

--- a/ts/editor/color.ts
+++ b/ts/editor/color.ts
@@ -1,8 +1,6 @@
 // Copyright: Ankitects Pty Ltd and contributors
 // License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
-import type ButtonGroup from "editor-toolbar/ButtonGroup.svelte";
-import type { ButtonGroupProps } from "editor-toolbar/ButtonGroup";
-import type { DynamicSvelteComponent } from "sveltelib/dynamicComponent";
+import type { IterableToolbarItem } from "editor-toolbar/types";
 
 import {
     iconButton,
@@ -29,8 +27,7 @@ function wrapWithForecolor(color: string): void {
     document.execCommand("forecolor", false, color);
 }
 
-export function getColorGroup(): DynamicSvelteComponent<typeof ButtonGroup> &
-    ButtonGroupProps {
+export function getColorGroup(): IterableToolbarItem {
     const forecolorButton = withShortcut({
         shortcut: "F7",
         button: iconButton({
@@ -52,6 +49,6 @@ export function getColorGroup(): DynamicSvelteComponent<typeof ButtonGroup> &
 
     return buttonGroup({
         id: "color",
-        buttons: [forecolorButton, colorpickerButton],
+        items: [forecolorButton, colorpickerButton],
     });
 }

--- a/ts/editor/fields.scss
+++ b/ts/editor/fields.scss
@@ -59,3 +59,7 @@
         opacity: 0.5;
     }
 }
+
+.flex-basis-100 {
+    flex-basis: 100%;
+}

--- a/ts/editor/formatBlock.ts
+++ b/ts/editor/formatBlock.ts
@@ -1,11 +1,6 @@
 // Copyright: Ankitects Pty Ltd and contributors
 // License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
-import type ButtonGroup from "editor-toolbar/ButtonGroup.svelte";
-import type { ButtonGroupProps } from "editor-toolbar/ButtonGroup";
-import type ButtonDropdown from "editor-toolbar/ButtonDropdown.svelte";
-import type { ButtonDropdownProps } from "editor-toolbar/ButtonDropdown";
-import type { DynamicSvelteComponent } from "sveltelib/dynamicComponent";
-
+import type { IterableToolbarItem } from "editor-toolbar/types";
 import type { EditingArea } from "./editingArea";
 
 import * as tr from "lib/i18n";
@@ -45,8 +40,7 @@ const indentListItem = () => {
     }
 };
 
-export function getFormatBlockMenus(): (DynamicSvelteComponent<typeof ButtonDropdown> &
-    ButtonDropdownProps)[] {
+export function getFormatBlockMenus(): IterableToolbarItem[] {
     const justifyLeftButton = commandIconButton({
         icon: justifyLeftIcon,
         command: "justifyLeft",
@@ -73,7 +67,7 @@ export function getFormatBlockMenus(): (DynamicSvelteComponent<typeof ButtonDrop
 
     const justifyGroup = buttonGroup({
         id: "justify",
-        buttons: [
+        items: [
             justifyLeftButton,
             justifyCenterButton,
             justifyRightButton,
@@ -95,19 +89,18 @@ export function getFormatBlockMenus(): (DynamicSvelteComponent<typeof ButtonDrop
 
     const indentationGroup = buttonGroup({
         id: "indentation",
-        buttons: [outdentButton, indentButton],
+        items: [outdentButton, indentButton],
     });
 
     const formattingOptions = buttonDropdown({
         id: "listFormatting",
-        buttons: [justifyGroup, indentationGroup],
+        items: [justifyGroup, indentationGroup],
     });
 
     return [formattingOptions];
 }
 
-export function getFormatBlockGroup(): DynamicSvelteComponent<typeof ButtonGroup> &
-    ButtonGroupProps {
+export function getFormatBlockGroup(): IterableToolbarItem {
     const ulButton = commandIconButton({
         icon: ulIcon,
         command: "insertUnorderedList",
@@ -131,6 +124,6 @@ export function getFormatBlockGroup(): DynamicSvelteComponent<typeof ButtonGroup
 
     return buttonGroup({
         id: "blockFormatting",
-        buttons: [ulButton, olButton, listFormatting],
+        items: [ulButton, olButton, listFormatting],
     });
 }

--- a/ts/editor/formatInline.ts
+++ b/ts/editor/formatInline.ts
@@ -1,8 +1,6 @@
 // Copyright: Ankitects Pty Ltd and contributors
 // License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
-import type ButtonGroup from "editor-toolbar/ButtonGroup.svelte";
-import type { ButtonGroupProps } from "editor-toolbar/ButtonGroup";
-import type { DynamicSvelteComponent } from "sveltelib/dynamicComponent";
+import type { IterableToolbarItem } from "editor-toolbar/types";
 
 import * as tr from "lib/i18n";
 import {
@@ -19,8 +17,7 @@ import superscriptIcon from "./format-superscript.svg";
 import subscriptIcon from "./format-subscript.svg";
 import eraserIcon from "./eraser.svg";
 
-export function getFormatInlineGroup(): DynamicSvelteComponent<typeof ButtonGroup> &
-    ButtonGroupProps {
+export function getFormatInlineGroup(): IterableToolbarItem {
     const boldButton = withShortcut({
         shortcut: "Control+KeyB",
         button: commandIconButton({
@@ -79,7 +76,7 @@ export function getFormatInlineGroup(): DynamicSvelteComponent<typeof ButtonGrou
 
     return buttonGroup({
         id: "inlineFormatting",
-        buttons: [
+        items: [
             boldButton,
             italicButton,
             underlineButton,

--- a/ts/editor/notetype.ts
+++ b/ts/editor/notetype.ts
@@ -1,8 +1,6 @@
 // Copyright: Ankitects Pty Ltd and contributors
 // License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
-import type ButtonGroup from "editor-toolbar/ButtonGroup.svelte";
-import type { ButtonGroupProps } from "editor-toolbar/ButtonGroup";
-import type { DynamicSvelteComponent } from "sveltelib/dynamicComponent";
+import type { IterableToolbarItem } from "editor-toolbar/types";
 
 import { bridgeCommand } from "lib/bridgecommand";
 import * as tr from "lib/i18n";
@@ -12,8 +10,7 @@ import {
     withShortcut,
 } from "editor-toolbar/dynamicComponents";
 
-export function getNotetypeGroup(): DynamicSvelteComponent<typeof ButtonGroup> &
-    ButtonGroupProps {
+export function getNotetypeGroup(): IterableToolbarItem {
     const fieldsButton = labelButton({
         onClick: () => bridgeCommand("fields"),
         disables: false,
@@ -33,6 +30,6 @@ export function getNotetypeGroup(): DynamicSvelteComponent<typeof ButtonGroup> &
 
     return buttonGroup({
         id: "notetype",
-        buttons: [fieldsButton, cardsButton],
+        items: [fieldsButton, cardsButton],
     });
 }

--- a/ts/editor/template.ts
+++ b/ts/editor/template.ts
@@ -1,10 +1,6 @@
 // Copyright: Ankitects Pty Ltd and contributors
 // License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
-import type DropdownMenu from "editor-toolbar/DropdownMenu.svelte";
-import type { DropdownMenuProps } from "editor-toolbar/DropdownMenu";
-import type ButtonGroup from "editor-toolbar/ButtonGroup.svelte";
-import type { ButtonGroupProps } from "editor-toolbar/ButtonGroup";
-import type { DynamicSvelteComponent } from "sveltelib/dynamicComponent";
+import type { IterableToolbarItem } from "editor-toolbar/types";
 
 import { bridgeCommand } from "lib/bridgecommand";
 import {
@@ -40,8 +36,7 @@ function onHtmlEdit(): void {
 
 const mathjaxMenuId = "mathjaxMenu";
 
-export function getTemplateGroup(): DynamicSvelteComponent<typeof ButtonGroup> &
-    ButtonGroupProps {
+export function getTemplateGroup(): IterableToolbarItem {
     const attachmentButton = withShortcut({
         shortcut: "F3",
         button: iconButton({
@@ -80,7 +75,7 @@ export function getTemplateGroup(): DynamicSvelteComponent<typeof ButtonGroup> &
 
     return buttonGroup({
         id: "template",
-        buttons: [
+        items: [
             attachmentButton,
             recordButton,
             getClozeButton(),
@@ -90,8 +85,7 @@ export function getTemplateGroup(): DynamicSvelteComponent<typeof ButtonGroup> &
     });
 }
 
-export function getTemplateMenus(): (DynamicSvelteComponent<typeof DropdownMenu> &
-    DropdownMenuProps)[] {
+export function getTemplateMenus(): IterableToolbarItem[] {
     const mathjaxMenuItems = [
         withShortcut({
             shortcut: "Control+KeyM, KeyM",
@@ -142,7 +136,7 @@ export function getTemplateMenus(): (DynamicSvelteComponent<typeof DropdownMenu>
 
     const mathjaxMenu = dropdownMenu({
         id: mathjaxMenuId,
-        menuItems: [...mathjaxMenuItems, ...latexMenuItems],
+        items: [...mathjaxMenuItems, ...latexMenuItems],
     });
 
     return [mathjaxMenu];

--- a/ts/editor/toolbar.ts
+++ b/ts/editor/toolbar.ts
@@ -1,8 +1,6 @@
 // Copyright: Ankitects Pty Ltd and contributors
 // License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
-import type { ToolbarItem } from "editor-toolbar/types";
-import type ButtonGroup from "editor-toolbar/ButtonGroup.svelte";
-import type { ButtonGroupProps } from "editor-toolbar/ButtonGroup";
+import type { ToolbarItem, IterableToolbarItem } from "editor-toolbar/types";
 import type { Writable } from "svelte/store";
 
 import { getNotetypeGroup } from "./notetype";
@@ -16,10 +14,8 @@ export function initToolbar(i18n: Promise<void>): void {
         i18n.then(() => {
             globalThis.$editorToolbar.buttonsPromise.then(
                 (
-                    buttons: Writable<
-                        (ToolbarItem<typeof ButtonGroup> & ButtonGroupProps)[]
-                    >
-                ): Writable<(ToolbarItem<typeof ButtonGroup> & ButtonGroupProps)[]> => {
+                    buttons: Writable<IterableToolbarItem[]>
+                ): Writable<IterableToolbarItem[]> => {
                     buttons.update(() => [
                         getNotetypeGroup(),
                         getFormatInlineGroup(),

--- a/ts/editor/toolbar.ts
+++ b/ts/editor/toolbar.ts
@@ -1,8 +1,5 @@
 // Copyright: Ankitects Pty Ltd and contributors
 // License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
-import type { ToolbarItem, IterableToolbarItem } from "editor-toolbar/types";
-import type { Writable } from "svelte/store";
-
 import { getNotetypeGroup } from "./notetype";
 import { getFormatInlineGroup } from "./formatInline";
 import { getFormatBlockGroup, getFormatBlockMenus } from "./formatBlock";
@@ -12,30 +9,18 @@ import { getTemplateGroup, getTemplateMenus } from "./template";
 export function initToolbar(i18n: Promise<void>): void {
     document.addEventListener("DOMContentLoaded", () => {
         i18n.then(() => {
-            globalThis.$editorToolbar.buttonsPromise.then(
-                (
-                    buttons: Writable<IterableToolbarItem[]>
-                ): Writable<IterableToolbarItem[]> => {
-                    buttons.update(() => [
-                        getNotetypeGroup(),
-                        getFormatInlineGroup(),
-                        getFormatBlockGroup(),
-                        getColorGroup(),
-                        getTemplateGroup(),
-                    ]);
-                    return buttons;
-                }
-            );
+            const buttons = [
+                getNotetypeGroup(),
+                getFormatInlineGroup(),
+                getFormatBlockGroup(),
+                getColorGroup(),
+                getTemplateGroup(),
+            ];
 
-            globalThis.$editorToolbar.menusPromise.then(
-                (menus: Writable<ToolbarItem[]>): Writable<ToolbarItem[]> => {
-                    menus.update(() => [
-                        ...getFormatBlockMenus(),
-                        ...getTemplateMenus(),
-                    ]);
-                    return menus;
-                }
-            );
+            const menus = [...getFormatBlockMenus(), ...getTemplateMenus()];
+
+            globalThis.$editorToolbar.updateButton(() => ({ items: buttons }));
+            globalThis.$editorToolbar.updateMenu(() => ({ items: menus }));
         });
     });
 }

--- a/ts/sass/base.scss
+++ b/ts/sass/base.scss
@@ -9,6 +9,7 @@ $link-hover-decoration: none;
 @import "ts/sass/bootstrap/bootstrap-reboot";
 @import "ts/sass/bootstrap/bootstrap-utilities";
 
-body, html {
+body,
+html {
     overscroll-behavior: none;
 }


### PR DESCRIPTION
Originally I wanted to add the note type chooser in this PR. This is what it would have looked like:
![Screenshot 2021-04-24 at 00 10 01](https://user-images.githubusercontent.com/7188844/115938368-ac71f380-a49a-11eb-9b90-a24dd76570c3.png)

But at the last stage I realized that I couldn't remove the Qt chooser buttons without disabling the modals ^^;.  1f05ebb shows how it would have been defined.

Instead, the PR contains all the preparation work for making this change, and some refactors:
- Instead of the raw Svelte classes, I know export the dynamic component functions `rawButton`, `iconButton`, etc. This way add-ons (and our Python code) and our TS can use the same interface.
- I've generalized the methods in editor-toolbar/index.ts, so they operate recursively. This allows for easier typing via `IterableToolbarItem`. Now we can also make `menusPromise` and `buttonsPromise` private.