### PR TITLE
Fix some problems with browser actions while selection is empty

### DIFF
--- a/ftl/core/browsing.ftl
+++ b/ftl/core/browsing.ftl
@@ -65,6 +65,7 @@ browsing-nd-names = { $num }: { $name }
 browsing-new = (new)
 browsing-new-note-type = New note type:
 browsing-no-flag = No Flag
+browsing-no-selection = No cards or notes selected.
 browsing-note = Note
 # Exactly one character representing 'Notes'; should differ from browsing-card-initial.
 browsing-note-initial = N

--- a/qt/aqt/browser/browser.py
+++ b/qt/aqt/browser/browser.py
@@ -71,6 +71,7 @@ from aqt.utils import (
     shortcut,
     showInfo,
     showWarning,
+    skip_if_selection_is_empty,
     tooltip,
     tr,
 )
@@ -573,11 +574,10 @@ where id in %s"""
     # Misc menu options
     ######################################################################
 
+    @skip_if_selection_is_empty
     @ensure_editor_saved_on_trigger
     def onChangeModel(self) -> None:
-        nids = self.oneModelNotes()
-        if nids:
-            ChangeModel(self, nids)
+        ChangeModel(self, self.oneModelNotes())
 
     def createFilteredDeck(self) -> None:
         search = self.current_search()
@@ -619,6 +619,7 @@ where id in %s"""
     # Card deletion
     ######################################################################
 
+    @skip_if_selection_is_empty
     def delete_selected_notes(self) -> None:
         # ensure deletion is not accidentally triggered when the user is focused
         # in the editing screen or search bar
@@ -626,11 +627,7 @@ where id in %s"""
         if focus != self.form.tableView:
             return
 
-        # nothing selected?
         nids = self.table.get_selected_note_ids()
-        if not nids:
-            return
-
         # select the next card if there is one
         self.focusTo = self.editor.currentField
         self.table.to_next_row()
@@ -644,14 +641,12 @@ where id in %s"""
     # Deck change
     ######################################################################
 
+    @skip_if_selection_is_empty
     @ensure_editor_saved_on_trigger
     def set_deck_of_selected_cards(self) -> None:
         from aqt.studydeck import StudyDeck
 
         cids = self.table.get_selected_card_ids()
-        if not cids:
-            return
-
         did = self.mw.col.db.scalar("select did from cards where id = ?", cids[0])
         current = self.mw.col.decks.get(did)["name"]
         ret = StudyDeck(
@@ -675,6 +670,7 @@ where id in %s"""
     # Tags
     ######################################################################
 
+    @skip_if_selection_is_empty
     @ensure_editor_saved_on_trigger
     def add_tags_to_selected_notes(
         self,
@@ -687,6 +683,7 @@ where id in %s"""
             parent=self, note_ids=self.selected_notes(), space_separated_tags=tags
         ).run_in_background(initiator=self)
 
+    @skip_if_selection_is_empty
     @ensure_editor_saved_on_trigger
     def remove_tags_from_selected_notes(self, tags: Optional[str] = None) -> None:
         "Shows prompt if tags not provided."
@@ -721,6 +718,7 @@ where id in %s"""
         is_suspended = bool(self.card and self.card.queue == QUEUE_TYPE_SUSPENDED)
         self.form.actionToggle_Suspend.setChecked(is_suspended)
 
+    @skip_if_selection_is_empty
     @ensure_editor_saved
     def suspend_selected_cards(self, checked: bool) -> None:
         cids = self.selected_cards()
@@ -732,14 +730,15 @@ where id in %s"""
     # Exporting
     ######################################################################
 
+    @skip_if_selection_is_empty
     def _on_export_notes(self) -> None:
         cids = self.selectedNotesAsCards()
-        if cids:
-            ExportDialog(self.mw, cids=list(cids))
+        ExportDialog(self.mw, cids=list(cids))
 
     # Flags & Marking
     ######################################################################
 
+    @skip_if_selection_is_empty
     @ensure_editor_saved
     def set_flag_of_selected_cards(self, flag: int) -> None:
         if not self.card:
@@ -782,6 +781,7 @@ where id in %s"""
     # Scheduling
     ######################################################################
 
+    @skip_if_selection_is_empty
     @ensure_editor_saved_on_trigger
     def reposition(self) -> None:
         if self.card and self.card.queue != QUEUE_TYPE_NEW:
@@ -792,6 +792,7 @@ where id in %s"""
             parent=self, card_ids=self.selected_cards()
         ).run_in_background()
 
+    @skip_if_selection_is_empty
     @ensure_editor_saved_on_trigger
     def set_due_date(self) -> None:
         set_due_date_dialog(
@@ -800,6 +801,7 @@ where id in %s"""
             config_key=Config.String.SET_DUE_BROWSER,
         ).run_in_background()
 
+    @skip_if_selection_is_empty
     @ensure_editor_saved_on_trigger
     def forget_cards(self) -> None:
         forget_cards(
@@ -810,6 +812,7 @@ where id in %s"""
     # Edit: selection
     ######################################################################
 
+    @skip_if_selection_is_empty
     @ensure_editor_saved_on_trigger
     def selectNotes(self) -> None:
         nids = self.selected_notes()
@@ -858,13 +861,10 @@ where id in %s"""
     # Edit: replacing
     ######################################################################
 
+    @skip_if_selection_is_empty
     @ensure_editor_saved_on_trigger
     def onFindReplace(self) -> None:
-        nids = self.selected_notes()
-        if not nids:
-            return
-
-        FindAndReplaceDialog(self, mw=self.mw, note_ids=nids)
+        FindAndReplaceDialog(self, mw=self.mw, note_ids=self.selected_notes())
 
     # Edit: finding dupes
     ######################################################################

--- a/qt/aqt/utils.py
+++ b/qt/aqt/utils.py
@@ -1009,6 +1009,19 @@ def ensure_editor_saved_on_trigger(func: Callable) -> Callable:
     return pyqtSlot()(ensure_editor_saved(func))  # type: ignore
 
 
+def skip_if_selection_is_empty(func: Callable) -> Callable:
+    """Make the wrapped method a no-op and show a hint if the table selection is empty."""
+
+    @wraps(func)
+    def decorated(self: Any, *args: Any, **kwargs: Any) -> None:
+        if self.table.len_selection() > 0:
+            func(self, *args, **kwargs)
+        else:
+            tooltip(tr.browsing_no_selection())
+
+    return decorated
+
+
 class KeyboardModifiersPressed:
     "Util for type-safe checks of currently-pressed modifier keys."
 


### PR DESCRIPTION
Curiously, the problem we had with `@ensure_editor_saved` did not occur. I would have thought that adding another decorator on top would cause the issue with the additional argument for triggers again?
