### PR TITLE
Store given input of type field in the frontside into data attribute of tag

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -78,6 +78,7 @@ Maksim Abramchuk <maximabramchuck@gmail.com>
 Benjamin Kulnik <benjamin.kulnik@student.tuwien.ac.at>
 Shaun Ren <shaun.ren@linux.com>
 Ryan Greenblatt <greenblattryan@gmail.com>
+Wathan Pratumwan <w.pratumwan@gmail.com>
 
 ********************
 

--- a/qt/aqt/reviewer.py
+++ b/qt/aqt/reviewer.py
@@ -655,7 +655,9 @@ class Reviewer:
                     res += good(txt)
                 else:
                     res += missed(txt)
-        res = f"<div><code id=typeans>{res}</code></div>"
+        given_escape = html.escape(given, quote=True)
+        data_attr = f'data-given="{given_escape}"'
+        res = f"<div><code id=typeans {data_attr}>{res}</code></div>"
         return res
 
     def _noLoneMarks(self, s: str) -> str:


### PR DESCRIPTION
Store the originally given answer in a data attribute of `typeans` in addition to the formatted answer comparison.

'Type in answer comparison' in the backside of the card scatters the originally given input from the frontside over many span tags. To get the original input from the backside template, template developers have to parse the built-in answer comparison output and stitch the spanned answer together.  This makes it hard to write custom answer comparisons.

In `correct` method of `Reviewer`, `data-given` custom attribute is added to `<code id="typeans">` in the backside to store the input information from the frontside. Card template developers can easily access this attribute via javascript.

![Screen Shot 2021-05-16 at 14 27 40](https://user-images.githubusercontent.com/5017878/118390170-d6f93b80-b657-11eb-84be-56cc7b7eaafe.png)
