### PR TITLE
Fix black workaround for format calls

### DIFF
--- a/pylib/tests/run_format.py
+++ b/pylib/tests/run_format.py
@@ -20,7 +20,7 @@ if __name__ == "__main__":
         args = ["--diff", "--check"]
 
     # work around issue with latest black
-    if sys.platform == "win32":
+    if sys.platform == "win32" and "HOME" in os.environ:
         os.environ["USERPROFILE"] = os.environ["HOME"]
 
     retcode = subprocess.run(

--- a/pylib/tools/hookslib.py
+++ b/pylib/tools/hookslib.py
@@ -162,7 +162,7 @@ def write_file(path: str, hooks: List[Hook], prefix: str, suffix: str):
     code += "\n" + suffix
 
     # work around issue with latest black
-    if sys.platform == "win32":
+    if sys.platform == "win32" and "HOME" in os.environ:
         os.environ["USERPROFILE"] = os.environ["HOME"]
     with open(path, "wb") as file:
         file.write(code.encode("utf8"))

--- a/qt/tests/run_format.py
+++ b/qt/tests/run_format.py
@@ -19,7 +19,7 @@ if __name__ == "__main__":
         args = ["--diff", "--check"]
 
     # work around issue with latest black
-    if sys.platform == "win32":
+    if sys.platform == "win32" and "HOME" in os.environ:
         os.environ["USERPROFILE"] = os.environ["HOME"]
 
     retcode = subprocess.run(


### PR DESCRIPTION
Apparently another environment is used for format calls like  `.\bazel run //pylib:format`, so we must not try to access "HOME" in this case.