### PR TITLE
Strip Unicode isolation characters from title

### DIFF
--- a/qt/aqt/deckoptions.py
+++ b/qt/aqt/deckoptions.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import aqt
+from anki.lang import without_unicode_isolation
 from aqt import gui_hooks
 from aqt.qt import *
 from aqt.utils import addCloseShortcut, disable_help_button, restoreGeom, saveGeom, tr
@@ -43,7 +44,9 @@ class DeckOptionsDialog(QDialog):
             f"""const $deckOptions = anki.deckOptions(
             document.getElementById('main'), {deck.id});"""
         )
-        self.setWindowTitle(tr.actions_options_for(val=deck.name))
+        self.setWindowTitle(
+            without_unicode_isolation(tr.actions_options_for(val=deck.name))
+        )
         gui_hooks.deck_options_did_load(self)
 
     def reject(self) -> None:


### PR DESCRIPTION
Unrelated: I'm getting this error when trying to open the new deck options screen running from source:
```
JS error /_anki/pages/deckoptions.js:22447 Uncaught (in promise) TypeError: Cannot read property 'decode' of undefined
```

It's coming from this line apparently: https://github.com/ankitects/anki/blob/581480191acc512b64b7af67f4660e3a49355f9b/ts/deckoptions/lib.ts#L18

