### PR TITLE
Switch to event.key for keyboard sequences

### DIFF
--- a/ts/components/WithShortcut.svelte
+++ b/ts/components/WithShortcut.svelte
@@ -8,7 +8,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     import { onDestroy } from "svelte";
     import { registerShortcut, getPlatformString } from "lib/shortcuts";
 
-    export let shortcut: string;
+    export let shortcut: string[][];
     export let optionalModifiers: Modifier[] | undefined = [];
 
     const shortcutLabel = getPlatformString(shortcut);

--- a/ts/components/WithShortcut.svelte
+++ b/ts/components/WithShortcut.svelte
@@ -6,8 +6,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     import { onDestroy } from "svelte";
     import { registerShortcut, getPlatformString } from "lib/shortcuts";
 
-    export let shortcut: string[][];
-    export let useCode = false;
+    export let shortcut: string;
 
     const shortcutLabel = getPlatformString(shortcut);
 
@@ -15,14 +14,10 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
     function createShortcut({ detail }: CustomEvent): void {
         const mounted: HTMLButtonElement = detail.button;
-        deregister = registerShortcut(
-            (event: KeyboardEvent) => {
-                mounted.dispatchEvent(new MouseEvent("click", event));
-                event.preventDefault();
-            },
-            shortcut,
-            useCode
-        );
+        deregister = registerShortcut((event: KeyboardEvent) => {
+            mounted.dispatchEvent(new MouseEvent("click", event));
+            event.preventDefault();
+        }, shortcut);
     }
 
     onDestroy(() => deregister());

--- a/ts/components/WithShortcut.svelte
+++ b/ts/components/WithShortcut.svelte
@@ -3,13 +3,11 @@ Copyright: Ankitects Pty Ltd and contributors
 License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 -->
 <script lang="typescript">
-    import type { Modifier } from "lib/shortcuts";
-
     import { onDestroy } from "svelte";
     import { registerShortcut, getPlatformString } from "lib/shortcuts";
 
     export let shortcut: string[][];
-    export let optionalModifiers: Modifier[] | undefined = [];
+    export let useCode = false;
 
     const shortcutLabel = getPlatformString(shortcut);
 
@@ -23,7 +21,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
                 event.preventDefault();
             },
             shortcut,
-            optionalModifiers
+            useCode
         );
     }
 

--- a/ts/deckoptions/DeckOptionsPage.svelte
+++ b/ts/deckoptions/DeckOptionsPage.svelte
@@ -36,9 +36,11 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
     let registerCleanup: () => void;
     onMount(() => {
-        registerCleanup = registerShortcut(() => state.save(false), [
-            ["Control", "Enter"],
-        ]);
+        registerCleanup = registerShortcut(
+            () => state.save(false),
+            [["Control", "Enter"]],
+            true
+        );
     });
     onDestroy(() => registerCleanup?.());
 </script>

--- a/ts/deckoptions/DeckOptionsPage.svelte
+++ b/ts/deckoptions/DeckOptionsPage.svelte
@@ -36,7 +36,9 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
     let registerCleanup: () => void;
     onMount(() => {
-        registerCleanup = registerShortcut(() => state.save(false), "Control+Enter");
+        registerCleanup = registerShortcut(() => state.save(false), [
+            ["Control", "Enter"],
+        ]);
     });
     onDestroy(() => registerCleanup?.());
 </script>

--- a/ts/deckoptions/DeckOptionsPage.svelte
+++ b/ts/deckoptions/DeckOptionsPage.svelte
@@ -36,11 +36,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
     let registerCleanup: () => void;
     onMount(() => {
-        registerCleanup = registerShortcut(
-            () => state.save(false),
-            [["Control", "Enter"]],
-            true
-        );
+        registerCleanup = registerShortcut(() => state.save(false), "Control+Enter");
     });
     onDestroy(() => registerCleanup?.());
 </script>

--- a/ts/deckoptions/deckoptions-base.scss
+++ b/ts/deckoptions/deckoptions-base.scss
@@ -51,5 +51,5 @@ code {
 
 // override the default down arrow colour in <select> elements
 .night-mode select {
-    background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3e%3cpath fill='none' stroke='%23FFFFFF' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M2 5l6 6 6-6'/%3e%3c/svg%3e")
+    background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3e%3cpath fill='none' stroke='%23FFFFFF' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M2 5l6 6 6-6'/%3e%3c/svg%3e");
 }

--- a/ts/editor/ClozeButton.svelte
+++ b/ts/editor/ClozeButton.svelte
@@ -42,7 +42,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 </script>
 
 <WithShortcut
-    shortcut="Control+Shift+KeyC"
+    shortcut={[['Control', 'Shift', 'C']]}
     optionalModifiers={['Alt']}
     let:createShortcut
     let:shortcutLabel>

--- a/ts/editor/ClozeButton.svelte
+++ b/ts/editor/ClozeButton.svelte
@@ -42,8 +42,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 </script>
 
 <WithShortcut
-    shortcut={[['Control', 'Shift', 'C']]}
-    optionalModifiers={['Alt']}
+    shortcut={[['Control', 'Alt?', 'Shift', 'C']]}
     let:createShortcut
     let:shortcutLabel>
     <IconButton

--- a/ts/editor/ClozeButton.svelte
+++ b/ts/editor/ClozeButton.svelte
@@ -41,10 +41,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     }
 </script>
 
-<WithShortcut
-    shortcut={[['Control', 'Alt?', 'Shift', 'C']]}
-    let:createShortcut
-    let:shortcutLabel>
+<WithShortcut shortcut={'Control+Alt?+Shift+C'} let:createShortcut let:shortcutLabel>
     <IconButton
         tooltip={`${tr.editingClozeDeletion()} (${shortcutLabel})`}
         on:click={onCloze}

--- a/ts/editor/ColorButtons.svelte
+++ b/ts/editor/ColorButtons.svelte
@@ -36,7 +36,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
 <ButtonGroup {api}>
     <ButtonGroupItem>
-        <WithShortcut shortcut="F7" let:createShortcut let:shortcutLabel>
+        <WithShortcut shortcut={[['F7']]} let:createShortcut let:shortcutLabel>
             <IconButton
                 class="forecolor"
                 tooltip={appendInParentheses(tr.editingSetForegroundColor(), shortcutLabel)}
@@ -48,7 +48,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     </ButtonGroupItem>
 
     <ButtonGroupItem>
-        <WithShortcut shortcut="F8" let:createShortcut let:shortcutLabel>
+        <WithShortcut shortcut={[['F8']]} let:createShortcut let:shortcutLabel>
             <ColorPicker
                 tooltip={appendInParentheses(tr.editingChangeColor(), shortcutLabel)}
                 on:change={setWithCurrentColor}

--- a/ts/editor/ColorButtons.svelte
+++ b/ts/editor/ColorButtons.svelte
@@ -36,7 +36,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
 <ButtonGroup {api}>
     <ButtonGroupItem>
-        <WithShortcut shortcut={[['F7']]} let:createShortcut let:shortcutLabel>
+        <WithShortcut shortcut={'F7'} let:createShortcut let:shortcutLabel>
             <IconButton
                 class="forecolor"
                 tooltip={appendInParentheses(tr.editingSetForegroundColor(), shortcutLabel)}
@@ -48,7 +48,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     </ButtonGroupItem>
 
     <ButtonGroupItem>
-        <WithShortcut shortcut={[['F8']]} let:createShortcut let:shortcutLabel>
+        <WithShortcut shortcut={'F8'} let:createShortcut let:shortcutLabel>
             <ColorPicker
                 tooltip={appendInParentheses(tr.editingChangeColor(), shortcutLabel)}
                 on:change={setWithCurrentColor}

--- a/ts/editor/FormatInlineButtons.svelte
+++ b/ts/editor/FormatInlineButtons.svelte
@@ -99,7 +99,8 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
     <ButtonGroupItem>
         <WithShortcut
-            shortcut={[['Control', '+']]}
+            shortcut={[['Control', 'Equal']]}
+            useCode={true}
             let:createShortcut
             let:shortcutLabel>
             <WithState
@@ -123,7 +124,8 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
     <ButtonGroupItem>
         <WithShortcut
-            shortcut={[['Control', '=']]}
+            shortcut={[['Control', 'Shift', 'Equal']]}
+            useCode={true}
             let:createShortcut
             let:shortcutLabel>
             <WithState

--- a/ts/editor/FormatInlineButtons.svelte
+++ b/ts/editor/FormatInlineButtons.svelte
@@ -26,10 +26,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
 <ButtonGroup {api}>
     <ButtonGroupItem>
-        <WithShortcut
-            shortcut={[['Control', 'b']]}
-            let:createShortcut
-            let:shortcutLabel>
+        <WithShortcut shortcut={'Control+B'} let:createShortcut let:shortcutLabel>
             <WithState
                 key="bold"
                 update={() => document.queryCommandState('bold')}
@@ -50,10 +47,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     </ButtonGroupItem>
 
     <ButtonGroupItem>
-        <WithShortcut
-            shortcut={[['Control', 'i']]}
-            let:createShortcut
-            let:shortcutLabel>
+        <WithShortcut shortcut={'Control+I'} let:createShortcut let:shortcutLabel>
             <WithState
                 key="italic"
                 update={() => document.queryCommandState('italic')}
@@ -74,10 +68,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     </ButtonGroupItem>
 
     <ButtonGroupItem>
-        <WithShortcut
-            shortcut={[['Control', 'u']]}
-            let:createShortcut
-            let:shortcutLabel>
+        <WithShortcut shortcut={'Control+U'} let:createShortcut let:shortcutLabel>
             <WithState
                 key="underline"
                 update={() => document.queryCommandState('underline')}
@@ -98,11 +89,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     </ButtonGroupItem>
 
     <ButtonGroupItem>
-        <WithShortcut
-            shortcut={[['Control', 'Equal']]}
-            useCode={true}
-            let:createShortcut
-            let:shortcutLabel>
+        <WithShortcut shortcut={'Control+='} let:createShortcut let:shortcutLabel>
             <WithState
                 key="superscript"
                 update={() => document.queryCommandState('superscript')}
@@ -123,11 +110,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     </ButtonGroupItem>
 
     <ButtonGroupItem>
-        <WithShortcut
-            shortcut={[['Control', 'Shift', 'Equal']]}
-            useCode={true}
-            let:createShortcut
-            let:shortcutLabel>
+        <WithShortcut shortcut={'Control+Shift+='} let:createShortcut let:shortcutLabel>
             <WithState
                 key="subscript"
                 update={() => document.queryCommandState('subscript')}
@@ -148,10 +131,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     </ButtonGroupItem>
 
     <ButtonGroupItem>
-        <WithShortcut
-            shortcut={[['Control', 'r']]}
-            let:createShortcut
-            let:shortcutLabel>
+        <WithShortcut shortcut={'Control+R'} let:createShortcut let:shortcutLabel>
             <IconButton
                 tooltip={appendInParentheses(tr.editingRemoveFormatting(), shortcutLabel)}
                 on:click={() => {

--- a/ts/editor/FormatInlineButtons.svelte
+++ b/ts/editor/FormatInlineButtons.svelte
@@ -26,7 +26,10 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
 <ButtonGroup {api}>
     <ButtonGroupItem>
-        <WithShortcut shortcut="Control+KeyB" let:createShortcut let:shortcutLabel>
+        <WithShortcut
+            shortcut={[['Control', 'b']]}
+            let:createShortcut
+            let:shortcutLabel>
             <WithState
                 key="bold"
                 update={() => document.queryCommandState('bold')}
@@ -47,7 +50,10 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     </ButtonGroupItem>
 
     <ButtonGroupItem>
-        <WithShortcut shortcut="Control+KeyI" let:createShortcut let:shortcutLabel>
+        <WithShortcut
+            shortcut={[['Control', 'i']]}
+            let:createShortcut
+            let:shortcutLabel>
             <WithState
                 key="italic"
                 update={() => document.queryCommandState('italic')}
@@ -68,7 +74,10 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     </ButtonGroupItem>
 
     <ButtonGroupItem>
-        <WithShortcut shortcut="Control+KeyU" let:createShortcut let:shortcutLabel>
+        <WithShortcut
+            shortcut={[['Control', 'u']]}
+            let:createShortcut
+            let:shortcutLabel>
             <WithState
                 key="underline"
                 update={() => document.queryCommandState('underline')}
@@ -90,7 +99,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
     <ButtonGroupItem>
         <WithShortcut
-            shortcut="Control+Shift+Equal"
+            shortcut={[['Control', '+']]}
             let:createShortcut
             let:shortcutLabel>
             <WithState
@@ -113,7 +122,10 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     </ButtonGroupItem>
 
     <ButtonGroupItem>
-        <WithShortcut shortcut="Control+Equal" let:createShortcut let:shortcutLabel>
+        <WithShortcut
+            shortcut={[['Control', '=']]}
+            let:createShortcut
+            let:shortcutLabel>
             <WithState
                 key="subscript"
                 update={() => document.queryCommandState('subscript')}
@@ -134,7 +146,10 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     </ButtonGroupItem>
 
     <ButtonGroupItem>
-        <WithShortcut shortcut="Control+KeyR" let:createShortcut let:shortcutLabel>
+        <WithShortcut
+            shortcut={[['Control', 'r']]}
+            let:createShortcut
+            let:shortcutLabel>
             <IconButton
                 tooltip={appendInParentheses(tr.editingRemoveFormatting(), shortcutLabel)}
                 on:click={() => {

--- a/ts/editor/NoteTypeButtons.svelte
+++ b/ts/editor/NoteTypeButtons.svelte
@@ -25,7 +25,10 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     </ButtonGroupItem>
 
     <ButtonGroupItem>
-        <WithShortcut shortcut="Control+KeyL" let:createShortcut let:shortcutLabel>
+        <WithShortcut
+            shortcut={[['Control', 'l']]}
+            let:createShortcut
+            let:shortcutLabel>
             <LabelButton
                 disables={false}
                 tooltip={`${tr.editingCustomizeCardTemplates()} (${shortcutLabel})`}

--- a/ts/editor/NoteTypeButtons.svelte
+++ b/ts/editor/NoteTypeButtons.svelte
@@ -25,10 +25,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     </ButtonGroupItem>
 
     <ButtonGroupItem>
-        <WithShortcut
-            shortcut={[['Control', 'l']]}
-            let:createShortcut
-            let:shortcutLabel>
+        <WithShortcut shortcut={'Control+L'} let:createShortcut let:shortcutLabel>
             <LabelButton
                 disables={false}
                 tooltip={`${tr.editingCustomizeCardTemplates()} (${shortcutLabel})`}

--- a/ts/editor/PreviewButton.svelte
+++ b/ts/editor/PreviewButton.svelte
@@ -10,10 +10,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     import LabelButton from "components/LabelButton.svelte";
 </script>
 
-<WithShortcut
-    shortcut={[['Control', 'Shift', 'P']]}
-    let:createShortcut
-    let:shortcutLabel>
+<WithShortcut shortcut={'Control+Shift+P'} let:createShortcut let:shortcutLabel>
     <LabelButton
         tooltip={tr.browsingPreviewSelectedCard({ val: shortcutLabel })}
         disables={false}

--- a/ts/editor/PreviewButton.svelte
+++ b/ts/editor/PreviewButton.svelte
@@ -10,7 +10,10 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     import LabelButton from "components/LabelButton.svelte";
 </script>
 
-<WithShortcut shortcut="Control+Shift+KeyP" let:createShortcut let:shortcutLabel>
+<WithShortcut
+    shortcut={[['Control', 'Shift', 'P']]}
+    let:createShortcut
+    let:shortcutLabel>
     <LabelButton
         tooltip={tr.browsingPreviewSelectedCard({ val: shortcutLabel })}
         disables={false}

--- a/ts/editor/TemplateButtons.svelte
+++ b/ts/editor/TemplateButtons.svelte
@@ -36,7 +36,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
 <ButtonGroup {api}>
     <ButtonGroupItem>
-        <WithShortcut shortcut="F3" let:createShortcut let:shortcutLabel>
+        <WithShortcut shortcut={[['F3']]} let:createShortcut let:shortcutLabel>
             <IconButton
                 tooltip={appendInParentheses(tr.editingAttachPicturesaudiovideo(), shortcutLabel)}
                 on:click={onAttachment}
@@ -47,7 +47,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     </ButtonGroupItem>
 
     <ButtonGroupItem>
-        <WithShortcut shortcut="F5" let:createShortcut let:shortcutLabel>
+        <WithShortcut shortcut={[['F5']]} let:createShortcut let:shortcutLabel>
             <IconButton
                 tooltip={appendInParentheses(tr.editingRecordAudio(), shortcutLabel)}
                 on:click={onRecord}
@@ -69,7 +69,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
             <DropdownMenu id={menuId}>
                 <WithShortcut
-                    shortcut="Control+KeyM, KeyM"
+                    shortcut={[['Control', 'm'], ['m']]}
                     let:createShortcut
                     let:shortcutLabel>
                     <DropdownItem
@@ -81,7 +81,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
                 </WithShortcut>
 
                 <WithShortcut
-                    shortcut="Control+KeyM, KeyE"
+                    shortcut={[['Control', 'm'], ['e']]}
                     let:createShortcut
                     let:shortcutLabel>
                     <DropdownItem
@@ -93,7 +93,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
                 </WithShortcut>
 
                 <WithShortcut
-                    shortcut="Control+KeyM, KeyC"
+                    shortcut={[['Control', 'm'], ['c']]}
                     let:createShortcut
                     let:shortcutLabel>
                     <DropdownItem
@@ -105,7 +105,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
                 </WithShortcut>
 
                 <WithShortcut
-                    shortcut="Control+KeyT, KeyT"
+                    shortcut={[['Control', 't'], ['t']]}
                     let:createShortcut
                     let:shortcutLabel>
                     <DropdownItem
@@ -117,7 +117,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
                 </WithShortcut>
 
                 <WithShortcut
-                    shortcut="Control+KeyT, KeyE"
+                    shortcut={[['Control', 't'], ['e']]}
                     let:createShortcut
                     let:shortcutLabel>
                     <DropdownItem
@@ -129,7 +129,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
                 </WithShortcut>
 
                 <WithShortcut
-                    shortcut="Control+KeyT, KeyM"
+                    shortcut={[['Control', 't'], ['m']]}
                     let:createShortcut
                     let:shortcutLabel>
                     <DropdownItem
@@ -145,7 +145,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
     <ButtonGroupItem>
         <WithShortcut
-            shortcut="Control+Shift+KeyX"
+            shortcut={[['Control', 'Shift', 'X']]}
             let:createShortcut
             let:shortcutLabel>
             <IconButton

--- a/ts/editor/TemplateButtons.svelte
+++ b/ts/editor/TemplateButtons.svelte
@@ -36,7 +36,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
 <ButtonGroup {api}>
     <ButtonGroupItem>
-        <WithShortcut shortcut={[['F3']]} let:createShortcut let:shortcutLabel>
+        <WithShortcut shortcut={'F3'} let:createShortcut let:shortcutLabel>
             <IconButton
                 tooltip={appendInParentheses(tr.editingAttachPicturesaudiovideo(), shortcutLabel)}
                 on:click={onAttachment}
@@ -47,7 +47,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     </ButtonGroupItem>
 
     <ButtonGroupItem>
-        <WithShortcut shortcut={[['F5']]} let:createShortcut let:shortcutLabel>
+        <WithShortcut shortcut={'F5'} let:createShortcut let:shortcutLabel>
             <IconButton
                 tooltip={appendInParentheses(tr.editingRecordAudio(), shortcutLabel)}
                 on:click={onRecord}
@@ -69,7 +69,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
             <DropdownMenu id={menuId}>
                 <WithShortcut
-                    shortcut={[['Control', 'm'], ['m']]}
+                    shortcut={'Control+M, M'}
                     let:createShortcut
                     let:shortcutLabel>
                     <DropdownItem
@@ -81,7 +81,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
                 </WithShortcut>
 
                 <WithShortcut
-                    shortcut={[['Control', 'm'], ['e']]}
+                    shortcut={'Control+M, E'}
                     let:createShortcut
                     let:shortcutLabel>
                     <DropdownItem
@@ -93,7 +93,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
                 </WithShortcut>
 
                 <WithShortcut
-                    shortcut={[['Control', 'm'], ['c']]}
+                    shortcut={'Control+M, C'}
                     let:createShortcut
                     let:shortcutLabel>
                     <DropdownItem
@@ -105,7 +105,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
                 </WithShortcut>
 
                 <WithShortcut
-                    shortcut={[['Control', 't'], ['t']]}
+                    shortcut={'Control+T, T'}
                     let:createShortcut
                     let:shortcutLabel>
                     <DropdownItem
@@ -117,7 +117,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
                 </WithShortcut>
 
                 <WithShortcut
-                    shortcut={[['Control', 't'], ['e']]}
+                    shortcut={'Control+T, E'}
                     let:createShortcut
                     let:shortcutLabel>
                     <DropdownItem
@@ -129,7 +129,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
                 </WithShortcut>
 
                 <WithShortcut
-                    shortcut={[['Control', 't'], ['m']]}
+                    shortcut={'Control+T, M'}
                     let:createShortcut
                     let:shortcutLabel>
                     <DropdownItem
@@ -144,10 +144,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     </ButtonGroupItem>
 
     <ButtonGroupItem>
-        <WithShortcut
-            shortcut={[['Control', 'Shift', 'X']]}
-            let:createShortcut
-            let:shortcutLabel>
+        <WithShortcut shortcut={'Control+Shift+X'} let:createShortcut let:shortcutLabel>
             <IconButton
                 tooltip={appendInParentheses(tr.editingHtmlEditor(), shortcutLabel)}
                 on:click={onHtmlEdit}

--- a/ts/editor/inputHandlers.ts
+++ b/ts/editor/inputHandlers.ts
@@ -66,8 +66,8 @@ function updateFocus(evt: FocusEvent) {
 
 registerShortcut(
     () => document.addEventListener("focusin", updateFocus, { once: true }),
-    [["Tab"]],
-    ["Shift"]
+    [["Shift?", "Tab"]],
+    true
 );
 
 export function onKeyUp(evt: KeyboardEvent): void {

--- a/ts/editor/inputHandlers.ts
+++ b/ts/editor/inputHandlers.ts
@@ -66,8 +66,7 @@ function updateFocus(evt: FocusEvent) {
 
 registerShortcut(
     () => document.addEventListener("focusin", updateFocus, { once: true }),
-    [["Shift?", "Tab"]],
-    true
+    "Shift?+Tab"
 );
 
 export function onKeyUp(evt: KeyboardEvent): void {

--- a/ts/editor/inputHandlers.ts
+++ b/ts/editor/inputHandlers.ts
@@ -66,7 +66,7 @@ function updateFocus(evt: FocusEvent) {
 
 registerShortcut(
     () => document.addEventListener("focusin", updateFocus, { once: true }),
-    "Tab",
+    [["Tab"]],
     ["Shift"]
 );
 

--- a/ts/lib/shortcuts.ts
+++ b/ts/lib/shortcuts.ts
@@ -18,10 +18,6 @@ const platformModifiers = isApplePlatform()
     ? ["Meta", "Alt", "Shift", "Control"]
     : ["Control", "Alt", "Shift", "OS"];
 
-function splitKeyCombinationString(keyCombinationString: string): string[][] {
-    return keyCombinationString.split(", ").map((segment) => segment.split("+"));
-}
-
 function modifiersToPlatformString(modifiers: string[]): string {
     const displayModifiers = isApplePlatform()
         ? ["^", "⌥", "⇧", "⌘"]
@@ -70,14 +66,12 @@ function toPlatformString(modifiersAndKey: string[]): string {
     )}${keyToPlatformString(modifiersAndKey[modifiersAndKey.length - 1])}`;
 }
 
-export function getPlatformString(keyCombinationString: string): string {
-    return splitKeyCombinationString(keyCombinationString)
-        .map(toPlatformString)
-        .join(", ");
+export function getPlatformString(keyCombination: string[][]): string {
+    return keyCombination.map(toPlatformString).join(", ");
 }
 
 function checkKey(event: KeyboardEvent, key: string): boolean {
-    return event.code === key;
+    return event.key === key;
 }
 
 function checkModifiers(
@@ -139,10 +133,9 @@ function innerShortcut(
 
 export function registerShortcut(
     callback: (event: KeyboardEvent) => void,
-    keyCombinationString: string,
+    keyCombination: string[][],
     optionalModifiers: Modifier[] = []
 ): () => void {
-    const keyCombination = splitKeyCombinationString(keyCombinationString);
     const [firstKey, ...restKeys] = keyCombination;
 
     const handler = (event: KeyboardEvent): void => {

--- a/ts/lib/shortcuts.ts
+++ b/ts/lib/shortcuts.ts
@@ -60,10 +60,15 @@ function keyToPlatformString(key: string): string {
     }
 }
 
+function capitalize(key: string): string {
+    return key[0].toLocaleUpperCase() + key.slice(1);
+}
+
 function toPlatformString(modifiersAndKey: string[]): string {
-    return `${modifiersToPlatformString(
-        modifiersAndKey.slice(0, -1)
-    )}${keyToPlatformString(modifiersAndKey[modifiersAndKey.length - 1])}`;
+    return (
+        modifiersToPlatformString(modifiersAndKey.slice(0, -1)) +
+        capitalize(keyToPlatformString(modifiersAndKey[modifiersAndKey.length - 1]))
+    );
 }
 
 export function getPlatformString(keyCombination: string[][]): string {

--- a/ts/lib/shortcuts.ts
+++ b/ts/lib/shortcuts.ts
@@ -100,8 +100,6 @@ function check(
     );
 }
 
-const shortcutTimeoutMs = 400;
-
 function innerShortcut(
     lastEvent: KeyboardEvent,
     callback: (event: KeyboardEvent) => void,
@@ -119,13 +117,11 @@ function innerShortcut(
             if (check(event, optionalModifiers, nextKey)) {
                 innerShortcut(event, callback, optionalModifiers, ...restKeys);
                 clearTimeout(interval);
+            } else if (event.location === 0) {
+                // Any non-modifier key will cancel the shortcut sequence
+                document.removeEventListener("keydown", handler);
             }
         };
-
-        interval = setTimeout(
-            (): void => document.removeEventListener("keydown", handler),
-            shortcutTimeoutMs
-        );
 
         document.addEventListener("keydown", handler, { once: true });
     }

--- a/ts/lib/shortcuts.ts
+++ b/ts/lib/shortcuts.ts
@@ -105,6 +105,9 @@ function check(
     );
 }
 
+const GENERAL_KEY = 0;
+const NUMPAD_KEY = 3;
+
 function innerShortcut(
     lastEvent: KeyboardEvent,
     callback: (event: KeyboardEvent) => void,
@@ -122,7 +125,7 @@ function innerShortcut(
             if (check(event, optionalModifiers, nextKey)) {
                 innerShortcut(event, callback, optionalModifiers, ...restKeys);
                 clearTimeout(interval);
-            } else if (event.location === 0) {
+            } else if (event.location === GENERAL_KEY || event.location === NUMPAD_KEY) {
                 // Any non-modifier key will cancel the shortcut sequence
                 document.removeEventListener("keydown", handler);
             }


### PR DESCRIPTION
This adresses #1162 by moving to `event.key` instead of `event.code`. I still think there might be use cases for `event.code`, as I mentioned in the issue, for when we port the reviewert shortcuts.

This also removes the keyboard sequence timeout, and disables a started keyboard sequence if you press a "general key" (characterized by `event.location === 0`).