### PR TITLE
Fix browser.onChangeModel()

### DIFF
--- a/qt/aqt/browser/browser.py
+++ b/qt/aqt/browser/browser.py
@@ -528,7 +528,17 @@ where id in %s"""
     @skip_if_selection_is_empty
     @ensure_editor_saved
     def onChangeModel(self) -> None:
-        ChangeModel(self, self.oneModelNotes())
+        ids = self.selected_notes()
+        if self._is_one_notetype(ids):
+            ChangeModel(self, ids)
+        else:
+            showInfo(tr.browsing_please_select_cards_from_only_one())
+
+    def _is_one_notetype(self, ids: Sequence[NoteId]) -> bool:
+        query = f"select count(distinct mid) from notes where id in {ids2str(ids)}"
+        if self.col.db.scalar(query) == 1:
+            return True
+        return False
 
     def createFilteredDeck(self) -> None:
         search = self.current_search()

--- a/qt/aqt/browser/browser.py
+++ b/qt/aqt/browser/browser.py
@@ -498,21 +498,6 @@ class Browser(QMainWindow):
     def selectedNotesAsCards(self) -> Sequence[CardId]:
         return self.table.get_card_ids_from_selected_note_ids()
 
-    def oneModelNotes(self) -> Sequence[NoteId]:
-        sf = self.selected_notes()
-        if not sf:
-            return []
-        mods = self.col.db.scalar(
-            """
-select count(distinct mid) from notes
-where id in %s"""
-            % ids2str(sf)
-        )
-        if mods > 1:
-            showInfo(tr.browsing_please_select_cards_from_only_one())
-            return []
-        return sf
-
     def onHelp(self) -> None:
         openHelp(HelpPage.BROWSING)
 


### PR DESCRIPTION
https://forums.ankiweb.net/t/error-message-when-trying-to-change-note-type-2-1-45a2/10183

I deleted the old helper method because I think it behaved a bit awkward. Or should it be kept around for legacy reasons?