### PR TITLE
Tweak button styling for more consistency

### DIFF
--- a/ts/sass/buttons.scss
+++ b/ts/sass/buttons.scss
@@ -23,6 +23,10 @@
     }
 }
 
+button {
+    cursor: pointer;
+}
+
 .nightMode {
     button {
         -webkit-appearance: none;

--- a/ts/sass/buttons.scss
+++ b/ts/sass/buttons.scss
@@ -25,6 +25,11 @@
 
 button {
     cursor: pointer;
+    
+    /* override transition for instant hover response */
+    transition:
+        color .15s ease-in-out,
+        box-shadow .15s ease-in-out !important;
 }
 
 .nightMode {

--- a/ts/sass/buttons.scss
+++ b/ts/sass/buttons.scss
@@ -32,6 +32,12 @@ button {
         box-shadow .15s ease-in-out !important;
 }
 
+button.dropdown-item {
+    background: none;
+    box-shadow: none;
+    border: none;
+}
+
 .nightMode {
     button {
         -webkit-appearance: none;


### PR DESCRIPTION
This addresses two issues from https://github.com/ankitects/anki/pull/1190:
## Dropdown issue
### status quo
![Screenshot from 2021-05-23 16-06-23](https://user-images.githubusercontent.com/62722460/119263943-674bf900-bbe1-11eb-8abd-1f8770dd589d.png)
### PR
![Screenshot from 2021-05-23 16-16-43](https://user-images.githubusercontent.com/62722460/119264172-5059d680-bbe2-11eb-9182-8f29192f56b5.png)
## Transition
By default, Svelte buttons have a .15s background transition on hover. This results in a slow, perhaps even laggy feeling.
### Changes
- remove button styling from dropdown items
- override the default background transition in favour of instant hover response

---

### Extra
@dae After you showed me the three buttons on the bottom of the main window, I noticed they don't cause the cursor to switch to pointer mode. Since I couldn't think of a button that wouldn't benefit from this, I made it the default behaviour with https://github.com/ankitects/anki/commit/f2c286792af8b1e0b9c4af71f4813eaf4d0cd10c.

I would love to hear everyone's feedback on these changes and potential other improvements.