### PR TITLE
Tweak button styling for more consistency 

### DIFF
--- a/ts/components/DropdownItem.svelte
+++ b/ts/components/DropdownItem.svelte
@@ -28,6 +28,10 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         justify-content: space-between;
 
         font-size: calc(var(--toolbar-size) / 2.3);
+
+        background: none;
+        box-shadow: none;
+        border: none;
     }
 
     .btn-day {

--- a/ts/sass/base.scss
+++ b/ts/sass/base.scss
@@ -22,3 +22,8 @@ body,
 html {
     overscroll-behavior: none;
 }
+
+button {
+    /* override transition for instant hover response */
+    transition: color .15s ease-in-out, box-shadow .15s ease-in-out !important;
+}


### PR DESCRIPTION
@kleinerpirat
Closes #1192. This puts the styling directly into the components. I'm somewhat trying to move away from `buttons.scss` (and `bootstrap-dark.scss`).

Regarding the cursor change: The other Qt buttons and other input widgets don't change the cursor either, so for consistency for now I'd still leave it out. (Looking at an electron app like Slack however, I can see that they make all buttons/inputs change the cursor).