### PR TITLE
Fix height misalignment of legacy buttons

### DIFF
--- a/ts/editor/legacy.scss
+++ b/ts/editor/legacy.scss
@@ -12,8 +12,9 @@
     border-bottom-right-radius: var(--border-right-radius) !important;
     
     min-width: 28px;
+    min-height: 28px;
     margin-left: -1px;
-    padding: 3.5px !important;
+    padding: 0px !important;
 }
 
 .linkb:hover,


### PR DESCRIPTION
Follow-up on https://github.com/ankitects/anki/pull/1190 due to crippling perfectionism.
Sorry for not noticing earlier, but the legacy button height didn't match the default button height.

### Before
![image](https://user-images.githubusercontent.com/62722460/119470060-3c2fe980-bd48-11eb-9c3d-acac79cc5494.png)

**The mismatch causes this atrocity** (when all buttons are in one line):
![image](https://user-images.githubusercontent.com/62722460/119470394-95981880-bd48-11eb-883c-474cdb7e1bd1.png)

The color picker seems to be the only button with a fixed height of 28px, all the others adjust to the greatest height (in that case defined by the legacy buttons) automatically.

---

### After
![image](https://user-images.githubusercontent.com/62722460/119470738-e6a80c80-bd48-11eb-8400-7b4fba292c9f.png)

**Misalignment fixed:**
![image](https://user-images.githubusercontent.com/62722460/119470514-b3fe1400-bd48-11eb-9b6a-b9f9b69e437d.png)

## Changes:
- add min-height 28px
- set padding to 0px (class btn-group has enough padding on its own)