### PR TITLE
Fix height misalignment of legacy buttons

### DIFF
--- a/ts/editor/legacy.scss
+++ b/ts/editor/legacy.scss
@@ -10,10 +10,11 @@
     border-bottom-left-radius: var(--border-left-radius) !important;
     border-top-right-radius: var(--border-right-radius) !important;
     border-bottom-right-radius: var(--border-right-radius) !important;
-    
-    min-width: 28px;
+
+    min-width: calc(var(--toolbar-size) - 2px);
+    min-height: calc(var(--toolbar-size) - 2px);
     margin-left: -1px;
-    padding: 3.5px !important;
+    padding: 0 !important;
 }
 
 .linkb:hover,
@@ -45,7 +46,7 @@
     .linkb {
         margin-left: 1px;
     }
-    
+
     .linkb:hover {
         background-color: #7a7a7a;
         border-color: #7a7a7a;
@@ -59,7 +60,7 @@
             rgba(0, 0, 0, 0.35);
         border-color: #525252;
     }
-    
+
     img.topbut,
     .linkb:active:hover img.topbut {
         filter: invert(1);

--- a/ts/editor/legacy.scss
+++ b/ts/editor/legacy.scss
@@ -1,9 +1,11 @@
-@use "ts/sass/button_mixins" as button;
-
 .linkb {
     display: inline-block;
+    width: calc(var(--toolbar-size) - 2px);
+    height: calc(var(--toolbar-size) - 2px);
+
     background-color: white;
     border: 1px solid var(--medium-border);
+    padding: 0 !important;
 
     /* !important cannot be used with @include */
     border-top-left-radius: var(--border-left-radius) !important;
@@ -11,28 +13,34 @@
     border-top-right-radius: var(--border-right-radius) !important;
     border-bottom-right-radius: var(--border-right-radius) !important;
 
-    min-width: calc(var(--toolbar-size) - 2px);
-    min-height: calc(var(--toolbar-size) - 2px);
     margin-left: -1px;
-    padding: 0 !important;
-}
 
-.linkb:hover,
-.linkb:active:hover {
-    background-color: #ebebeb;
-}
+    &:hover {
+        background-color: #ebebeb;
+    }
 
-.linkb:active,
-.linkb:active:hover {
-    background-color: white;
-    box-shadow: inset 0
-        calc(var(--toolbar-size) / 15)
-        calc(var(--toolbar-size) / 5)
-        rgba(0, 0, 0, 0.25);
-}
+    &:active,
+    &:active:hover {
+        background-color: white;
+        box-shadow: inset 0 calc(var(--toolbar-size) / 15) calc(var(--toolbar-size) / 5)
+            rgba(0, 0, 0, 0.25);
+    }
 
-.linkb:active:hover .topbut {
-    filter: invert(1) grayscale(1) brightness(100);
+    .nightMode & {
+        margin-left: 1px;
+
+        &:hover {
+            background-color: #7a7a7a;
+            border-color: #7a7a7a;
+        }
+
+        &:active,
+        &:active:hover {
+            box-shadow: inset 0 calc(var(--toolbar-size) / 15)
+                calc(var(--toolbar-size) / 5) rgba(0, 0, 0, 0.35);
+            border-color: #525252;
+        }
+    }
 }
 
 .topbut {
@@ -42,27 +50,6 @@
     height: calc(var(--toolbar-size) - 12px);
 }
 
-.nightMode {
-    .linkb {
-        margin-left: 1px;
-    }
-
-    .linkb:hover {
-        background-color: #7a7a7a;
-        border-color: #7a7a7a;
-    }
-
-    .linkb:active,
-    .linkb:active:hover {
-        box-shadow: inset 0
-            calc(var(--toolbar-size) / 15)
-            calc(var(--toolbar-size) / 5)
-            rgba(0, 0, 0, 0.35);
-        border-color: #525252;
-    }
-
-    img.topbut,
-    .linkb:active:hover img.topbut {
-        filter: invert(1);
-    }
+.nightMode img.topbut {
+    filter: invert(1);
 }

--- a/ts/editor/legacy.scss
+++ b/ts/editor/legacy.scss
@@ -1,7 +1,7 @@
 .linkb {
     display: inline-block;
-    width: calc(var(--toolbar-size) - 2px);
-    height: calc(var(--toolbar-size) - 2px);
+    min-width: calc(var(--toolbar-size) - 2px);
+    min-height: calc(var(--toolbar-size) - 2px);
 
     background-color: white;
     border: 1px solid var(--medium-border);

--- a/ts/sass/base.scss
+++ b/ts/sass/base.scss
@@ -25,5 +25,5 @@ html {
 
 button {
     /* override transition for instant hover response */
-    transition: color .15s ease-in-out, box-shadow .15s ease-in-out !important;
+    transition: color 0.15s ease-in-out, box-shadow 0.15s ease-in-out !important;
 }


### PR DESCRIPTION
Another approach to #1194.

@kleinerpirat Could you have a look this covers all your cases? Specifically, I removed this line: ` filter: invert(1) grayscale(1) brightness(100)`. I couldn't quite see what was its purpose, and it removed the color of the color selector from "Mini format pack" upon `:active` state.