### PR TITLE
Fix some sidebar issues

### DIFF
--- a/qt/aqt/browser/sidebar/item.py
+++ b/qt/aqt/browser/sidebar/item.py
@@ -140,6 +140,11 @@ class SidebarItem:
                 return self.full_name == other.full_name
             elif self.item_type == SidebarItemType.SAVED_SEARCH:
                 return self.name == other.name
+            elif self.item_type == SidebarItemType.NOTETYPE_TEMPLATE:
+                return (
+                    other.id == self.id
+                    and other._parent_item.id == self._parent_item.id
+                )
             else:
                 return other.id == self.id
 

--- a/qt/aqt/browser/sidebar/toolbar.py
+++ b/qt/aqt/browser/sidebar/toolbar.py
@@ -30,6 +30,7 @@ class SidebarToolbar(QToolBar):
         qconnect(self._action_group.triggered, self._on_action_group_triggered)
         self._setup_tools()
         self.setIconSize(QSize(16, 16))
+        self.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
         self.setStyle(QStyleFactory.create("fusion"))
 
     def _setup_tools(self) -> None:


### PR DESCRIPTION
Is it intentional that the `rename_tag()` op returns success in the case of an unused tag which can't be renamed?
I ended up copying the success code to catch this case.