### PR TITLE
Detect MathJax and Wikipedia equations when pasting text

### DIFF
--- a/pip/requirements.txt
+++ b/pip/requirements.txt
@@ -156,3 +156,5 @@ pip==21.1.1
     # via pip-tools
 setuptools==56.1.0
     # via jsonschema
+
+lxml


### PR DESCRIPTION
This PR adds an idea to transform equations from Wikipedia and MathJax HTML elements into Anki's `\[ ... \]` and `\( ... \)` formats.

- Wikipedia equations are straightforward, I lookup the class name for equations and extract the LaTeX string from the image attribute.
- MathJax contains the MathML expression, which needs to be transformed into LaTeX. For this purpose, I have added a downloader of [these files](https://github.com/oerpub/mathconverter/tree/master/xsl_yarosh), (under [MIT license](https://github.com/oerpub/mathconverter/blob/master/LICENSE)), which are XSL transformation rules to convert MathML XML into LaTeX.