### PR TITLE
Implement new text color / highlight color buttons

### DIFF
--- a/ts/components/ColorPicker.svelte
+++ b/ts/components/ColorPicker.svelte
@@ -3,72 +3,21 @@ Copyright: Ankitects Pty Ltd and contributors
 License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 -->
 <script lang="typescript">
-    import { onMount, createEventDispatcher, getContext } from "svelte";
-    import { nightModeKey } from "./contextKeys";
+    import { onMount, createEventDispatcher } from "svelte";
 
-    export let id: string | undefined = undefined;
-    let className = "";
-    export { className as class };
-
-    export let tooltip: string | undefined = undefined;
-
-    const nightMode = getContext(nightModeKey);
-
-    function delegateToInput() {
-        inputRef.click();
-    }
-
-    let buttonRef: HTMLButtonElement;
     let inputRef: HTMLInputElement;
 
     const dispatch = createEventDispatcher();
-    onMount(() => dispatch("mount", { button: buttonRef, input: inputRef }));
+    onMount(() => dispatch("mount", { input: inputRef }));
 </script>
 
-<button
-    bind:this={buttonRef}
-    tabindex="-1"
-    {id}
-    class={`btn ${className}`}
-    class:btn-day={!nightMode}
-    class:btn-night={nightMode}
-    title={tooltip}
-    on:click={delegateToInput}
-    on:mousedown|preventDefault
->
-    <input tabindex="-1" bind:this={inputRef} type="color" on:change />
-</button>
+<input tabindex="-1" bind:this={inputRef} type="color" on:change />
 
 <style lang="scss">
-    @use "ts/sass/button_mixins" as button;
-
-    @import "ts/sass/bootstrap/functions";
-    @import "ts/sass/bootstrap/variables";
-
-    button {
-        width: calc(var(--buttons-size) - 0px);
-        height: calc(var(--buttons-size) - 0px);
-
-        padding: 4px;
-        overflow: hidden;
-
-        border-top-left-radius: var(--border-left-radius);
-        border-bottom-left-radius: var(--border-left-radius);
-
-        border-top-right-radius: var(--border-right-radius);
-        border-bottom-right-radius: var(--border-right-radius);
-    }
-
-    @include button.btn-day($with-disabled: false) using ($base) {
-        @include button.rainbow($base);
-    }
-
-    @include button.btn-night($with-disabled: false) using ($base) {
-        @include button.rainbow($base);
-    }
-
     input {
         display: inline-block;
+        width: 100%;
+        height: 100%;
         cursor: pointer;
         opacity: 0;
     }

--- a/ts/components/IconButton.svelte
+++ b/ts/components/IconButton.svelte
@@ -13,6 +13,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     export { className as class };
 
     export let tooltip: string | undefined = undefined;
+    export let iconSize: number = 80;
     export let active = false;
     export let disables = true;
     export let tabbable = false;
@@ -37,6 +38,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     class:dropdown-toggle={dropdownProps.dropdown}
     class:btn-day={!nightMode}
     class:btn-night={nightMode}
+    style={`--icon-size: ${iconSize}%`}
     title={tooltip}
     {...dropdownProps}
     disabled={_disabled}
@@ -44,7 +46,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     on:click
     on:mousedown|preventDefault
 >
-    <span class="p-1"><slot /></span>
+    <span> <slot /> </span>
 </button>
 
 <style lang="scss">
@@ -60,6 +62,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
     span {
         display: inline-block;
+        position: relative;
         vertical-align: middle;
 
         /* constrain icon */
@@ -68,10 +71,16 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
         & > :global(svg),
         & > :global(img) {
+            position: absolute;
+            width: var(--icon-size);
+            height: var(--icon-size);
+            top: calc((100% - var(--icon-size)) / 2);
+            bottom: calc((100% - var(--icon-size)) / 2);
+            left: calc((100% - var(--icon-size)) / 2);
+            right: calc((100% - var(--icon-size)) / 2);
+
             fill: currentColor;
             vertical-align: unset;
-            width: 100%;
-            height: 100%;
         }
     }
 

--- a/ts/components/IconButton.svelte
+++ b/ts/components/IconButton.svelte
@@ -13,10 +13,12 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     export { className as class };
 
     export let tooltip: string | undefined = undefined;
-    export let iconSize: number = 80;
     export let active = false;
     export let disables = true;
     export let tabbable = false;
+
+    export let iconSize: number = 80;
+    export let widthMultiplier: number = 1;
 
     let buttonRef: HTMLButtonElement;
 
@@ -46,7 +48,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     on:click
     on:mousedown|preventDefault
 >
-    <span> <slot /> </span>
+    <span style={`--width-multiplier: ${widthMultiplier};`}> <slot /> </span>
 </button>
 
 <style lang="scss">
@@ -66,7 +68,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         vertical-align: middle;
 
         /* constrain icon */
-        width: calc(var(--buttons-size) - 2px);
+        width: calc((var(--buttons-size) - 2px) * var(--width-multiplier));
         height: calc(var(--buttons-size) - 2px);
 
         & > :global(svg),

--- a/ts/components/IconButton.svelte
+++ b/ts/components/IconButton.svelte
@@ -17,7 +17,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     export let disables = true;
     export let tabbable = false;
 
-    export let iconSize: number = 80;
+    export let iconSize: number = 75;
     export let widthMultiplier: number = 1;
 
     let buttonRef: HTMLButtonElement;

--- a/ts/editor/BUILD.bazel
+++ b/ts/editor/BUILD.bazel
@@ -38,7 +38,6 @@ compile_sass(
 
 compile_sass(
     srcs = [
-        "color.scss",
         "fields.scss",
     ],
     group = "base_css",

--- a/ts/editor/BUILD.bazel
+++ b/ts/editor/BUILD.bazel
@@ -113,6 +113,10 @@ copy_mdi_icons(
         "function-variant.svg",
         "code-brackets.svg",
         "xml.svg",
+
+        "format-color-text.svg",
+        "format-color-highlight.svg",
+        "color-helper.svg",
     ],
     visibility = ["//visibility:public"],
 )

--- a/ts/editor/ColorButtons.svelte
+++ b/ts/editor/ColorButtons.svelte
@@ -12,7 +12,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     import WithShortcut from "components/WithShortcut.svelte";
     import WithColorHelper from "./WithColorHelper.svelte";
 
-    import { textColorIcon, highlightColorIcon } from "./icons";
+    import { textColorIcon, highlightColorIcon, arrowIcon } from "./icons";
     import { appendInParentheses } from "./helpers";
 
     export let api = {};
@@ -52,7 +52,9 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
                         shortcutLabel
                     )}
                     disables={false}
+                    widthMultiplier={0.5}
                 >
+                    {@html arrowIcon}
                     <ColorPicker on:change={setColor} on:mount={createShortcut} />
                 </IconButton>
             </WithShortcut>
@@ -61,23 +63,19 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
     <WithColorHelper let:colorHelperIcon let:color let:setColor>
         <ButtonGroupItem>
-            <WithShortcut shortcut={"F7"} let:createShortcut let:shortcutLabel>
-                <IconButton
-                    tooltip={appendInParentheses(
-                        tr.editingSetForegroundColor(),
-                        shortcutLabel
-                    )}
-                    on:click={wrapWithBackcolor(color)}
-                    on:mount={createShortcut}
-                >
-                    {@html highlightColorIcon}
-                    {@html colorHelperIcon}
-                </IconButton>
-            </WithShortcut>
+            <IconButton on:click={wrapWithBackcolor(color)}>
+                {@html highlightColorIcon}
+                {@html colorHelperIcon}
+            </IconButton>
         </ButtonGroupItem>
 
         <ButtonGroupItem>
-            <IconButton tooltip={tr.editingChangeColor()} disables={false}>
+            <IconButton
+                tooltip={tr.editingChangeColor()}
+                disables={false}
+                widthMultiplier={0.5}
+            >
+                {@html arrowIcon}
                 <ColorPicker on:change={setColor} />
             </IconButton>
         </ButtonGroupItem>

--- a/ts/editor/ColorButtons.svelte
+++ b/ts/editor/ColorButtons.svelte
@@ -8,66 +8,26 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     import ButtonGroup from "components/ButtonGroup.svelte";
     import ButtonGroupItem from "components/ButtonGroupItem.svelte";
     import IconButton from "components/IconButton.svelte";
+    import ColorPicker from "components/ColorPicker.svelte";
     import WithShortcut from "components/WithShortcut.svelte";
     import WithColorHelper from "./WithColorHelper.svelte";
 
     import { textColorIcon, highlightColorIcon } from "./icons";
     import { appendInParentheses } from "./helpers";
 
-    import "./color.css";
-
     export let api = {};
-
-    const foregroundColorKeyword = "--foreground-color";
-    let color = "black";
-
-    $: {
-        document.documentElement.style.setProperty(foregroundColorKeyword, color);
-    }
 
     const wrapWithForecolor = (color: string) => () => {
         document.execCommand("forecolor", false, color);
-    }
+    };
 
     const wrapWithBackcolor = (color: string) => () => {
         document.execCommand("backcolor", false, color);
-    }
-
-    function setWithCurrentColor({ currentTarget }: Event): void {
-        color = (currentTarget as HTMLInputElement).value;
-    }
+    };
 </script>
 
 <ButtonGroup {api}>
-    <!--
-    <ButtonGroupItem>
-        <WithShortcut shortcut={"F7"} let:createShortcut let:shortcutLabel>
-            <IconButton
-                class="forecolor"
-                tooltip={appendInParentheses(
-                    tr.editingSetForegroundColor(),
-                    shortcutLabel
-                )}
-                on:click={wrapWithForecolor}
-                on:mount={createShortcut}
-            >
-                {@html squareFillIcon}
-            </IconButton>
-        </WithShortcut>
-    </ButtonGroupItem>
-
-    <ButtonGroupItem>
-        <WithShortcut shortcut={"F8"} let:createShortcut let:shortcutLabel>
-            <ColorPicker
-                tooltip={appendInParentheses(tr.editingChangeColor(), shortcutLabel)}
-                on:change={setWithCurrentColor}
-                on:mount={createShortcut}
-            />
-        </WithShortcut>
-    </ButtonGroupItem>
-    -->
-
-    <WithColorHelper let:colorHelperIcon let:color>
+    <WithColorHelper let:colorHelperIcon let:color let:setColor>
         <ButtonGroupItem>
             <WithShortcut shortcut={"F7"} let:createShortcut let:shortcutLabel>
                 <IconButton
@@ -83,9 +43,23 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
                 </IconButton>
             </WithShortcut>
         </ButtonGroupItem>
+
+        <ButtonGroupItem>
+            <WithShortcut shortcut={"F8"} let:createShortcut let:shortcutLabel>
+                <IconButton
+                    tooltip={appendInParentheses(
+                        tr.editingChangeColor(),
+                        shortcutLabel
+                    )}
+                    disables={false}
+                >
+                    <ColorPicker on:change={setColor} on:mount={createShortcut} />
+                </IconButton>
+            </WithShortcut>
+        </ButtonGroupItem>
     </WithColorHelper>
 
-    <WithColorHelper let:colorHelperIcon let:color>
+    <WithColorHelper let:colorHelperIcon let:color let:setColor>
         <ButtonGroupItem>
             <WithShortcut shortcut={"F7"} let:createShortcut let:shortcutLabel>
                 <IconButton
@@ -100,6 +74,12 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
                     {@html colorHelperIcon}
                 </IconButton>
             </WithShortcut>
+        </ButtonGroupItem>
+
+        <ButtonGroupItem>
+            <IconButton tooltip={tr.editingChangeColor()} disables={false}>
+                <ColorPicker on:change={setColor} />
+            </IconButton>
         </ButtonGroupItem>
     </WithColorHelper>
 </ButtonGroup>

--- a/ts/editor/ColorButtons.svelte
+++ b/ts/editor/ColorButtons.svelte
@@ -8,10 +8,10 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     import ButtonGroup from "components/ButtonGroup.svelte";
     import ButtonGroupItem from "components/ButtonGroupItem.svelte";
     import IconButton from "components/IconButton.svelte";
-    import ColorPicker from "components/ColorPicker.svelte";
     import WithShortcut from "components/WithShortcut.svelte";
+    import WithColorHelper from "./WithColorHelper.svelte";
 
-    import { squareFillIcon } from "./icons";
+    import { textColorIcon, highlightColorIcon } from "./icons";
     import { appendInParentheses } from "./helpers";
 
     import "./color.css";
@@ -25,8 +25,12 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         document.documentElement.style.setProperty(foregroundColorKeyword, color);
     }
 
-    function wrapWithForecolor(): void {
+    const wrapWithForecolor = (color: string) => () => {
         document.execCommand("forecolor", false, color);
+    }
+
+    const wrapWithBackcolor = (color: string) => () => {
+        document.execCommand("backcolor", false, color);
     }
 
     function setWithCurrentColor({ currentTarget }: Event): void {
@@ -35,6 +39,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 </script>
 
 <ButtonGroup {api}>
+    <!--
     <ButtonGroupItem>
         <WithShortcut shortcut={"F7"} let:createShortcut let:shortcutLabel>
             <IconButton
@@ -60,4 +65,41 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
             />
         </WithShortcut>
     </ButtonGroupItem>
+    -->
+
+    <WithColorHelper let:colorHelperIcon let:color>
+        <ButtonGroupItem>
+            <WithShortcut shortcut={"F7"} let:createShortcut let:shortcutLabel>
+                <IconButton
+                    tooltip={appendInParentheses(
+                        tr.editingSetForegroundColor(),
+                        shortcutLabel
+                    )}
+                    on:click={wrapWithForecolor(color)}
+                    on:mount={createShortcut}
+                >
+                    {@html textColorIcon}
+                    {@html colorHelperIcon}
+                </IconButton>
+            </WithShortcut>
+        </ButtonGroupItem>
+    </WithColorHelper>
+
+    <WithColorHelper let:colorHelperIcon let:color>
+        <ButtonGroupItem>
+            <WithShortcut shortcut={"F7"} let:createShortcut let:shortcutLabel>
+                <IconButton
+                    tooltip={appendInParentheses(
+                        tr.editingSetForegroundColor(),
+                        shortcutLabel
+                    )}
+                    on:click={wrapWithBackcolor(color)}
+                    on:mount={createShortcut}
+                >
+                    {@html highlightColorIcon}
+                    {@html colorHelperIcon}
+                </IconButton>
+            </WithShortcut>
+        </ButtonGroupItem>
+    </WithColorHelper>
 </ButtonGroup>

--- a/ts/editor/TemplateButtons.svelte
+++ b/ts/editor/TemplateButtons.svelte
@@ -42,6 +42,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
                     tr.editingAttachPicturesaudiovideo(),
                     shortcutLabel
                 )}
+                iconSize={70}
                 on:click={onAttachment}
                 on:mount={createShortcut}
             >
@@ -54,6 +55,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         <WithShortcut shortcut={"F5"} let:createShortcut let:shortcutLabel>
             <IconButton
                 tooltip={appendInParentheses(tr.editingRecordAudio(), shortcutLabel)}
+                iconSize={70}
                 on:click={onRecord}
                 on:mount={createShortcut}
             >
@@ -164,6 +166,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         <WithShortcut shortcut={"Control+Shift+X"} let:createShortcut let:shortcutLabel>
             <IconButton
                 tooltip={appendInParentheses(tr.editingHtmlEditor(), shortcutLabel)}
+                iconSize={70}
                 on:click={onHtmlEdit}
                 on:mount={createShortcut}
             >

--- a/ts/editor/WithColorHelper.svelte
+++ b/ts/editor/WithColorHelper.svelte
@@ -1,0 +1,23 @@
+<!--
+Copyright: Ankitects Pty Ltd and contributors
+License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
+-->
+<script lang="typescript">
+    import { colorHelperIcon } from "./icons";
+
+    export let color = "black";
+
+    function setColor(newColor: string): void {
+        color = newColor;
+    }
+</script>
+
+<div style={`--color-helper-color: ${color}`}>
+    <slot {colorHelperIcon} {color} {setColor} />
+</div>
+
+<style lang="scss">
+    div :global(#mdi-color-helper) {
+        fill: var(--color-helper-color);
+    }
+</style>

--- a/ts/editor/WithColorHelper.svelte
+++ b/ts/editor/WithColorHelper.svelte
@@ -7,8 +7,8 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
     export let color = "black";
 
-    function setColor(newColor: string): void {
-        color = newColor;
+    function setColor({ currentTarget }: Event): void {
+        color = (currentTarget! as HTMLInputElement).value;
     }
 </script>
 
@@ -17,7 +17,11 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 </div>
 
 <style lang="scss">
-    div :global(#mdi-color-helper) {
-        fill: var(--color-helper-color);
+    div {
+        display: contents;
+
+        :global(#mdi-color-helper) {
+            fill: var(--color-helper-color);
+        }
     }
 </style>

--- a/ts/editor/color.scss
+++ b/ts/editor/color.scss
@@ -1,7 +1,0 @@
-:root {
-    --foreground-color: black;
-}
-
-.forecolor {
-    color: var(--foreground-color) !important;
-}

--- a/ts/editor/icons.ts
+++ b/ts/editor/icons.ts
@@ -23,7 +23,7 @@ export { default as outdentIcon } from "./text-indent-right.svg";
 export { default as squareFillIcon } from "./square-fill.svg";
 export { default as textColorIcon } from "./format-color-text.svg";
 export { default as highlightColorIcon } from "./format-color-highlight.svg";
-export { default as colorHelper } from "./color-helper.svg";
+export { default as colorHelperIcon } from "./color-helper.svg";
 
 export { default as paperclipIcon } from "./paperclip.svg";
 export { default as micIcon } from "./mic.svg";

--- a/ts/editor/icons.ts
+++ b/ts/editor/icons.ts
@@ -30,3 +30,6 @@ export { default as micIcon } from "./mic.svg";
 export { default as bracketsIcon } from "./code-brackets.svg";
 export { default as functionIcon } from "./function-variant.svg";
 export { default as xmlIcon } from "./xml.svg";
+
+export const arrowIcon =
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"><path fill="transparent" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2 5l6 6 6-6"/></svg>';

--- a/ts/editor/icons.ts
+++ b/ts/editor/icons.ts
@@ -21,6 +21,9 @@ export { default as indentIcon } from "./text-indent-left.svg";
 export { default as outdentIcon } from "./text-indent-right.svg";
 
 export { default as squareFillIcon } from "./square-fill.svg";
+export { default as textColorIcon } from "./format-color-text.svg";
+export { default as highlightColorIcon } from "./format-color-highlight.svg";
+export { default as colorHelper } from "./color-helper.svg";
 
 export { default as paperclipIcon } from "./paperclip.svg";
 export { default as micIcon } from "./mic.svg";

--- a/ts/sass/button_mixins.scss
+++ b/ts/sass/button_mixins.scss
@@ -116,13 +116,3 @@ $focus-color: $blue;
     box-shadow: inset 0 calc(var(--buttons-size) / 15) calc(var(--buttons-size) / 5)
         rgba(black, $intensity);
 }
-
-@mixin rainbow($base) {
-    background: content-box
-            linear-gradient(217deg, rgba(255, 0, 0, 0.8), rgba(255, 0, 0, 0) 70.71%),
-        content-box
-            linear-gradient(127deg, rgba(0, 255, 0, 0.8), rgba(0, 255, 0, 0) 70.71%),
-        content-box
-            linear-gradient(336deg, rgba(0, 0, 255, 0.8), rgba(0, 0, 255, 0) 70.71%),
-        border-box $base;
-}


### PR DESCRIPTION
I've made some CSS changes to `IconButton`, which allows for better control:
1. `iconSize` allows how much of the available width/height of a button an icon uses.
2. `widthMultiplier` allows for changing the icon button width from its original square design

<img width="692" alt="Screenshot 2021-05-31 at 00 34 38" src="https://user-images.githubusercontent.com/7188844/120122270-09eb1580-c1a8-11eb-92d2-9e07bced9286.png">

What do you think about instead of using the terms "foreground color" and "background color" for those buttons, using "text color" and "highlight color"? I think those terms might better describe the behavior for users, and better suit their icons as well.