### PR TITLE
Apply grid layout to deck options 2

### DIFF
--- a/ts/deckoptions/AudioOptions.svelte
+++ b/ts/deckoptions/AudioOptions.svelte
@@ -4,7 +4,6 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 -->
 <script lang="ts">
     import * as tr from "lib/i18n";
-    import SpinBox from "./SpinBox.svelte";
     import CheckBox from "./CheckBox.svelte";
     import type { DeckOptionsState } from "./lib";
 
@@ -12,25 +11,6 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     let config = state.currentConfig;
     let defaults = state.defaults;
 </script>
-
-<h2>{tr.deckConfigTimerTitle()}</h2>
-
-<SpinBox
-    label={tr.deckConfigMaximumAnswerSecs()}
-    tooltip={tr.deckConfigMaximumAnswerSecsTooltip()}
-    min={30}
-    max={600}
-    defaultValue={defaults.capAnswerTimeToSecs}
-    bind:value={$config.capAnswerTimeToSecs}
-/>
-
-<CheckBox
-    id="showAnswerTimer"
-    label={tr.schedulingShowAnswerTimer()}
-    tooltip={tr.deckConfigShowAnswerTimerTooltip()}
-    defaultValue={defaults.showTimer}
-    bind:value={$config.showTimer}
-/>
 
 <h2>{tr.deckConfigAudioTitle()}</h2>
 

--- a/ts/deckoptions/ConfigEditor.svelte
+++ b/ts/deckoptions/ConfigEditor.svelte
@@ -9,7 +9,8 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     import AdvancedOptions from "./AdvancedOptions.svelte";
     import BuryOptions from "./BuryOptions.svelte";
     import LapseOptions from "./LapseOptions.svelte";
-    import GeneralOptions from "./GeneralOptions.svelte";
+    import TimerOptions from "./TimerOptions.svelte";
+    import AudioOptions from "./AudioOptions.svelte";
     import Addons from "./Addons.svelte";
     import type { DeckOptionsState } from "./lib";
 
@@ -17,16 +18,43 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 </script>
 
 <div class="outer">
-    <DailyLimits {state} />
-    <NewOptions {state} />
-    <LapseOptions {state} />
-    <BuryOptions {state} />
+    <div class="small">
+        <DailyLimits {state} />
+    </div>
+
+    <div class="large">
+        <NewOptions {state} />
+    </div>
+
+    <div class="large">
+        <LapseOptions {state} />
+    </div>
+
+    <div class="small">
+        <BuryOptions {state} />
+    </div>
+
     {#if state.v3Scheduler}
-        <DisplayOrder {state} />
+        <div class="small">
+            <DisplayOrder {state} />
+        </div>
     {/if}
-    <GeneralOptions {state} />
-    <Addons {state} />
-    <AdvancedOptions {state} />
+
+    <div class="small">
+        <TimerOptions {state} />
+    </div>
+
+    <div class="small">
+        <AudioOptions {state} />
+    </div>
+
+    <div class="small">
+        <Addons {state} />
+    </div>
+
+    <div class="large">
+        <AdvancedOptions {state} />
+    </div>
 </div>
 
 <style lang="scss">
@@ -35,14 +63,28 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         font-weight: bold;
         // adding a border decreases the default font size,
         // so increase it again
-        font-size: 2em;
+        font-size: 1.5em;
         border-bottom: 1px solid var(--medium-border);
         margin-right: 16px;
         margin-bottom: 0.5em;
     }
     .outer {
         // the right margin has an indent to allow for the undo
-        // buttons; add the same indent on the left for balance
-        padding-left: 16px;
+        // buttons; add some indentation on the left for balance
+        padding-left: 6px;
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(24em, 1fr));
+        column-gap: 2em;
+        row-gap: 1.5em;
     }
+
+    .small {
+        grid-row: span 1;
+    }
+
+    // make grid items with more options span two rows
+    .large {
+        grid-row: span 2;
+    }
+
 </style>

--- a/ts/deckoptions/LapseOptions.svelte
+++ b/ts/deckoptions/LapseOptions.svelte
@@ -27,39 +27,37 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     const leechChoices = [tr.actionsSuspendCard(), tr.schedulingTagOnly()];
 </script>
 
-<div>
-    <h2>{tr.schedulingLapses()}</h2>
+<h2>{tr.schedulingLapses()}</h2>
 
-    <StepsInput
-        label={tr.deckConfigRelearningSteps()}
-        tooltip={tr.deckConfigRelearningStepsTooltip()}
-        defaultValue={defaults.relearnSteps}
-        value={$config.relearnSteps}
-        on:changed={(evt) => ($config.relearnSteps = evt.detail.value)}
-    />
+<StepsInput
+    label={tr.deckConfigRelearningSteps()}
+    tooltip={tr.deckConfigRelearningStepsTooltip()}
+    defaultValue={defaults.relearnSteps}
+    value={$config.relearnSteps}
+    on:changed={(evt) => ($config.relearnSteps = evt.detail.value)}
+/>
 
-    <SpinBox
-        label={tr.schedulingMinimumInterval()}
-        tooltip={tr.deckConfigMinimumIntervalTooltip()}
-        warnings={[stepsExceedMinimumInterval]}
-        min={1}
-        defaultValue={defaults.minimumLapseInterval}
-        bind:value={$config.minimumLapseInterval}
-    />
+<SpinBox
+    label={tr.schedulingMinimumInterval()}
+    tooltip={tr.deckConfigMinimumIntervalTooltip()}
+    warnings={[stepsExceedMinimumInterval]}
+    min={1}
+    defaultValue={defaults.minimumLapseInterval}
+    bind:value={$config.minimumLapseInterval}
+/>
 
-    <SpinBox
-        label={tr.schedulingLeechThreshold()}
-        tooltip={tr.deckConfigLeechThresholdTooltip()}
-        min={1}
-        defaultValue={defaults.leechThreshold}
-        bind:value={$config.leechThreshold}
-    />
+<SpinBox
+    label={tr.schedulingLeechThreshold()}
+    tooltip={tr.deckConfigLeechThresholdTooltip()}
+    min={1}
+    defaultValue={defaults.leechThreshold}
+    bind:value={$config.leechThreshold}
+/>
 
-    <EnumSelector
-        label={tr.schedulingLeechAction()}
-        tooltip={tr.deckConfigLeechActionTooltip()}
-        choices={leechChoices}
-        defaultValue={defaults.leechAction}
-        bind:value={$config.leechAction}
-    />
-</div>
+<EnumSelector
+    label={tr.schedulingLeechAction()}
+    tooltip={tr.deckConfigLeechActionTooltip()}
+    choices={leechChoices}
+    defaultValue={defaults.leechAction}
+    bind:value={$config.leechAction}
+/>

--- a/ts/deckoptions/TimerOptions.svelte
+++ b/ts/deckoptions/TimerOptions.svelte
@@ -1,0 +1,33 @@
+<!--
+Copyright: Ankitects Pty Ltd and contributors
+License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
+-->
+<script lang="ts">
+    import * as tr from "lib/i18n";
+    import SpinBox from "./SpinBox.svelte";
+    import CheckBox from "./CheckBox.svelte";
+    import type { DeckOptionsState } from "./lib";
+
+    export let state: DeckOptionsState;
+    let config = state.currentConfig;
+    let defaults = state.defaults;
+</script>
+
+<h2>{tr.deckConfigTimerTitle()}</h2>
+
+<SpinBox
+    label={tr.deckConfigMaximumAnswerSecs()}
+    tooltip={tr.deckConfigMaximumAnswerSecsTooltip()}
+    min={30}
+    max={600}
+    defaultValue={defaults.capAnswerTimeToSecs}
+    bind:value={$config.capAnswerTimeToSecs}
+/>
+
+<CheckBox
+    id="showAnswerTimer"
+    label={tr.schedulingShowAnswerTimer()}
+    tooltip={tr.deckConfigShowAnswerTimerTooltip()}
+    defaultValue={defaults.showTimer}
+    bind:value={$config.showTimer}
+/>

--- a/ts/deckoptions/deckoptions-base.scss
+++ b/ts/deckoptions/deckoptions-base.scss
@@ -23,7 +23,7 @@
 }
 
 body {
-    width: min(100vw, 35em);
+    width: 100vw;
     margin: 0 auto;
     // leave some space for rounded screens
     margin-bottom: 2em;
@@ -34,7 +34,7 @@ html {
 }
 
 #main {
-    padding: 0.5em;
+    padding: 1.5em;
     padding-top: 0;
 }
 


### PR DESCRIPTION
Closes https://github.com/ankitects/anki/pull/1210.

This is a less intrusive version of my previous PR. I have split `GeneralOptions.svelte` into
- `TimerOptions.svelte`
- `AudioOptions.svelte`

for more consistency.

The grid layout is now better encapsulated in `ConfigEditor.svelte`.

---

### Other changes
- reduce `<h2>` font size to 1.5em
- adjust padding of `#main` and `.outer`


### Showcase
<img width="64%" src="https://user-images.githubusercontent.com/62722460/120177427-b78e1100-c208-11eb-821b-a0f426777c65.png"><img width="36%" src="https://user-images.githubusercontent.com/62722460/120177562-dab8c080-c208-11eb-889f-9ccb6dd50008.png">
![image](https://user-images.githubusercontent.com/62722460/120177687-f623cb80-c208-11eb-8679-2b66bc683030.png)

---
*I would highly appreciate if someone could tell me how to run Prettier on checkout via VS-Code.*