### PR TITLE
fix documentation links

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -80,6 +80,7 @@ Shaun Ren <shaun.ren@linux.com>
 Ryan Greenblatt <greenblattryan@gmail.com>
 Matthias Metelka <github.com/kleinerpirat>
 qubist-pixel-ux <github.com/qubist-pixel-ux>
+cherryblossom <github.com/cherryblossom000>
 
 ********************
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,6 @@
 This repo contains the source code for the computer version of Anki.
 
 If you'd like to try development builds of Anki but don't feel comfortable
-building the code, please see https://betas.ankiweb.net/#/
+building the code, please see https://betas.ankiweb.net/
 
 For more information on building, please see [Development](./docs/development.md).

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,7 +1,7 @@
 # Contributing Code
 
 For info on contributing things other than code, such as translations, decks
-and add-ons, please see https://docs.ankiweb.net/#/contrib
+and add-ons, please see https://docs.ankiweb.net/contrib
 
 With most users now on 2.1, the past year has been focused on paying down some
 of the technical debt that Anki's codebase has built up over the years, and making
@@ -92,7 +92,7 @@ in one of those files will update the generated files.
 ## Translations
 
 For information on adding new translatable strings to Anki, please see
-https://translating.ankiweb.net/#/anki/developers
+https://translating.ankiweb.net/anki/developers
 
 ## Tests Must Pass
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -5,7 +5,7 @@
 For non-developers who want to try beta versions, the easiest way is to use a
 packaged version - please see:
 
-https://betas.ankiweb.net/#/
+https://betas.ankiweb.net/
 
 ## Pre-built Python wheels
 
@@ -61,7 +61,7 @@ were used on old Anki versions and will be automatically moved.
 
 Before contributing code, please see [Contributing](./contributing.md).
 
-If you'd like to contribute translations, please see <https://translating.ankiweb.net/#/>.
+If you'd like to contribute translations, please see <https://translating.ankiweb.net/>.
 
 ## Building redistributable wheels
 

--- a/ftl/README.md
+++ b/ftl/README.md
@@ -1,3 +1,3 @@
 Files related to Anki's translations.
 
-Please see https://translating.ankiweb.net/#/anki/developers
+Please see https://translating.ankiweb.net/anki/developers

--- a/pylib/anki/consts.py
+++ b/pylib/anki/consts.py
@@ -71,7 +71,7 @@ MODEL_CLOZE = 1
 
 STARTING_FACTOR = 2500
 
-HELP_SITE = "https://docs.ankiweb.net/#/"
+HELP_SITE = "https://docs.ankiweb.net/"
 
 # Leech actions
 LEECH_SUSPEND = 0

--- a/qt/aqt/browser/change_notetype.py
+++ b/qt/aqt/browser/change_notetype.py
@@ -204,4 +204,4 @@ class ChangeModel(QDialog):
         QDialog.accept(self)
 
     def onHelp(self) -> None:
-        openHelp(HelpPage.BROWSING_OTHER_MENU_ITEMS)
+        openHelp(HelpPage.BROWSING_NOTES_MENU)

--- a/qt/aqt/profiles.py
+++ b/qt/aqt/profiles.py
@@ -517,7 +517,7 @@ create table if not exists profiles
             file.write(
                 without_unicode_isolation(
                     tr.profiles_folder_readme(
-                        link=f"{appHelpSite}files?id=startup-options",
+                        link=f"{appHelpSite}files#startup-options",
                     )
                 )
             )

--- a/qt/aqt/utils.py
+++ b/qt/aqt/utils.py
@@ -71,23 +71,23 @@ tr = tr_legacyglobal
 
 
 class HelpPage(Enum):
-    NOTE_TYPE = "getting-started?id=note-types"
+    NOTE_TYPE = "getting-started#note-types"
     BROWSING = "browsing"
-    BROWSING_FIND_AND_REPLACE = "browsing?id=find-and-replace"
-    BROWSING_OTHER_MENU_ITEMS = "browsing?id=other-menu-items"
-    KEYBOARD_SHORTCUTS = "studying?id=keyboard-shortcuts"
+    BROWSING_FIND_AND_REPLACE = "browsing#find-and-replace"
+    BROWSING_NOTES_MENU = "browsing#notes"
+    KEYBOARD_SHORTCUTS = "studying#keyboard-shortcuts"
     EDITING = "editing"
-    ADDING_CARD_AND_NOTE = "editing?id=adding-cards-and-notes"
-    ADDING_A_NOTE_TYPE = "editing?id=adding-a-note-type"
-    LATEX = "math?id=latex"
+    ADDING_CARD_AND_NOTE = "editing#adding-cards-and-notes"
+    ADDING_A_NOTE_TYPE = "editing#adding-a-note-type"
+    LATEX = "math#latex"
     PREFERENCES = "preferences"
     INDEX = ""
     TEMPLATES = "templates/intro"
     FILTERED_DECK = "filtered-decks"
     IMPORTING = "importing"
-    CUSTOMIZING_FIELDS = "editing?id=customizing-fields"
+    CUSTOMIZING_FIELDS = "editing#customizing-fields"
     DECK_OPTIONS = "deck-options"
-    EDITING_FEATURES = "editing?id=features"
+    EDITING_FEATURES = "editing#features"
 
 
 HelpPageArgument = Optional[Union[HelpPage, str]]


### PR DESCRIPTION
Fix help pages and other links so that they use URL fragments (`#foo`) instead of `?id=foo`. This also removes the `#/` before the path of these URLs.

For example:

- before: https://docs.ankiweb.net/#/getting-started?id=note-types (goes to home introduction page)
- after: https://docs.ankiweb.net/getting-started#note-types (correctly goes to getting started page and the note types section)