### PR TITLE
Audio pause fix

### DIFF
--- a/qt/aqt/mpv.py
+++ b/qt/aqt/mpv.py
@@ -89,7 +89,6 @@ class MPVBase:
         "--ontop",
         "--audio-display=no",
         "--keep-open=no",
-        "--reset-on-next-file=pause",
         "--autoload-files=no",
     ]
 

--- a/qt/aqt/mpv.py
+++ b/qt/aqt/mpv.py
@@ -90,6 +90,7 @@ class MPVBase:
         "--audio-display=no",
         "--keep-open=no",
         "--autoload-files=no",
+        "--gapless-audio=no",
     ]
 
     def __init__(self, window_id=None, debug=False):

--- a/qt/aqt/sound.py
+++ b/qt/aqt/sound.py
@@ -402,7 +402,7 @@ class MpvManager(MPV, SoundOrVideoPlayer):
         filename = hooks.media_file_filter(tag.filename)
         path = os.path.join(os.getcwd(), filename)
 
-        self.command("loadfile", path, "append-play")
+        self.command("loadfile", path, "append-play", "pause=no")
         gui_hooks.av_player_did_begin_playing(self, tag)
 
     def stop(self) -> None:

--- a/qt/aqt/sound.py
+++ b/qt/aqt/sound.py
@@ -409,7 +409,7 @@ class MpvManager(MPV, SoundOrVideoPlayer):
         self.command("stop")
 
     def toggle_pause(self) -> None:
-        self.set_property("pause", not self.get_property("pause"))
+        self.command("cycle", "pause")
 
     def seek_relative(self, secs: int) -> None:
         self.command("seek", secs, "relative")


### PR DESCRIPTION
An attempt to fix #1164 and update toggle pause with 'cycle' command.

The issue could be reproduced by repeatedly pressing `5` to pause/unpause the player until the end of the audio to try to set the player to be in paused state when idle and before playing the next audio file.

It was fixed by adding 'pause=no' option to `loadfile` command instead of using `--reset-on-next-file=pause` command line option.

https://mpv.io/manual/master/#command-interface-[%3Coptions%3E]]

It appears both of these options might not work properly on recent mpv builds (20200830-git-bb1f821 seems to be good and 20200906-git-f57b90b seems to be bad), the audio file might be cut short and the last second of the audio won't be played, if the player is in paused state, but adding `--gapless-audio=no` seems to help and everything seems to work fine.