### PR TITLE
Keep the internal mpv playlist from growing on

### DIFF
--- a/qt/aqt/sound.py
+++ b/qt/aqt/sound.py
@@ -402,7 +402,7 @@ class MpvManager(MPV, SoundOrVideoPlayer):
         filename = hooks.media_file_filter(tag.filename)
         path = os.path.join(os.getcwd(), filename)
 
-        self.command("loadfile", path, "append-play", "pause=no")
+        self.command("loadfile", path, "replace", "pause=no")
         gui_hooks.av_player_did_begin_playing(self, tag)
 
     def stop(self) -> None:


### PR DESCRIPTION
Just a small change, just in case.

Probably, since Anki 2.1.20, `append-file` is no longer necessary to play multiple files sequentially and it started to misbehave a bit. If the audio playback was never interruped, the internal mpv playlist might keep growing on and on.

It could be reproduced by reviewing a few cards with audio by listening to the whole audio file each time and running this code in the debug console a few times.

```
from aqt.sound import mpvManager
length = mpvManager.get_property("playlist-count")
for i in range(length):
  print("Filename:", mpvManager.get_property(f"playlist/{i}/filename"));
print("==================")
print("Length:", length)
print("==================")
```