### PR TITLE
Fix  Segoe UI got replaced with Arial on Windows

### DIFF
--- a/ts/sass/core.scss
+++ b/ts/sass/core.scss
@@ -8,7 +8,6 @@
 }
 
 body {
-    font-family: Helvetica, Arial;
     color: var(--text-fg);
     background: var(--window-bg);
     margin: 1em;


### PR DESCRIPTION
I'm not sure if this is the best fix, but it looks like this line was never used in recent Anki versions, but with https://github.com/ankitects/anki/commit/fdd162a7b9d187cb4a88a372d87a8b08e2162ca0, to move the default font size and family from body to html, it started to take priority and Segoe UI font got replaced with Arial on Windows, and simply deleting it seems to fix the issue.

![изображение](https://user-images.githubusercontent.com/16260735/121503331-a653ba00-c9e9-11eb-94a9-dbcadd9b0043.png)
