### PR TITLE
Check for misplaced or missing clozes when adding and in the editor

### DIFF
--- a/ftl/core/adding.ftl
+++ b/ftl/core/adding.ftl
@@ -6,4 +6,6 @@ adding-history = History
 adding-note-deleted = (Note deleted)
 adding-shortcut = Shortcut: { $val }
 adding-the-first-field-is-empty = The first field is empty.
-adding-you-have-a-cloze-deletion-note = You have a cloze deletion note type but have not made any cloze deletions. Proceed?
+adding-missing-cloze = You have a cloze notetype but have not made any cloze deletions.
+adding-cloze-outside-cloze-notetype = Cloze deletion can only be used on cloze notetypes.
+adding-cloze-outside-cloze-field = Cloze deletion can only be used in fields which use the 'cloze:' filter (see 'Cards...').

--- a/ftl/core/adding.ftl
+++ b/ftl/core/adding.ftl
@@ -6,6 +6,6 @@ adding-history = History
 adding-note-deleted = (Note deleted)
 adding-shortcut = Shortcut: { $val }
 adding-the-first-field-is-empty = The first field is empty.
-adding-missing-cloze = You have a cloze notetype but have not made any cloze deletions.
+adding-you-have-a-cloze-deletion-note = You have a cloze notetype but have not made any cloze deletions. Proceed?
 adding-cloze-outside-cloze-notetype = Cloze deletion can only be used on cloze notetypes.
 adding-cloze-outside-cloze-field = Cloze deletion can only be used in fields which use the 'cloze:' filter. This is typically the first field.

--- a/ftl/core/adding.ftl
+++ b/ftl/core/adding.ftl
@@ -8,4 +8,4 @@ adding-shortcut = Shortcut: { $val }
 adding-the-first-field-is-empty = The first field is empty.
 adding-missing-cloze = You have a cloze notetype but have not made any cloze deletions.
 adding-cloze-outside-cloze-notetype = Cloze deletion can only be used on cloze notetypes.
-adding-cloze-outside-cloze-field = Cloze deletion can only be used in fields which use the 'cloze:' filter (see 'Cards...').
+adding-cloze-outside-cloze-field = Cloze deletion can only be used in fields which use the 'cloze:' filter. This is typically the first field.

--- a/pylib/.pylintrc
+++ b/pylib/.pylintrc
@@ -11,7 +11,7 @@ ignored-classes=
   QueuedCards,
   UnburyDeckIn,
   BuryOrSuspendCardsIn,
-  NoteIsDuplicateOrEmptyOut,
+  NoteFieldsCheckOut,
   BackendError,
   SetDeckCollapsedIn,
 

--- a/pylib/anki/notes.py
+++ b/pylib/anki/notes.py
@@ -14,7 +14,8 @@ from anki.consts import MODEL_STD
 from anki.models import NotetypeDict, NotetypeId, TemplateDict
 from anki.utils import joinFields
 
-NoteFieldsCheckResult = DuplicateOrEmptyResult = _pb.NoteFieldsCheckOut.State
+DuplicateOrEmptyResult = _pb.NoteFieldsCheckOut.State
+NoteFieldsCheckResult = _pb.NoteFieldsCheckOut.State
 
 # types
 NoteId = NewType("NoteId", int)

--- a/pylib/anki/notes.py
+++ b/pylib/anki/notes.py
@@ -14,7 +14,7 @@ from anki.consts import MODEL_STD
 from anki.models import NotetypeDict, NotetypeId, TemplateDict
 from anki.utils import joinFields
 
-DuplicateOrEmptyResult = _pb.NoteIsDuplicateOrEmptyOut.State
+NoteFieldsCheckResult = DuplicateOrEmptyResult = _pb.NoteFieldsCheckOut.State
 
 # types
 NoteId = NewType("NoteId", int)
@@ -190,12 +190,10 @@ class Note:
     addTag = add_tag
     delTag = remove_tag
 
-    # Unique/duplicate check
+    # Unique/duplicate/cloze check
     ##################################################
 
-    def duplicate_or_empty(self) -> DuplicateOrEmptyResult.V:
-        return self.col._backend.note_is_duplicate_or_empty(
-            self._to_backend_note()
-        ).state
+    def fields_check(self) -> NoteFieldsCheckResult.V:
+        return self.col._backend.note_fields_check(self._to_backend_note()).state
 
-    dupeOrEmpty = duplicate_or_empty
+    dupeOrEmpty = duplicate_or_empty = fields_check

--- a/pylib/tests/test_collection.py
+++ b/pylib/tests/test_collection.py
@@ -74,15 +74,15 @@ def test_noteAddDelete():
     c0 = note.cards()[0]
     assert "three" in c0.q()
     # it should not be a duplicate
-    assert not note.duplicate_or_empty()
+    assert not note.fields_check()
     # now let's make a duplicate
     note2 = col.newNote()
     note2["Front"] = "one"
     note2["Back"] = ""
-    assert note2.duplicate_or_empty()
+    assert note2.fields_check()
     # empty first field should not be permitted either
     note2["Front"] = " "
-    assert note2.duplicate_or_empty()
+    assert note2.fields_check()
 
 
 def test_fieldChecksum():

--- a/qt/aqt/addcards.py
+++ b/qt/aqt/addcards.py
@@ -234,7 +234,8 @@ class AddCards(QDialog):
         if result == NoteFieldsCheckResult.EMPTY:
             problem = tr.adding_the_first_field_is_empty()
         elif result == NoteFieldsCheckResult.MISSING_CLOZE:
-            problem = tr.adding_missing_cloze()
+            if not askUser(tr.adding_you_have_a_cloze_deletion_note()):
+                return False
         elif result == NoteFieldsCheckResult.NOTETYPE_NOT_CLOZE:
             problem = tr.adding_cloze_outside_cloze_notetype()
         elif result == NoteFieldsCheckResult.FIELD_NOT_CLOZE:

--- a/qt/aqt/editor.py
+++ b/qt/aqt/editor.py
@@ -81,8 +81,7 @@ _html = """
 <div id="dupes" class="is-inactive">
     <a href="#" onclick="pycmd('dupes');return false;">{}</a>
 </div>
-<div id="not-a-cloze-notetype" class="is-inactive">{}</div>
-<div id="not-a-cloze-field" class="is-inactive">{}</div>
+<div id="cloze-hint"></div>
 """
 
 
@@ -131,11 +130,7 @@ class Editor:
 
         # then load page
         self.web.stdHtml(
-            _html.format(
-                tr.editing_show_duplicates(),
-                tr.adding_cloze_outside_cloze_notetype(),
-                tr.adding_cloze_outside_cloze_field(),
-            ),
+            _html.format(tr.editing_show_duplicates()),
             css=[
                 "css/editor.css",
             ],
@@ -515,16 +510,16 @@ $editorToolbar.then(({{ toolbar }}) => toolbar.appendGroup({{
 
     def _update_duplicate_display(self, result: NoteFieldsCheckResult.V) -> None:
         cols = [""] * len(self.note.fields)
-        wrong_notetype = wrong_field = "false"
+        cloze_hint = ""
         if result == NoteFieldsCheckResult.DUPLICATE:
             cols[0] = "dupe"
         elif result == NoteFieldsCheckResult.NOTETYPE_NOT_CLOZE:
-            wrong_notetype = "true"
+            cloze_hint = tr.adding_cloze_outside_cloze_notetype()
         elif result == NoteFieldsCheckResult.FIELD_NOT_CLOZE:
-            wrong_field = "true"
+            cloze_hint = tr.adding_cloze_outside_cloze_field()
 
         self.web.eval(f"setBackgrounds({json.dumps(cols)});")
-        self.web.eval(f"setClozeHints({wrong_notetype}, {wrong_field});")
+        self.web.eval(f"setClozeHint({json.dumps(cloze_hint)});")
 
     def showDupes(self) -> None:
         aqt.dialogs.open(

--- a/rslib/backend.proto
+++ b/rslib/backend.proto
@@ -174,7 +174,7 @@ service NotesService {
   rpc ClozeNumbersInNote(Note) returns (ClozeNumbersInNoteOut);
   rpc AfterNoteUpdates(AfterNoteUpdatesIn) returns (OpChangesWithCount);
   rpc FieldNamesForNotes(FieldNamesForNotesIn) returns (FieldNamesForNotesOut);
-  rpc NoteIsDuplicateOrEmpty(Note) returns (NoteIsDuplicateOrEmptyOut);
+  rpc NoteFieldsCheck(Note) returns (NoteFieldsCheckOut);
   rpc CardsOfNote(NoteId) returns (CardIds);
 }
 
@@ -1231,11 +1231,14 @@ message ReparentDecksIn {
   int64 new_parent = 2;
 }
 
-message NoteIsDuplicateOrEmptyOut {
+message NoteFieldsCheckOut {
   enum State {
     NORMAL = 0;
     EMPTY = 1;
     DUPLICATE = 2;
+    MISSING_CLOZE = 3;
+    NOTETYPE_NOT_CLOZE = 4;
+    FIELD_NOT_CLOZE = 5;
   }
   State state = 1;
 }

--- a/rslib/src/backend/notes.rs
+++ b/rslib/src/backend/notes.rs
@@ -120,11 +120,11 @@ impl NotesService for Backend {
         })
     }
 
-    fn note_is_duplicate_or_empty(&self, input: pb::Note) -> Result<pb::NoteIsDuplicateOrEmptyOut> {
+    fn note_fields_check(&self, input: pb::Note) -> Result<pb::NoteFieldsCheckOut> {
         let note: Note = input.into();
         self.with_col(|col| {
-            col.note_is_duplicate_or_empty(&note)
-                .map(|r| pb::NoteIsDuplicateOrEmptyOut { state: r as i32 })
+            col.note_fields_check(&note)
+                .map(|r| pb::NoteFieldsCheckOut { state: r as i32 })
         })
     }
 

--- a/rslib/src/cloze.rs
+++ b/rslib/src/cloze.rs
@@ -139,6 +139,10 @@ pub fn expand_clozes_to_reveal_latex(text: &str) -> String {
     buf
 }
 
+pub(crate) fn contains_cloze(text: &str) -> bool {
+    CLOZE.is_match(text)
+}
+
 pub fn cloze_numbers_in_string(html: &str) -> HashSet<u16> {
     let mut set = HashSet::with_capacity(4);
     add_cloze_numbers_in_string(html, &mut set);

--- a/rslib/src/notes/mod.rs
+++ b/rslib/src/notes/mod.rs
@@ -14,7 +14,8 @@ use num_integer::Integer;
 
 use crate::{
     backend_proto as pb,
-    backend_proto::note_is_duplicate_or_empty_out::State as DuplicateState,
+    backend_proto::note_fields_check_out::State as NoteFieldsState,
+    cloze::contains_cloze,
     decks::DeckId,
     define_newtype,
     error::{AnkiError, Result},
@@ -529,35 +530,71 @@ impl Collection {
         Ok(changed_notes)
     }
 
-    pub(crate) fn note_is_duplicate_or_empty(&self, note: &Note) -> Result<DuplicateState> {
-        if let Some(field1) = note.fields.get(0) {
+    /// Check if the note's first field is empty or a duplicate. Then for cloze
+    /// notetypes, check if there is a cloze in a non-cloze field or if there's
+    /// no cloze at all. For other notetypes, just check if there's a cloze.
+    pub(crate) fn note_fields_check(&mut self, note: &Note) -> Result<NoteFieldsState> {
+        if let Some(text) = note.fields.get(0) {
             let field1 = if self.get_config_bool(BoolKey::NormalizeNoteText) {
-                normalize_to_nfc(field1)
+                normalize_to_nfc(text)
             } else {
-                field1.into()
+                text.into()
             };
             let stripped = strip_html_preserving_media_filenames(&field1);
             if stripped.trim().is_empty() {
-                Ok(DuplicateState::Empty)
+                Ok(NoteFieldsState::Empty)
+            } else if self.is_duplicate(&stripped, note)? {
+                Ok(NoteFieldsState::Duplicate)
             } else {
-                let csum = field_checksum(&stripped);
-                let have_dupe = self
-                    .storage
-                    .note_fields_by_checksum(note.notetype_id, csum)?
-                    .into_iter()
-                    .any(|(nid, field)| {
-                        nid != note.id && strip_html_preserving_media_filenames(&field) == stripped
-                    });
-
-                if have_dupe {
-                    Ok(DuplicateState::Duplicate)
-                } else {
-                    Ok(DuplicateState::Normal)
-                }
+                self.field_cloze_check(note)
             }
         } else {
-            Ok(DuplicateState::Empty)
+            Ok(NoteFieldsState::Empty)
         }
+    }
+
+    fn is_duplicate(&self, first_field: &str, note: &Note) -> Result<bool> {
+        let csum = field_checksum(&first_field);
+        Ok(self
+            .storage
+            .note_fields_by_checksum(note.notetype_id, csum)?
+            .into_iter()
+            .any(|(nid, field)| {
+                nid != note.id && strip_html_preserving_media_filenames(&field) == first_field
+            }))
+    }
+
+    fn field_cloze_check(&mut self, note: &Note) -> Result<NoteFieldsState> {
+        let notetype = self
+            .get_notetype(note.notetype_id)?
+            .ok_or(AnkiError::NotFound)?;
+        let cloze_fields = notetype.cloze_fields();
+        let mut has_cloze = false;
+        let extraneous_cloze = note.fields.iter().enumerate().find_map(|(i, field)| {
+            if notetype.is_cloze() {
+                if contains_cloze(field) {
+                    if cloze_fields.contains(&i) {
+                        has_cloze = true;
+                        None
+                    } else {
+                        Some(NoteFieldsState::FieldNotCloze)
+                    }
+                } else {
+                    None
+                }
+            } else if contains_cloze(field) {
+                Some(NoteFieldsState::NotetypeNotCloze)
+            } else {
+                None
+            }
+        });
+        Ok(if let Some(state) = extraneous_cloze {
+            state
+        } else if notetype.is_cloze() && !has_cloze {
+            NoteFieldsState::MissingCloze
+        } else {
+            NoteFieldsState::Normal
+        })
     }
 }
 

--- a/rslib/src/notes/mod.rs
+++ b/rslib/src/notes/mod.rs
@@ -534,7 +534,7 @@ impl Collection {
     /// notetypes, check if there is a cloze in a non-cloze field or if there's
     /// no cloze at all. For other notetypes, just check if there's a cloze.
     pub(crate) fn note_fields_check(&mut self, note: &Note) -> Result<NoteFieldsState> {
-        if let Some(text) = note.fields.get(0) {
+        Ok(if let Some(text) = note.fields.get(0) {
             let field1 = if self.get_config_bool(BoolKey::NormalizeNoteText) {
                 normalize_to_nfc(text)
             } else {
@@ -542,15 +542,20 @@ impl Collection {
             };
             let stripped = strip_html_preserving_media_filenames(&field1);
             if stripped.trim().is_empty() {
-                Ok(NoteFieldsState::Empty)
-            } else if self.is_duplicate(&stripped, note)? {
-                Ok(NoteFieldsState::Duplicate)
+                NoteFieldsState::Empty
             } else {
-                self.field_cloze_check(note)
+                let cloze_state = self.field_cloze_check(note)?;
+                if cloze_state != NoteFieldsState::Normal {
+                    cloze_state
+                } else if self.is_duplicate(&stripped, note)? {
+                    NoteFieldsState::Duplicate
+                } else {
+                    NoteFieldsState::Normal
+                }
             }
         } else {
-            Ok(NoteFieldsState::Empty)
-        }
+            NoteFieldsState::Empty
+        })
     }
 
     fn is_duplicate(&self, first_field: &str, note: &Note) -> Result<bool> {

--- a/rslib/src/notetype/mod.rs
+++ b/rslib/src/notetype/mod.rs
@@ -548,6 +548,22 @@ impl Notetype {
     pub(crate) fn is_cloze(&self) -> bool {
         matches!(self.config.kind(), NotetypeKind::Cloze)
     }
+
+    /// Return all clozable fields. A field is clozable when it belongs to a cloze
+    /// notetype and a 'cloze' filter is applied to it in the template.
+    pub(crate) fn cloze_fields(&self) -> HashSet<usize> {
+        if !self.is_cloze() {
+            HashSet::new()
+        } else if let Some((Some(front), _)) = self.parsed_templates().get(0) {
+            front
+                .cloze_fields()
+                .iter()
+                .filter_map(|name| self.get_field_ord(name))
+                .collect()
+        } else {
+            HashSet::new()
+        }
+    }
 }
 
 /// True if the slice is empty or either template of the first tuple doesn't have a cloze field.

--- a/ts/editor/fields.scss
+++ b/ts/editor/fields.scss
@@ -28,7 +28,9 @@
     padding: 0;
 }
 
-#dupes {
+#dupes,
+#not-a-cloze-notetype,
+#not-a-cloze-field {
     position: sticky;
     bottom: 0;
 

--- a/ts/editor/fields.scss
+++ b/ts/editor/fields.scss
@@ -29,8 +29,7 @@
 }
 
 #dupes,
-#not-a-cloze-notetype,
-#not-a-cloze-field {
+#cloze-hint {
     position: sticky;
     bottom: 0;
 

--- a/ts/editor/index.ts
+++ b/ts/editor/index.ts
@@ -144,13 +144,8 @@ export function setBackgrounds(cols: ("dupe" | "")[]): void {
         .classList.toggle("is-inactive", !cols.includes("dupe"));
 }
 
-export function setClozeHints(wrong_notetype: boolean, wrong_field: boolean): void {
-    document
-        .getElementById("not-a-cloze-notetype")!
-        .classList.toggle("is-inactive", !wrong_notetype);
-    document
-        .getElementById("not-a-cloze-field")!
-        .classList.toggle("is-inactive", !wrong_field);
+export function setClozeHint(cloze_hint: string): void {
+    document.getElementById("cloze-hint")!.innerHTML = cloze_hint;
 }
 
 export function setFonts(fonts: [string, number, boolean][]): void {

--- a/ts/editor/index.ts
+++ b/ts/editor/index.ts
@@ -144,6 +144,15 @@ export function setBackgrounds(cols: ("dupe" | "")[]): void {
         .classList.toggle("is-inactive", !cols.includes("dupe"));
 }
 
+export function setClozeHints(wrong_notetype: boolean, wrong_field: boolean): void {
+    document
+        .getElementById("not-a-cloze-notetype")!
+        .classList.toggle("is-inactive", !wrong_notetype);
+    document
+        .getElementById("not-a-cloze-field")!
+        .classList.toggle("is-inactive", !wrong_field);
+}
+
 export function setFonts(fonts: [string, number, boolean][]): void {
     forEditorField(
         fonts,


### PR DESCRIPTION
I couldn't get mypy to shut up. Do I have to ignore the pb class somewhere else than in .pylintrc?
Some more notes:
- I've made adding a cloze mandatory. (Before you could skip the warning.) It seems more in line with the new strict checks.
- I've decided against reporting the field with the misplaced cloze to keep the pb message simple and preserve backwards compatibility.