### PR TITLE
Make fieldname:test act like fieldname:%test%

### DIFF
--- a/pylib/tests/test_find.py
+++ b/pylib/tests/test_find.py
@@ -109,7 +109,7 @@ def test_findCards():
     assert len(col.findCards("front:sheep")) == 0
     assert len(col.findCards("back:sheep")) == 2
     assert len(col.findCards("-back:sheep")) == 3
-    assert len(col.findCards("front:do")) == 0
+    assert len(col.findCards("front:do")) == 1
     assert len(col.findCards("front:*")) == 5
     # ordering
     col.conf["sortType"] = "noteCrt"

--- a/pylib/tests/test_find.py
+++ b/pylib/tests/test_find.py
@@ -219,12 +219,12 @@ def test_findCards():
     else:
         print("some find tests disabled near cutoff")
     # empty field
-    assert len(col.findCards("front:")) == 0
+    assert len(col.findCards("-front:_*")) == len(col.findCards("front:re:^$")) == 0
     note = col.newNote()
     note["Front"] = ""
     note["Back"] = "abc2"
     assert col.addNote(note) == 1
-    assert len(col.findCards("front:")) == 1
+    assert len(col.findCards("-front:_*")) == len(col.findCards("front:re:^$")) == 1
     # OR searches and nesting
     assert len(col.findCards("tag:monkey or tag:sheep")) == 2
     assert len(col.findCards("(tag:monkey OR tag:sheep)")) == 2

--- a/rslib/src/search/sqlwriter.rs
+++ b/rslib/src/search/sqlwriter.rs
@@ -448,7 +448,7 @@ impl SqlWriter<'_> {
         } else {
             cmp = "like";
             cmp_trailer = "escape '\\'";
-            self.args.push(to_sql(val).into())
+            self.args.push(format!("%{}%", &to_sql(val)))
         }
 
         let arg_idx = self.args.len();

--- a/rslib/src/search/sqlwriter.rs
+++ b/rslib/src/search/sqlwriter.rs
@@ -674,7 +674,7 @@ mod test {
                     "(n.mid = 1581236385347 and field_at_index(n.flds, 0) like ?1 escape '\\')))"
                 )
                 .into(),
-                vec!["te%st".into()]
+                vec!["%te%st%".into()]
             )
         );
 


### PR DESCRIPTION
This would make it act more like unqualified searches or `nc:text` searches. The old behavior could be recreated with `fieldname:re:^test$`.

I think users would benefit from this more "fuzzy" search, because you can do without resorting to special symbols (`*`, `^`, `$`).