### PR TITLE
Make field queries default to field:Fieldname:Text

### DIFF
--- a/rslib/src/search/parser.rs
+++ b/rslib/src/search/parser.rs
@@ -382,6 +382,7 @@ fn search_node_for_text_with_argument<'a>(
     val: &'a str,
 ) -> ParseResult<'a, SearchNode> {
     Ok(match key.to_ascii_lowercase().as_str() {
+        "field" => parse_field(val)?,
         "deck" => SearchNode::Deck(unescape(val)?),
         "note" => SearchNode::Notetype(unescape(val)?),
         "tag" => SearchNode::Tag(unescape(val)?),
@@ -659,6 +660,18 @@ fn parse_dupe(s: &str) -> ParseResult<SearchNode> {
             s,
             FailKind::Other(Some("invalid 'dupe:' search".into())),
         ))
+    }
+}
+
+fn parse_field<'a>(s: &'a str) -> ParseResult<'a, SearchNode> {
+    let mut it = s.splitn(2, ':');
+    let key = it.next().unwrap();
+
+    if let Some(val) = it.next() {
+        parse_single_field(key, val)
+    } else {
+        // Searches for existence of field
+        parse_single_field(key, "")
     }
 }
 

--- a/rslib/src/search/parser.rs
+++ b/rslib/src/search/parser.rs
@@ -663,7 +663,7 @@ fn parse_dupe(s: &str) -> ParseResult<SearchNode> {
     }
 }
 
-fn parse_field<'a>(s: &'a str) -> ParseResult<'a, SearchNode> {
+fn parse_field(s: &str) -> ParseResult<SearchNode> {
     let mut it = s.splitn(2, ':');
     let key = it.next().unwrap();
 
@@ -834,9 +834,9 @@ mod test {
 
         // escaping is independent of quotation
         assert_eq!(
-            parse(r#""field:va\"lue""#)?,
+            parse(r#""fieldname:va\"lue""#)?,
             vec![Search(SingleField {
-                field: "field".into(),
+                field: "fieldname".into(),
                 text: "va\"lue".into(),
                 is_re: false
             })]
@@ -860,9 +860,9 @@ mod test {
         assert_eq!(parse(r#""\)\(""#), parse(r#"")(""#));
 
         // escaping : is optional if it is preceded by another :
-        assert_eq!(parse("field:val:ue"), parse(r"field:val\:ue"));
-        assert_eq!(parse(r#""field:val:ue""#), parse(r"field:val\:ue"));
-        assert_eq!(parse(r#"field:"val:ue""#), parse(r"field:val\:ue"));
+        assert_eq!(parse("fieldname:val:ue"), parse(r"fieldname:val\:ue"));
+        assert_eq!(parse(r#""fieldname:val:ue""#), parse(r"fieldname:val\:ue"));
+        assert_eq!(parse(r#"fieldname:"val:ue""#), parse(r"fieldname:val\:ue"));
 
         // escaping - is optional if it cannot be mistaken for a negator
         assert_eq!(parse("-"), parse(r"\-"));

--- a/rslib/src/search/writer.rs
+++ b/rslib/src/search/writer.rs
@@ -127,7 +127,14 @@ fn write_single_field(field: &str, text: &str, is_re: bool) -> String {
     } else {
         text.to_string()
     };
-    maybe_quote(&format!("{}:{}{}", field.replace(":", "\\:"), re, &text))
+
+    let colon = if text == "" {
+        ""
+    } else {
+        ":"
+    };
+
+    maybe_quote(&format!("field:{}{}{}{}", field.replace(":", "\\:"), colon, re, &text))
 }
 
 fn write_template(template: &TemplateKind) -> String {

--- a/rslib/src/search/writer.rs
+++ b/rslib/src/search/writer.rs
@@ -128,7 +128,7 @@ fn write_single_field(field: &str, text: &str, is_re: bool) -> String {
         text.to_string()
     };
 
-    let colon = if !is_re && text == "" {
+    let colon = if !is_re && text.is_empty() {
         ""
     } else {
         ":"

--- a/rslib/src/search/writer.rs
+++ b/rslib/src/search/writer.rs
@@ -128,13 +128,15 @@ fn write_single_field(field: &str, text: &str, is_re: bool) -> String {
         text.to_string()
     };
 
-    let colon = if !is_re && text.is_empty() {
-        ""
-    } else {
-        ":"
-    };
+    let colon = if !is_re && text.is_empty() { "" } else { ":" };
 
-    maybe_quote(&format!("field:{}{}{}{}", field.replace(":", "\\:"), colon, re, &text))
+    maybe_quote(&format!(
+        "field:{}{}{}{}",
+        field.replace(":", "\\:"),
+        colon,
+        re,
+        &text
+    ))
 }
 
 fn write_template(template: &TemplateKind) -> String {

--- a/rslib/src/search/writer.rs
+++ b/rslib/src/search/writer.rs
@@ -128,7 +128,7 @@ fn write_single_field(field: &str, text: &str, is_re: bool) -> String {
         text.to_string()
     };
 
-    let colon = if text == "" {
+    let colon = if !is_re && text == "" {
         ""
     } else {
         ":"


### PR DESCRIPTION
My original intention was to generalize `re`, `nc`, and `w`, to a new `TextNode`, and make it available to more search queries. The biggest hurdle to this realization is the catch-all `SingleField`. If we had field queries prefixed with `field:`, we could be a bit more creative with queries going forward. This PR will not turn them off yet, just "auto-correct" them to be prefixed with `field:` instead.

Another issue with non-prefixed field queries, that users cannot search for field content anymore, if the field is named `Introduced` or other already existing queries.

Together with #1235, this would mean that we can have a query `field:Fieldname`, which will search for notes/cards of note types which have the field "Fieldname", which I think makes sense.