### PR TITLE
Update icons of the browser sidebar

### DIFF
--- a/qt/aqt/browser/sidebar/item.py
+++ b/qt/aqt/browser/sidebar/item.py
@@ -25,6 +25,7 @@ class SidebarItemType(Enum):
     NOTETYPE_ROOT = auto()
     NOTETYPE = auto()
     NOTETYPE_TEMPLATE = auto()
+    NOTETYPE_FIELD = auto()
     TAG_ROOT = auto()
     TAG_NONE = auto()
     TAG = auto()
@@ -144,7 +145,10 @@ class SidebarItem:
                 SidebarItemType.CARD_STATE,
             ):
                 return self.name == other.name
-            elif self.item_type == SidebarItemType.NOTETYPE_TEMPLATE:
+            elif self.item_type in [
+                SidebarItemType.NOTETYPE_TEMPLATE,
+                SidebarItemType.NOTETYPE_FIELD,
+            ]:
                 return (
                     other.id == self.id
                     and other._parent_item.id == self._parent_item.id

--- a/qt/aqt/browser/sidebar/tree.py
+++ b/qt/aqt/browser/sidebar/tree.py
@@ -666,15 +666,16 @@ class SidebarTreeView(QTreeView):
 
     def _flags_tree(self, root: SidebarItem) -> None:
         icon = ":/icons/flag.svg"
+        icon_outline = ":/icons/flag-outline.svg"
+
         root = self._section_root(
             root=root,
             name=tr.browsing_sidebar_flags(),
-            icon=icon,
+            icon=icon_outline,
             collapse_key=Config.Bool.COLLAPSE_FLAGS,
             type=SidebarItemType.FLAG_ROOT,
         )
         root.search_node = SearchNode(flag=SearchNode.FLAG_ANY)
-        colored_icon = ColoredIcon(path=icon, color=colors.DISABLED)
 
         for flag in load_flags(self.col):
             root.add_child(
@@ -689,7 +690,7 @@ class SidebarTreeView(QTreeView):
 
         root.add_simple(
             tr.browsing_no_flag(),
-            icon=colored_icon,
+            icon=icon_outline,
             type=SidebarItemType.FLAG,
             search_node=SearchNode(flag=SearchNode.FLAG_NONE),
         )

--- a/qt/aqt/browser/sidebar/tree.py
+++ b/qt/aqt/browser/sidebar/tree.py
@@ -802,10 +802,10 @@ class SidebarTreeView(QTreeView):
     ###########################
 
     def _notetype_tree(self, root: SidebarItem) -> None:
-        icon = ":/icons/notetype.svg"
-        notetype_multiple_icon = icon
-        notetype_icon = icon
-        template_icon = icon
+        notetype_icon = ":/icons/newspaper-variant-outline.svg"
+        notetype_multiple_icon = ":/icons/newspaper-variant-multiple-outline.svg"
+        template_icon = ":/icons/card-bulleted-outline.svg"
+        # field_icon = ":/icons/form-textbox.svg"
 
         root = self._section_root(
             root=root,

--- a/qt/aqt/browser/sidebar/tree.py
+++ b/qt/aqt/browser/sidebar/tree.py
@@ -694,6 +694,7 @@ class SidebarTreeView(QTreeView):
 
     def _tag_tree(self, root: SidebarItem) -> None:
         icon = ":/icons/tag-outline.svg"
+        icon_multiple = ":/icons/tag-multiple-outline.svg"
         icon_off = ":/icons/tag-off-outline.svg"
 
         def render(
@@ -708,7 +709,7 @@ class SidebarTreeView(QTreeView):
             for node in nodes:
                 item = SidebarItem(
                     name=node.name,
-                    icon=icon,
+                    icon=icon_multiple if node.children else icon,
                     search_node=SearchNode(tag=head + node.name),
                     on_expanded=toggle_expand(node),
                     expanded=not node.collapsed,
@@ -723,7 +724,7 @@ class SidebarTreeView(QTreeView):
         root = self._section_root(
             root=root,
             name=tr.browsing_sidebar_tags(),
-            icon=icon,
+            icon=icon_multiple,
             collapse_key=Config.Bool.COLLAPSE_TAGS,
             type=SidebarItemType.TAG_ROOT,
         )
@@ -795,10 +796,15 @@ class SidebarTreeView(QTreeView):
 
     def _notetype_tree(self, root: SidebarItem) -> None:
         icon = ":/icons/notetype.svg"
+        notetype_multiple_icon = icon
+        notetype_icon = icon
+        template_icon = icon
+
+
         root = self._section_root(
             root=root,
             name=tr.browsing_sidebar_notetypes(),
-            icon=icon,
+            icon=notetype_multiple_icon,
             collapse_key=Config.Bool.COLLAPSE_NOTETYPES,
             type=SidebarItemType.NOTETYPE_ROOT,
         )
@@ -807,7 +813,7 @@ class SidebarTreeView(QTreeView):
         for nt in sorted(self.col.models.all(), key=lambda nt: nt["name"].lower()):
             item = SidebarItem(
                 nt["name"],
-                icon,
+                notetype_icon,
                 search_node=SearchNode(note=nt["name"]),
                 item_type=SidebarItemType.NOTETYPE,
                 id=nt["id"],
@@ -816,7 +822,7 @@ class SidebarTreeView(QTreeView):
             for c, tmpl in enumerate(nt["tmpls"]):
                 child = SidebarItem(
                     tmpl["name"],
-                    icon,
+                    template_icon,
                     search_node=self.col.group_searches(
                         SearchNode(note=nt["name"]), SearchNode(template=c)
                     ),

--- a/qt/aqt/browser/sidebar/tree.py
+++ b/qt/aqt/browser/sidebar/tree.py
@@ -547,7 +547,7 @@ class SidebarTreeView(QTreeView):
     ###########################
 
     def _today_tree(self, root: SidebarItem) -> None:
-        icon = ":/icons/clock.svg"
+        icon = ":/icons/clock-outline.svg"
         root = self._section_root(
             root=root,
             name=tr.browsing_today(),
@@ -617,44 +617,47 @@ class SidebarTreeView(QTreeView):
     ###########################
 
     def _card_state_tree(self, root: SidebarItem) -> None:
-        icon = ColoredIcon(path=":/icons/card-state.svg", color=colors.DISABLED)
+        icon = ":/icons/circle.svg"
+        icon_outline = ":/icons/circle-outline.svg"
+
         root = self._section_root(
             root=root,
             name=tr.browsing_sidebar_card_state(),
-            icon=icon,
+            icon=icon_outline,
             collapse_key=Config.Bool.COLLAPSE_CARD_STATE,
             type=SidebarItemType.CARD_STATE_ROOT,
         )
         type = SidebarItemType.CARD_STATE
+        colored_icon = ColoredIcon(path=icon, color=colors.DISABLED)
 
         root.add_simple(
             tr.actions_new(),
-            icon=icon.with_color(colors.NEW_COUNT),
+            icon=colored_icon.with_color(colors.NEW_COUNT),
             type=type,
             search_node=SearchNode(card_state=SearchNode.CARD_STATE_NEW),
         )
 
         root.add_simple(
             name=tr.scheduling_learning(),
-            icon=icon.with_color(colors.LEARN_COUNT),
+            icon=colored_icon.with_color(colors.LEARN_COUNT),
             type=type,
             search_node=SearchNode(card_state=SearchNode.CARD_STATE_LEARN),
         )
         root.add_simple(
             name=tr.scheduling_review(),
-            icon=icon.with_color(colors.REVIEW_COUNT),
+            icon=colored_icon.with_color(colors.REVIEW_COUNT),
             type=type,
             search_node=SearchNode(card_state=SearchNode.CARD_STATE_REVIEW),
         )
         root.add_simple(
             name=tr.browsing_suspended(),
-            icon=icon.with_color(colors.SUSPENDED_FG),
+            icon=colored_icon.with_color(colors.SUSPENDED_FG),
             type=type,
             search_node=SearchNode(card_state=SearchNode.CARD_STATE_SUSPENDED),
         )
         root.add_simple(
             name=tr.browsing_buried(),
-            icon=icon.with_color(colors.BURIED_FG),
+            icon=colored_icon.with_color(colors.BURIED_FG),
             type=type,
             search_node=SearchNode(card_state=SearchNode.CARD_STATE_BURIED),
         )
@@ -663,7 +666,7 @@ class SidebarTreeView(QTreeView):
     ###########################
 
     def _flags_tree(self, root: SidebarItem) -> None:
-        icon = ColoredIcon(path=":/icons/flag.svg", color=colors.DISABLED)
+        icon = ":/icons/flag.svg"
         root = self._section_root(
             root=root,
             name=tr.browsing_sidebar_flags(),
@@ -672,6 +675,7 @@ class SidebarTreeView(QTreeView):
             type=SidebarItemType.FLAG_ROOT,
         )
         root.search_node = SearchNode(flag=SearchNode.FLAG_ANY)
+        colored_icon = ColoredIcon(path=icon, color=colors.DISABLED)
 
         for flag in load_flags(self.col):
             root.add_child(
@@ -686,7 +690,7 @@ class SidebarTreeView(QTreeView):
 
         root.add_simple(
             tr.browsing_no_flag(),
-            icon=icon,
+            icon=colored_icon,
             type=SidebarItemType.FLAG,
             search_node=SearchNode(flag=SearchNode.FLAG_NONE),
         )

--- a/qt/aqt/browser/sidebar/tree.py
+++ b/qt/aqt/browser/sidebar/tree.py
@@ -25,6 +25,7 @@ from aqt.browser.sidebar.model import SidebarModel
 from aqt.browser.sidebar.searchbar import SidebarSearchBar
 from aqt.browser.sidebar.toolbar import SidebarTool, SidebarToolbar
 from aqt.clayout import CardLayout
+from aqt.fields import FieldDialog
 from aqt.flags import load_flags
 from aqt.models import Models
 from aqt.operations import CollectionOp, QueryOp
@@ -805,7 +806,7 @@ class SidebarTreeView(QTreeView):
         notetype_icon = ":/icons/newspaper-variant-outline.svg"
         notetype_multiple_icon = ":/icons/newspaper-variant-multiple-outline.svg"
         template_icon = ":/icons/card-bulleted-outline.svg"
-        # field_icon = ":/icons/form-textbox.svg"
+        field_icon = ":/icons/form-textbox.svg"
 
         root = self._section_root(
             root=root,
@@ -838,6 +839,19 @@ class SidebarTreeView(QTreeView):
                 )
                 item.add_child(child)
 
+            for c, fld in enumerate(nt["flds"]):
+                child = SidebarItem(
+                    fld["name"],
+                    field_icon,
+                    search_node=self.col.group_searches(
+                        SearchNode(note=nt["name"]), SearchNode(field_name=fld["name"])
+                    ),
+                    item_type=SidebarItemType.NOTETYPE_FIELD,
+                    name_prefix=f"{nt['name']}::",
+                    id=fld["ord"],
+                )
+                item.add_child(child)
+
             root.add_child(item)
 
     # Context menu
@@ -867,6 +881,8 @@ class SidebarTreeView(QTreeView):
             )
         elif item.item_type == SidebarItemType.NOTETYPE_TEMPLATE:
             menu.addAction(tr.notetypes_cards(), lambda: self.manage_template(item))
+        elif item.item_type == SidebarItemType.NOTETYPE_FIELD:
+            menu.addAction(tr.notetypes_fields(), lambda: self.manage_fields(item))
         elif item.item_type == SidebarItemType.SAVED_SEARCH_ROOT:
             menu.addAction(
                 tr.browsing_sidebar_save_current_search(), self.save_current_search
@@ -1107,6 +1123,10 @@ class SidebarTreeView(QTreeView):
     def manage_template(self, item: SidebarItem) -> None:
         note = Note(self.col, self.col.models.get(NotetypeId(item._parent_item.id)))
         CardLayout(self.mw, note, ord=item.id, parent=self, fill_empty=True)
+
+    def manage_fields(self, item: SidebarItem) -> None:
+        notetype = self.mw.col.models.get(NotetypeId(item._parent_item.id))
+        FieldDialog(self.mw, notetype, parent=self, open_at=item.id)
 
     # Helpers
     ####################################

--- a/qt/aqt/browser/sidebar/tree.py
+++ b/qt/aqt/browser/sidebar/tree.py
@@ -522,14 +522,13 @@ class SidebarTreeView(QTreeView):
     ###########################
 
     def _saved_searches_tree(self, root: SidebarItem) -> None:
-        icon = ":/icons/bookmark-outline.svg"
-        icon_multiple = ":/icons/bookmark-multiple-outline.svg"
+        icon = ":/icons/heart-outline.svg"
         saved = self._get_saved_searches()
 
         root = self._section_root(
             root=root,
             name=tr.browsing_sidebar_saved_searches(),
-            icon=icon_multiple,
+            icon=icon,
             collapse_key=Config.Bool.COLLAPSE_SAVED_SEARCHES,
             type=SidebarItemType.SAVED_SEARCH_ROOT,
         )
@@ -700,7 +699,6 @@ class SidebarTreeView(QTreeView):
 
     def _tag_tree(self, root: SidebarItem) -> None:
         icon = ":/icons/tag-outline.svg"
-        icon_multiple = ":/icons/tag-multiple-outline.svg"
         icon_off = ":/icons/tag-off-outline.svg"
 
         def render(
@@ -715,7 +713,7 @@ class SidebarTreeView(QTreeView):
             for node in nodes:
                 item = SidebarItem(
                     name=node.name,
-                    icon=icon_multiple if node.children else icon,
+                    icon=icon,
                     search_node=SearchNode(tag=head + node.name),
                     on_expanded=toggle_expand(node),
                     expanded=not node.collapsed,
@@ -730,7 +728,7 @@ class SidebarTreeView(QTreeView):
         root = self._section_root(
             root=root,
             name=tr.browsing_sidebar_tags(),
-            icon=icon_multiple,
+            icon=icon,
             collapse_key=Config.Bool.COLLAPSE_TAGS,
             type=SidebarItemType.TAG_ROOT,
         )
@@ -749,7 +747,6 @@ class SidebarTreeView(QTreeView):
 
     def _deck_tree(self, root: SidebarItem) -> None:
         icon = ":/icons/book-outline.svg"
-        icon_multiple = ":/icons/book-multiple-outline.svg"
         icon_current = ":/icons/book-clock-outline.svg"
         icon_filtered = ":/icons/book-cog-outline.svg"
 
@@ -769,11 +766,7 @@ class SidebarTreeView(QTreeView):
             for node in nodes:
                 item = SidebarItem(
                     name=node.name,
-                    icon=icon_filtered
-                    if node.filtered
-                    else icon_multiple
-                    if node.children
-                    else icon,
+                    icon=icon_filtered if node.filtered else icon,
                     search_node=SearchNode(deck=head + node.name),
                     on_expanded=toggle_expand(node),
                     expanded=not node.collapsed,
@@ -789,7 +782,7 @@ class SidebarTreeView(QTreeView):
         root = self._section_root(
             root=root,
             name=tr.browsing_sidebar_decks(),
-            icon=icon_multiple,
+            icon=icon,
             collapse_key=Config.Bool.COLLAPSE_DECKS,
             type=SidebarItemType.DECK_ROOT,
         )
@@ -808,15 +801,14 @@ class SidebarTreeView(QTreeView):
     ###########################
 
     def _notetype_tree(self, root: SidebarItem) -> None:
-        notetype_icon = ":/icons/newspaper-variant-outline.svg"
-        notetype_multiple_icon = ":/icons/newspaper-variant-multiple-outline.svg"
-        template_icon = ":/icons/card-bulleted-outline.svg"
+        notetype_icon = ":/icons/newspaper.svg"
+        template_icon = ":/icons/iframe-braces-outline.svg"
         field_icon = ":/icons/form-textbox.svg"
 
         root = self._section_root(
             root=root,
             name=tr.browsing_sidebar_notetypes(),
-            icon=notetype_multiple_icon,
+            icon=notetype_icon,
             collapse_key=Config.Bool.COLLAPSE_NOTETYPES,
             type=SidebarItemType.NOTETYPE_ROOT,
         )

--- a/qt/aqt/browser/sidebar/tree.py
+++ b/qt/aqt/browser/sidebar/tree.py
@@ -522,13 +522,14 @@ class SidebarTreeView(QTreeView):
     ###########################
 
     def _saved_searches_tree(self, root: SidebarItem) -> None:
-        icon = ":/icons/heart.svg"
+        icon = ":/icons/bookmark-outline.svg"
+        icon_multiple = ":/icons/bookmark-multiple-outline.svg"
         saved = self._get_saved_searches()
 
         root = self._section_root(
             root=root,
             name=tr.browsing_sidebar_saved_searches(),
-            icon=icon,
+            icon=icon_multiple,
             collapse_key=Config.Bool.COLLAPSE_SAVED_SEARCHES,
             type=SidebarItemType.SAVED_SEARCH_ROOT,
         )

--- a/qt/aqt/browser/sidebar/tree.py
+++ b/qt/aqt/browser/sidebar/tree.py
@@ -742,7 +742,10 @@ class SidebarTreeView(QTreeView):
     ###########################
 
     def _deck_tree(self, root: SidebarItem) -> None:
-        icon = ":/icons/deck.svg"
+        icon = ":/icons/book-outline.svg"
+        icon_multiple = ":/icons/book-multiple-outline.svg"
+        icon_current = ":/icons/book-clock-outline.svg"
+        icon_filtered = ":/icons/book-cog-outline.svg"
 
         def render(
             root: SidebarItem, nodes: Iterable[DeckTreeNode], head: str = ""
@@ -760,7 +763,11 @@ class SidebarTreeView(QTreeView):
             for node in nodes:
                 item = SidebarItem(
                     name=node.name,
-                    icon=icon,
+                    icon=icon_filtered
+                    if node.filtered
+                    else icon_multiple
+                    if node.children
+                    else icon,
                     search_node=SearchNode(deck=head + node.name),
                     on_expanded=toggle_expand(node),
                     expanded=not node.collapsed,
@@ -776,14 +783,14 @@ class SidebarTreeView(QTreeView):
         root = self._section_root(
             root=root,
             name=tr.browsing_sidebar_decks(),
-            icon=icon,
+            icon=icon_multiple,
             collapse_key=Config.Bool.COLLAPSE_DECKS,
             type=SidebarItemType.DECK_ROOT,
         )
         root.search_node = SearchNode(deck="_*")
         current = root.add_simple(
             name=tr.browsing_current_deck(),
-            icon=icon,
+            icon=icon_current,
             type=SidebarItemType.DECK_CURRENT,
             search_node=SearchNode(deck="current"),
         )
@@ -799,7 +806,6 @@ class SidebarTreeView(QTreeView):
         notetype_multiple_icon = icon
         notetype_icon = icon
         template_icon = icon
-
 
         root = self._section_root(
             root=root,

--- a/qt/aqt/browser/sidebar/tree.py
+++ b/qt/aqt/browser/sidebar/tree.py
@@ -852,7 +852,6 @@ class SidebarTreeView(QTreeView):
                         SearchNode(note=nt["name"]), SearchNode(field_name=fld["name"])
                     ),
                     item_type=SidebarItemType.NOTETYPE_FIELD,
-                    name_prefix=f"{nt['name']}::",
                     id=fld["ord"],
                 )
                 item.add_child(child)

--- a/qt/aqt/fields.py
+++ b/qt/aqt/fields.py
@@ -28,7 +28,7 @@ class FieldDialog(QDialog):
         mw: AnkiQt,
         nt: NotetypeDict,
         parent: Optional[QWidget] = None,
-        open_at=0,
+        open_at: int = 0,
     ) -> None:
         QDialog.__init__(self, parent or mw)
         self.mw = mw

--- a/qt/aqt/fields.py
+++ b/qt/aqt/fields.py
@@ -24,7 +24,11 @@ from aqt.utils import (
 
 class FieldDialog(QDialog):
     def __init__(
-        self, mw: AnkiQt, nt: NotetypeDict, parent: Optional[QWidget] = None
+        self,
+        mw: AnkiQt,
+        nt: NotetypeDict,
+        parent: Optional[QWidget] = None,
+        open_at=0,
     ) -> None:
         QDialog.__init__(self, parent or mw)
         self.mw = mw
@@ -47,7 +51,7 @@ class FieldDialog(QDialog):
         self.setupSignals()
         self.form.fieldList.setDragDropMode(QAbstractItemView.InternalMove)
         self.form.fieldList.dropEvent = self.onDrop  # type: ignore[assignment]
-        self.form.fieldList.setCurrentRow(0)
+        self.form.fieldList.setCurrentRow(open_at)
         self.exec_()
 
     ##########################################################################

--- a/qt/aqt/forms/icons/BUILD.bazel
+++ b/qt/aqt/forms/icons/BUILD.bazel
@@ -4,8 +4,7 @@ copy_mdi_icons(
     name = "mdi-icons",
     icons = [
         # saved searches
-        "bookmark-outline.svg",
-        "bookmark-multiple-outline.svg",
+        "heart-outline.svg",
 
         # today
         "clock-outline.svg",
@@ -16,21 +15,18 @@ copy_mdi_icons(
 
         # decks
         "book-outline.svg",
-        "book-multiple-outline.svg",
         "book-clock-outline.svg",
         "book-cog-outline.svg",
 
         # notetypes
-        "newspaper-variant-outline.svg",
-        "newspaper-variant-multiple-outline.svg",
-        # cards
-        "card-bulleted-outline.svg",
+        "newspaper.svg",
+        # cardtype
+        "iframe-braces-outline.svg",
         # fields
         "form-textbox.svg",
 
         # tags
         "tag-outline.svg",
-        "tag-multiple-outline.svg",
         "tag-off-outline.svg",
     ],
 )

--- a/qt/aqt/forms/icons/BUILD.bazel
+++ b/qt/aqt/forms/icons/BUILD.bazel
@@ -14,9 +14,10 @@ copy_mdi_icons(
         "circle-outline.svg",
 
         # decks
-        "book-multiple-outline.svg",
         "book-outline.svg",
+        "book-multiple-outline.svg",
         "book-clock-outline.svg",
+        "book-cog-outline.svg",
 
         # notetypes
         "newspaper-variant-outline.svg",

--- a/qt/aqt/forms/icons/BUILD.bazel
+++ b/qt/aqt/forms/icons/BUILD.bazel
@@ -3,11 +3,11 @@ load("//ts:vendor.bzl", "copy_mdi_icons", "copy_bootstrap_icons")
 copy_mdi_icons(
     name = "mdi-icons",
     icons = [
-        "bookmark-multiple-outline.svg",
         "bookmark-outline.svg",
+        "bookmark-multiple-outline.svg",
 
-        "flag-variant.svg",
         "flag-variant-outline.svg",
+        "flag-variant.svg",
 
         # state
         "circle.svg",

--- a/qt/aqt/forms/icons/BUILD.bazel
+++ b/qt/aqt/forms/icons/BUILD.bazel
@@ -3,11 +3,12 @@ load("//ts:vendor.bzl", "copy_mdi_icons", "copy_bootstrap_icons")
 copy_mdi_icons(
     name = "mdi-icons",
     icons = [
+        # saved searches
         "bookmark-outline.svg",
         "bookmark-multiple-outline.svg",
 
-        "flag-variant-outline.svg",
-        "flag-variant.svg",
+        # today
+        "clock-outline.svg",
 
         # state
         "circle.svg",
@@ -34,16 +35,8 @@ copy_mdi_icons(
     ],
 )
 
-copy_bootstrap_icons(
-    name = "bootstrap-icons",
-    icons = [
-        "clock.svg",
-        "clock-history.svg",
-    ],
-)
-
 filegroup(
     name = "icons",
-    srcs = ["mdi-icons", "bootstrap-icons"] + glob(["*.svg", "*.png"]),
+    srcs = ["mdi-icons"] + glob(["*.svg", "*.png"]),
     visibility = ["//visibility:public"],
 )

--- a/qt/aqt/forms/icons/BUILD.bazel
+++ b/qt/aqt/forms/icons/BUILD.bazel
@@ -13,6 +13,10 @@ copy_mdi_icons(
         "circle.svg",
         "circle-outline.svg",
 
+        # flags
+        "flag.svg",
+        "flag-outline.svg",
+
         # decks
         "book-outline.svg",
         "book-clock-outline.svg",

--- a/qt/aqt/forms/icons/BUILD.bazel
+++ b/qt/aqt/forms/icons/BUILD.bazel
@@ -1,15 +1,48 @@
-load("//ts:vendor.bzl", "copy_mdi_icons")
+load("//ts:vendor.bzl", "copy_mdi_icons", "copy_bootstrap_icons")
 
 copy_mdi_icons(
     name = "mdi-icons",
     icons = [
+        "bookmark-multiple-outline.svg",
+        "bookmark-outline.svg",
+
+        "flag-variant.svg",
+        "flag-variant-outline.svg",
+
+        # state
+        "circle.svg",
+        "circle-outline.svg",
+
+        # decks
+        "book-multiple-outline.svg",
+        "book-outline.svg",
+        "book-clock-outline.svg",
+
+        # notetypes
+        "newspaper-variant-outline.svg",
+        "newspaper-variant-multiple-outline.svg",
+        # cards
+        "card-bulleted-outline.svg",
+        # fields
+        "form-textbox.svg",
+
+        # tags
         "tag-outline.svg",
+        "tag-multiple-outline.svg",
         "tag-off-outline.svg",
+    ],
+)
+
+copy_bootstrap_icons(
+    name = "bootstrap-icons",
+    icons = [
+        "clock.svg",
+        "clock-history.svg",
     ],
 )
 
 filegroup(
     name = "icons",
-    srcs = ["mdi-icons"] + glob(["*.svg", "*.png"]),
+    srcs = ["mdi-icons", "bootstrap-icons"] + glob(["*.svg", "*.png"]),
     visibility = ["//visibility:public"],
 )

--- a/rslib/src/backend/search/search_node.rs
+++ b/rslib/src/backend/search/search_node.rs
@@ -42,7 +42,7 @@ impl TryFrom<pb::SearchNode> for Node {
                 }),
                 Filter::FieldName(s) => Node::Search(SearchNode::SingleField {
                     field: escape_anki_wildcards_for_search_node(&s),
-                    text: "*".to_string(),
+                    text: "_*".to_string(),
                     is_re: false,
                 }),
                 Filter::Rated(rated) => Node::Search(SearchNode::Rated {


### PR DESCRIPTION
All icons of `SidebarItem`s are updated, except for flags.

Images:
<img width="216" alt="Screenshot 2021-06-16 at 16 23 07" src="https://user-images.githubusercontent.com/7188844/122240398-094dc100-cec2-11eb-8900-6dae088ff294.png">

<img width="218" alt="Screenshot 2021-06-16 at 16 24 59" src="https://user-images.githubusercontent.com/7188844/122240423-0eab0b80-cec2-11eb-8c3c-d7838e418f3e.png">

Highlights:
* I've added Notetype fields as `SidebarItem`s. These items will search for cards of this notetype, which are non-empty in this specific field. They also have a special menu item, to go to the Fields dialog. @RumovZ Could you possibly review d918a195856ca93c866af16bb55726c4e5b64de6?
* Collapse decks and tags have special icons.
* The current deck has a special icon
* Filtered decks have special icons
* The saved search icon now resembles a bookmark. There would also a heart and multiple heart icon available in the mdi iconset. 
* Flags and Card State have a neutral colour on their root icon, rather than grey.

Personally I like how the icons look more uniform now. 
I didn't change the flag icon, because the mdi version was a tad smaller, which made it hard to distinguish the colour, and ours doesn't stick out.
I'm not super happy with how the notetype icon and template/card type icon look a bit too similiar...