### PR TITLE
Add darwin arm 64 to platforms (Apple silicon / M1)

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -83,6 +83,7 @@ qubist-pixel-ux <github.com/qubist-pixel-ux>
 cherryblossom <github.com/cherryblossom000>
 Hikaru Yoshiga <github.com/hikaru-y>
 Thore Tyborski <github.com/ThoreBor>
+Sergio Isidoro <smaisidoro@gmail.com>
 
 ********************
 

--- a/platforms/BUILD.bazel
+++ b/platforms/BUILD.bazel
@@ -20,7 +20,7 @@ config_setting(
     name = "macos_darwin_arm64",
     constraint_values = [
         "@platforms//os:macos",
-        "@platforms//cpu:darwin_arm64",
+        "@platforms//cpu:arm64",
     ],
 )
 

--- a/platforms/BUILD.bazel
+++ b/platforms/BUILD.bazel
@@ -17,6 +17,14 @@ config_setting(
 )
 
 config_setting(
+    name = "macos_darwin_arm64",
+    constraint_values = [
+        "@platforms//os:macos",
+        "@platforms//cpu:darwin_arm64",
+    ],
+)
+
+config_setting(
     name = "linux_x86_64",
     constraint_values = [
         "@platforms//os:linux",

--- a/protobuf.bzl
+++ b/protobuf.bzl
@@ -14,6 +14,7 @@ alias(
     actual = select({
         "@net_ankiweb_anki//platforms:windows_x86_64": "@protoc_bin_windows//:bin/protoc.exe",
         "@net_ankiweb_anki//platforms:macos_x86_64": "@protoc_bin_macos//:bin/protoc",
+        "@net_ankiweb_anki//platforms:macos_darwin_arm64": "@protoc_bin_macos_arm//:bin/protoc",
         "@net_ankiweb_anki//platforms:linux_x86_64": "@protoc_bin_linux_x86_64//:bin/protoc",
         "@net_ankiweb_anki//platforms:linux_arm64": "@protoc_bin_linux_arm64//:bin/protoc"
     }),
@@ -31,6 +32,16 @@ def setup_protobuf_binary(name):
     maybe(
         http_archive,
         name = "protoc_bin_macos",
+        urls = [
+            "https://github.com/protocolbuffers/protobuf/releases/download/v3.14.0/protoc-3.14.0-osx-x86_64.zip",
+        ],
+        sha256 = "699ceee7ef0988ecf72bf1c146dee5d9d89351a19d4093d30ebea3c04008bb8c",
+        build_file_content = """exports_files(["bin/protoc"])""",
+    )
+
+    maybe(
+        http_archive,
+        name = "protoc_bin_macos_arm",
         urls = [
             "https://github.com/protocolbuffers/protobuf/releases/download/v3.14.0/protoc-3.14.0-osx-x86_64.zip",
         ],

--- a/pylib/anki/BUILD.bazel
+++ b/pylib/anki/BUILD.bazel
@@ -70,6 +70,7 @@ py_wheel(
     platform = select({
         "//platforms:windows_x86_64": "win_amd64",
         "//platforms:macos_x86_64": "macosx_10_7_x86_64",
+        "//platforms:macos_darwin_arm64": "macosx_10_7_arm64",
         "//platforms:linux_x86_64": "manylinux2014_x86_64",
         "//platforms:linux_arm64": "manylinux2014_aarch64",
     }),

--- a/rslib/clang_format.bzl
+++ b/rslib/clang_format.bzl
@@ -16,6 +16,7 @@ alias(
     actual = select({
         "@net_ankiweb_anki//platforms:windows_x86_64": "@clang_format_windows_x86_64//:clang-format.exe",
         "@net_ankiweb_anki//platforms:macos_x86_64": "@clang_format_macos_x86_64//:clang-format",
+        "@net_ankiweb_anki//platforms:macos_darwin_arm64": "@clang_format_macos_arm64//:clang-format",
         "@net_ankiweb_anki//platforms:linux_x86_64": "@clang_format_linux_x86_64//:clang-format",
     }),
     visibility = ["//visibility:public"]
@@ -36,6 +37,16 @@ def setup_clang_format(name):
         sha256 = "238be68d9478163a945754f06a213483473044f5a004c4125d3d9d8d3556466e",
         urls = [
             "https://github.com/ankitects/clang-format-binaries/releases/download/anki-2021-01-09/clang-format_macos_x86_64.zip",
+        ],
+    )
+
+    maybe(
+        http_archive,
+        name = "clang_format_macos_arm64",
+        build_file_content = """exports_files(["clang-format"])""",
+        sha256 = "238be68d9478163a945754f06a213483473044f5a004c4125d3d9d8d3556466e",
+        urls = [
+            "https://github.com/ankitects/clang-format-binaries/releases/download/anki-2021-01-09/clang-format_macos_arm64.zip",
         ],
     )
 


### PR DESCRIPTION
Hey there,

This is a long shot because I'm still trying to understand the build process

I hope I got this right, that build-kite just uses Bazel with dynamic arguments picked up from the platforms.
But I'm not sure how this will work on build-kite, and if there needs to be some configuration to run this build in an ARM machine.

Thought of opening an PR instead of just opening an issue.

Have a great day.