### PR TITLE
add support for native certificates (on Linux)

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -83,6 +83,7 @@ qubist-pixel-ux <github.com/qubist-pixel-ux>
 cherryblossom <github.com/cherryblossom000>
 Hikaru Yoshiga <github.com/hikaru-y>
 Thore Tyborski <github.com/ThoreBor>
+Deminder <tremminder@gmail.com>
 
 ********************
 

--- a/cargo/BUILD.reqwest.rustls.bazel
+++ b/cargo/BUILD.reqwest.rustls.bazel
@@ -57,6 +57,7 @@ rust_library(
         "rustls",
         "rustls-tls",
         "rustls-tls-webpki-roots",
+        "rustls-tls-native-roots",
         "serde_json",
         "socks",
         "stream",
@@ -114,6 +115,7 @@ rust_library(
             "@raze__tokio_rustls__0_22_0//:tokio_rustls",
             "@raze__tokio_socks__0_5_1//:tokio_socks",
             "@raze__webpki_roots__0_21_1//:webpki_roots",
+            "@raze__rustls_native_certs__0_5_0//:rustls_native_certs",
         ],
         "//conditions:default": [],
     }) + selects.with_or({

--- a/cargo/crates.bzl
+++ b/cargo/crates.bzl
@@ -2930,3 +2930,15 @@ def raze_fetch_remote_crates():
         build_file = Label("//cargo:BUILD.reqwest.rustls.bazel"),
         init_submodules = True,
     )
+
+    maybe(
+        http_archive,
+        name = "raze__rustls_native_certs__0_5_0",
+        url = "https://crates.io/api/v1/crates/rustls-native-certs/0.5.0/download",
+        type = "tar.gz",
+        sha256 = "5a07b7c1885bd8ed3831c289b7870b13ef46fe0e856d288c30d9cc17d75a2092",
+        strip_prefix = "rustls-native-certs-0.5.0",
+        build_file = Label("//cargo/remote:BUILD.rustls-native-certs-0.5.0.bazel"),
+    )
+
+

--- a/cargo/remote/BUILD.rustls-native-certs-0.5.0.bazel
+++ b/cargo/remote/BUILD.rustls-native-certs-0.5.0.bazel
@@ -1,0 +1,61 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # Apache-2.0 from expression "Apache-2.0 OR (ISC OR MIT)"
+])
+
+
+# Generated Targets
+
+rust_library(
+    name = "rustls_native_certs",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+        "default",
+        "rustls",
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    data = [],
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.5.0",
+    # buildifier: leave-alone
+    deps = [
+        "@raze__openssl_probe__0_1_4//:openssl_probe",
+        "@raze__schannel__0_1_19//:schannel",
+        "@raze__security_framework__2_3_1//:security_framework",
+        "@raze__rustls__0_19_1//:rustls",
+    ],
+)
+

--- a/rslib/Cargo.toml
+++ b/rslib/Cargo.toml
@@ -64,6 +64,7 @@ reqwest = { git = "https://github.com/ankitects/reqwest.git", rev = "7591444614d
     "native-tls",
     "rustls-tls",
     "rustls-tls-webpki-roots",
+    "rustls-tls-native-roots",
 ] }
 rusqlite = { version = "0.24.1", features = ["trace", "functions", "collation", "bundled"] }
 scopeguard = "1.1.0"


### PR DESCRIPTION
Hey,

I was playing around with the latest version of anki and noticed that native configured root certificates do not work.
It may very well be that I just missed something, but I reckon that this should be fixed.

I enabled the `rustls-tls-native-roots` feature of `reqwest` in `rslib/Cargo.toml` for the `rustls-native-certs` crate.
(The bazel files are manually adjusted, since I had problems with cargo-raze ignoring build-dependencies)