### PR TITLE
Add minimal tests to html-filter

### DIFF
--- a/ts/html-filter/BUILD.bazel
+++ b/ts/html-filter/BUILD.bazel
@@ -5,17 +5,18 @@ load("//ts:eslint.bzl", "eslint_test")
 
 ts_library(
     name = "html-filter",
-    module_name = "html-filter",
     srcs = glob(
         ["*.ts"],
         exclude = ["*.test.ts"],
     ),
+    module_name = "html-filter",
     tsconfig = "//ts:tsconfig.json",
     visibility = ["//visibility:public"],
     deps = [],
 )
 
 jest_test(
+    env = "jsdom",
     deps = [
         "html-filter",
     ],

--- a/ts/html-filter/index.test.ts
+++ b/ts/html-filter/index.test.ts
@@ -1,6 +1,12 @@
 // Copyright: Ankitects Pty Ltd and contributors
 // License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
-test("it should work", () => {
-    expect("test").toBe("test");
+import { filterHTML } from ".";
+
+describe("filterHTML", () => {
+    test("zero input creates zero output", () => {
+        expect(filterHTML("", true, false)).toBe("");
+        expect(filterHTML("", true, false)).toBe("");
+        expect(filterHTML("", false, false)).toBe("");
+    });
 });

--- a/ts/jest.bzl
+++ b/ts/jest.bzl
@@ -2,7 +2,7 @@ load("@npm//@bazel/typescript:index.bzl", "ts_library")
 load("@esbuild_toolchain//:esbuild.bzl", esbuild = "esbuild_macro")
 load("@npm//jest-cli:index.bzl", _jest_test = "jest_test")
 
-def jest_test(deps, name = "jest", protobuf = False):
+def jest_test(deps, name = "jest", protobuf = False, env = "node"):
     "Build *.test.ts into a library, then test it with Jest."
 
     ts_sources = native.glob(["*.test.ts"])
@@ -61,6 +61,7 @@ def jest_test(deps, name = "jest", protobuf = False):
             "--colors",
             "--config",
             "$(location //ts:jest.config.js)",
+            "--env=" + env,
         ],
         data = bundled_srcs + [
             "//ts:jest.config.js",


### PR DESCRIPTION
This is more of an issue, then a PR: When actually trying to create actual tests that use the DOM API, I get this error:

```
 FAIL  ts/html-filter/index.bundle.test.js
  filterHTML
    ✕ zero input creates zero output (1 ms)

  ● filterHTML › zero input creates zero output

    The error below may be caused by using the wrong test environment, see https://jestjs.io/docs/configuration#testenvironment-string.
    Consider using the "jsdom" test environment.

    ReferenceError: document is not defined

      at filterHTML (../../../../ts/html-filter/index.ts:41:22)
      at Object.<anonymous> (../../../../ts/html-filter/index.test.ts:8:16)

Test Suites: 1 failed, 1 total
Tests:       1 failed, 1 total
Snapshots:   0 total
Time:        0.754 s
Ran all test suites.
```

I tried adding the header 
```
/**
  * jest-environment jsdom
  */
```
to the header of `index.test.ts`, like it is suggested in the link. However this is filtered out, once it is compiled to `index.bundle.test.js`.