### PR TITLE
Move deck options revert button to right; hide when inactive

### DIFF
--- a/ts/deckoptions/EnumSelectorRow.svelte
+++ b/ts/deckoptions/EnumSelectorRow.svelte
@@ -20,10 +20,10 @@
 
 <Row>
     <Col size={7}>
-        <RevertButton bind:value {defaultValue} />
         <TooltipLabel {markdownTooltip}><slot /></TooltipLabel>
     </Col>
     <Col {breakpoint} size={5}>
         <EnumSelector bind:value {choices} />
+        <RevertButton bind:value {defaultValue} />
     </Col>
 </Row>

--- a/ts/deckoptions/RevertButton.svelte
+++ b/ts/deckoptions/RevertButton.svelte
@@ -32,7 +32,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
     let modified: boolean;
     $: modified = !isEqual(value, defaultValue);
-    $: className = !modified ? "opacity-25" : "";
+    $: className = !modified ? "opacity-0" : "";
 
     const isTouchDevice = getContext<boolean>(touchDeviceKey);
 

--- a/ts/deckoptions/SpinBoxFloatRow.svelte
+++ b/ts/deckoptions/SpinBoxFloatRow.svelte
@@ -18,10 +18,10 @@
 
 <Row>
     <Col size={7}>
-        <RevertButton bind:value {defaultValue} />
         <TooltipLabel {markdownTooltip}><slot /></TooltipLabel>
     </Col>
     <Col size={5}>
         <SpinBoxFloat bind:value {min} {max} />
+        <RevertButton bind:value {defaultValue} />
     </Col>
 </Row>

--- a/ts/deckoptions/SpinBoxRow.svelte
+++ b/ts/deckoptions/SpinBoxRow.svelte
@@ -18,10 +18,10 @@
 
 <Row>
     <Col size={7}>
-        <RevertButton bind:value {defaultValue} />
         <TooltipLabel {markdownTooltip}><slot /></TooltipLabel>
     </Col>
     <Col size={5}>
         <SpinBox bind:value {min} {max} />
+        <RevertButton bind:value {defaultValue} />
     </Col>
 </Row>

--- a/ts/deckoptions/StepsInputRow.svelte
+++ b/ts/deckoptions/StepsInputRow.svelte
@@ -16,10 +16,10 @@
 
 <Row>
     <Col size={7}>
-        <RevertButton bind:value {defaultValue} />
         <TooltipLabel {markdownTooltip}><slot /></TooltipLabel>
     </Col>
     <Col size={5}>
         <StepsInput bind:value />
+        <RevertButton bind:value {defaultValue} />
     </Col>
 </Row>

--- a/ts/deckoptions/SwitchRow.svelte
+++ b/ts/deckoptions/SwitchRow.svelte
@@ -19,12 +19,12 @@
 
 <Row>
     <Col>
-        <RevertButton bind:value {defaultValue} />
         {#if markdownTooltip}<TooltipLabel for={id} {markdownTooltip}
                 ><slot /></TooltipLabel
             >{:else}<Label for={id}><slot /></Label>{/if}
     </Col>
     <Col grow={false}>
         <Switch {id} bind:value />
+        <RevertButton bind:value {defaultValue} />
     </Col>
 </Row>


### PR DESCRIPTION
IMHO, showing an inactive button next to every element makes the screen feel a bit busy:

![IMG_8F064466F6E0-1](https://user-images.githubusercontent.com/180542/122841133-e34f7300-d33e-11eb-8c63-8c4db9332069.jpeg)

If we hide the button when inactive, the margins then look odd. Note also that the second bury switch wraps awkwardly:

![IMG_1363](https://user-images.githubusercontent.com/180542/122841181-f7937000-d33e-11eb-97e4-e5afd1137ef3.PNG)

While no masterpiece, having the revert button on the right seems to be slightly preferable to me. Now that it has a separate confirmation step, there shouldn't be a risk of accidental triggering, and it allows a bit more room for the text on the left. Thoughts?

![IMG_1364](https://user-images.githubusercontent.com/180542/122841222-0f6af400-d33f-11eb-937f-d8cc393cd1b8.PNG)
