### PR TITLE
Adapt use of createDropdown for editor buttons

### DIFF
--- a/ts/editor/FormatBlockButtons.svelte
+++ b/ts/editor/FormatBlockButtons.svelte
@@ -65,7 +65,10 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     <ButtonGroupItem>
         <WithDropdownMenu let:createDropdown let:menuId>
             <OnlyEditable let:disabled>
-                <IconButton {disabled} on:mount={createDropdown}>
+                <IconButton
+                    {disabled}
+                    on:mount={(event) => createDropdown(event.detail.button)}
+                >
                     {@html listOptionsIcon}
                 </IconButton>
             </OnlyEditable>

--- a/ts/editor/TemplateButtons.svelte
+++ b/ts/editor/TemplateButtons.svelte
@@ -88,7 +88,10 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     <ButtonGroupItem>
         <WithDropdownMenu let:createDropdown let:menuId>
             <WithContext key={disabledKey} let:context={disabled}>
-                <IconButton {disabled} on:mount={createDropdown}>
+                <IconButton
+                    {disabled}
+                    on:mount={(event) => createDropdown(event.detail.button)}
+                >
                     {@html functionIcon}
                 </IconButton>
             </WithContext>


### PR DESCRIPTION
I introduced a regression in #1207 for the dropdowns in the editor when creating the dropdown on the gear icon badge.