### PR TITLE
Clozes as web components

### DIFF
--- a/ts/editor/BUILD.bazel
+++ b/ts/editor/BUILD.bazel
@@ -27,17 +27,6 @@ compile_svelte(
 
 compile_sass(
     srcs = [
-        "editable.scss",
-    ],
-    group = "editable_scss",
-    visibility = ["//visibility:public"],
-    deps = [
-        "//ts/sass:scrollbar_lib",
-    ],
-)
-
-compile_sass(
-    srcs = [
         "fields.scss",
     ],
     group = "base_css",
@@ -45,6 +34,17 @@ compile_sass(
     deps = [
         "//ts/sass:base_lib",
         "//ts/sass:buttons_lib",
+        "//ts/sass:scrollbar_lib",
+    ],
+)
+
+compile_sass(
+    srcs = [
+        "editable.scss",
+    ],
+    group = "editable_scss",
+    visibility = ["//visibility:public"],
+    deps = [
         "//ts/sass:scrollbar_lib",
     ],
 )

--- a/ts/editor/ClozeButton.svelte
+++ b/ts/editor/ClozeButton.svelte
@@ -39,7 +39,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
     function onCloze(event: KeyboardEvent | MouseEvent): void {
         const highestCloze = getCurrentHighestCloze(!event.getModifierState("Alt"));
-        wrapCurrent(`{{c${highestCloze}::`, "}}");
+        wrapCurrent(`<anki-cloze card="${highestCloze}">`, "</anki-cloze>");
     }
 </script>
 

--- a/ts/editor/ClozeButton.svelte
+++ b/ts/editor/ClozeButton.svelte
@@ -10,9 +10,9 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     import WithShortcut from "components/WithShortcut.svelte";
     import WithContext from "components/WithContext.svelte";
 
+    import type { Cloze } from "./cloze";
     import { bracketsIcon } from "./icons";
-    import { forEditorField } from ".";
-    import { wrapCurrent } from "./wrap";
+    import { forEditorField, getCurrentField } from ".";
 
     const clozePattern = /\{\{c(\d+)::/gu;
     function getCurrentHighestCloze(increment: boolean): number {
@@ -39,7 +39,15 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
     function onCloze(event: KeyboardEvent | MouseEvent): void {
         const highestCloze = getCurrentHighestCloze(!event.getModifierState("Alt"));
-        wrapCurrent(`<anki-cloze card="${highestCloze}">`, "</anki-cloze>");
+        const clozeWrapper = document.createElement("anki-cloze") as Cloze;
+        clozeWrapper.setAttribute("card", String(highestCloze))
+
+        const currentField = getCurrentField()!;
+        const selection = currentField.getSelection()!;
+
+        const range = selection.getRangeAt(0);
+        range.surroundContents(clozeWrapper);
+        clozeWrapper.caretToEnd();
     }
 </script>
 

--- a/ts/editor/FormatBlockButtons.svelte
+++ b/ts/editor/FormatBlockButtons.svelte
@@ -65,7 +65,10 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     <ButtonGroupItem>
         <WithDropdownMenu let:createDropdown let:menuId>
             <OnlyEditable let:disabled>
-                <IconButton {disabled} on:mount={createDropdown}>
+                <IconButton
+                    {disabled}
+                    on:mount={(event) => createDropdown(event.detail.button)}
+                >
                     {@html listOptionsIcon}
                 </IconButton>
             </OnlyEditable>

--- a/ts/editor/TemplateButtons.svelte
+++ b/ts/editor/TemplateButtons.svelte
@@ -88,7 +88,10 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     <ButtonGroupItem>
         <WithDropdownMenu let:createDropdown let:menuId>
             <WithContext key={disabledKey} let:context={disabled}>
-                <IconButton {disabled} on:mount={createDropdown}>
+                <IconButton
+                    {disabled}
+                    on:mount={(event) => createDropdown(event.detail.button)}
+                >
                     {@html functionIcon}
                 </IconButton>
             </WithContext>

--- a/ts/editor/cloze.ts
+++ b/ts/editor/cloze.ts
@@ -157,6 +157,14 @@ export class Cloze extends HTMLElement {
         return ["card"];
     }
 
+    attributeChangedCallback(name: string, _oldValue: string, newValue: string): void {
+        switch (name) {
+            case "card":
+                this.input.value = newValue;
+                break;
+        }
+    }
+
     connectedCallback(): void {
         this.decorate();
         this.observe();
@@ -168,14 +176,6 @@ export class Cloze extends HTMLElement {
         this.disconnect();
 
         this.input.removeEventListener("change", this.updateCardValue);
-    }
-
-    attributeChangedCallback(name: string, _oldValue: string, newValue: string): void {
-        switch (name) {
-            case "card":
-                this.input.value = newValue;
-                break;
-        }
     }
 
     updateCardValue(): void {

--- a/ts/editor/cloze.ts
+++ b/ts/editor/cloze.ts
@@ -1,0 +1,87 @@
+// Copyright: Ankitects Pty Ltd and contributors
+// License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
+
+function autoresizeInput(input: HTMLInputElement) {
+    input.style.width = "0";
+    while (input.style.width !== `${input.scrollWidth}px`) {
+        console.log("autoresize:", input.style.width, "to", `${input.scrollWidth}px`);
+        input.style.width = `${input.scrollWidth}px`;
+    }
+}
+
+function noEmpty(input: HTMLInputElement) {
+    if (input.value.length === 0) {
+        input.value = "1";
+    }
+}
+
+function respondToVisibility(
+    element: HTMLElement,
+    callback: () => void
+) {
+    const options = {
+        root: document.documentElement,
+    };
+    const observer = new IntersectionObserver(
+        (entries) => entries.forEach((entry) => {
+            if (entry.intersectionRatio > 0) {
+                callback();
+            }
+        }),
+        options
+    );
+    observer.observe(element);
+}
+
+export class ClozeNumberInput extends HTMLInputElement {
+    constructor() {
+        super();
+        this.type = "number";
+        this.min = "1";
+        this.max = "499";
+
+        this.className = "anki-cloze-number-input";
+
+        this.onInput = this.onInput.bind(this);
+        this.onChange = this.onChange.bind(this);
+
+        noEmpty(this);
+        respondToVisibility(this, () => autoresizeInput(this));
+    }
+
+    onChange(): void {
+        noEmpty(this);
+    }
+
+    onInput(): void {
+        autoresizeInput(this);
+    }
+
+    connectedCallback(): void {
+        this.addEventListener("change", this.onChange);
+        this.addEventListener("input", this.onInput);
+    }
+
+    disconnectedCallback(): void {
+        this.removeEventListener("change", this.onChange);
+        this.removeEventListener("input", this.onInput);
+    }
+}
+
+customElements.define("anki-cloze-number-input", ClozeNumberInput, {
+    extends: "input",
+});
+
+export class Cloze extends HTMLElement {
+    input: ClozeNumberInput;
+
+    constructor() {
+        super();
+        this.input = document.createElement("input", {
+            is: "anki-cloze-number-input",
+        }) as ClozeNumberInput;
+        this.appendChild(this.input);
+    }
+
+    connectedCallback(): void {}
+}

--- a/ts/editor/cloze.ts
+++ b/ts/editor/cloze.ts
@@ -153,7 +153,7 @@ export class Cloze extends HTMLElement {
         return close;
     }
 
-    static get observedAttributes() {
+    static get observedAttributes(): string[] {
         return ["card"];
     }
 
@@ -229,16 +229,19 @@ export class Cloze extends HTMLElement {
             this.replaceWith(...clozed);
 
             if (parent && movePosition) {
-                // place caret at the end of the inner text
-                const range = new Range();
-                range.setStart(...movePosition);
-                range.collapse(true);
-
                 const selection = (
                     parent.getRootNode() as ShadowRoot | Document
-                ).getSelection()!;
-                selection.removeAllRanges();
-                selection.addRange(range);
+                ).getSelection();
+
+                if (selection) {
+                    // place caret at the end of the inner text
+                    const range = new Range();
+                    range.setStart(...movePosition);
+                    range.collapse(true);
+
+                    selection.removeAllRanges();
+                    selection.addRange(range);
+                }
             }
 
             // anki-cloze could have been removed as well in the meantime

--- a/ts/editor/cloze.ts
+++ b/ts/editor/cloze.ts
@@ -222,7 +222,7 @@ export class Cloze extends HTMLElement {
             );
 
             let movePosition: [Node, number] | null = null;
-            if (closeRemoved && !openRemoved) {
+            if (closeRemoved && !openRemoved && clozed.length > 0) {
                 movePosition = getLastPossiblePosition(clozed[clozed.length - 1]);
             }
 

--- a/ts/editor/cloze.ts
+++ b/ts/editor/cloze.ts
@@ -178,6 +178,29 @@ export class Cloze extends HTMLElement {
         this.input.removeEventListener("change", this.updateCardValue);
     }
 
+    caretToEnd(): void {
+        const selection = (
+            this.getRootNode() as ShadowRoot | Document
+        ).getSelection();
+        const clozed = Array.prototype.slice.call(this.childNodes, 1, -1);
+        const range = new Range();
+
+        if (clozed.length === 0) {
+            range.setStart(this, 1);
+            range.collapse(true);
+        }
+        else {
+            const position = getLastPossiblePosition(clozed[clozed.length - 1]);
+            range.setStart(...position);
+        }
+
+        if (selection) {
+            // place caret at the end of the inner text
+            selection.removeAllRanges();
+            selection.addRange(range);
+        }
+    }
+
     updateCardValue(): void {
         this.setAttribute("card", this.input.value);
     }

--- a/ts/editor/cloze.ts
+++ b/ts/editor/cloze.ts
@@ -15,19 +15,17 @@ function noEmpty(input: HTMLInputElement) {
     }
 }
 
-function respondToVisibility(
-    element: HTMLElement,
-    callback: () => void
-) {
+function respondToVisibility(element: HTMLElement, callback: () => void) {
     const options = {
         root: document.documentElement,
     };
     const observer = new IntersectionObserver(
-        (entries) => entries.forEach((entry) => {
-            if (entry.intersectionRatio > 0) {
-                callback();
-            }
-        }),
+        (entries) =>
+            entries.forEach((entry) => {
+                if (entry.intersectionRatio > 0) {
+                    callback();
+                }
+            }),
         options
     );
     observer.observe(element);
@@ -45,7 +43,6 @@ export class ClozeNumberInput extends HTMLInputElement {
         this.onInput = this.onInput.bind(this);
         this.onChange = this.onChange.bind(this);
 
-        noEmpty(this);
         respondToVisibility(this, () => autoresizeInput(this));
     }
 
@@ -74,14 +71,41 @@ customElements.define("anki-cloze-number-input", ClozeNumberInput, {
 
 export class Cloze extends HTMLElement {
     input: ClozeNumberInput;
+    open: HTMLSpanElement;
+    close: HTMLSpanElement;
 
     constructor() {
         super();
+        this.open = document.createElement("span");
+        this.open.setAttribute("contenteditable", "false");
+
+        const prefix = document.createTextNode("{{c");
+        this.open.append(prefix);
+
         this.input = document.createElement("input", {
             is: "anki-cloze-number-input",
         }) as ClozeNumberInput;
-        this.appendChild(this.input);
+        this.open.append(this.input);
+
+        const infix = document.createTextNode("::");
+        this.open.appendChild(infix);
+        this.prepend(this.open);
+
+        this.close = document.createElement("span");
+        this.close.textContent = "}}";
+        this.close.setAttribute("contenteditable", "false");
+        this.append(this.close);
     }
 
-    connectedCallback(): void {}
+    static get observedAttributes() {
+        return ["card"];
+    }
+
+    attributeChangedCallback(name: string, _oldValue: string, newValue: string): void {
+        switch (name) {
+            case "card":
+                this.input.value = newValue;
+                break;
+        }
+    }
 }

--- a/ts/editor/editable.scss
+++ b/ts/editor/editable.scss
@@ -50,3 +50,15 @@ img.drawing {
     height: auto;
     padding: 6px 0;
 }
+
+.anki-cloze-number-input {
+    // width: 0;
+    padding: 0;
+    border: none;
+    color: inherit;
+    background: inherit;
+    display: inline;
+    font-family: inherit;
+    font-weight: inherit;
+    font-size: inherit;
+}

--- a/ts/editor/editable.scss
+++ b/ts/editor/editable.scss
@@ -51,6 +51,10 @@ img.drawing {
     padding: 6px 0;
 }
 
+anki-cloze {
+    display: inline-block;
+}
+
 .anki-cloze-number-input {
     // width: 0;
     padding: 0;

--- a/ts/editor/editable.scss
+++ b/ts/editor/editable.scss
@@ -65,4 +65,9 @@ anki-cloze {
     font-family: inherit;
     font-weight: inherit;
     font-size: inherit;
+
+    &::-webkit-inner-spin-button,
+    &::-webkit-outer-spin-button {
+        opacity: 1;
+    }
 }

--- a/ts/editor/editable.ts
+++ b/ts/editor/editable.ts
@@ -45,9 +45,10 @@ export class Editable extends HTMLElement {
             cloze.cleanup();
         }
 
-        const result = containsInlineContent(this) && this.innerHTML.endsWith("<br>")
-            ? this.innerHTML.slice(0, -4) // trim trailing <br>
-            : this.innerHTML;
+        const result =
+            containsInlineContent(this) && this.innerHTML.endsWith("<br>")
+                ? this.innerHTML.slice(0, -4) // trim trailing <br>
+                : this.innerHTML;
 
         for (const cloze of this.containedClozes) {
             cloze.decorate();
@@ -59,10 +60,12 @@ export class Editable extends HTMLElement {
     connectedCallback(): void {
         this.setAttribute("contenteditable", "");
         this.addEventListener("newcloze", this.onNewCloze);
+        this.addEventListener("removecloze", this.onRemoveCloze);
     }
 
     disconnectedCallback(): void {
         this.removeEventListener("newcloze", this.onNewCloze);
+        this.removeEventListener("removecloze", this.onRemoveCloze);
     }
 
     focus(): void {
@@ -95,5 +98,12 @@ export class Editable extends HTMLElement {
 
     onNewCloze(event: Event): void {
         this.containedClozes.push(event.target as Cloze);
+    }
+
+    onRemoveCloze(event: Event): void {
+        this.containedClozes.splice(
+            this.containedClozes.indexOf(event.target as Cloze),
+            1
+        );
     }
 }

--- a/ts/editor/index.ts
+++ b/ts/editor/index.ts
@@ -18,6 +18,7 @@ import { LabelContainer } from "./labelContainer";
 import { EditingArea } from "./editingArea";
 import { Editable } from "./editable";
 import { Codable } from "./codable";
+import { Cloze } from "./cloze";
 import { initToolbar } from "./toolbar";
 
 export { setNoteId, getNoteId } from "./noteId";
@@ -34,11 +35,12 @@ declare global {
     }
 }
 
-customElements.define("anki-editable", Editable);
-customElements.define("anki-codable", Codable, { extends: "textarea" });
-customElements.define("anki-editing-area", EditingArea, { extends: "div" });
-customElements.define("anki-label-container", LabelContainer, { extends: "div" });
 customElements.define("anki-editor-field", EditorField, { extends: "div" });
+customElements.define("anki-label-container", LabelContainer, { extends: "div" });
+customElements.define("anki-editing-area", EditingArea, { extends: "div" });
+customElements.define("anki-codable", Codable, { extends: "textarea" });
+customElements.define("anki-editable", Editable);
+customElements.define("anki-cloze", Cloze);
 
 export function getCurrentField(): EditingArea | null {
     return document.activeElement instanceof EditingArea


### PR DESCRIPTION
This is a draft which addresses https://github.com/ankitects/anki/issues/1051, but in a different way than suggested in the issue.

I have tried something similar before, but always failed. Two takeaways I can take from those failed attempts:
1. pseudo elements (`::before`, and `::after`) are terribly buggy in contenteditable. (Especially in WebKit browsers) (e.g. https://jsfiddle.net/bj0p3evr/).
2. Shadow roots are buggy in contenteditable (interestingly in the same way as pseudo elements)

This PR uses neither.
In the folllwing screenshot, `c1` is a web component, `c2` is just regular text.

![Screenshot 2021-06-23 at 12 22 05](https://user-images.githubusercontent.com/7188844/123080825-9f7f6b00-d41d-11eb-8feb-ae3660c05bd5.png)

To the unknowing eye, the web component cloze does not look much different. But it has separate representations, depending on whether you ask `EditingArea`, `Editable`, or `Codable`.:

`EditingArea.fieldHTML` sees it as just text, just as the current implementation:
```
This is a {{c1::cloze}}.
```

`Editable.fieldHTML` sees it as a web component:
```html
This is a <anki-cloze card="1"><span contenteditable="false" data-cloze="open">{{c<input is="anki-cloze-number-input" type="number" tabindex="-1" min="1" max="499" class="anki-cloze-number-input" style="width: 25px;">::</span>cloze<span contenteditable="false" data-cloze="close">}}</span>.</anki-cloze>
```

`Codable.fieldHTML` sees it as a web component without the extra markup (allows for easier editing, and hiding of implementation details):
```html
This is a <anki-cloze card="1">cloze.</anki-cloze>
```

Treating the cloze as HTML in Editable and Codable will prevent invalid HTML being rendered upon review.

Other advantages could include:
1. The tags are just an editor phenomenon. To everything beyond the editor, nothing will have changed (we keep compatibility with other platforms).
2. Hitting delete when the caret is situated right after the opening element `{{c1::`, or the closing element `}}` will entirely unwrap the clozed text from the cloze markup.
3. The cloze number is an input element now, allowing only for valid values.
4. Clicking three times within the clozed text will select the entire clozed text.

Disadvantages might include (might be able to be addressed):
1. If the `<anki-cloze>` is the last element in the `Editable`, the caret will be invisible, if it is positioned behind it
2. `<anki-cloze>` will sometimes "swallow up" text positioned behind it. This is certainly a bug.

Things not implemented yet:
- [ ] Copying the anki-cloze should probably copy the cleaned up version.
- [ ] Using Control-Shift-C needs to use `Range.surroundContents` instead of `execCommand`. `Range.surroundContents` is quite low level, so we need some additional logic (currently only works, if you're clozing over plain text (no other inline / block tags))
- [ ] The undo history does not work for this. We currently just rely on the built-in undo history of contenteditable in the Editor. For this to work, we would have to make `Control+Z` trigger our own undo and make the Editor create snapshots regularly. These snapshots would be the set of editor fields (and the tag editor, see below...) and a list of offsets, indicating the caret position at the moment of the snapshot.

PRs which need to come first.
1. Tag Editor: #1079
2. A PR implementing our own undo history for the editor, which will probably be required after the Tag Editor anyway.

What do you think of the idea in general?
My hope is that we could also use a similar strategy to display rendered MathJax (and maybe Latex) as images in the editor and add some controls, to edit the underlying MathJax code. (`<anki-mathjax>`, `<anki-mathjax-chemistry>`, etc.)