### PR TITLE
Fix toggle night mode in clayout

### DIFF
--- a/qt/aqt/clayout.py
+++ b/qt/aqt/clayout.py
@@ -344,6 +344,10 @@ class CardLayout(QDialog):
 
     def on_night_mode_action_toggled(self) -> None:
         self.night_mode_is_enabled = not self.night_mode_is_enabled
+        force = json.dumps(self.night_mode_is_enabled)
+        self.preview_web.eval(
+            f"document.documentElement.classList.toggle('night-mode', {force});"
+        )
         self.on_preview_toggled()
 
     def on_mobile_class_action_toggled(self) -> None:

--- a/qt/aqt/data/web/css/reviewer.scss
+++ b/qt/aqt/data/web/css/reviewer.scss
@@ -8,6 +8,7 @@ hr {
 body {
     margin: 20px;
     overflow-wrap: break-word;
+    background-color: var(--window-bg);
 }
 
 // explicit nightMode definition required

--- a/qt/aqt/theme.py
+++ b/qt/aqt/theme.py
@@ -35,6 +35,7 @@ class ThemeManager:
     _icon_cache_dark: Dict[str, QIcon] = {}
     _icon_size = 128
     _dark_mode_available: Optional[bool] = None
+    default_palette: Optional[QPalette] = None
 
     # Qt applies a gradient to the buttons in dark mode
     # from about #505050 to #606060.
@@ -133,6 +134,7 @@ class ThemeManager:
         return QColor(self.color(colors))
 
     def apply_style(self, app: QApplication) -> None:
+        self.default_palette = app.style().standardPalette()
         self._apply_palette(app)
         self._apply_style(app)
 


### PR DESCRIPTION
Fixes #1166.

### Regarding emulation of day mode (especially on non-Linux platforms):

Taking into account the possibility that the background color is not set in the `.card` styling, I think we need to set the background color of the `<body>` element to the `QPalette.Window` color value of the system default palette in order to emulate it correctly. However, on Windows (and probably on macOS as well), once the `fusion` QStyle is applied to enable night mode, the palette retrieved by `standardPalette()` will be different from that in day mode.

#### On Windows:
![QPalette_Window_day_mode](https://user-images.githubusercontent.com/47855854/123282436-76f29080-d545-11eb-874a-a0c5682afcb3.png)
![QPalette_Window_night_mode](https://user-images.githubusercontent.com/47855854/123282445-7823bd80-d545-11eb-82ab-c3763f35c608.png)

This is probably because the default QStyle on Windows and macOS is not `fusion`. So in this PR, the system default palette is stored in `theme_manager.default_palette` before the `fusion` style is applied, so that the `QPalette.Window` color value in day mode can be used in night mode on any platform.