### PR TITLE
Extensible two-column layout for deck options

### DIFF
--- a/ts/components/Container.svelte
+++ b/ts/components/Container.svelte
@@ -10,9 +10,12 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     export { className as class };
 
     export let api: Record<string, never> | undefined = undefined;
+
+    export let rows: number | undefined = undefined;
+    $: style = (rows ? `--rows: ${rows}` : undefined)
 </script>
 
-<div {id} class={`container mb-1 ${className}`}>
+<div {id} class={`container mb-1 ${className}`} {style}>
     <Section {api}>
         <slot />
     </Section>

--- a/ts/components/Container.svelte
+++ b/ts/components/Container.svelte
@@ -12,7 +12,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     export let api: Record<string, never> | undefined = undefined;
 
     export let rows: number | undefined = undefined;
-    $: style = (rows ? `--rows: ${rows}` : undefined)
+    $: style = rows ? `--rows: ${rows}` : undefined;
 </script>
 
 <div {id} class={`container mb-1 ${className}`} {style}>

--- a/ts/deckoptions/DeckOptionsPage.svelte
+++ b/ts/deckoptions/DeckOptionsPage.svelte
@@ -2,6 +2,10 @@
 Copyright: Ankitects Pty Ltd and contributors
 License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 -->
+<script context="module">
+    import { writable } from "svelte/store";
+    export const lineCount = writable(0);
+</script>
 
 <script lang="ts">
     import ConfigSelector from "./ConfigSelector.svelte";
@@ -59,11 +63,6 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     $: {
         rows = Math.ceil($lineCount / 2) + 1;
     }
-</script>
-
-<script context="module">
-    import { writable } from "svelte/store";
-    export const lineCount = writable(0);
 </script>
 
 <ConfigSelector {state} />

--- a/ts/deckoptions/DeckOptionsPage.svelte
+++ b/ts/deckoptions/DeckOptionsPage.svelte
@@ -2,17 +2,8 @@
 Copyright: Ankitects Pty Ltd and contributors
 License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 -->
-<script context="module">
-    import { writable } from "svelte/store";
-    export const lineCount = writable(0);
-</script>
 
 <script lang="ts">
-    let rows: number | undefined = undefined;
-    $: {
-        rows = Math.ceil($lineCount / 2) + 1;
-    }
-
     import ConfigSelector from "./ConfigSelector.svelte";
     import Container from "components/Container.svelte";
     import Item from "components/Item.svelte";
@@ -63,6 +54,16 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     export const audioOptions = {};
     export const addonOptions = {};
     export const advancedOptions = {};
+
+    let rows: number | undefined = undefined;
+    $: {
+        rows = Math.ceil($lineCount / 2) + 1;
+    }
+</script>
+
+<script context="module">
+    import { writable } from "svelte/store";
+    export const lineCount = writable(0);
 </script>
 
 <ConfigSelector {state} />

--- a/ts/deckoptions/DeckOptionsPage.svelte
+++ b/ts/deckoptions/DeckOptionsPage.svelte
@@ -57,7 +57,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
 <ConfigSelector {state} />
 
-<Container api={options} class="g-1">
+<Container api={options} class="g-1 grid">
     <Item>
         <DailyLimits {state} api={dailyLimits} />
     </Item>

--- a/ts/deckoptions/DeckOptionsPage.svelte
+++ b/ts/deckoptions/DeckOptionsPage.svelte
@@ -3,12 +3,11 @@ Copyright: Ankitects Pty Ltd and contributors
 License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 -->
 <script context="module">
-    import { writable } from 'svelte/store';
+    import { writable } from "svelte/store";
     export const lineCount = writable(0);
 </script>
 
 <script lang="ts">
-
     let rows: number | undefined = undefined;
     $: {
         rows = Math.ceil($lineCount / 2) + 1;

--- a/ts/deckoptions/DeckOptionsPage.svelte
+++ b/ts/deckoptions/DeckOptionsPage.svelte
@@ -3,6 +3,7 @@ Copyright: Ankitects Pty Ltd and contributors
 License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 -->
 <script lang="ts">
+    let rows: number | undefined = undefined;
     import ConfigSelector from "./ConfigSelector.svelte";
     import Container from "components/Container.svelte";
     import Item from "components/Item.svelte";
@@ -57,7 +58,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
 <ConfigSelector {state} />
 
-<Container api={options} class="g-1 grid">
+<Container api={options} class="g-1 grid" {rows}>
     <Item>
         <DailyLimits {state} api={dailyLimits} />
     </Item>

--- a/ts/deckoptions/DeckOptionsPage.svelte
+++ b/ts/deckoptions/DeckOptionsPage.svelte
@@ -2,8 +2,18 @@
 Copyright: Ankitects Pty Ltd and contributors
 License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 -->
+<script context="module">
+    import { writable } from 'svelte/store';
+    export const lineCount = writable(0);
+</script>
+
 <script lang="ts">
+
     let rows: number | undefined = undefined;
+    $: {
+        rows = Math.ceil($lineCount / 2) + 1;
+    }
+
     import ConfigSelector from "./ConfigSelector.svelte";
     import Container from "components/Container.svelte";
     import Item from "components/Item.svelte";

--- a/ts/deckoptions/TitledContainer.svelte
+++ b/ts/deckoptions/TitledContainer.svelte
@@ -15,11 +15,10 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     let span: number;
 
     onMount(() => {
-        span = container.querySelectorAll(".row").length | 1;
-        lineCount.update(n => n + span);
+        span = 1;
+        lineCount.update((n) => n + span);
         style = "--size: " + span;
     });
-
 </script>
 
 <div class="container-fluid my-4" {style} bind:this={container}>

--- a/ts/deckoptions/TitledContainer.svelte
+++ b/ts/deckoptions/TitledContainer.svelte
@@ -5,10 +5,21 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 <script lang="ts">
     import Section from "components/Section.svelte";
     import { onMount } from "svelte";
+    import { lineCount } from "./DeckOptionsPage.svelte";
 
     export let title: string;
     export let api: Record<string, never> | undefined = undefined;
+
     let container: HTMLElement;
+    let style: string | undefined;
+    let span: number;
+
+    onMount(() => {
+        span = container.querySelectorAll(".row").length | 1;
+        lineCount.update(n => n + span);
+        style = "--size: " + span;
+    });
+
 </script>
 
 <div class="container-fluid my-4" {style} bind:this={container}>

--- a/ts/deckoptions/TitledContainer.svelte
+++ b/ts/deckoptions/TitledContainer.svelte
@@ -4,12 +4,14 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 -->
 <script lang="ts">
     import Section from "components/Section.svelte";
+    import { onMount } from "svelte";
 
     export let title: string;
     export let api: Record<string, never> | undefined = undefined;
+    let container: HTMLElement;
 </script>
 
-<div class="container-fluid my-4">
+<div class="container-fluid my-4" {style} bind:this={container}>
     <h1>{title}</h1>
 
     <Section {api}>

--- a/ts/deckoptions/TitledContainer.svelte
+++ b/ts/deckoptions/TitledContainer.svelte
@@ -21,4 +21,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     h1 {
         border-bottom: 1px solid var(--medium-border);
     }
+    div {
+        grid-row: span var(--size);
+    }
 </style>

--- a/ts/deckoptions/TitledContainer.svelte
+++ b/ts/deckoptions/TitledContainer.svelte
@@ -32,6 +32,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 <style lang="scss">
     h1 {
         border-bottom: 1px solid var(--medium-border);
+        font-size: clamp(1rem, calc(1.375rem + 1.5vw), 2rem);
     }
     div {
         grid-row: span var(--size);

--- a/ts/deckoptions/TitledContainer.svelte
+++ b/ts/deckoptions/TitledContainer.svelte
@@ -15,9 +15,9 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     let span: number;
 
     onMount(() => {
-        span = 1;
+        span = container.querySelectorAll(".row").length | 1;
         lineCount.update((n) => n + span);
-        style = "--size: " + span;
+        style = `--size: ${span}`;
     });
 </script>
 

--- a/ts/deckoptions/deckoptions-base.scss
+++ b/ts/deckoptions/deckoptions-base.scss
@@ -49,3 +49,29 @@ textarea.form-control {
     color: var(--text-fg);
     background-color: var(--frame-bg) !important;
 }
+
+h1 {
+    font-size: clamp(1rem, calc(1.375rem + 1.5vw), 2rem);
+}
+
+.grid {
+    display: grid;
+    position: relative;
+}
+
+@media (min-width: 992px) {
+    .grid {
+        grid-auto-flow: column;
+        column-gap: 4em;
+        grid-template-rows: repeat(var(--rows), auto);
+        grid-template-columns: repeat(2, minmax(24em, 1fr));
+    }
+
+    .grid:after {
+        position: absolute;
+        content: "";
+        height: 100%;
+        left: 50%;
+        border-left: 1px solid var(--medium-border);
+    }
+}

--- a/ts/deckoptions/deckoptions-base.scss
+++ b/ts/deckoptions/deckoptions-base.scss
@@ -50,10 +50,6 @@ textarea.form-control {
     background-color: var(--frame-bg) !important;
 }
 
-h1 {
-    font-size: clamp(1rem, calc(1.375rem + 1.5vw), 2rem);
-}
-
 .grid {
     display: grid;
     position: relative;


### PR DESCRIPTION
I had another go at making the deck options responsive for wide screens.
(Previous attempts: https://github.com/ankitects/anki/pull/1210, https://github.com/ankitects/anki/pull/1212)

The task was to make [this idea of mine](https://github.com/ankitects/anki/pull/1207#issuecomment-855393388) work with the Svelte components. [Here is the CodePen](https://codepen.io/kleinerpirat/pen/zYZjyKX) I created as a proof-of-concept.
I tried my best to keep the necessary changes at a minimum and make it extensible.

![image](https://user-images.githubusercontent.com/62722460/123517926-fdbd7f80-d6a3-11eb-8401-6421528e2afa.png)
The grid layout takes effect when viewport width is `>= 992px`.

### How the current approach works
1. approximate size of each `TitledContainer` at runtime via amount of contained `.row` elements
2. add up total amount of `TitledContainer` sizes with store `lineCount`
3. calculate amount of rows needed to fit all elements on two columns

#### Why the extra effort with individual row spans?
<img src="https://user-images.githubusercontent.com/62722460/123542285-1895ff80-d749-11eb-8f16-90c51f24b58e.png" width="49%"> <img src="https://user-images.githubusercontent.com/62722460/123542241-d076dd00-d748-11eb-8731-81c47bc96726.png" width="49%">
**Left**: all elements span 1 row -> Big elements like "Advanced" create a lot of white space
**Right**: individual row spans reduce that white space significantly


### Extra
- set upper limit (currently `2rem`) for h1 font-size with [clamp](https://developer.mozilla.org/en-US/docs/Web/CSS/clamp()) function, because indefinite scaling with viewport width doesn't make much sense for the two-column layout.

I am not really happy with the way I implemented the `lineCount` store to get the total row span of all components. I'm sure @hgiesel knows of multiple better ways to allow child components to change a parent component's variable.
The addition to `Container.svelte` is a bit dirty, but I found it more elegant than to wrap the options in an extra div within `DeckOptionsPage.svelte`. Let me know if I should still go for that second option.

### Tasks
- [ ] Find more elegant way to add up total amount of `TitledContainer` sizes (`lineCount`) across components
- [ ] Use more accurate and universal way to approximate size (e.g. [offsetHeight](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/offsetHeight) of containing `div`)
One issue is that the correct offsetHeight is not immediately available with [onMount](https://svelte.dev/docs#onMount), probably due to rendering delay.

---

I don't have much faith in this getting merged because it feels a bit hacky. But I'd invite you to try it out and perhaps create something along these lines yourself (or guide me in the right direction), if you like the look of it.