### PR TITLE
Fix id check for `today` and `card state` items

### DIFF
--- a/qt/aqt/browser/sidebar/item.py
+++ b/qt/aqt/browser/sidebar/item.py
@@ -138,7 +138,11 @@ class SidebarItem:
         if other.item_type == self.item_type:
             if self.item_type == SidebarItemType.TAG:
                 return self.full_name == other.full_name
-            elif self.item_type == SidebarItemType.SAVED_SEARCH:
+            elif self.item_type in (
+                SidebarItemType.SAVED_SEARCH,
+                SidebarItemType.TODAY,
+                SidebarItemType.CARD_STATE,
+            ):
                 return self.name == other.name
             elif self.item_type == SidebarItemType.NOTETYPE_TEMPLATE:
                 return (


### PR DESCRIPTION
Some more missing cases for the item comparison. But that should finally be it.