### PR TITLE
Use better cloze button icon

### DIFF
--- a/ts/editor/BUILD.bazel
+++ b/ts/editor/BUILD.bazel
@@ -112,7 +112,7 @@ copy_mdi_icons(
         "format-superscript.svg",
         "format-subscript.svg",
         "function-variant.svg",
-        "code-brackets.svg",
+        "contain.svg",
         "xml.svg",
 
         "format-color-text.svg",

--- a/ts/editor/ClozeButton.svelte
+++ b/ts/editor/ClozeButton.svelte
@@ -11,7 +11,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     import WithShortcut from "components/WithShortcut.svelte";
     import WithContext from "components/WithContext.svelte";
 
-    import { bracketsIcon } from "./icons";
+    import { ellipseIcon } from "./icons";
     import { forEditorField } from ".";
     import { wrapCurrent } from "./wrap";
 
@@ -53,7 +53,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
                 on:click={onCloze}
                 on:mount={createShortcut}
             >
-                {@html bracketsIcon}
+                {@html ellipseIcon}
             </IconButton>
         </WithContext>
     </WithContext>

--- a/ts/editor/icons.ts
+++ b/ts/editor/icons.ts
@@ -27,7 +27,7 @@ export { default as colorHelperIcon } from "./color-helper.svg";
 
 export { default as paperclipIcon } from "./paperclip.svg";
 export { default as micIcon } from "./mic.svg";
-export { default as bracketsIcon } from "./code-brackets.svg";
+export { default as ellipseIcon } from "./contain.svg";
 export { default as functionIcon } from "./function-variant.svg";
 export { default as xmlIcon } from "./xml.svg";
 


### PR DESCRIPTION
While looking through the icons yesterday, I also found a an icon, that includes brackets with an ellipsis.

![image](https://user-images.githubusercontent.com/7188844/124106856-ef38e480-da64-11eb-81b5-7103e4844261.png)
