### PR TITLE
Preload answer images

### DIFF
--- a/qt/aqt/reviewer.py
+++ b/qt/aqt/reviewer.py
@@ -339,8 +339,11 @@ class Reviewer:
         self._run_state_mutation_hook()
 
         bodyclass = theme_manager.body_classes_for_card_ord(c.ord)
+        a = self.mw.col.media.escape_media_filenames(c.answer())
 
-        self.web.eval(f"_showQuestion({json.dumps(q)},'{bodyclass}');")
+        self.web.eval(
+            f"_showQuestion({json.dumps(q)}, {json.dumps(a)}, '{bodyclass}');"
+        )
         self._update_flag_icon()
         self._update_mark_icon()
         self._showAnswerButton()


### PR DESCRIPTION
Related thread on the forum: [Pre-load the back side of the card](https://forums.ankiweb.net/t/pre-load-the-back-side-of-the-card/9865)

This PR is based on my posts in the above thread.

If you look at the `Network` tab in the *chrome developer tools* while reviewing a card, you'll see that while the question is being displayed, the images that will be displayed on the answer side are being loaded. I think it is easy to see the effect of preloading when scrolling to the `#answer` element occurs. Without preloading, there is sometimes a momentary lag before scrolling, but with preloading, there seems to be no lag at all.   If you don't see any effect, please make sure that the `Disable cache` option in the network tab is unchecked, otherwise you won't be able to see the effect.

I think that preloading images would be useful for users who use decks that have a lot of images on the back, such as some pre-made decks for med students. Ideally, it would be nice to be able to preload the images for the questions on the next card as well, but I think even just preloading the answer images would improve the UX a bit.