### PR TITLE
Move selection into editable, if it's not there after focus

### DIFF
--- a/ts/editor/focus-handlers.ts
+++ b/ts/editor/focus-handlers.ts
@@ -1,6 +1,10 @@
 // Copyright: Ankitects Pty Ltd and contributors
 // License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
+/* eslint
+@typescript-eslint/no-non-null-assertion: "off",
+ */
+
 import { enableButtons, disableButtons } from "./toolbar";
 import type { EditingArea } from "./editing-area";
 

--- a/ts/editor/focus-handlers.ts
+++ b/ts/editor/focus-handlers.ts
@@ -10,6 +10,12 @@ import { bridgeCommand } from "./lib";
 export function onFocus(evt: FocusEvent): void {
     const currentField = evt.currentTarget as EditingArea;
     currentField.focus();
+
+    if (currentField.shadowRoot!.getSelection()!.anchorNode === null) {
+        // selection is not inside editable after focusing
+        currentField.caretToEnd();
+    }
+
     bridgeCommand(`focus:${currentField.ord}`);
     enableButtons();
 }


### PR DESCRIPTION
I recently noticed that there is still a focus issue (our old favorite issue), when the Editable contains  mostly block elements (e.g. just a single `<div>`)), and you click the field.

The blue highlight will show, but the caret will not be inside the editor field. This seems to have been the case ever since 972993b42.