### PR TITLE
Execute Ctrl+C/V/X/A via execCommand in editor

### DIFF
--- a/qt/aqt/editor.py
+++ b/qt/aqt/editor.py
@@ -1052,7 +1052,7 @@ $editorToolbar.then(({{ toolbar }}) => toolbar.appendGroup({{
 
 class EditorWebView(AnkiWebView):
     def __init__(self, parent: QWidget, editor: Editor) -> None:
-        AnkiWebView.__init__(self, title="editor")
+        AnkiWebView.__init__(self, title="editor", mac_default_shortcuts=False)
         self.editor = editor
         self.setAcceptDrops(True)
         self._markInternal = False

--- a/qt/aqt/editor.py
+++ b/qt/aqt/editor.py
@@ -1052,7 +1052,7 @@ $editorToolbar.then(({{ toolbar }}) => toolbar.appendGroup({{
 
 class EditorWebView(AnkiWebView):
     def __init__(self, parent: QWidget, editor: Editor) -> None:
-        AnkiWebView.__init__(self, title="editor", mac_default_shortcuts=False)
+        AnkiWebView.__init__(self, title="editor")
         self.editor = editor
         self.setAcceptDrops(True)
         self._markInternal = False

--- a/qt/aqt/webview.py
+++ b/qt/aqt/webview.py
@@ -210,7 +210,7 @@ class WebContent:
 
 class AnkiWebView(QWebEngineView):
     def __init__(
-        self, parent: Optional[QWidget] = None, title: str = "default"
+        self, parent: Optional[QWidget] = None, title: str = "default", *, mac_default_shortcuts: bool = True
     ) -> None:
         QWebEngineView.__init__(self, parent=parent)
         self.set_title(title)
@@ -238,7 +238,7 @@ class AnkiWebView(QWebEngineView):
             context=Qt.WidgetWithChildrenShortcut,
             activated=self.onEsc,
         )
-        if isMac:
+        if isMac and mac_default_shortcuts:
             for key, fn in [
                 (QKeySequence.Copy, self.onCopy),
                 (QKeySequence.Paste, self.onPaste),
@@ -248,6 +248,7 @@ class AnkiWebView(QWebEngineView):
                 QShortcut(  # type: ignore
                     key, self, context=Qt.WidgetWithChildrenShortcut, activated=fn
                 )
+
             QShortcut(  # type: ignore
                 QKeySequence("ctrl+shift+v"),
                 self,

--- a/qt/aqt/webview.py
+++ b/qt/aqt/webview.py
@@ -210,7 +210,11 @@ class WebContent:
 
 class AnkiWebView(QWebEngineView):
     def __init__(
-        self, parent: Optional[QWidget] = None, title: str = "default", *, mac_default_shortcuts: bool = True
+        self,
+        parent: Optional[QWidget] = None,
+        title: str = "default",
+        *,
+        mac_default_shortcuts: bool = True,
     ) -> None:
         QWebEngineView.__init__(self, parent=parent)
         self.set_title(title)

--- a/qt/aqt/webview.py
+++ b/qt/aqt/webview.py
@@ -213,8 +213,6 @@ class AnkiWebView(QWebEngineView):
         self,
         parent: Optional[QWidget] = None,
         title: str = "default",
-        *,
-        mac_default_shortcuts: bool = True,
     ) -> None:
         QWebEngineView.__init__(self, parent=parent)
         self.set_title(title)
@@ -242,23 +240,6 @@ class AnkiWebView(QWebEngineView):
             context=Qt.WidgetWithChildrenShortcut,
             activated=self.onEsc,
         )
-        if isMac and mac_default_shortcuts:
-            for key, fn in [
-                (QKeySequence.Copy, self.onCopy),
-                (QKeySequence.Paste, self.onPaste),
-                (QKeySequence.Cut, self.onCut),
-                (QKeySequence.SelectAll, self.onSelectAll),
-            ]:
-                QShortcut(  # type: ignore
-                    key, self, context=Qt.WidgetWithChildrenShortcut, activated=fn
-                )
-
-            QShortcut(  # type: ignore
-                QKeySequence("ctrl+shift+v"),
-                self,
-                context=Qt.WidgetWithChildrenShortcut,
-                activated=self.onPaste,
-            )
 
     def set_title(self, title: str) -> None:
         self.title = title  # type: ignore[assignment]

--- a/ts/editor/index.ts
+++ b/ts/editor/index.ts
@@ -8,6 +8,8 @@
 import { filterHTML } from "html-filter";
 import { updateActiveButtons, disableButtons } from "./toolbar";
 import { setupI18n, ModuleName } from "lib/i18n";
+import { registerShortcut } from "lib/shortcuts";
+import { bridgeCommand } from "./lib";
 
 import "./fields.css";
 
@@ -39,6 +41,11 @@ customElements.define("anki-codable", Codable, { extends: "textarea" });
 customElements.define("anki-editing-area", EditingArea, { extends: "div" });
 customElements.define("anki-label-container", LabelContainer, { extends: "div" });
 customElements.define("anki-editor-field", EditorField, { extends: "div" });
+
+registerShortcut(() => document.execCommand("copy"), "Control+C");
+registerShortcut(() => document.execCommand("cut"), "Control+X");
+registerShortcut(() => document.execCommand("selectAll"), "Control+A");
+registerShortcut(() => bridgeCommand("paste"), "Control+Shift+V");
 
 export function getCurrentField(): EditingArea | null {
     return document.activeElement instanceof EditingArea


### PR DESCRIPTION
Right now, Cmd+C/V/X/A are captured in AnkiWebViews on Macs so that we cannot modify it from within the AnkiWebView.

This is related to #1264: You can select tags via Ctrl/Shift - Click and then I would like them to be copyable via Control+C, and selectable via Control+A (and maybe overwritable via Control+V), to make the interaction with tags as natural and easy as possible.

I personally could not notice any difference, once I registered the shortcuts directly in JS via `execCommand`.