### PR TITLE
Follow-up to #1271 (Preload answer images)

### DIFF
--- a/qt/aqt/browser/previewer.py
+++ b/qt/aqt/browser/previewer.py
@@ -170,7 +170,6 @@ class Previewer(QDialog):
         if not self._open:
             return
         c = self.card()
-        func = "_showQuestion"
         ans_txt = ""
         if not c:
             txt = tr.qt_misc_please_select_1_card()
@@ -190,9 +189,7 @@ class Previewer(QDialog):
             # need to force reload even if answer
             txt = c.question(reload=True)
             ans_txt = c.answer()
-
             if self._state == "answer":
-                func = "_showAnswer"
                 txt = ans_txt
             txt = re.sub(r"\[\[type:[^]]+\]\]", "", txt)
 
@@ -221,12 +218,10 @@ class Previewer(QDialog):
             txt = gui_hooks.card_will_show(txt, c, f"preview{self._state.capitalize()}")
             self._last_state = self._state_and_mod()
 
-        js: str
         if self._state == "question":
-            ans_txt = self.mw.col.media.escape_media_filenames(ans_txt)
-            js = f"{func}({json.dumps(txt)}, {json.dumps(ans_txt)}, '{bodyclass}');"
+            js = f"_showQuestion({json.dumps(txt)}, {json.dumps(ans_txt)}, '{bodyclass}');"
         else:
-            js = f"{func}({json.dumps(txt)}, '{bodyclass}');"
+            js = f"_showAnswer({json.dumps(txt)}, '{bodyclass}');"
         self._web.eval(js)
         self._card_changed = False
 

--- a/qt/aqt/reviewer.py
+++ b/qt/aqt/reviewer.py
@@ -338,10 +338,9 @@ class Reviewer:
         self._run_state_mutation_hook()
 
         bodyclass = theme_manager.body_classes_for_card_ord(c.ord)
-        a = self.mw.col.media.escape_media_filenames(c.answer())
 
         self.web.eval(
-            f"_showQuestion({json.dumps(q)}, {json.dumps(a)}, '{bodyclass}');"
+            f"_showQuestion({json.dumps(q)}, {json.dumps(c.answer())}, '{bodyclass}');"
         )
         self._update_flag_icon()
         self._update_mark_icon()


### PR DESCRIPTION
After the commit 14110ad, the following message is shown in the console log:
`qt\aqt\reviewer.py:341:escape_media_filenames() is deprecated: no longer required`