### PR TITLE
Add constants for literal config keys

### DIFF
--- a/pylib/anki/browser.py
+++ b/pylib/anki/browser.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+# Copyright: Ankitects Pty Ltd and contributors
+# License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
+
+
+class BrowserConfig:
+    ACTIVE_CARD_COLUMNS_KEY = "activeCols"
+    ACTIVE_NOTE_COLUMNS_KEY = "activeNoteCols"
+    CARDS_SORT_COLUMN_KEY = "sortType"
+    NOTES_SORT_COLUMN_KEY = "noteSortType"
+    CARDS_SORT_BACKWARDS_KEY = "sortBackwards"
+    NOTES_SORT_BACKWARDS_KEY = "browserNoteSortBackwards"
+
+    @staticmethod
+    def active_columns_key(is_notes_mode: bool) -> str:
+        if is_notes_mode:
+            return BrowserConfig.ACTIVE_NOTE_COLUMNS_KEY
+        return BrowserConfig.ACTIVE_CARD_COLUMNS_KEY
+
+    @staticmethod
+    def sort_column_key(is_notes_mode: bool) -> str:
+        if is_notes_mode:
+            return BrowserConfig.NOTES_SORT_COLUMN_KEY
+        return BrowserConfig.CARDS_SORT_COLUMN_KEY
+
+    @staticmethod
+    def sort_backwards_key(is_notes_mode: bool) -> str:
+        if is_notes_mode:
+            return BrowserConfig.NOTES_SORT_BACKWARDS_KEY
+        return BrowserConfig.CARDS_SORT_BACKWARDS_KEY
+
+
+class BrowserDefaults:
+    CARD_COLUMNS = ["noteFld", "template", "cardDue", "deck"]
+    NOTE_COLUMNS = ["noteFld", "note", "noteCards", "noteTags"]

--- a/pylib/anki/collection.py
+++ b/pylib/anki/collection.py
@@ -37,6 +37,7 @@ from dataclasses import dataclass, field
 import anki.latex
 from anki import hooks
 from anki._backend import RustBackend, Translations
+from anki.browser import BrowserConfig, BrowserDefaults
 from anki.cards import Card, CardId
 from anki.config import Config, ConfigManager
 from anki.consts import *
@@ -493,14 +494,10 @@ class Collection(DeprecatedNamesMixin):
             if order is False:
                 return _pb.SortOrder(none=_pb.Empty())
             # order=True: set args to sort column and reverse from config
-            sort_key = "noteSortType" if finding_notes else "sortType"
+            sort_key = BrowserConfig.sort_column_key(finding_notes)
             order = self.get_browser_column(self.get_config(sort_key))
-            reverse_key = (
-                Config.Bool.BROWSER_NOTE_SORT_BACKWARDS
-                if finding_notes
-                else Config.Bool.BROWSER_SORT_BACKWARDS
-            )
-            reverse = self.get_config_bool(reverse_key)
+            reverse_key = BrowserConfig.sort_backwards_key(finding_notes)
+            reverse = self.get_config(reverse_key)
         if isinstance(order, BrowserColumns.Column):
             if order.sorting != BrowserColumns.SORTING_NONE:
                 return _pb.SortOrder(
@@ -679,25 +676,25 @@ class Collection(DeprecatedNamesMixin):
     def load_browser_card_columns(self) -> List[str]:
         """Return the stored card column names and ensure the backend columns are set and in sync."""
         columns = self.get_config(
-            "activeCols", ["noteFld", "template", "cardDue", "deck"]
+            BrowserConfig.ACTIVE_CARD_COLUMNS_KEY, BrowserDefaults.CARD_COLUMNS
         )
         self._backend.set_active_browser_columns(columns)
         return columns
 
     def set_browser_card_columns(self, columns: List[str]) -> None:
-        self.set_config("activeCols", columns)
+        self.set_config(BrowserConfig.ACTIVE_CARD_COLUMNS_KEY, columns)
         self._backend.set_active_browser_columns(columns)
 
     def load_browser_note_columns(self) -> List[str]:
         """Return the stored note column names and ensure the backend columns are set and in sync."""
         columns = self.get_config(
-            "activeNoteCols", ["noteFld", "note", "noteCards", "noteTags"]
+            BrowserConfig.ACTIVE_NOTE_COLUMNS_KEY, BrowserDefaults.NOTE_COLUMNS
         )
         self._backend.set_active_browser_columns(columns)
         return columns
 
     def set_browser_note_columns(self, columns: List[str]) -> None:
-        self.set_config("activeNoteCols", columns)
+        self.set_config(BrowserConfig.ACTIVE_NOTE_COLUMNS_KEY, columns)
         self._backend.set_active_browser_columns(columns)
 
     # Config

--- a/pylib/tests/test_find.py
+++ b/pylib/tests/test_find.py
@@ -4,7 +4,7 @@
 # coding: utf-8
 import pytest
 
-from anki.collection import Config
+from anki.browser import BrowserConfig
 from anki.consts import *
 from tests.shared import getEmptyCol, isNearCutoff
 
@@ -121,7 +121,7 @@ def test_find_cards():
     col.conf["sortType"] = "cardMod"
     assert col.find_cards("", order=True)[-1] in latestCardIds
     assert col.find_cards("", order=True)[0] == firstCardId
-    col.set_config_bool(Config.Bool.BROWSER_SORT_BACKWARDS, True)
+    col.set_config(BrowserConfig.CARDS_SORT_BACKWARDS_KEY, True)
     assert col.find_cards("", order=True)[0] in latestCardIds
     assert (
         col.find_cards("", order=col.get_browser_column("cardDue"), reverse=False)[0]

--- a/qt/aqt/browser/table/table.py
+++ b/qt/aqt/browser/table/table.py
@@ -252,11 +252,11 @@ class Table:
         hh.setCascadingSectionResizes(False)
 
     def _save_header(self) -> None:
-        saveHeader(self._view.horizontalHeader(), self._state.config_key_prefix)
+        saveHeader(self._view.horizontalHeader(), self._state.GEOMETRY_KEY_PREFIX)
 
     def _restore_header(self) -> None:
         self._view.horizontalHeader().blockSignals(True)
-        restoreHeader(self._view.horizontalHeader(), self._state.config_key_prefix)
+        restoreHeader(self._view.horizontalHeader(), self._state.GEOMETRY_KEY_PREFIX)
         self._set_column_sizes()
         self._set_sort_indicator()
         self._view.horizontalHeader().blockSignals(False)

--- a/rslib/backend.proto
+++ b/rslib/backend.proto
@@ -1447,8 +1447,6 @@ message Config {
   message Bool {
     enum Key {
       BROWSER_TABLE_SHOW_NOTES_MODE = 0;
-      BROWSER_SORT_BACKWARDS = 1;
-      BROWSER_NOTE_SORT_BACKWARDS = 2;
       PREVIEW_BOTH_SIDES = 3;
       COLLAPSE_TAGS = 4;
       COLLAPSE_NOTETYPES = 5;

--- a/rslib/src/backend/config.rs
+++ b/rslib/src/backend/config.rs
@@ -16,8 +16,6 @@ impl From<BoolKeyProto> for BoolKey {
     fn from(k: BoolKeyProto) -> Self {
         match k {
             BoolKeyProto::BrowserTableShowNotesMode => BoolKey::BrowserTableShowNotesMode,
-            BoolKeyProto::BrowserSortBackwards => BoolKey::BrowserSortBackwards,
-            BoolKeyProto::BrowserNoteSortBackwards => BoolKey::BrowserNoteSortBackwards,
             BoolKeyProto::PreviewBothSides => BoolKey::PreviewBothSides,
             BoolKeyProto::CollapseTags => BoolKey::CollapseTags,
             BoolKeyProto::CollapseNotetypes => BoolKey::CollapseNotetypes,

--- a/rslib/src/config/bool.rs
+++ b/rslib/src/config/bool.rs
@@ -11,7 +11,6 @@ use crate::prelude::*;
 #[strum(serialize_all = "camelCase")]
 pub enum BoolKey {
     BrowserTableShowNotesMode,
-    BrowserNoteSortBackwards,
     CardCountsSeparateInactive,
     CollapseCardState,
     CollapseDecks,
@@ -28,8 +27,6 @@ pub enum BoolKey {
     PreviewBothSides,
     Sched2021,
 
-    #[strum(to_string = "sortBackwards")]
-    BrowserSortBackwards,
     #[strum(to_string = "normalize_note_text")]
     NormalizeNoteText,
     #[strum(to_string = "dayLearnFirst")]
@@ -50,12 +47,6 @@ struct BoolLike(#[serde(deserialize_with = "deserialize_bool_from_anything")] bo
 impl Collection {
     pub fn get_config_bool(&self, key: BoolKey) -> bool {
         match key {
-            BoolKey::BrowserSortBackwards => {
-                // older clients were storing this as an int
-                self.get_config_default::<BoolLike, _>(BoolKey::BrowserSortBackwards)
-                    .0
-            }
-
             // some keys default to true
             BoolKey::InterruptAudioWhenAnswering
             | BoolKey::ShowIntervalsAboveAnswerButtons


### PR DESCRIPTION
Not sure where the assignments should go. I've put them in the classes that use them, but now something like "sortBackwards" is redeclared in `Collection._build_sort_mode()` because pylib can't access `CardState`. It doesn't matter in this case, but looks bad.
Should I put them all in `consts.py`? That means we have to do more namespacing, though. Maybe something like below?

```py
class ConfigKey:
    class Browser:
        class Cards:
            SORT_BACKWARDS = "sortBackwards"
            ...
        class Notes:
            SORT_BACKWARDS = "browserNoteSortBackwards"
            ...
        ...
    ...
```