### PR TITLE
Prevent #dupe bgcolor from being carried over when copying text

### DIFF
--- a/ts/editor/fields.scss
+++ b/ts/editor/fields.scss
@@ -19,7 +19,7 @@
     background: var(--frame-bg);
 
     &.dupe {
-        background: var(--flag1-bg);
+        background-image: linear-gradient(var(--flag1-bg), var(--flag1-bg));
     }
 }
 

--- a/ts/editor/fields.scss
+++ b/ts/editor/fields.scss
@@ -19,6 +19,8 @@
     background: var(--frame-bg);
 
     &.dupe {
+        // this works around the background colour persisting in copy+paste
+        // (https://github.com/ankitects/anki/pull/1278)
         background-image: linear-gradient(var(--flag1-bg), var(--flag1-bg));
     }
 }


### PR DESCRIPTION
This is a workaround for the issue reported in the forum:
[21](https://forums.ankiweb.net/t/anki-2-1-45-alpha/10061/21), [31](https://forums.ankiweb.net/t/anki-2-1-45-alpha/10061/31) @ Anki 2.1.45 Alpha

This issue only occurs in day mode, because `stylingLightMode` includes `background-color`, while `stylingNightMode` does not.
https://github.com/ankitects/anki/blob/6ffa7440967ca537d721924474466f527815c572/ts/html-filter/styling.ts#L12-L22
