### PR TITLE
Export via components for Deck Options

### DIFF
--- a/ts/deck-options/DeckOptionsPage.svelte
+++ b/ts/deck-options/DeckOptionsPage.svelte
@@ -57,8 +57,8 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
 <ConfigSelector {state} />
 
-<Container api={options} class="g-1 mb-3 mt-3">
-    <div class="multi-column">
+<div class="multi-column">
+    <Container api={options} class="g-1 mb-3 mt-3">
         <Item>
             <DailyLimits {state} api={dailyLimits} />
         </Item>
@@ -96,17 +96,17 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         <Item>
             <AdvancedOptions {state} api={advancedOptions} />
         </Item>
-    </div>
-</Container>
+    </Container>
+</div>
 
 <style lang="scss">
-    .multi-column {
+    .multi-column :global(.container) {
         column-count: 2;
         column-gap: 5em;
     }
 
     @media (max-width: 1000px) {
-        .multi-column {
+        .multi-column :global(.container) {
             column-count: 1;
         }
     }

--- a/ts/deck-options/index.ts
+++ b/ts/deck-options/index.ts
@@ -9,11 +9,6 @@ import { getDeckOptionsInfo, DeckOptionsState } from "./lib";
 import { setupI18n, ModuleName } from "lib/i18n";
 import { checkNightMode } from "lib/nightmode";
 import DeckOptionsPage from "./DeckOptionsPage.svelte";
-import SpinBox from "./SpinBox.svelte";
-import SpinBoxFloat from "./SpinBoxFloat.svelte";
-import EnumSelector from "./EnumSelector.svelte";
-import CheckBox from "./CheckBox.svelte";
-
 import { nightModeKey, touchDeviceKey, modalsKey } from "components/context-keys";
 
 export async function deckOptions(
@@ -49,9 +44,16 @@ export async function deckOptions(
     } as any);
 }
 
-export const deckConfigComponents = {
-    SpinBox,
-    SpinBoxFloat,
-    EnumSelector,
-    CheckBox,
+import TitledContainer from "./TitledContainer.svelte";
+import SpinBoxRow from "./SpinBoxRow.svelte";
+import SpinBoxFloatRow from "./SpinBoxFloatRow.svelte";
+import EnumSelectorRow from "./EnumSelectorRow.svelte";
+import SwitchRow from "./SwitchRow.svelte";
+
+export const components = {
+    TitledContainer,
+    SpinBoxRow,
+    SpinBoxFloatRow,
+    EnumSelectorRow,
+    SwitchRow,
 };

--- a/ts/editor/index_wrapper.ts
+++ b/ts/editor/index_wrapper.ts
@@ -6,3 +6,6 @@ import * as globals from "./index";
 for (const key in globals) {
     window[key] = globals[key];
 }
+
+// but also export as window.anki
+window["anki"] = globals;


### PR DESCRIPTION
I guess in the future, we will always want to export our globals under anki namespace, which is why I included  an assignment in `editor/index_wrapper.ts`.

I also wanted to export `components/Item.svelte` from `deck-options/index.ts` for `components`, but couldn't get it to work. Just trying to add an import from `ts/components` caused a bug (which is just like in editor), but when I tried a hack via `Components.svelte`, like I used in #1279, it wanted me to use a default import. Happy for any pointers, `Item.svelte` is technically not necessary to use within dynamic components, but for future guarantees it would be better.