### PR TITLE
Add the CardOrdinal special field

### DIFF
--- a/rslib/src/notetype/mod.rs
+++ b/rslib/src/notetype/mod.rs
@@ -64,6 +64,7 @@ lazy_static! {
         "Subdeck",
         "Tags",
         "Type",
+        "CardOrdinal",
     ]);
 }
 

--- a/rslib/src/notetype/render.rs
+++ b/rslib/src/notetype/render.rs
@@ -156,6 +156,8 @@ impl Collection {
             .or_insert_with(|| flag_name(card.flags).into());
         map.entry("Card")
             .or_insert_with(|| template.name.clone().into());
+        map.entry("CardOrdinal")
+            .or_insert_with(|| (card.template_idx + 1).to_string().into());
 
         Ok(())
     }


### PR DESCRIPTION
I have a JavaScript script that pulls data from a service called [Youglish](https://youglish.com/) and need a way to get the current card ordinal to support kind of a custom implementation of the `cloze-only` filter that reveals the elided sections on both sides of the card. I initially wrote it as an add-on ([38866997](https://ankiweb.net/shared/info/38866997)) without problems, but then I wanted this to work on mobile, so I tried rewriting it in JavaScript.

This is how I would use the field in templates:
```html
<script src="_aglish.js"></script>
<div class="aglish">
	<div class="aglish-filter">lang=turkish clozeonly={{CardOrdinal}}</div>
	<div class="aglish-field">{{Text}}</div>
</div>
```

Hopefully, there is some way to get the card ordinal without adding a new special field that I overlooked (using the `c[n]` fields is not practical).