### PR TITLE
Tweak deck options tooltips for RTL languages

### DIFF
--- a/ts/deck-options/deck-options-base.scss
+++ b/ts/deck-options/deck-options-base.scss
@@ -30,7 +30,7 @@ $tooltip-max-width: 300px;
 }
 
 .tooltip-inner {
-    text-align: left;
+    text-align: start;
 
     // marked transpiles tooltips into multiple paragraphs
     // where trailing <p>s cause a bottom margin
@@ -42,6 +42,7 @@ $tooltip-max-width: 300px;
     // want to add more of our own styling in the future
     code {
         color: #ffaaaa;
+        direction: inherit;
     }
 }
 


### PR DESCRIPTION
Just some small tweaks.

The direction override on the code tag is because the `Deck` and `Position` labels in the Display Order section strangely run backward character-wise with RTL langs (maybe `unicode-bidi` is applied by default or something).

![image](https://user-images.githubusercontent.com/41397710/125139553-69c6cb80-e119-11eb-9e47-04f0bd1e4899.png)
