### PR TITLE
Persistent Editor / Reviewer as preview

### DIFF
--- a/qt/aqt/editcurrent.py
+++ b/qt/aqt/editcurrent.py
@@ -54,8 +54,7 @@ class EditCurrent(QDialog):
         QDialog.reject(self)
 
     def reopen(self, mw: aqt.AnkiQt) -> None:
-        if card := self.mw.reviewer.card:
-            self.editor.set_note(card.note())
+        self.editor.web.setFocus()
 
     def reject(self) -> None:
         self.saveAndClose()

--- a/qt/aqt/editcurrent.py
+++ b/qt/aqt/editcurrent.py
@@ -27,6 +27,11 @@ class EditCurrent(QDialog):
         self.editor = aqt.editor.Editor(self.mw, self.form.fieldsArea, self)
         self.editor.card = self.mw.reviewer.card
         self.editor.set_note(self.mw.reviewer.card.note(), focusTo=0)
+        self.set_card_format(self.mw.reviewer.state)
+        self.editor.web.eval(
+            '$editorToolbar.then(({ templateButtons }) => templateButtons.appendButton({ component: editorToolbar.ObscureButton })); '
+        )
+
         restoreGeom(self, "editcurrent")
         gui_hooks.operation_did_execute.append(self.on_operation_did_execute)
         gui_hooks.card_will_show.append(self.refresh_editor_on_review)
@@ -48,11 +53,15 @@ class EditCurrent(QDialog):
 
             self.editor.set_note(note)
 
+    def set_card_format(self, format: str) -> None:
+        self.editor.web.eval(f'setCardFormat("{format}"); ')
+
     def refresh_editor_on_review(self, qa: str, card, type: str) -> None:
-        if type.startswith("review") and (
-            not self.editor.card or self.editor.card.nid != card.nid
-        ):
-            self.editor.setNote(card.note())
+        if type.startswith("review"):
+            if not self.editor.card or self.editor.card.nid != card.nid:
+                self.editor.setNote(card.note())
+
+            self.set_card_format(type[len("review"):].lower())
 
         return qa
 

--- a/qt/aqt/editcurrent.py
+++ b/qt/aqt/editcurrent.py
@@ -49,8 +49,11 @@ class EditCurrent(QDialog):
             self.editor.set_note(note)
 
     def refresh_editor_on_review(self, qa: str, card, type: str) -> None:
-        if type.startswith("review"):
+        if type.startswith("review") and (
+            not self.editor.card or self.editor.card.nid != card.nid
+        ):
             self.editor.setNote(card.note())
+
         return qa
 
     def cleanup_and_close(self) -> None:

--- a/qt/aqt/editcurrent.py
+++ b/qt/aqt/editcurrent.py
@@ -3,6 +3,7 @@
 from typing import Optional
 
 import aqt.editor
+from anki.cards import Card
 from anki.collection import OpChanges
 from anki.errors import NotFoundError
 from aqt import gui_hooks
@@ -26,7 +27,7 @@ class EditCurrent(QDialog):
         self.editor.set_note(self.mw.reviewer.card.note(), focusTo=0)
         self.set_card_format(self.mw.reviewer.state)
         self.editor.web.eval(
-            '$editorToolbar.then(({ templateButtons }) => templateButtons.appendButton({ component: editorToolbar.ObscureButton })); '
+            "$editorToolbar.then(({ templateButtons }) => templateButtons.appendButton({ component: editorToolbar.ObscureButton })); "
         )
         QShortcut(QKeySequence("Ctrl+Return"), self, activated=self.focus_reviewer)
         QShortcut(QKeySequence("Ctrl+W"), self, activated=self.saveAndClose)
@@ -59,9 +60,9 @@ class EditCurrent(QDialog):
     def set_card_format(self, format: str) -> None:
         self.editor.web.eval(f'setCardFormat("{format}"); ')
 
-    def refresh_editor_on_review(self, qa: str, card, type: str) -> None:
+    def refresh_editor_on_review(self, qa: str, card: Card, type: str) -> None:
         if type.startswith("review"):
-            self.set_card_format(type[len("review"):].lower())
+            self.set_card_format(type[len("review") :].lower())
 
             if not self.editor.card or self.editor.card.nid != card.nid:
                 self.editor.setNote(card.note())

--- a/qt/aqt/editcurrent.py
+++ b/qt/aqt/editcurrent.py
@@ -61,11 +61,11 @@ class EditCurrent(QDialog):
 
     def refresh_editor_on_review(self, qa: str, card, type: str) -> None:
         if type.startswith("review"):
+            self.set_card_format(type[len("review"):].lower())
+
             if not self.editor.card or self.editor.card.nid != card.nid:
                 self.editor.setNote(card.note())
                 self.editor.card = card
-
-            self.set_card_format(type[len("review"):].lower())
 
         return qa
 

--- a/qt/aqt/editcurrent.py
+++ b/qt/aqt/editcurrent.py
@@ -29,8 +29,8 @@ class EditCurrent(QDialog):
         self.editor.web.eval(
             "$editorToolbar.then(({ templateButtons }) => templateButtons.appendButton({ component: editorToolbar.ObscureButton })); "
         )
-        QShortcut(QKeySequence("Ctrl+Return"), self, activated=self.focus_reviewer)
-        QShortcut(QKeySequence("Ctrl+W"), self, activated=self.saveAndClose)
+        QShortcut(QKeySequence("Ctrl+Return"), self, activated=self.focus_reviewer)  # type: ignore
+        QShortcut(QKeySequence("Ctrl+W"), self, activated=self.saveAndClose)  # type: ignore
 
         restoreGeom(self, "editcurrent")
         gui_hooks.operation_did_execute.append(self.on_operation_did_execute)
@@ -60,7 +60,7 @@ class EditCurrent(QDialog):
     def set_card_format(self, format: str) -> None:
         self.editor.web.eval(f'setCardFormat("{format}"); ')
 
-    def refresh_editor_on_review(self, qa: str, card: Card, type: str) -> None:
+    def refresh_editor_on_review(self, qa: str, card: Card, type: str) -> str:
         if type.startswith("review"):
             self.set_card_format(type[len("review") :].lower())
 

--- a/qt/aqt/editcurrent.py
+++ b/qt/aqt/editcurrent.py
@@ -29,6 +29,8 @@ class EditCurrent(QDialog):
         self.editor.set_note(self.mw.reviewer.card.note(), focusTo=0)
         restoreGeom(self, "editcurrent")
         gui_hooks.operation_did_execute.append(self.on_operation_did_execute)
+        gui_hooks.card_will_show.append(self.refresh_editor_on_review)
+        gui_hooks.reviewer_will_end.append(self.saveAndClose)
         self.show()
 
     def on_operation_did_execute(
@@ -46,8 +48,15 @@ class EditCurrent(QDialog):
 
             self.editor.set_note(note)
 
+    def refresh_editor_on_review(self, qa: str, card, type: str) -> None:
+        if type.startswith("review"):
+            self.editor.setNote(card.note())
+        return qa
+
     def cleanup_and_close(self) -> None:
         gui_hooks.operation_did_execute.remove(self.on_operation_did_execute)
+        gui_hooks.card_will_show.remove(self.refresh_editor_on_review)
+        gui_hooks.reviewer_will_end.remove(self.saveAndClose)
         self.editor.cleanup()
         saveGeom(self, "editcurrent")
         aqt.dialogs.markClosed("EditCurrent")

--- a/qt/aqt/editcurrent.py
+++ b/qt/aqt/editcurrent.py
@@ -63,6 +63,7 @@ class EditCurrent(QDialog):
         if type.startswith("review"):
             if not self.editor.card or self.editor.card.nid != card.nid:
                 self.editor.setNote(card.note())
+                self.editor.card = card
 
             self.set_card_format(type[len("review"):].lower())
 

--- a/qt/aqt/editcurrent.py
+++ b/qt/aqt/editcurrent.py
@@ -28,6 +28,8 @@ class EditCurrent(QDialog):
         self.editor.web.eval(
             '$editorToolbar.then(({ templateButtons }) => templateButtons.appendButton({ component: editorToolbar.ObscureButton })); '
         )
+        QShortcut(QKeySequence("Ctrl+Return"), self, activated=self.focus_reviewer)
+        QShortcut(QKeySequence("Ctrl+W"), self, activated=self.saveAndClose)
 
         restoreGeom(self, "editcurrent")
         gui_hooks.operation_did_execute.append(self.on_operation_did_execute)
@@ -49,6 +51,10 @@ class EditCurrent(QDialog):
                 return
 
             self.editor.set_note(note)
+
+    def focus_reviewer(self) -> None:
+        self.mw.activateWindow()
+        self.mw.raise_()
 
     def set_card_format(self, format: str) -> None:
         self.editor.web.eval(f'setCardFormat("{format}"); ')

--- a/qt/aqt/editcurrent.py
+++ b/qt/aqt/editcurrent.py
@@ -21,9 +21,6 @@ class EditCurrent(QDialog):
         disable_help_button(self)
         self.setMinimumHeight(400)
         self.setMinimumWidth(250)
-        self.form.buttonBox.button(QDialogButtonBox.Close).setShortcut(
-            QKeySequence("Ctrl+Return")
-        )
         self.editor = aqt.editor.Editor(self.mw, self.form.fieldsArea, self)
         self.editor.card = self.mw.reviewer.card
         self.editor.set_note(self.mw.reviewer.card.note(), focusTo=0)

--- a/qt/aqt/forms/editcurrent.ui
+++ b/qt/aqt/forms/editcurrent.ui
@@ -27,53 +27,10 @@
    <item>
     <widget class="QWidget" name="fieldsArea" native="true"/>
    </item>
-   <item>
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Close</set>
-     </property>
-    </widget>
-   </item>
   </layout>
  </widget>
  <resources>
   <include location="icons.qrc"/>
  </resources>
- <connections>
-  <connection>
-   <sender>buttonBox</sender>
-   <signal>accepted()</signal>
-   <receiver>Dialog</receiver>
-   <slot>accept()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>248</x>
-     <y>254</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>157</x>
-     <y>274</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>buttonBox</sender>
-   <signal>rejected()</signal>
-   <receiver>Dialog</receiver>
-   <slot>reject()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>316</x>
-     <y>260</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>286</x>
-     <y>274</y>
-    </hint>
-   </hints>
-  </connection>
- </connections>
+ <connections/>
 </ui>

--- a/qt/aqt/forms/main.ui
+++ b/qt/aqt/forms/main.ui
@@ -219,7 +219,7 @@
     <string>qt_misc_create_filtered_deck</string>
    </property>
    <property name="shortcut">
-    <string notr="true">F</string>
+    <string notr="true">Ctrl+F</string>
    </property>
   </action>
   <action name="actionNoteTypes">

--- a/ts/editor/BUILD.bazel
+++ b/ts/editor/BUILD.bazel
@@ -102,6 +102,10 @@ copy_bootstrap_icons(
         "text-center.svg",
         "text-indent-left.svg",
         "text-indent-right.svg",
+
+        # obscure
+        "eye.svg",
+        "eye-slash.svg",
     ],
     visibility = ["//visibility:public"],
 )

--- a/ts/editor/EditorToolbar.svelte
+++ b/ts/editor/EditorToolbar.svelte
@@ -18,10 +18,12 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     /* Our dynamic components */
     import AddonButtons from "./AddonButtons.svelte";
     import PreviewButton from "./PreviewButton.svelte";
+    import ObscureButton from "./ObscureButton.svelte";
 
     export const editorToolbar = {
         AddonButtons,
         PreviewButton,
+        ObscureButton,
     };
 </script>
 

--- a/ts/editor/ObscureButton.svelte
+++ b/ts/editor/ObscureButton.svelte
@@ -8,7 +8,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     import { getContext } from "svelte";
     import { eyeIcon, eyeSlashIcon } from "./icons";
     import { cardFormatKey } from "./context-keys";
-    import { forEditorField } from ".";
+    import { getCurrentField, forEditorField } from ".";
 
     import WithShortcut from "components/WithShortcut.svelte";
     import IconButton from "components/IconButton.svelte";
@@ -31,11 +31,19 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         icon = eyeIcon;
         forEditorField([], (field) => field.editingArea.unobscure());
     }
+
+    function blurIfObscured(): void {
+        if (obscure) {
+            getCurrentField()?.blur();
+        }
+    }
 </script>
 
-<WithShortcut shortcut={"Control+P"} let:createShortcut>
+<svelte:window on:blur={blurIfObscured} />
+
+<WithShortcut shortcut={"Control+P"} let:createShortcut let:shortcutLabel>
     <IconButton
-        tooltip="Obscure fields while displaying front side"
+        tooltip={`Obscure fields while displaying front side (${shortcutLabel})`}
         on:click={toggleObscure}
         on:mount={createShortcut}
         active={obscureMode}

--- a/ts/editor/ObscureButton.svelte
+++ b/ts/editor/ObscureButton.svelte
@@ -8,18 +8,29 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     import { getContext } from "svelte";
     import { eyeIcon, eyeSlashIcon } from "./icons";
     import { cardFormatKey } from "./context-keys";
+    import { forEditorField } from ".";
 
     import WithShortcut from "components/WithShortcut.svelte";
     import IconButton from "components/IconButton.svelte";
 
-    let obscure = true;
+    let obscureMode = true;
+    let icon = eyeIcon;
+
     function toggleObscure(): void {
-        obscure = !obscure;
+        obscureMode = !obscureMode;
     }
 
     const cardFormat = getContext<Readable<"question" | "answer">>(cardFormatKey);
 
-    $: icon = obscure && $cardFormat === "question" ? eyeSlashIcon : eyeIcon;
+    $: obscure = obscureMode && $cardFormat === "question";
+
+    $: if (obscure) {
+        icon = eyeSlashIcon;
+        forEditorField([], (field) => field.editingArea.obscure());
+    } else {
+        icon = eyeIcon;
+        forEditorField([], (field) => field.editingArea.unobscure());
+    }
 </script>
 
 <WithShortcut shortcut={"Control+P"} let:createShortcut>
@@ -27,7 +38,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         tooltip="Obscure fields while displaying front side"
         on:click={toggleObscure}
         on:mount={createShortcut}
-        active={obscure}
+        active={obscureMode}
     >
         {@html icon}
     </IconButton>

--- a/ts/editor/ObscureButton.svelte
+++ b/ts/editor/ObscureButton.svelte
@@ -1,0 +1,34 @@
+<!--
+Copyright: Ankitects Pty Ltd and contributors
+License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
+-->
+<script lang="typescript">
+    /* import * as tr from "lib/i18n"; */
+    import type { Readable } from "svelte/store";
+    import { getContext } from "svelte";
+    import { eyeIcon, eyeSlashIcon } from "./icons";
+    import { cardFormatKey } from "./context-keys";
+
+    import WithShortcut from "components/WithShortcut.svelte";
+    import IconButton from "components/IconButton.svelte";
+
+    let obscure = true;
+    function toggleObscure(): void {
+        obscure = !obscure;
+    }
+
+    const cardFormat = getContext<Readable<"question" | "answer">>(cardFormatKey);
+
+    $: icon = obscure && $cardFormat === "question" ? eyeSlashIcon : eyeIcon;
+</script>
+
+<WithShortcut shortcut={"Control+P"} let:createShortcut>
+    <IconButton
+        tooltip="Obscure fields while displaying front side"
+        on:click={toggleObscure}
+        on:mount={createShortcut}
+        active={obscure}
+    >
+        {@html icon}
+    </IconButton>
+</WithShortcut>

--- a/ts/editor/codable.ts
+++ b/ts/editor/codable.ts
@@ -1,6 +1,10 @@
 // Copyright: Ankitects Pty Ltd and contributors
 // License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
+/* eslint
+@typescript-eslint/no-non-null-assertion: "off",
+ */
+
 import * as CodeMirror from "codemirror/lib/codemirror";
 import "codemirror/mode/htmlmixed/htmlmixed";
 import "codemirror/addon/fold/foldcode";

--- a/ts/editor/codable.ts
+++ b/ts/editor/codable.ts
@@ -34,6 +34,19 @@ function parseHTML(html: string): string {
 
 export class Codable extends HTMLTextAreaElement {
     codeMirror: CodeMirror | undefined;
+    obscureDiv: HTMLDivElement;
+
+    constructor() {
+        super();
+        this.obscureDiv = document.createElement("div");
+        this.obscureDiv.className = "CodeMirror-obscure";
+        this.obscureDiv.addEventListener("mousedown", this.focusTextarea.bind(this));
+    }
+
+    focusTextarea(event: Event): void {
+        this.codeMirror!.display.input.textarea.focus();
+        event.preventDefault();
+    }
 
     get active(): boolean {
         return Boolean(this.codeMirror);
@@ -58,6 +71,7 @@ export class Codable extends HTMLTextAreaElement {
     setup(html: string): void {
         this.fieldHTML = html;
         this.codeMirror = CodeMirror.fromTextArea(this, codeMirrorOptions);
+        this.codeMirror!.display.wrapper.appendChild(this.obscureDiv);
     }
 
     teardown(): string {
@@ -72,11 +86,11 @@ export class Codable extends HTMLTextAreaElement {
     }
 
     obscure(): void {
-        // this.activeInput.obscure();
+        this.classList.add("obscured");
     }
 
     unobscure(): void {
-        // this.activeInput.obscure();
+        this.classList.remove("obscured");
     }
 
     caretToEnd(): void {

--- a/ts/editor/codable.ts
+++ b/ts/editor/codable.ts
@@ -71,6 +71,14 @@ export class Codable extends HTMLTextAreaElement {
         inCodable.set(true);
     }
 
+    obscure(): void {
+        // this.activeInput.obscure();
+    }
+
+    unobscure(): void {
+        // this.activeInput.obscure();
+    }
+
     caretToEnd(): void {
         this.codeMirror.setCursor(this.codeMirror.lineCount(), 0);
     }

--- a/ts/editor/context-keys.ts
+++ b/ts/editor/context-keys.ts
@@ -3,3 +3,4 @@
 
 export const fieldFocusedKey = Symbol("fieldFocused");
 export const inCodableKey = Symbol("inCodable");
+export const cardFormatKey = Symbol("cardFormat");

--- a/ts/editor/editable.scss
+++ b/ts/editor/editable.scss
@@ -6,6 +6,14 @@ anki-editable {
     overflow: auto;
     padding: 6px;
 
+    &.obscured {
+        opacity: 0;
+
+        &:focus {
+            opacity: inherit;
+        }
+    }
+
     &:empty::after {
         content: "\a";
         white-space: pre;
@@ -49,4 +57,14 @@ img.drawing {
 .CodeMirror {
     height: auto;
     padding: 6px 0;
+
+    > .CodeMirror-obscure {
+        width: 100%;
+        height: 100%;
+        position: absolute;
+        top: 0;
+        left: 0;
+        background-color: inherit;
+        z-index: 3;
+    }
 }

--- a/ts/editor/editable.scss
+++ b/ts/editor/editable.scss
@@ -58,13 +58,20 @@ img.drawing {
     height: auto;
     padding: 6px 0;
 
-    > .CodeMirror-obscure {
+    .CodeMirror-obscure {
         width: 100%;
         height: 100%;
         position: absolute;
         top: 0;
         left: 0;
         background-color: inherit;
-        z-index: 3;
+    }
+
+    .obscured + & .CodeMirror-obscure {
+        z-index: 4;
+    }
+
+    .obscured + &.CodeMirror-focused .CodeMirror-obscure {
+        z-index: initial;
     }
 }

--- a/ts/editor/editable.ts
+++ b/ts/editor/editable.ts
@@ -45,6 +45,14 @@ export class Editable extends HTMLElement {
         inCodable.set(false);
     }
 
+    obscure(): void {
+        this.classList.add("obscured");
+    }
+
+    unobscure(): void {
+        this.classList.remove("obscured");
+    }
+
     caretToEnd(): void {
         caretToEnd(this);
     }

--- a/ts/editor/editing-area.ts
+++ b/ts/editor/editing-area.ts
@@ -12,6 +12,7 @@ import { updateActiveButtons } from "./toolbar";
 import { bridgeCommand } from "./lib";
 import { onInput, onKey, onKeyUp } from "./input-handlers";
 import { onFocus, onBlur } from "./focus-handlers";
+import { obscure as obscureStore } from "./ObscureButton.svelte";
 
 function onCutOrCopy(): void {
     bridgeCommand("cutOrCopy");
@@ -31,18 +32,26 @@ export class EditingArea extends HTMLDivElement {
         const rootStyle = document.createElement("link");
         rootStyle.setAttribute("rel", "stylesheet");
         rootStyle.setAttribute("href", "./_anki/css/editable.css");
-        this.shadowRoot!.appendChild(rootStyle);
 
         this.baseStyle = document.createElement("style");
         this.baseStyle.setAttribute("rel", "stylesheet");
-        this.shadowRoot!.appendChild(this.baseStyle);
 
         this.editable = document.createElement("anki-editable") as Editable;
-        this.shadowRoot!.appendChild(this.editable);
-
         this.codable = document.createElement("textarea", {
             is: "anki-codable",
         }) as Codable;
+
+        obscureStore.subscribe((value: boolean) => {
+            if (value) {
+                this.obscure();
+            } else {
+                this.unobscure();
+            }
+        });
+
+        this.shadowRoot!.appendChild(rootStyle);
+        this.shadowRoot!.appendChild(this.baseStyle);
+        this.shadowRoot!.appendChild(this.editable);
         this.shadowRoot!.appendChild(this.codable);
 
         this.onPaste = this.onPaste.bind(this);

--- a/ts/editor/editing-area.ts
+++ b/ts/editor/editing-area.ts
@@ -127,6 +127,10 @@ export class EditingArea extends HTMLDivElement {
     obscure(): void {
         this.editable.obscure();
         this.codable.obscure();
+
+        if (document.activeElement === this) {
+            this.blur();
+        }
     }
 
     unobscure(): void {

--- a/ts/editor/editing-area.ts
+++ b/ts/editor/editing-area.ts
@@ -125,11 +125,13 @@ export class EditingArea extends HTMLDivElement {
     }
 
     obscure(): void {
-        this.activeInput.obscure();
+        this.editable.obscure();
+        this.codable.obscure();
     }
 
     unobscure(): void {
-        this.activeInput.unobscure();
+        this.editable.unobscure();
+        this.codable.unobscure();
     }
 
     caretToEnd(): void {

--- a/ts/editor/editing-area.ts
+++ b/ts/editor/editing-area.ts
@@ -24,6 +24,7 @@ export class EditingArea extends HTMLDivElement {
 
     constructor() {
         super();
+
         this.attachShadow({ mode: "open" });
         this.className = "field";
 
@@ -121,6 +122,14 @@ export class EditingArea extends HTMLDivElement {
 
     blur(): void {
         this.activeInput.blur();
+    }
+
+    obscure(): void {
+        this.activeInput.obscure();
+    }
+
+    unobscure(): void {
+        this.activeInput.unobscure();
     }
 
     caretToEnd(): void {

--- a/ts/editor/icons.ts
+++ b/ts/editor/icons.ts
@@ -31,5 +31,8 @@ export { default as ellipseIcon } from "./contain.svg";
 export { default as functionIcon } from "./function-variant.svg";
 export { default as xmlIcon } from "./xml.svg";
 
+export { default as eyeIcon } from "./eye.svg";
+export { default as eyeSlashIcon } from "./eye-slash.svg";
+
 export const arrowIcon =
     '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"><path fill="transparent" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2 5l6 6 6-6"/></svg>';

--- a/ts/editor/index.ts
+++ b/ts/editor/index.ts
@@ -20,7 +20,7 @@ import { LabelContainer } from "./label-container";
 import { EditingArea } from "./editing-area";
 import { Editable } from "./editable";
 import { Codable } from "./codable";
-import { initToolbar, fieldFocused } from "./toolbar";
+import { initToolbar, fieldFocused, cardFormat } from "./toolbar";
 
 export { setNoteId, getNoteId } from "./note-id";
 export { saveNow } from "./change-timer";
@@ -181,6 +181,10 @@ export function setFormat(cmd: string, arg?: string, nosave = false): void {
         saveField(getCurrentField() as EditingArea, "key");
         updateActiveButtons(new Event(cmd));
     }
+}
+
+export function setCardFormat(side: "question" | "answer"): void {
+    cardFormat.set(side);
 }
 
 const i18n = setupI18n({

--- a/ts/editor/index.ts
+++ b/ts/editor/index.ts
@@ -37,6 +37,19 @@ declare global {
     }
 }
 
+const i18n = setupI18n({
+    modules: [
+        ModuleName.EDITING,
+        ModuleName.KEYBOARD,
+        ModuleName.ACTIONS,
+        ModuleName.BROWSING,
+    ],
+});
+
+import type EditorToolbar from "./EditorToolbar.svelte";
+
+export const $editorToolbar: Promise<EditorToolbar> = initToolbar(i18n);
+
 customElements.define("anki-editable", Editable);
 customElements.define("anki-codable", Codable, { extends: "textarea" });
 customElements.define("anki-editing-area", EditingArea, { extends: "div" });
@@ -186,16 +199,3 @@ export function setFormat(cmd: string, arg?: string, nosave = false): void {
 export function setCardFormat(side: "question" | "answer"): void {
     cardFormat.set(side);
 }
-
-const i18n = setupI18n({
-    modules: [
-        ModuleName.EDITING,
-        ModuleName.KEYBOARD,
-        ModuleName.ACTIONS,
-        ModuleName.BROWSING,
-    ],
-});
-
-import type EditorToolbar from "./EditorToolbar.svelte";
-
-export const $editorToolbar: Promise<EditorToolbar> = initToolbar(i18n);

--- a/ts/editor/toolbar.ts
+++ b/ts/editor/toolbar.ts
@@ -7,12 +7,13 @@
  */
 
 import { nightModeKey } from "components/context-keys";
-import { fieldFocusedKey, inCodableKey } from "./context-keys";
+import { cardFormatKey, fieldFocusedKey, inCodableKey } from "./context-keys";
 import { writable } from "svelte/store";
 
 import EditorToolbar from "./EditorToolbar.svelte";
 import "./bootstrap.css";
 
+export const cardFormat = writable("unknown");
 export const fieldFocused = writable(false);
 export const inCodable = writable(false);
 
@@ -28,6 +29,7 @@ export function initToolbar(i18n: Promise<void>): Promise<EditorToolbar> {
             const anchor = document.getElementById("fields")!;
 
             const context = new Map();
+            context.set(cardFormatKey, cardFormat);
             context.set(fieldFocusedKey, fieldFocused);
             context.set(inCodableKey, inCodable);
             context.set(


### PR DESCRIPTION
This could be seen as the first PR adressing the issue of "Previewing cards from the editor" (and thus is post v2.1.45 :) ), even though it does not add any Previewer component. It adds several features:

1. Flip cards during review with <kbd>f</kbd>. "f" previously was "Create filtered deck", which I put on "Ctrl+F". Other options would be "c", etc, but I thought the mnemonic was good.
2. Make <kbd>F5</kbd> update the current card, rather than just replay audio. "r" already replays audio, and F5 refreshing the card makes intuitive sense.
3. Make Edit Current update alongside the reviewer. Advancing in the reviewer will update Edit Current (this also makes it act more according to its name).
4. Make Reviewer live-update upon edits in Edit Current. I don't think NOTE_TEXT ops can lead the reviewer to an invalid state (?).
5. Add "obscure mode" to the Edit Current window. Obscure mode will:
    * Generally obscure fields, if edit current has no focus
    * While displaying the question/front, it will only unobscure the currently focused field.
6. Remove the Close button in EditCurrent, <kbd>Ctrl+Enter</kbd> will focus the reviewer, allow <kbd>Ctrl+W</kbd> to close the window.

There are two add-ons which currently implement something akin to this PR<sup>1</sup>:
1. My [Persistent Editor](https://ankiweb.net/shared/info/1686259334)
2. [Migaku Editor](https://ankiweb.net/shared/info/1051095155)

These changes combined enable a new way to use the Edit Current window: Rather than opening the editor, making the change, and closing, the user can alternatively leave the window open, focus it when he wants to edit the current card, and refocus the reviewer afterwards. This is really beneficial, if the user wants to make a lot of small changes during review.

I personally constantly edit during review, and [it seems I'm not alone with this](https://www.reddit.com/r/Anki/comments/ogxc4g/how_often_do_you_edit_cards_during_review/). Updates to the Undo mechanism, has made flipping cards back to the question side impossible (previously it was possible by opening and closing the editor, which I actually did a lot).

I think obscuring the fields upon opening the editor during question makes sense even, if he does not want to persist the window: Following scenario: The user sees an error in the question, wants to edit it immediately, however spoils himself because he sees the answer to the question in the Edit Current window.

<sup>1</sup>There are also several add-ons, which implement editing cards directly in the reviewer. The issue with "Editing in the reviewer" is, that it cannot work if the user uses any JavaScript that modifies field HTML, which is impossible to predict.

For future reference: there's actually a "blur" in mdicons.