### PR TITLE
Show key of unknown browser columns

### DIFF
--- a/qt/aqt/browser/table/model.py
+++ b/qt/aqt/browser/table/model.py
@@ -302,8 +302,8 @@ def addon_column_fillin(key: str) -> Column:
     """
     return Column(
         key=key,
-        cards_mode_label=tr.browsing_addon(),
-        notes_mode_label=tr.browsing_addon(),
+        cards_mode_label=f"{tr.browsing_addon()} ({key})",
+        notes_mode_label=f"{tr.browsing_addon()} ({key})",
         sorting=Columns.SORTING_NONE,
         uses_cell_font=False,
         alignment=Columns.ALIGNMENT_CENTER,


### PR DESCRIPTION
This should help users to understand where add-on columns are coming from. Also useful for debugging.