### PR TITLE
Find & Replace

### DIFF
--- a/ftl/core/actions.ftl
+++ b/ftl/core/actions.ftl
@@ -23,6 +23,7 @@ actions-rebuild = Rebuild
 actions-rename = Rename
 actions-rename-deck = Rename Deck
 actions-rename-tag = Rename Tag
+actions-rename-with-parents = Rename with Parents
 actions-remove-tag = Remove Tag
 actions-replay-audio = Replay Audio
 actions-reposition = Reposition

--- a/ftl/core/browsing.ftl
+++ b/ftl/core/browsing.ftl
@@ -92,6 +92,7 @@ browsing-reschedule = Reschedule
 browsing-search-bar-hint = Search cards/notes (type text, then press Enter)
 browsing-search-in = Search in:
 browsing-search-within-formatting-slow = Search within formatting (slow)
+browsing-selected-notes-only = Selected notes only
 browsing-shift-position-of-existing-cards = Shift position of existing cards
 browsing-sidebar = Sidebar
 browsing-sidebar-filter = Sidebar filter

--- a/qt/aqt/browser/browser.py
+++ b/qt/aqt/browser/browser.py
@@ -812,7 +812,6 @@ class Browser(QMainWindow):
     ######################################################################
 
     @no_arg_trigger
-    @skip_if_selection_is_empty
     @ensure_editor_saved
     def onFindReplace(self) -> None:
         FindAndReplaceDialog(self, mw=self.mw, note_ids=self.selected_notes())

--- a/qt/aqt/browser/sidebar/tree.py
+++ b/qt/aqt/browser/sidebar/tree.py
@@ -1034,29 +1034,16 @@ class SidebarTreeView(QTreeView):
     ###########################
 
     def rename_deck(self, item: SidebarItem, new_name: str) -> None:
-        if not new_name:
+        if not new_name or new_name == item.name:
             return
 
         # update UI immediately, to avoid redraw
         item.name = new_name
 
-        full_name = item.name_prefix + new_name
-        deck_id = DeckId(item.id)
-
-        def after_fetch(name: str) -> None:
-            if full_name == name:
-                return
-
-            rename_deck(
-                parent=self,
-                deck_id=deck_id,
-                new_name=full_name,
-            ).run_in_background()
-
-        QueryOp(
-            parent=self.browser,
-            op=lambda col: col.decks.name(deck_id),
-            success=after_fetch,
+        rename_deck(
+            parent=self,
+            deck_id=DeckId(item.id),
+            new_name=item.name_prefix + new_name,
         ).run_in_background()
 
     def delete_decks(self, _item: SidebarItem) -> None:

--- a/qt/aqt/browser/sidebar/tree.py
+++ b/qt/aqt/browser/sidebar/tree.py
@@ -837,7 +837,6 @@ class SidebarTreeView(QTreeView):
                         SearchNode(note=nt["name"]), SearchNode(template=c)
                     ),
                     item_type=SidebarItemType.NOTETYPE_TEMPLATE,
-                    name_prefix=f"{nt['name']}::",
                     id=tmpl["ord"],
                 )
                 item.add_child(child)

--- a/qt/aqt/forms/findreplace.ui
+++ b/qt/aqt/forms/findreplace.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>367</width>
+    <width>377</width>
     <height>224</height>
    </rect>
   </property>
@@ -16,15 +16,8 @@
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
     <layout class="QGridLayout" name="gridLayout">
-     <item row="0" column="0">
-      <widget class="QLabel" name="label">
-       <property name="text">
-        <string>browsing_find</string>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="1">
-      <widget class="QComboBox" name="find">
+     <item row="1" column="1">
+      <widget class="QComboBox" name="replace">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
          <horstretch>9</horstretch>
@@ -49,8 +42,46 @@
        </property>
       </widget>
      </item>
-     <item row="1" column="1">
-      <widget class="QComboBox" name="replace">
+     <item row="2" column="0">
+      <widget class="QLabel" name="label_3">
+       <property name="text">
+        <string>browsing_in</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="0">
+      <widget class="QLabel" name="label">
+       <property name="text">
+        <string>browsing_find</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="1">
+      <widget class="QComboBox" name="field">
+       <property name="sizeAdjustPolicy">
+        <enum>QComboBox::AdjustToMinimumContentsLength</enum>
+       </property>
+      </widget>
+     </item>
+     <item row="5" column="1">
+      <widget class="QCheckBox" name="re">
+       <property name="text">
+        <string>browsing_treat_input_as_regular_expression</string>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="1">
+      <widget class="QCheckBox" name="ignoreCase">
+       <property name="text">
+        <string>browsing_ignore_case</string>
+       </property>
+       <property name="checked">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="QComboBox" name="find">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
          <horstretch>9</horstretch>
@@ -68,31 +99,10 @@
        </property>
       </widget>
      </item>
-     <item row="2" column="0">
-      <widget class="QLabel" name="label_3">
-       <property name="text">
-        <string>browsing_in</string>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="1">
-      <widget class="QComboBox" name="field">
-       <property name="sizeAdjustPolicy">
-        <enum>QComboBox::AdjustToMinimumContentsLength</enum>
-       </property>
-      </widget>
-     </item>
-     <item row="4" column="1">
-      <widget class="QCheckBox" name="re">
-       <property name="text">
-        <string>browsing_treat_input_as_regular_expression</string>
-       </property>
-      </widget>
-     </item>
      <item row="3" column="1">
-      <widget class="QCheckBox" name="ignoreCase">
+      <widget class="QCheckBox" name="selected_notes">
        <property name="text">
-        <string>browsing_ignore_case</string>
+        <string>browsing_selected_notes_only</string>
        </property>
        <property name="checked">
         <bool>true</bool>

--- a/rslib/src/backend/tags.rs
+++ b/rslib/src/backend/tags.rs
@@ -73,8 +73,13 @@ impl TagsService for Backend {
         input: pb::FindAndReplaceTagRequest,
     ) -> Result<pb::OpChangesWithCount> {
         self.with_col(|col| {
+            let note_ids = if input.note_ids.is_empty() {
+                col.search_notes_unordered("")?
+            } else {
+                to_note_ids(input.note_ids)
+            };
             col.find_and_replace_tag(
-                &to_note_ids(input.note_ids),
+                &note_ids,
                 &input.search,
                 &input.replacement,
                 input.regex,


### PR DESCRIPTION
The first commit fixes a bug, where the replacement was performed in all fields of notes, which didn't own the specified field. I've fixed it in Rust, even though there was a comment indicating that this was the intended behaviour. I hope that was right.

<hr>

The rest is as discussed in https://forums.ankiweb.net/t/anki-2-1-45-beta/10664/.