### PR TITLE
Fix browser search completer

### DIFF
--- a/qt/aqt/browser/browser.py
+++ b/qt/aqt/browser/browser.py
@@ -285,7 +285,7 @@ class Browser(QMainWindow):
         self.form.searchEdit.lineEdit().setPlaceholderText(
             tr.browsing_search_bar_hint()
         )
-        self.form.searchEdit.addItems(self.mw.pm.profile["searchHistory"])
+        self.form.searchEdit.addItems([""] + self.mw.pm.profile["searchHistory"])
         if search is not None:
             self.search_for_terms(*search)
         else:


### PR DESCRIPTION
Adding an empty entry at the top fixes
https://forums.ankiweb.net/t/anki-2-1-45-beta/10664/45
and allows for scrolling back to an empty line.