### PR TITLE
Refactor editor fields

### DIFF
--- a/ts/components/Spacer.svelte
+++ b/ts/components/Spacer.svelte
@@ -1,0 +1,12 @@
+<!--
+Copyright: Ankitects Pty Ltd and contributors
+License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
+-->
+<div />
+
+<style lang="scss">
+    div {
+        width: var(--width, auto);
+        height: var(--height, auto);
+    }
+</style>

--- a/ts/components/StickyBar.svelte
+++ b/ts/components/StickyBar.svelte
@@ -6,15 +6,16 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     export let id: string | undefined = undefined;
     let className: string = "";
     export { className as class };
+    export let height: number;
 </script>
 
-<nav {id} class={`container-fluid pb-1 pt-1 ${className}`}>
+<nav {id} bind:offsetHeight={height} class={`container-fluid pb-1 pt-1 ${className}`}>
     <slot />
 </nav>
 
 <style lang="scss">
     nav {
-        position: sticky;
+        position: fixed;
         top: 0;
         left: 0;
         right: 0;

--- a/ts/deck-options/ConfigSelector.svelte
+++ b/ts/deck-options/ConfigSelector.svelte
@@ -12,6 +12,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     import TextInputModal from "./TextInputModal.svelte";
     import StickyBar from "components/StickyBar.svelte";
     import ButtonToolbar from "components/ButtonToolbar.svelte";
+    import Spacer from "components/Spacer.svelte";
     import Item from "components/Item.svelte";
     import ButtonGroup from "components/ButtonGroup.svelte";
     import ButtonGroupItem from "components/ButtonGroupItem.svelte";
@@ -77,6 +78,8 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         modalStartingValue = state.getCurrentName();
         modals.get(modalKey)!.show();
     }
+
+    let height: number;
 </script>
 
 <TextInputModal
@@ -87,7 +90,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     bind:modalKey
 />
 
-<StickyBar class="g-1">
+<StickyBar class="g-1" bind:height>
     <ButtonToolbar class="justify-content-between" size={2.3} wrap={false}>
         <Item>
             <ButtonGroup class="flex-grow-1">
@@ -116,3 +119,5 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         </Item>
     </ButtonToolbar>
 </StickyBar>
+
+<Spacer --height="{height}px" />

--- a/ts/editor/BUILD.bazel
+++ b/ts/editor/BUILD.bazel
@@ -83,6 +83,7 @@ copy_bootstrap_icons(
     name = "bootstrap-icons",
     icons = [
         "pin-angle.svg",
+        "grip-vertical.svg",
 
         # inline formatting
         "type-bold.svg",

--- a/ts/editor/BUILD.bazel
+++ b/ts/editor/BUILD.bazel
@@ -83,7 +83,6 @@ copy_bootstrap_icons(
     name = "bootstrap-icons",
     icons = [
         "pin-angle.svg",
-        "grip-vertical.svg",
 
         # inline formatting
         "type-bold.svg",

--- a/ts/editor/EditorToolbar.svelte
+++ b/ts/editor/EditorToolbar.svelte
@@ -29,6 +29,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     import { isApplePlatform } from "lib/platform";
     import StickyBar from "components/StickyBar.svelte";
     import ButtonToolbar from "components/ButtonToolbar.svelte";
+    import Spacer from "components/Spacer.svelte";
     import Item from "components/Item.svelte";
 
     import NoteTypeButtons from "./NoteTypeButtons.svelte";
@@ -40,6 +41,8 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     export let size = isApplePlatform() ? 1.6 : 2.0;
     export let wrap = true;
 
+    let height: number;
+
     export const toolbar = {};
     export const notetypeButtons = {};
     export const formatInlineButtons = {};
@@ -48,7 +51,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     export const templateButtons = {};
 </script>
 
-<StickyBar>
+<StickyBar bind:height>
     <ButtonToolbar {size} {wrap} api={toolbar}>
         <Item id="notetype">
             <NoteTypeButtons api={notetypeButtons} />
@@ -71,3 +74,5 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         </Item>
     </ButtonToolbar>
 </StickyBar>
+
+<Spacer --height={`${height}px`} />

--- a/ts/editor/EditorToolbar.svelte
+++ b/ts/editor/EditorToolbar.svelte
@@ -75,4 +75,4 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     </ButtonToolbar>
 </StickyBar>
 
-<Spacer --height={`${height}px`} />
+<Spacer --height="{height}px" />

--- a/ts/editor/editable.scss
+++ b/ts/editor/editable.scss
@@ -26,7 +26,7 @@ p {
     }
 }
 
-:host-context(.nightMode) * {
+:host(.night-mode) * {
     @include scrollbar.night-mode;
 }
 

--- a/ts/editor/editing-area.ts
+++ b/ts/editor/editing-area.ts
@@ -27,6 +27,10 @@ export class EditingArea extends HTMLDivElement {
         this.attachShadow({ mode: "open" });
         this.className = "field";
 
+        if (document.documentElement.classList.contains("night-mode")) {
+            this.classList.add("night-mode");
+        }
+
         const rootStyle = document.createElement("link");
         rootStyle.setAttribute("rel", "stylesheet");
         rootStyle.setAttribute("href", "./_anki/css/editable.css");

--- a/ts/editor/editor-field.ts
+++ b/ts/editor/editor-field.ts
@@ -10,6 +10,8 @@ export class EditorField extends HTMLDivElement {
 
     constructor() {
         super();
+        this.classList.add("editorfield");
+
         this.labelContainer = document.createElement("div", {
             is: "anki-label-container",
         }) as LabelContainer;

--- a/ts/editor/fields.scss
+++ b/ts/editor/fields.scss
@@ -33,7 +33,6 @@
         border: 1px dashed var(--border);
         background-color: red;
     }
-
 }
 
 .fname {

--- a/ts/editor/fields.scss
+++ b/ts/editor/fields.scss
@@ -28,17 +28,6 @@
         // (https://github.com/ankitects/anki/pull/1278)
         background-image: linear-gradient(var(--flag1-bg), var(--flag1-bg));
     }
-
-    .is-dragged > & {
-        border: 1px dashed var(--border);
-        background-color: red;
-    }
-}
-
-.fname {
-    .is-dragged > & {
-        visibility: hidden;
-    }
 }
 
 #dupes,

--- a/ts/editor/fields.scss
+++ b/ts/editor/fields.scss
@@ -9,14 +9,19 @@
 }
 
 #fields {
-    display: flex;
-    flex-direction: column;
+    display: grid;
     margin: 5px;
+
+    > * {
+        display: flex;
+        flex-flow: column;
+    }
 }
 
 .field {
     border: 1px solid var(--border);
     background: var(--frame-bg);
+    flex-grow: 1;
 
     &.dupe {
         // this works around the background colour persisting in copy+paste
@@ -26,6 +31,7 @@
 }
 
 .fname {
+    white-space: nowrap;
     vertical-align: middle;
     padding: 0;
 }

--- a/ts/editor/fields.scss
+++ b/ts/editor/fields.scss
@@ -53,18 +53,23 @@
     }
 }
 
-.icon > svg {
-    fill: var(--text-fg);
-}
-
-.pin-icon {
+.icon {
     cursor: pointer;
+    opacity: 0.8;
 
     &.is-inactive {
         opacity: 0.1;
     }
 
     &.icon--hover {
-        opacity: 0.5;
+        opacity: 1;
+
+        &.icon-toggle {
+            opacity: 0.5;
+        }
+    }
+
+    > svg {
+        fill: var(--text-fg);
     }
 }

--- a/ts/editor/fields.scss
+++ b/ts/editor/fields.scss
@@ -11,11 +11,11 @@
 #fields {
     display: grid;
     margin: 5px;
+}
 
-    > * {
-        display: flex;
-        flex-flow: column;
-    }
+.editorfield {
+    display: flex;
+    flex-flow: column;
 }
 
 .field {
@@ -28,12 +28,18 @@
         // (https://github.com/ankitects/anki/pull/1278)
         background-image: linear-gradient(var(--flag1-bg), var(--flag1-bg));
     }
+
+    .is-dragged > & {
+        border: 1px dashed var(--border);
+        background-color: red;
+    }
+
 }
 
 .fname {
-    white-space: nowrap;
-    vertical-align: middle;
-    padding: 0;
+    .is-dragged > & {
+        visibility: hidden;
+    }
 }
 
 #dupes,

--- a/ts/editor/label-container.ts
+++ b/ts/editor/label-container.ts
@@ -26,9 +26,11 @@ function setFieldDraggable(evt: Event): void {
 
     document.addEventListener("dragstart", (event) => {
         dragged = event.target as HTMLElement;
+        dragged.classList.add("is-dragged");
     });
 
     document.addEventListener("dragend", () => {
+        dragged.classList.remove("is-dragged");
         dragged.draggable = false;
     });
 }
@@ -40,7 +42,7 @@ export class LabelContainer extends HTMLDivElement {
 
     constructor() {
         super();
-        this.className = "d-flex justify-content-between";
+        this.className = "fname d-flex justify-content-between";
 
         this.label = document.createElement("span");
         this.label.className = "fieldname";

--- a/ts/editor/label-container.ts
+++ b/ts/editor/label-container.ts
@@ -3,7 +3,6 @@
 
 import { bridgeCommand } from "./lib";
 import pinIcon from "./pin-angle.svg";
-import gripIcon from "./grip-vertical.svg";
 
 function removeHoverIcon(evt: Event): void {
     const icon = evt.currentTarget as HTMLElement;
@@ -15,29 +14,8 @@ function hoverIcon(evt: Event): void {
     icon.classList.add("icon--hover");
 }
 
-function setFieldDraggable(evt: Event): void {
-    const icon = evt.currentTarget as HTMLElement;
-
-    // TODO make this event-based when moving to Svelte
-    const field = icon.parentElement!.parentElement!;
-    field.draggable = true;
-
-    let dragged: HTMLElement;
-
-    document.addEventListener("dragstart", (event) => {
-        dragged = event.target as HTMLElement;
-        dragged.classList.add("is-dragged");
-    });
-
-    document.addEventListener("dragend", () => {
-        dragged.classList.remove("is-dragged");
-        dragged.draggable = false;
-    });
-}
-
 export class LabelContainer extends HTMLDivElement {
     sticky: HTMLSpanElement;
-    grip: HTMLSpanElement;
     label: HTMLSpanElement;
 
     constructor() {
@@ -58,11 +36,6 @@ export class LabelContainer extends HTMLDivElement {
         this.sticky.hidden = true;
         this.appendChild(this.sticky);
 
-        this.grip = document.createElement("span");
-        this.grip.className = "icon ms-1";
-        this.grip.innerHTML = gripIcon;
-        this.appendChild(this.grip);
-
         this.toggleSticky = this.toggleSticky.bind(this);
     }
 
@@ -70,18 +43,12 @@ export class LabelContainer extends HTMLDivElement {
         this.sticky.addEventListener("click", this.toggleSticky);
         this.sticky.addEventListener("mouseenter", hoverIcon);
         this.sticky.addEventListener("mouseleave", removeHoverIcon);
-        this.grip.addEventListener("mousedown", setFieldDraggable);
-        this.grip.addEventListener("mouseenter", hoverIcon);
-        this.grip.addEventListener("mouseleave", removeHoverIcon);
     }
 
     disconnectedCallback(): void {
         this.sticky.removeEventListener("click", this.toggleSticky);
         this.sticky.removeEventListener("mouseenter", hoverIcon);
         this.sticky.removeEventListener("mouseleave", removeHoverIcon);
-        this.grip.removeEventListener("mousedown", setFieldDraggable);
-        this.grip.removeEventListener("mouseenter", hoverIcon);
-        this.grip.removeEventListener("mouseleave", removeHoverIcon);
     }
 
     initialize(labelName: string): void {

--- a/ts/editor/label-container.ts
+++ b/ts/editor/label-container.ts
@@ -3,6 +3,7 @@
 
 import { bridgeCommand } from "./lib";
 import pinIcon from "./pin-angle.svg";
+import gripIcon from "./grip-vertical.svg";
 
 function removeHoverIcon(evt: Event): void {
     const icon = evt.currentTarget as HTMLElement;
@@ -14,8 +15,27 @@ function hoverIcon(evt: Event): void {
     icon.classList.add("icon--hover");
 }
 
+function setFieldDraggable(evt: Event): void {
+    const icon = evt.currentTarget as HTMLElement;
+
+    // TODO make this event-based when moving to Svelte
+    const field = icon.parentElement!.parentElement!;
+    field.draggable = true;
+
+    let dragged: HTMLElement;
+
+    document.addEventListener("dragstart", (event) => {
+        dragged = event.target as HTMLElement;
+    });
+
+    document.addEventListener("dragend", () => {
+        dragged.draggable = false;
+    });
+}
+
 export class LabelContainer extends HTMLDivElement {
     sticky: HTMLSpanElement;
+    grip: HTMLSpanElement;
     label: HTMLSpanElement;
 
     constructor() {
@@ -26,11 +46,20 @@ export class LabelContainer extends HTMLDivElement {
         this.label.className = "fieldname";
         this.appendChild(this.label);
 
+        const spacer = document.createElement("span");
+        spacer.className = "flex-grow-1";
+        this.appendChild(spacer);
+
         this.sticky = document.createElement("span");
-        this.sticky.className = "icon pin-icon me-1";
+        this.sticky.className = "icon icon-toggle ms-1";
         this.sticky.innerHTML = pinIcon;
         this.sticky.hidden = true;
         this.appendChild(this.sticky);
+
+        this.grip = document.createElement("span");
+        this.grip.className = "icon ms-1";
+        this.grip.innerHTML = gripIcon;
+        this.appendChild(this.grip);
 
         this.toggleSticky = this.toggleSticky.bind(this);
     }
@@ -39,12 +68,18 @@ export class LabelContainer extends HTMLDivElement {
         this.sticky.addEventListener("click", this.toggleSticky);
         this.sticky.addEventListener("mouseenter", hoverIcon);
         this.sticky.addEventListener("mouseleave", removeHoverIcon);
+        this.grip.addEventListener("mousedown", setFieldDraggable);
+        this.grip.addEventListener("mouseenter", hoverIcon);
+        this.grip.addEventListener("mouseleave", removeHoverIcon);
     }
 
     disconnectedCallback(): void {
         this.sticky.removeEventListener("click", this.toggleSticky);
         this.sticky.removeEventListener("mouseenter", hoverIcon);
         this.sticky.removeEventListener("mouseleave", removeHoverIcon);
+        this.grip.removeEventListener("mousedown", setFieldDraggable);
+        this.grip.removeEventListener("mouseenter", hoverIcon);
+        this.grip.removeEventListener("mouseleave", removeHoverIcon);
     }
 
     initialize(labelName: string): void {


### PR DESCRIPTION
This started as an attempt to implement something like [Multi-column note editor](https://ankiweb.net/shared/info/3491767031), or [Grid fields](https://ankiweb.net/shared/info/796923308) directly into Anki.

I wanted to implement this using Drag'n'Drop, however QWebView does not allow for `dragover` / `dragenter` events. Instead this features some other changes / improvements:

- Use `:host` instead of `:host-context`, as `:host-context` does not have wide support.
- Make StickyBar fixed rather sticky. Fixes an issue when an editor field contained an element wider than the viewport. It should also be renamed as the name is kinda misleading, but I'd rather do that after #1264.
- Make `#fields` a grid rather than flexbox

My end goal with this PR was, and also #1285, is that I want to add some of the popular editor features / add-ons concerning fields, before we can make it the `Fields` Svelte Component, and as a result of this, make the whole Editor a svelte component, which will probably break several editor add-ons yet again.

How would you recommend me to continue with this? My optimal UI solution would have Drag'n'Drop, something like [this](https://github.com/SortableJS/Sortable), however like mentioned above, this won't work. Should I:
1. Drop the functionality altogether
2. Try to build a UI solution without drag'n'drop (e.g. sorting with key presses)
3. Postpone UI interface, and just build the backend support, and add access to the raw preferences, which would look kinda like this:
```
[[0, 0, 1, 1], [0, 1, 1, 1], /* one for each field */]
-- position-x, position-y, extent-x, extent-y
```