### PR TITLE
Prevent webview from freezing due to error in _runHook

### DIFF
--- a/ts/reviewer/index.ts
+++ b/ts/reviewer/index.ts
@@ -27,14 +27,12 @@ export function getTypedAnswer(): string | null {
     return typeans?.value ?? null;
 }
 
-function _runHook(arr: Array<Callback>): Promise<void[]> {
-    const promises: (Promise<void> | void)[] = [];
-
-    for (let i = 0; i < arr.length; i++) {
-        promises.push(arr[i]());
+async function _runHook(arr: Array<Callback>): Promise<void> {
+    for (const callback of arr) {
+        const promise = new Promise((resolve) => resolve(callback()));
+        // swallow error to prevent webview from freezing
+        await promise.catch((e) => console.error(e));
     }
-
-    return Promise.all(promises);
 }
 
 let _updatingQueue: Promise<void> = Promise.resolve();


### PR DESCRIPTION
Fixes https://forums.ankiweb.net/t/2-1-45-release-candidate/11362/20 .

I know that add-on authors and users should make sure that there are no errors in the hook functions, but I created this PR because the clayout's webview also freezes while editing a template.