### PR TITLE
Catch hook errors in two ways:

### DIFF
--- a/ts/reviewer/index.ts
+++ b/ts/reviewer/index.ts
@@ -28,13 +28,13 @@ export function getTypedAnswer(): string | null {
 }
 
 function _runHook(
-    arr: Array<Callback>
+    hooks: Array<Callback>
 ): Promise<PromiseSettledResult<void | Promise<void>>[]> {
     const promises: (Promise<void> | void)[] = [];
 
-    for (let i = 0; i < arr.length; i++) {
+    for (const hook of hooks) {
         try {
-            const result = arr[i]();
+            const result = hook();
             promises.push(result);
         } catch (error) {
             console.log("Hook failed: ", error);

--- a/ts/reviewer/index.ts
+++ b/ts/reviewer/index.ts
@@ -27,14 +27,21 @@ export function getTypedAnswer(): string | null {
     return typeans?.value ?? null;
 }
 
-function _runHook(arr: Array<Callback>): Promise<void[]> {
+function _runHook(
+    arr: Array<Callback>
+): Promise<PromiseSettledResult<void | Promise<void>>[]> {
     const promises: (Promise<void> | void)[] = [];
 
     for (let i = 0; i < arr.length; i++) {
-        promises.push(arr[i]());
+        try {
+            const result = arr[i]();
+            promises.push(result);
+        } catch (error) {
+            console.log("Hook failed: ", error);
+        }
     }
 
-    return Promise.all(promises);
+    return Promise.allSettled(promises);
 }
 
 let _updatingQueue: Promise<void> = Promise.resolve();

--- a/ts/tsconfig.json
+++ b/ts/tsconfig.json
@@ -3,7 +3,14 @@
     "compilerOptions": {
         "target": "es6",
         "module": "es6",
-        "lib": ["es2017", "es2019.array", "es2018.promise", "dom", "dom.iterable"],
+        "lib": [
+            "es2017",
+            "es2019.array",
+            "es2018.promise",
+            "es2020.promise",
+            "dom",
+            "dom.iterable"
+        ],
         "baseUrl": ".",
         "paths": {
             "lib/*": ["../bazel-bin/ts/lib/*"],


### PR DESCRIPTION
This is an alternative to #1301. After thinking about it, I realized that there are actually two scenarios in which the hooks can fail:
- If it fails synchronously, it seems to freeze the reviewer on Windows/Linux
- If it fails asynchronously, it can cancel out other hooks, as `Promise.all` will fast-fail.

These are addressed by:
- try/catch for catching synchronous errors
- Promise.allSettled will allow for rejected promises without fast-failing other promises

@hikaru-y Could you try this PR out, as the freezing did not happen on macOS in the first place.
Hooks are still evaluated in order, but asynchronously. JS in the browser is single-threaded, so using "parallel" was confusing. Using `Promise.all` means that hooks can fetch resources asynchronously, without blocking other hooks. If there was really a dependency between hooks, they can simply wait on each other. E.g. my [Closet add-on](https://ankiweb.net/shared/info/272311064) will fetch resources immediately on the template loaded:

```javascript
var closetPromise = fetchResources(/* returns a promise */);
onShownHook.push(() => closetPromise);
```

If an add-ons needed to coordinate with that, it could still call `.then()` on `closetPromise` directly if necessary. Same goes the other way. However generally, it should not be necessary. If we do sequential by default, we'll do the slowest method by default, making optimisation difficult; using `Promise.all(Settled)` means we do the fastest method, allowing for individual coordination if necessary.