### PR TITLE
fix card flag clearance when exporting

### DIFF
--- a/pylib/anki/exporting.py
+++ b/pylib/anki/exporting.py
@@ -214,11 +214,11 @@ class AnkiExporter(Exporter):
         for row in self.src.db.execute(
             "select * from cards where id in " + ids2str(cids)
         ):
-            nids[row[1]] = True
-            data.append(row)
             # clear flags
             row = list(row)
             row[-2] = 0
+            nids[row[1]] = True
+            data.append(row)
         self.dst.db.executemany(
             "insert into cards values (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)", data
         )


### PR DESCRIPTION
The card tuple is inserted into `data` for insertion after the loop, but then a separate list is created and modified which has no effect because it is the tuple that will be used to insert data into the new collection.