### PR TITLE
ignore importing cards of existing notes

### DIFF
--- a/pylib/anki/importing/anki2.py
+++ b/pylib/anki/importing/anki2.py
@@ -142,6 +142,7 @@ class Anki2Importer(Importer):
                             self._ignoredGuids[note[GUID]] = True
                     else:
                         dupesIdentical.append(note)
+                        self._ignoredGuids[note[GUID]] = True
 
         self.log.append(self.dst.tr.importing_notes_found_in_file(val=total))
 


### PR DESCRIPTION
When `Anki2Importer` imports notes, it doesn't import notes which already exist and were modified more recently than the ones being imported. But I notice that it also doesn't "ignore" them by inserting them into `_ignoredGuids`. Is this a bug?