### PR TITLE
Fix importing when current deck is filtered

### DIFF
--- a/pylib/anki/importing/noteimp.py
+++ b/pylib/anki/importing/noteimp.py
@@ -214,7 +214,7 @@ class NoteImporter(Importer):
         did = self.col.decks.selected()
         conf = self.col.decks.config_dict_for_deck_id(did)
         # in order due?
-        if conf["new"]["order"] == NEW_CARDS_RANDOM:
+        if not conf["dyn"] and conf["new"]["order"] == NEW_CARDS_RANDOM:
             self.col.sched.randomizeCards(did)
 
         part1 = self.col.tr.importing_note_added(count=len(new))

--- a/qt/aqt/deckchooser.py
+++ b/qt/aqt/deckchooser.py
@@ -70,7 +70,8 @@ class DeckChooser(QHBoxLayout):
             self._update_button_label()
 
     def _ensure_selected_deck_valid(self) -> None:
-        if not self.mw.col.decks.get(self._selected_deck_id, default=False):
+        deck = self.mw.col.decks.get(self._selected_deck_id, default=False)
+        if not deck or deck["dyn"]:
             self.selected_deck_id = DEFAULT_DECK_ID
 
     def _update_button_label(self) -> None:


### PR DESCRIPTION
The first commit prevents the current deck to be set in the DeckChooser (viz the Import Dialogue) if it's filtered. The second one prevents a KeyError if the current deck is filtered when importing.
Not sure if this is the correct way of fixing it.