### PR TITLE
Remove registerShortcut for Ctrl+C/V/A/X from editor/index.ts

### DIFF
--- a/ts/editor/index.ts
+++ b/ts/editor/index.ts
@@ -8,8 +8,6 @@
 import { filterHTML } from "html-filter";
 import { updateActiveButtons } from "./toolbar";
 import { setupI18n, ModuleName } from "lib/i18n";
-import { registerShortcut } from "lib/shortcuts";
-import { bridgeCommand } from "./lib";
 
 import "./fields.css";
 
@@ -42,11 +40,6 @@ customElements.define("anki-codable", Codable, { extends: "textarea" });
 customElements.define("anki-editing-area", EditingArea, { extends: "div" });
 customElements.define("anki-label-container", LabelContainer, { extends: "div" });
 customElements.define("anki-editor-field", EditorField, { extends: "div" });
-
-registerShortcut(() => document.execCommand("copy"), "Control+C");
-registerShortcut(() => document.execCommand("cut"), "Control+X");
-registerShortcut(() => document.execCommand("selectAll"), "Control+A");
-registerShortcut(() => bridgeCommand("paste"), "Control+Shift+V");
 
 export function getCurrentField(): EditingArea | null {
     return document.activeElement instanceof EditingArea

--- a/ts/editor/index.ts
+++ b/ts/editor/index.ts
@@ -8,6 +8,9 @@
 import { filterHTML } from "html-filter";
 import { updateActiveButtons } from "./toolbar";
 import { setupI18n, ModuleName } from "lib/i18n";
+import { isApplePlatform } from "lib/platform";
+import { registerShortcut } from "lib/shortcuts";
+import { bridgeCommand } from "lib/bridgecommand";
 
 import "./fields.css";
 
@@ -40,6 +43,10 @@ customElements.define("anki-codable", Codable, { extends: "textarea" });
 customElements.define("anki-editing-area", EditingArea, { extends: "div" });
 customElements.define("anki-label-container", LabelContainer, { extends: "div" });
 customElements.define("anki-editor-field", EditorField, { extends: "div" });
+
+if (isApplePlatform()) {
+    registerShortcut(() => bridgeCommand("paste"), "Control+Shift+V");
+}
 
 export function getCurrentField(): EditingArea | null {
     return document.activeElement instanceof EditingArea


### PR DESCRIPTION
Should fix https://forums.ankiweb.net/t/shift-ctrl-v-to-strip-preserve-formatting-of-pasted-text-results-in-text-being-pasted-twice-in-2-1-45/11792.

I swore I remember that I wasn't able to copy the field names on macOS without these, but I guess I messed up ^^;