### PR TITLE
Svelte allow cross unit compilation

### DIFF
--- a/ts/editor/Components.svelte
+++ b/ts/editor/Components.svelte
@@ -6,6 +6,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     import IconButton from "components/IconButton.svelte";
     import LabelButton from "components/LabelButton.svelte";
     import WithContext from "components/WithContext.svelte";
+    import WithShortcut from "components/WithShortcut.svelte";
     import WithState from "components/WithState.svelte";
 
     import * as contextKeys from "components/context-keys";
@@ -15,6 +16,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         IconButton,
         LabelButton,
         WithContext,
+        WithShortcut,
         WithState,
         contextKeys: { ...contextKeys, ...editorContextKeys },
     };

--- a/ts/patches/svelte+3.42.1.patch
+++ b/ts/patches/svelte+3.42.1.patch
@@ -1,0 +1,135 @@
+diff --git a/node_modules/svelte/internal/index.mjs b/node_modules/svelte/internal/index.mjs
+index 59116ca..a76c710 100644
+--- a/node_modules/svelte/internal/index.mjs
++++ b/node_modules/svelte/internal/index.mjs
+@@ -1,5 +1,5 @@
+ function noop() { }
+-const identity = x => x;
++const identity = globalThis.svelteCrossUnit.identity = x => x;
+ function assign(tar, src) {
+     // @ts-ignore
+     for (const k in src)
+@@ -151,12 +151,12 @@ function set_store_value(store, ret, value) {
+     store.set(value);
+     return ret;
+ }
+-const has_prop = (obj, prop) => Object.prototype.hasOwnProperty.call(obj, prop);
++const has_prop = globalThis.svelteCrossUnit.has_prop = (obj, prop) => Object.prototype.hasOwnProperty.call(obj, prop);
+ function action_destroyer(action_result) {
+     return action_result && is_function(action_result.destroy) ? action_result.destroy : noop;
+ }
+ 
+-const is_client = typeof window !== 'undefined';
++const is_client = globalThis.svelteCrossUnit.is_client = typeof window !== 'undefined';
+ let now = is_client
+     ? () => window.performance.now()
+     : () => Date.now();
+@@ -169,7 +169,7 @@ function set_raf(fn) {
+     raf = fn;
+ }
+ 
+-const tasks = new Set();
++const tasks = globalThis.svelteCrossUnit.tasks = new Set();
+ function run_tasks(now) {
+     tasks.forEach(task => {
+         if (!task.c(now)) {
+@@ -792,7 +792,7 @@ function get_custom_elements_slots(element) {
+     return result;
+ }
+ 
+-const active_docs = new Set();
++const active_docs = globalThis.svelteCrossUnit.active_docs = new Set();
+ let active = 0;
+ // https://github.com/darkskyapp/string-hash/blob/master/index.js
+ function hash(str) {
+@@ -980,12 +980,12 @@ function bubble(component, event) {
+     }
+ }
+ 
+-const dirty_components = [];
+-const intros = { enabled: false };
+-const binding_callbacks = [];
+-const render_callbacks = [];
+-const flush_callbacks = [];
+-const resolved_promise = Promise.resolve();
++const dirty_components = globalThis.svelteCrossUnit.dirty_components = [];
++const intros = globalThis.svelteCrossUnit.intros = { enabled: false };
++const binding_callbacks = globalThis.svelteCrossUnit.binding_callbacks = [];
++const render_callbacks = globalThis.svelteCrossUnit.render_callbacks = [];
++const flush_callbacks = globalThis.svelteCrossUnit.flush_callbacks = [];
++const resolved_promise = globalThis.svelteCrossUnit.resolved_promise = Promise.resolve();
+ let update_scheduled = false;
+ function schedule_update() {
+     if (!update_scheduled) {
+@@ -1004,7 +1004,7 @@ function add_flush_callback(fn) {
+     flush_callbacks.push(fn);
+ }
+ let flushing = false;
+-const seen_callbacks = new Set();
++const seen_callbacks = globalThis.svelteCrossUnit.seen_callbacks = new Set();
+ function flush() {
+     if (flushing)
+         return;
+@@ -1065,7 +1065,7 @@ function wait() {
+ function dispatch(node, direction, kind) {
+     node.dispatchEvent(custom_event(`${direction ? 'intro' : 'outro'}${kind}`));
+ }
+-const outroing = new Set();
++const outroing = globalThis.svelteCrossUnit.outroing = new Set();
+ let outros;
+ function group_outros() {
+     outros = {
+@@ -1102,7 +1102,7 @@ function transition_out(block, local, detach, callback) {
+         block.o(local);
+     }
+ }
+-const null_transition = { duration: 0 };
++const null_transition = globalThis.svelteCrossUnit.null_transition = { duration: 0 };
+ function create_in_transition(node, fn, params) {
+     let config = fn(node, params);
+     let running = false;
+@@ -1410,7 +1410,7 @@ function update_await_block_branch(info, ctx, dirty) {
+     info.block.p(child_ctx, dirty);
+ }
+ 
+-const globals = (typeof window !== 'undefined'
++const globals = globalThis.svelteCrossUnit.globals = (typeof window !== 'undefined'
+     ? window
+     : typeof globalThis !== 'undefined'
+         ? globalThis
+@@ -1557,7 +1557,7 @@ function get_spread_object(spread_props) {
+ }
+ 
+ // source: https://html.spec.whatwg.org/multipage/indices.html
+-const boolean_attributes = new Set([
++const boolean_attributes = globalThis.svelteCrossUnit.boolean_attributes = new Set([
+     'allowfullscreen',
+     'allowpaymentrequest',
+     'async',
+@@ -1584,7 +1584,7 @@ const boolean_attributes = new Set([
+     'selected'
+ ]);
+ 
+-const invalid_attribute_name_character = /[\s'">/=\u{FDD0}-\u{FDEF}\u{FFFE}\u{FFFF}\u{1FFFE}\u{1FFFF}\u{2FFFE}\u{2FFFF}\u{3FFFE}\u{3FFFF}\u{4FFFE}\u{4FFFF}\u{5FFFE}\u{5FFFF}\u{6FFFE}\u{6FFFF}\u{7FFFE}\u{7FFFF}\u{8FFFE}\u{8FFFF}\u{9FFFE}\u{9FFFF}\u{AFFFE}\u{AFFFF}\u{BFFFE}\u{BFFFF}\u{CFFFE}\u{CFFFF}\u{DFFFE}\u{DFFFF}\u{EFFFE}\u{EFFFF}\u{FFFFE}\u{FFFFF}\u{10FFFE}\u{10FFFF}]/u;
++const invalid_attribute_name_character = globalThis.svelteCrossUnit.invalid_attribute_name_character = /[\s'">/=\u{FDD0}-\u{FDEF}\u{FFFE}\u{FFFF}\u{1FFFE}\u{1FFFF}\u{2FFFE}\u{2FFFF}\u{3FFFE}\u{3FFFF}\u{4FFFE}\u{4FFFF}\u{5FFFE}\u{5FFFF}\u{6FFFE}\u{6FFFF}\u{7FFFE}\u{7FFFF}\u{8FFFE}\u{8FFFF}\u{9FFFE}\u{9FFFF}\u{AFFFE}\u{AFFFF}\u{BFFFE}\u{BFFFF}\u{CFFFE}\u{CFFFF}\u{DFFFE}\u{DFFFF}\u{EFFFE}\u{EFFFF}\u{FFFFE}\u{FFFFF}\u{10FFFE}\u{10FFFF}]/u;
+ // https://html.spec.whatwg.org/multipage/syntax.html#attributes-2
+ // https://infra.spec.whatwg.org/#noncharacter
+ function spread(args, classes_to_add) {
+@@ -1614,7 +1614,7 @@ function spread(args, classes_to_add) {
+     });
+     return str;
+ }
+-const escaped = {
++const escaped = globalThis.svelteCrossUnit.escaped = {
+     '"': '&quot;',
+     "'": '&#39;',
+     '&': '&amp;',
+@@ -1641,7 +1641,7 @@ function each(items, fn) {
+     }
+     return str;
+ }
+-const missing_component = {
++const missing_component = globalThis.svelteCrossUnit.missing_component = {
+     $$render: () => ''
+ };
+ function validate_component(component, name) {

--- a/ts/yarn.lock
+++ b/ts/yarn.lock
@@ -4215,9 +4215,9 @@ svelte2tsx@^0.1.133:
     pascal-case "^3.1.1"
 
 svelte@^3.25.0:
-  version "3.38.2"
-  resolved "https://registry.yarnpkg.com/svelte/-/svelte-3.38.2.tgz#55e5c681f793ae349b5cc2fe58e5782af4275ef5"
-  integrity sha512-q5Dq0/QHh4BLJyEVWGe7Cej5NWs040LWjMbicBGZ+3qpFWJ1YObRmUDZKbbovddLC9WW7THTj3kYbTOFmU9fbg==
+  version "3.42.1"
+  resolved "https://registry.yarnpkg.com/svelte/-/svelte-3.42.1.tgz#d4b4d9068cce911835f7c6b8ff1d290e1a0b5657"
+  integrity sha512-XtExLd2JAU3T7M2g/DkO3UNj/3n1WdTXrfL63OZ5nZq7nAqd9wQw+lR4Pv/wkVbrWbAIPfLDX47UjFdmnY+YtQ==
 
 symbol-tree@^3.2.4:
   version "3.2.4"


### PR DESCRIPTION
To allow for cross-compilation unit functionality, and fix the missing reactivity, we need a way to allow for the sharing of the variables in `node_modules/svelte/internal/index.mjs`.

I've applied a patch using patch-package, which basically does this, where `input` is the file:

```javascript
const svelteConstPattern = /^const (.*?) = (.*?);$/gmsu;
const globalIdentifier = 'globalThis.svelteCrossUnit';

output = input.replace(
    svelteConstPattern,
    (_match, identifier, value) => `const ${identifier} = ${globalIdentifier}.${identifier} = ${value}`,
);
```

and prepended `globalThis.svelteCrossUnit = {};` to the file.

The add-on (in this case https://github.com/hgiesel/anki_new_format_pack), needs to be compiled using the esbuild plugin https://github.com/hgiesel/svelte-cross-unit, which I've written myself today.

It basically transforms "creating new state" to "accessing the global state": `const a = x;` becomes `const a = globalThis.svelteCrossUnit.a;`.

After doing this, I could already make use of `WithShortcut` in the add-on, which didn't work before. What do you think about this approach? It doesn't feel right, but then again, I can't think of anything else. The scope of `index.mjs` is quite small, and relevant state can be found by grepping through the file with `^const` (`^let`).

P.S.
There are also some `let` declarations in `index.mjs`, which could be shared across compilation units. However proxying them won't be quite that easy (as every occurence needs to be changed).