### PR TITLE
Quote font family names

### DIFF
--- a/ts/editor/editing-area.ts
+++ b/ts/editor/editing-area.ts
@@ -105,10 +105,18 @@ export class EditingArea extends HTMLDivElement {
         firstRule.style.color = color;
     }
 
+    quoteFontFamily(fontFamily: string): string {
+        // generic families (e.g. sans-serif) must not be quoted
+        if (!/^[a-z|-]+$/.test(fontFamily)) {
+            fontFamily = `"${fontFamily}"`;
+        }
+        return fontFamily;
+    }
+
     setBaseStyling(fontFamily: string, fontSize: string, direction: string): void {
         const styleSheet = this.baseStyle.sheet as CSSStyleSheet;
         const firstRule = styleSheet.cssRules[0] as CSSStyleRule;
-        firstRule.style.fontFamily = fontFamily;
+        firstRule.style.fontFamily = this.quoteFontFamily(fontFamily);
         firstRule.style.fontSize = fontSize;
         firstRule.style.direction = direction;
     }


### PR DESCRIPTION
Fixes https://forums.ankiweb.net/t/font-script-is-not-changing-in-the-anki-windows/12465 .

According to [the w3c specification](https://www.w3.org/TR/2018/REC-css-fonts-3-20180920/#generic-family-value), generic families must not be quoted, so in this PR, font names will not be quoted if the string consists only of lowercase alphabetic characters and hyphens. This is just in case an add-on sets the font family to a generic family using `editor_will_use_font_for_field` hook.