### PR TITLE
Fix bug when add-on package string is ""

### DIFF
--- a/qt/aqt/addons.py
+++ b/qt/aqt/addons.py
@@ -157,7 +157,7 @@ class AddonManager:
         "type": "object",
         "properties": {
             # the name of the folder
-            "package": {"type": "string", "meta": False},
+            "package": {"type": "string", "minLength": 1, "meta": False},
             # the displayed name to the user
             "name": {"type": "string", "meta": True},
             # the time the add-on was last modified


### PR DESCRIPTION
Trying to install an add-on whose package string in manifest is "" deletes the entire add-on folder and installs the addon inside the base addon folder. (Caused by using `os.path.join(base, addon_package_string)` as add-on directory path)

I forgot to set the package string by mistake and lost all my add-ons. Luckily it wasn't my main Anki profile :relieved: 