### PR TITLE
Add a hook for subscribing to dialog creation / opening

### DIFF
--- a/qt/aqt/__init__.py
+++ b/qt/aqt/__init__.py
@@ -18,6 +18,7 @@ from anki.buildinfo import version as _version
 from anki.collection import Collection
 from anki.consts import HELP_SITE
 from anki.utils import checksum, isLin, isMac
+from aqt import gui_hooks
 from aqt.qt import *
 from aqt.utils import TR, locale_dir, tr
 
@@ -114,6 +115,7 @@ class DialogManager:
         else:
             instance = creator(*args, **kwargs)
             self._dialogs[name][1] = instance
+        gui_hooks.dialog_manager_did_open_dialog(self, name, instance)
         return instance
 
     def markClosed(self, name: str) -> None:

--- a/qt/tools/genhooks_gui.py
+++ b/qt/tools/genhooks_gui.py
@@ -736,6 +736,17 @@ gui_hooks.webview_did_inject_style_into_page.append(mytest)
         Note that the media sync did not necessarily finish at this point.""",
     ),
     Hook(name="media_check_will_start", args=[]),
+    # Dialog Manager
+    ###################
+    Hook(
+        name="dialog_manager_did_open_dialog",
+        args=[
+            "dialog_manager: aqt.DialogManager",
+            "dialog_name: str",
+            "dialog_instance: QWidget",
+        ],
+        doc="""Executed after aqt.dialogs creates a dialog window""",
+    ),
     # Adding cards
     ###################
     Hook(


### PR DESCRIPTION
Super-simple hook that allows add-ons to subscribe to dialog creation / raise events.

One use case would be in Speed Focus Mode, which currently [monkey-patches](https://github.com/glutanimate/speed-focus-mode/blob/59165bd3bd057b7e9b2f613bcede24557d7a30d5/src/speed_focus_mode/reviewer.py#L317) `aqt.DialogManager.open` to time suspending its timers upon e.g. editing the current card.

Example snippet to test / debug:

```python
from aqt import gui_hooks

def on_dialog_manager_did_open_dialog(dialog_manager, name, instance):
    print(dialog_manager, name, instance)

gui_hooks.dialog_manager_did_open_dialog.append(on_dialog_manager_did_open_dialog)
```