### PR TITLE
Implement register-package and export some packages

### DIFF
--- a/ts/editor/index.ts
+++ b/ts/editor/index.ts
@@ -7,6 +7,7 @@
  */
 
 import "sveltelib/export-runtime";
+import "lib/register-package";
 
 import { filterHTML } from "html-filter";
 import { updateActiveButtons } from "./toolbar";

--- a/ts/lib/bridgecommand.ts
+++ b/ts/lib/bridgecommand.ts
@@ -1,6 +1,8 @@
 // Copyright: Ankitects Pty Ltd and contributors
 // License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
+import { registerPackage } from "./register-package";
+
 declare global {
     interface Window {
         bridgeCommand<T>(command: string, callback?: (value: T) => void): void;
@@ -15,3 +17,7 @@ export function bridgeLink(command: string, label: string): string {
 export function bridgeCommand<T>(command: string, callback?: (value: T) => void): void {
     window.bridgeCommand<T>(command, callback);
 }
+
+registerPackage("anki/bridgecommand", {
+    bridgeCommand,
+});

--- a/ts/lib/register-package.ts
+++ b/ts/lib/register-package.ts
@@ -1,0 +1,52 @@
+// Copyright: Ankitects Pty Ltd and contributors
+// License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
+
+import { runtimeLibraries } from "./runtime-require";
+
+export function registerPackage(
+    name: string,
+    entries: Record<string, unknown>,
+    deprecation?: Record<string, string>
+): void {
+    const pack = deprecation
+        ? new Proxy(entries, {
+              get: (target, name: string) => {
+                  if (name in deprecation) {
+                      console.log(`anki: ${name} is deprecated: ${deprecation[name]}`);
+                  }
+
+                  return target[name];
+              },
+          })
+        : entries;
+
+    runtimeLibraries[name] = pack;
+}
+
+function listPackages(): string[] {
+    return Object.keys(runtimeLibraries);
+}
+
+function hasPackages(...names: string[]): boolean {
+    const libraries = listPackages();
+    return names.reduce(
+        (accu: boolean, name: string) => accu && libraries.includes(name),
+        true
+    );
+}
+
+function immediatelyDeprecated() {
+    return false;
+}
+
+registerPackage(
+    "anki/packages",
+    {
+        listPackages,
+        hasPackages,
+        immediatelyDeprecated,
+    },
+    {
+        [immediatelyDeprecated.name]: "Do not use this function",
+    }
+);

--- a/ts/lib/shortcuts.ts
+++ b/ts/lib/shortcuts.ts
@@ -3,6 +3,7 @@
 
 import * as tr from "./i18n";
 import { isApplePlatform } from "./platform";
+import { registerPackage } from "./register-package";
 
 export type Modifier = "Control" | "Alt" | "Shift" | "Meta";
 
@@ -183,3 +184,8 @@ export function registerShortcut(
     document.addEventListener("keydown", handler);
     return (): void => document.removeEventListener("keydown", handler);
 }
+
+registerPackage("anki/shortcuts", {
+    registerShortcut,
+    getPlatformString,
+});


### PR DESCRIPTION
This is the idea I menioned in https://github.com/ankitects/anki/issues/1341#issuecomment-907808073.

Exported packages are:
* `anki/packages`
* `anki/shortcuts`
* `anki/bridgecommand`

We can define the exported package directly in the file, and have the "package registration" as a side effect of using the functions in our own code. This way we don't need to pay that much attention to what is exported, but rather add-on devs can always _generally do what Anki does_.

As a test, I've set up my add-on "Asset Manager" to use this approach. You basically just need to mark "anki" as external, and you can use the `import` syntax for anki: https://github.com/hgiesel/anki_asset_manager/compare/ankilibs.

Trying to import a nonexistent package results in:

> Uncaught Error: Cannot require(anki/nonexistent) at runtime.
>     at globalThis.require (editor.js:19900)
>     at __require (editor-compiled.js:11)
>     at editor-compiled.js:41
>     at editor-compiled.js:123

The package `anki/packages` contains some inspection utils. `listPackages` simply lists all available packages, and `hasPackages` checks for their existence. This combined with the fact, that you can still use `require` syntax, allows you to be quite flexible when importing (similiar to python):

```typescript
import { hasPackages } from "anki/packages";

if (hasPackages("anki/nonexistent")) {
    /* do something */
} else {
    console.log("not there");
}

const { registerShortcut } = hasPackages("anki/shortcuts")
    ? require("anki/shortcuts")
    : {
        registerShortcut: function() { console.log("shim") },
    }
```