### PR TITLE
Disallow setting, deleting or defining properties on packages

### DIFF
--- a/ts/lib/register-package.ts
+++ b/ts/lib/register-package.ts
@@ -3,6 +3,8 @@
 
 import { runtimeLibraries } from "./runtime-require";
 
+const prohibit = () => false;
+
 export function registerPackage(
     name: string,
     entries: Record<string, unknown>,
@@ -10,6 +12,9 @@ export function registerPackage(
 ): void {
     const pack = deprecation
         ? new Proxy(entries, {
+              set: prohibit,
+              defineProperty: prohibit,
+              deleteProperty: prohibit,
               get: (target, name: string) => {
                   if (name in deprecation) {
                       console.log(`anki: ${name} is deprecated: ${deprecation[name]}`);


### PR DESCRIPTION
I've noticed that you can actually set/overwrite/delete properties on our packages.
So you could do:

```js
require("anki/packages").listPackages = 5;
const n = require("anki/packages").listPackages;
// n is 5
```

I don't think we'll want this. It's not like it would affect Ankis code, but it could be confusing to add-on devs if somebody were to do this.