### PR TITLE
Add a hook for modifiying pasted MIME data

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -84,6 +84,7 @@ cherryblossom <github.com/cherryblossom000>
 Hikaru Yoshiga <github.com/hikaru-y>
 Thore Tyborski <github.com/ThoreBor>
 Alexander Giorev <alex.giorev@gmail.com>
+Ren Tatsumoto <tatsu@autistici.org>
 
 ********************
 

--- a/qt/aqt/editor.py
+++ b/qt/aqt/editor.py
@@ -1172,7 +1172,8 @@ class EditorWebView(AnkiWebView):
 
         # try various content types in turn
         if mime.hasHtml():
-            return mime.html().replace("<!--anki-->", ""), internal
+            html_content = mime.html()[11:] if internal else mime.html()
+            return html_content, internal
 
         # favour url if it's a local link
         if mime.hasUrls() and mime.urls()[0].toString().startswith("file://"):

--- a/qt/aqt/editor.py
+++ b/qt/aqt/editor.py
@@ -863,12 +863,16 @@ $editorToolbar.then(({{ toolbar }}) => toolbar.appendGroup({{
         self.web.eval(f"pasteHTML({json.dumps(html)}, {json.dumps(internal)}, {ext});")
         gui_hooks.editor_did_paste(self, html, internal, extended)
 
-    def doDrop(self, html: str, internal: bool, extended: bool, cursor_pos: QPoint) -> None:
+    def doDrop(
+        self, html: str, internal: bool, extended: bool, cursor_pos: QPoint
+    ) -> None:
         def pasteIfField(ret: bool) -> None:
             if ret:
                 self.doPaste(html, internal, extended)
 
-        self.web.evalWithCallback(f"focusIfField({cursor_pos.x()}, {cursor_pos.y()});", pasteIfField)
+        self.web.evalWithCallback(
+            f"focusIfField({cursor_pos.x()}, {cursor_pos.y()});", pasteIfField
+        )
 
     def onPaste(self) -> None:
         self.web.onPaste()
@@ -1151,7 +1155,9 @@ class EditorWebView(AnkiWebView):
         self.editor.doDrop(html, internal, extended, cursor_pos)
 
     # returns (html, isInternal)
-    def _processMime(self, mime: QMimeData, extended: bool = False, drop_event: bool = False) -> Tuple[str, bool]:
+    def _processMime(
+        self, mime: QMimeData, extended: bool = False, drop_event: bool = False
+    ) -> Tuple[str, bool]:
         # print("html=%s image=%s urls=%s txt=%s" % (
         #     mime.hasHtml(), mime.hasImage(), mime.hasUrls(), mime.hasText()))
         # print("html", mime.html())
@@ -1160,11 +1166,13 @@ class EditorWebView(AnkiWebView):
 
         internal = mime.html().startswith("<!--anki-->")
 
-        mime = gui_hooks.editor_will_process_mime(self, mime, internal, extended, drop_event)
+        mime = gui_hooks.editor_will_process_mime(
+            mime, self, internal, extended, drop_event
+        )
 
         # try various content types in turn
         if mime.hasHtml():
-            return mime.html().replace("<!--anki-->", ''), internal
+            return mime.html().replace("<!--anki-->", ""), internal
 
         # favour url if it's a local link
         if mime.hasUrls() and mime.urls()[0].toString().startswith("file://"):

--- a/qt/aqt/editor.py
+++ b/qt/aqt/editor.py
@@ -863,13 +863,12 @@ $editorToolbar.then(({{ toolbar }}) => toolbar.appendGroup({{
         self.web.eval(f"pasteHTML({json.dumps(html)}, {json.dumps(internal)}, {ext});")
         gui_hooks.editor_did_paste(self, html, internal, extended)
 
-    def doDrop(self, html: str, internal: bool, extended: bool = False) -> None:
+    def doDrop(self, html: str, internal: bool, extended: bool, cursor_pos: QPoint) -> None:
         def pasteIfField(ret: bool) -> None:
             if ret:
                 self.doPaste(html, internal, extended)
 
-        p = self.web.mapFromGlobal(QCursor.pos())
-        self.web.evalWithCallback(f"focusIfField({p.x()}, {p.y()});", pasteIfField)
+        self.web.evalWithCallback(f"focusIfField({cursor_pos.x()}, {cursor_pos.y()});", pasteIfField)
 
     def onPaste(self) -> None:
         self.web.onPaste()
@@ -1138,30 +1137,34 @@ class EditorWebView(AnkiWebView):
     def dropEvent(self, evt: QDropEvent) -> None:
         extended = self._wantsExtendedPaste()
         mime = evt.mimeData()
+        cursor_pos = self.mapFromGlobal(QCursor.pos())
 
         if evt.source() and mime.hasHtml():
             # don't filter html from other fields
             html, internal = mime.html(), True
         else:
-            html, internal = self._processMime(mime, extended)
+            html, internal = self._processMime(mime, extended, drop_event=True)
 
         if not html:
             return
 
-        self.editor.doDrop(html, internal, extended)
+        self.editor.doDrop(html, internal, extended, cursor_pos)
 
     # returns (html, isInternal)
-    def _processMime(self, mime: QMimeData, extended: bool = False) -> Tuple[str, bool]:
+    def _processMime(self, mime: QMimeData, extended: bool = False, drop_event: bool = False) -> Tuple[str, bool]:
         # print("html=%s image=%s urls=%s txt=%s" % (
         #     mime.hasHtml(), mime.hasImage(), mime.hasUrls(), mime.hasText()))
         # print("html", mime.html())
         # print("urls", mime.urls())
         # print("text", mime.text())
 
+        internal = mime.html().startswith("<!--anki-->")
+
+        mime = gui_hooks.editor_will_process_mime(self, mime, internal, extended, drop_event)
+
         # try various content types in turn
-        html, internal = self._processHtml(mime)
-        if html:
-            return html, internal
+        if mime.hasHtml():
+            return mime.html().replace("<!--anki-->", ''), internal
 
         # favour url if it's a local link
         if mime.hasUrls() and mime.urls()[0].toString().startswith("file://"):
@@ -1226,17 +1229,6 @@ class EditorWebView(AnkiWebView):
         # remove last <br>
         processed.pop()
         return "".join(processed)
-
-    def _processHtml(self, mime: QMimeData) -> Tuple[Optional[str], bool]:
-        if not mime.hasHtml():
-            return None, False
-        html = mime.html()
-
-        # no filtering required for internal pastes
-        if html.startswith("<!--anki-->"):
-            return html[11:], True
-
-        return html, False
 
     def _processImage(self, mime: QMimeData, extended: bool = False) -> Optional[str]:
         if not mime.hasImage():

--- a/qt/tools/genhooks_gui.py
+++ b/qt/tools/genhooks_gui.py
@@ -29,7 +29,7 @@ from anki.decks import DeckDict, DeckConfigDict
 from anki.hooks import runFilter, runHook
 from anki.models import NotetypeDict
 from anki.collection import OpChangesAfterUndo
-from aqt.qt import QDialog, QEvent, QMenu, QModelIndex, QWidget
+from aqt.qt import QDialog, QEvent, QMenu, QModelIndex, QWidget, QMimeData
 from aqt.tagedit import TagEdit
 from aqt.undo import UndoActionsInfo
 """
@@ -867,8 +867,8 @@ gui_hooks.webview_did_inject_style_into_page.append(mytest)
     Hook(
         name="editor_will_process_mime",
         args=[
-            "editor_web_view: aqt.editor.EditorWebView",
             "mime: QMimeData",
+            "editor_web_view: aqt.editor.EditorWebView",
             "internal: bool",
             "extended: bool",
             "drop_event: bool",

--- a/qt/tools/genhooks_gui.py
+++ b/qt/tools/genhooks_gui.py
@@ -864,6 +864,31 @@ gui_hooks.webview_did_inject_style_into_page.append(mytest)
         ],
         doc="""Called after some data is pasted by python into an editor field.""",
     ),
+    Hook(
+        name="editor_will_process_mime",
+        args=[
+            "editor_web_view: aqt.editor.EditorWebView",
+            "mime: QMimeData",
+            "internal: bool",
+            "extended: bool",
+            "drop_event: bool",
+        ],
+        return_type="QMimeData",
+        doc="""
+        Used to modify MIME data stored in the clipboard after a drop or a paste.
+        Called after the user pastes or drag-and-drops something to Anki
+        before Anki processes the data.
+
+        The function should return a new or existing QMimeData object.
+
+        "mime" contains the corresponding QMimeData object.
+        "internal" indicates whether the drop or paste is performed between Anki fields.
+        Most likely you want to skip processing if "internal" was set to True.
+        "extended" indicates whether the user requested an extended paste.
+        "drop_event" indicates whether the event was triggered by a drag-and-drop
+        or by a right-click paste.
+        """,
+    ),
     # Tag
     ###################
     Hook(name="tag_editor_did_process_key", args=["tag_edit: TagEdit", "evt: QEvent"]),


### PR DESCRIPTION
See https://forums.ankiweb.net/t/investigating-an-ambigous-add-on-error/12846

After running into a bug that prevented me from wrapping the right-click-paste functionality I decided to add a new hook. I hope to use it in [Paste Images As WebP](https://ankiweb.net/shared/info/1151815987).

I had to move around some existing code, but only when necessary. Namely, cursor position has to be calculated before the hook is called because its position might move when the user interacts with the popup window.

![screenshot](https://user-images.githubusercontent.com/69171671/132123822-3f4b70c8-c7c5-4217-bb40-c144b904d560.png)

An additional variable `drop_event` is passed to the hook in order to let the user take different actions depending on where the event comes from (drop or paste).

