### PR TITLE
Prevent sticky bubble

### DIFF
--- a/ts/editor/editor-field.ts
+++ b/ts/editor/editor-field.ts
@@ -41,11 +41,11 @@ export class EditorField extends HTMLDivElement {
     }
 
     connectedCallback(): void {
-        this.labelContainer.addEventListener("mousedown", this.focusIfNotFocused);
+        this.addEventListener("mousedown", this.focusIfNotFocused);
     }
 
     disconnectedCallback(): void {
-        this.labelContainer.removeEventListener("mousedown", this.focusIfNotFocused);
+        this.removeEventListener("mousedown", this.focusIfNotFocused);
     }
 
     attributeChangedCallback(name: string, _oldValue: string, newValue: string): void {

--- a/ts/editor/label-container.ts
+++ b/ts/editor/label-container.ts
@@ -7,6 +7,7 @@ import * as tr from "lib/i18n";
 import { registerShortcut } from "lib/shortcuts";
 import { bridgeCommand } from "./lib";
 import { appendInParentheses } from "./helpers";
+import { saveField } from "./change-timer";
 import { getCurrentField, forEditorField, i18n } from ".";
 import pinIcon from "./pin-angle.svg";
 
@@ -63,23 +64,27 @@ export class LabelContainer extends HTMLDivElement {
         this.hoverIcon = this.hoverIcon.bind(this);
         this.removeHoverIcon = this.removeHoverIcon.bind(this);
         this.toggleSticky = this.toggleSticky.bind(this);
+        this.toggleStickyEvent = this.toggleStickyEvent.bind(this);
         this.keepFocus = this.keepFocus.bind(this);
     }
 
     keepFocus(event: Event): void {
+        event.stopPropagation();
         event.preventDefault();
     }
 
     connectedCallback(): void {
         this.addEventListener("mousedown", this.keepFocus);
-        this.sticky.addEventListener("click", this.toggleSticky);
+        this.sticky.addEventListener("mousedown", this.keepFocus);
+        this.sticky.addEventListener("click", this.toggleStickyEvent);
         this.sticky.addEventListener("mouseenter", this.hoverIcon);
         this.sticky.addEventListener("mouseleave", this.removeHoverIcon);
     }
 
     disconnectedCallback(): void {
         this.removeEventListener("mousedown", this.keepFocus);
-        this.sticky.removeEventListener("click", this.toggleSticky);
+        this.sticky.removeEventListener("mousedown", this.keepFocus);
+        this.sticky.removeEventListener("click", this.toggleStickyEvent);
         this.sticky.removeEventListener("mouseenter", this.hoverIcon);
         this.sticky.removeEventListener("mouseleave", this.removeHoverIcon);
     }
@@ -106,7 +111,13 @@ export class LabelContainer extends HTMLDivElement {
     }
 
     toggleSticky(): void {
+        saveField((this.parentElement as EditorField).editingArea, "key");
         bridgeCommand(`toggleSticky:${this.getAttribute("ord")}`, this.setSticky);
         this.removeHoverIcon();
+    }
+
+    toggleStickyEvent(event: Event): void {
+        event.stopPropagation();
+        this.toggleSticky();
     }
 }

--- a/ts/editor/label-container.ts
+++ b/ts/editor/label-container.ts
@@ -67,16 +67,21 @@ export class LabelContainer extends HTMLDivElement {
         this.toggleSticky = this.toggleSticky.bind(this);
         this.toggleStickyEvent = this.toggleStickyEvent.bind(this);
         this.keepFocus = this.keepFocus.bind(this);
+        this.stopPropagation = this.stopPropagation.bind(this);
     }
 
     keepFocus(event: Event): void {
-        event.stopPropagation();
         event.preventDefault();
+    }
+
+    stopPropagation(event: Event): void {
+        this.keepFocus(event);
+        event.stopPropagation();
     }
 
     connectedCallback(): void {
         this.addEventListener("mousedown", this.keepFocus);
-        this.sticky.addEventListener("mousedown", this.keepFocus);
+        this.sticky.addEventListener("mousedown", this.stopPropagation);
         this.sticky.addEventListener("click", this.toggleStickyEvent);
         this.sticky.addEventListener("mouseenter", this.hoverIcon);
         this.sticky.addEventListener("mouseleave", this.removeHoverIcon);
@@ -84,7 +89,7 @@ export class LabelContainer extends HTMLDivElement {
 
     disconnectedCallback(): void {
         this.removeEventListener("mousedown", this.keepFocus);
-        this.sticky.removeEventListener("mousedown", this.keepFocus);
+        this.sticky.removeEventListener("mousedown", this.stopPropagation);
         this.sticky.removeEventListener("click", this.toggleStickyEvent);
         this.sticky.removeEventListener("mouseenter", this.hoverIcon);
         this.sticky.removeEventListener("mouseleave", this.removeHoverIcon);

--- a/ts/editor/label-container.ts
+++ b/ts/editor/label-container.ts
@@ -42,10 +42,6 @@ export class LabelContainer extends HTMLDivElement {
         super();
         this.className = "fname d-flex justify-content-between";
 
-        i18n.then(() => {
-            this.title = appendInParentheses(tr.editingToggleSticky(), "F9");
-        });
-
         this.label = document.createElement("span");
         this.label.className = "fieldname";
         this.appendChild(this.label);
@@ -58,6 +54,11 @@ export class LabelContainer extends HTMLDivElement {
         this.sticky.className = "icon pin-icon";
         this.sticky.innerHTML = pinIcon;
         this.sticky.hidden = true;
+
+        i18n.then(() => {
+            this.sticky.title = appendInParentheses(tr.editingToggleSticky(), "F9");
+        });
+
         this.fieldState.appendChild(this.sticky);
 
         this.setSticky = this.setSticky.bind(this);


### PR DESCRIPTION
* Clicking on the sticky does not focus the field - I think toggling the sticky state does not necessarily mean you want to focus/edit the field.
* Save the field before you toggle the sticky state:
  * Before, typing something and quickly toggling the sticky state before the change timer resolved would undo what you just typed.
  * It still does reset the caret position, because toggling the sticky state will actually update all fields. I think this is best to be fixed, when we change how sticky works, as discussed [here](https://forums.ankiweb.net/t/default-editor-settings-instead-of-persistent/12761/7).
* Put the tooltip on the sticky icon. It was on the label container before, which was probably an oversight