### PR TITLE
Make anki close faster (add missing waitress shutdown callbacks)

### DIFF
--- a/qt/aqt/mediasrv.py
+++ b/qt/aqt/mediasrv.py
@@ -97,7 +97,9 @@ class MediaServer(threading.Thread):
         for socket in sockets:
             socket.handle_close()
         # https://github.com/Pylons/webtest/blob/4b8a3ebf984185ff4fefb31b4d0cf82682e1fcf7/webtest/http.py#L93-L104
+        self.server.maintenance(0)
         self.server.task_dispatcher.shutdown()
+        self.server.close()
 
     def getPort(self) -> int:
         self._ready.wait()

--- a/qt/aqt/mediasrv.py
+++ b/qt/aqt/mediasrv.py
@@ -97,7 +97,7 @@ class MediaServer(threading.Thread):
         for socket in sockets:
             socket.handle_close()
         # https://github.com/Pylons/webtest/blob/4b8a3ebf984185ff4fefb31b4d0cf82682e1fcf7/webtest/http.py#L93-L104
-        self.server.maintenance(0)
+        self.server.maintenance(0)  # type: ignore
         self.server.task_dispatcher.shutdown()
         self.server.close()
 


### PR DESCRIPTION
There is some time since the new server, anki seems to be closing slower, sometimes taking a long time. I think it is because it is waiting for the background waitress server to close.

When first implemented the new server system with waitress (https://github.com/ankitects/anki/pull/554), it looks it was missing to close some other handles from the example code used: https://github.com/Pylons/webtest/blob/4b8a3ebf984185ff4fefb31b4d0cf82682e1fcf7/webtest/http.py#L93-L104

I also added close() because when I looked at the class, it seems reasonable to call it too: https://github.com/Pylons/waitress/blob/e5d443750e30b7ea61bd183d5270820bc4e9a81a/src/waitress/server.py
```
class BaseWSGIServer(wasyncore.dispatcher, object):
    def bind_server_socket(self):
    def get_server_name(self, ip):
    def getsockname(self):
    def accept_connections(self):
    def add_task(self, task):
    def readable(self):
    def writable(self):
    def handle_read(self):
    def handle_connect(self):
    def handle_accept(self):
    def run(self):
    def pull_trigger(self):
    def set_socket_options(self, conn):
    def fix_addr(self, addr):
    def print_listen(self, format_str):  # pragma: nocover

    def maintenance(self, now):
        """
        Closes channels that have not had any activity in a while.

        The timeout is configured through adj.channel_timeout (seconds).
        """
        cutoff = now - self.adj.channel_timeout
        for channel in self.active_channels.values():
            if (not channel.requests) and channel.last_activity < cutoff:
                channel.will_close = True

    def close(self):
        self.trigger.close()
        return wasyncore.dispatcher.close(self)
```