### PR TITLE
Fix previous card attribute not initialized

### DIFF
--- a/qt/aqt/reviewer.py
+++ b/qt/aqt/reviewer.py
@@ -119,6 +119,7 @@ class Reviewer:
         self.web = mw.web
         self.card: Optional[Card] = None
         self.cardQueue: List[Card] = []
+        self.previous_card: Optional[Card] = None
         self.hadCardQueue = False
         self._answeredIds: List[CardId] = []
         self._recordedAudio: Optional[str] = None


### PR DESCRIPTION
I forgot to add on the last pull request: https://github.com/ankitects/anki/pull/1358, I noticed because I was merging the upstream https://github.com/evandroforks/anki/commit/fb9295c905191aa2fa5a8bea68f56b38ac25a7f1 and I saw it was missing while reviewing the code.

To keep my fork updated with this repo, I first checkout on this main branch, and merge my main branch here (then, I force the main branch on my fork), this way I see all the changes I added to Anki instead of seeing what changes were added here. This is better because:
1. I know well my changes so it is simple to review all the changes on git a conflict.
2. It creates a single commit showing a diff between the two forks (the lastest one is https://github.com/evandroforks/anki/commit/fb9295c905191aa2fa5a8bea68f56b38ac25a7f1)

Just pointing out a strategy I figured out today to keep my fork updated with this main repository with less effort. Also this way, there is no need to open a pull-request as https://github.com/ankitects/anki/pull/1367 to show the differences between forks.