### PR TITLE
Experiments with Server-Sent Events (SSE)

### DIFF
--- a/qt/aqt/editcurrent.py
+++ b/qt/aqt/editcurrent.py
@@ -28,7 +28,6 @@ class EditCurrent(QDialog):
         self.editor.card = self.mw.reviewer.card
         self.editor.set_note(self.mw.reviewer.card.note(), focusTo=0)
         restoreGeom(self, "editcurrent")
-        gui_hooks.operation_did_execute.append(self.on_operation_did_execute)
         self.show()
 
     def on_operation_did_execute(
@@ -47,7 +46,6 @@ class EditCurrent(QDialog):
             self.editor.set_note(note)
 
     def cleanup_and_close(self) -> None:
-        gui_hooks.operation_did_execute.remove(self.on_operation_did_execute)
         self.editor.cleanup()
         saveGeom(self, "editcurrent")
         aqt.dialogs.markClosed("EditCurrent")

--- a/qt/aqt/operations/note.py
+++ b/qt/aqt/operations/note.py
@@ -9,6 +9,7 @@ from anki.collection import OpChanges, OpChangesWithCount
 from anki.decks import DeckId
 from anki.notes import Note, NoteId
 from aqt.operations import CollectionOp
+from aqt.mediasrv import update_note_bus, remove_notes_bus
 from aqt.qt import QWidget
 from aqt.utils import tooltip, tr
 
@@ -23,6 +24,7 @@ def add_note(
 
 
 def update_note(*, parent: QWidget, note: Note) -> CollectionOp[OpChanges]:
+    update_note_bus.dispatch(note)
     return CollectionOp(parent, lambda col: col.update_note(note))
 
 
@@ -31,6 +33,7 @@ def remove_notes(
     parent: QWidget,
     note_ids: Sequence[NoteId],
 ) -> CollectionOp[OpChangesWithCount]:
+    remove_notes_bus.dispatch(note_ids)
     return CollectionOp(parent, lambda col: col.remove_notes(note_ids)).success(
         lambda out: tooltip(tr.browsing_cards_deleted(count=out.count)),
     )

--- a/qt/aqt/operations/note.py
+++ b/qt/aqt/operations/note.py
@@ -8,8 +8,8 @@ from typing import Optional, Sequence
 from anki.collection import OpChanges, OpChangesWithCount
 from anki.decks import DeckId
 from anki.notes import Note, NoteId
+from aqt.mediasrv import remove_notes_queue, update_note_queue
 from aqt.operations import CollectionOp
-from aqt.mediasrv import update_note_bus, remove_notes_bus
 from aqt.qt import QWidget
 from aqt.utils import tooltip, tr
 
@@ -24,7 +24,7 @@ def add_note(
 
 
 def update_note(*, parent: QWidget, note: Note) -> CollectionOp[OpChanges]:
-    update_note_bus.dispatch(note)
+    update_note_queue.dispatch(note)
     return CollectionOp(parent, lambda col: col.update_note(note))
 
 
@@ -33,7 +33,7 @@ def remove_notes(
     parent: QWidget,
     note_ids: Sequence[NoteId],
 ) -> CollectionOp[OpChangesWithCount]:
-    remove_notes_bus.dispatch(note_ids)
+    remove_notes_queue.dispatch(note_ids)
     return CollectionOp(parent, lambda col: col.remove_notes(note_ids)).success(
         lambda out: tooltip(tr.browsing_cards_deleted(count=out.count)),
     )


### PR DESCRIPTION
I've been thinking about the architecture of the Editor a bit.
For the sticky icon, e.g., we currently set it via `web.eval` from Python, making the NoteEditor _aware_, that it is run in different _contexts_ (like from the `AddCards` window for example).

In the end, I'd like to remove this _context-awareness_ and rather configure the NoteEditor top-down, e.g. from an `AddCards.svelte` file with the NoteEditor having multiple slots:

```svelte
// AddCards.svelte
<AddCardsButtons />
<NoteEditor
    on:fieldsupdate={...}
    on:tagsupdate={...}
/>
    <ButtonsAddMode slot="toolbar" />
    <FieldAddMode slot="field" />
    <TagAddMode slot="tag" />
</NoteEditor>
``` 

This way they
* pass slots to the NoteEditor to provide their individualed functionality

* can be defined in their own directory ( `ts/addcards`, or `ts/editcurrent`) for better code separation

* can also dispense with `bridgeCommand`, and prefer bubbling up events, like `fieldsupdate`, `tagsupdate`, which then can be handled differently in the different contexts (and make `postRequest` calls directly to Rust if necessary).

My ultimate goal would be that that these views are completely decoupled from Python, so no `web.eval`, and instead they use `postRequest` to contact the rslib APIs directly (just like the Graphs screen), and maybe minimal use of `bridgeCommand` (for OS things like closing the window).

However... there's one thing I don't thing we can currently implement just in Svelte, and that is the functionality of the `operation_did_execute` hook, and how it updates the Editor if the note is updated upstream in another view.

For that, I think, we'd need either SSE (server-sent events) using `EventSource`, or `WebSocket`s.
This way, we could basically _listen_ to an EventQueue in Python from JavaScript.

---

In this PR I implemented SSE. With the AnkiWebView Inspector you can connect to the `EventQueue` in the EditCurrent window by executing:

```javascript
q = new EventSource(`_anki/_stream/update_note/${getNoteId()}`);
q.addEventListener("message", console.log);
```

This way, whenever the note changes in a different view (e.g. the Browser), the EditCurrent will receive an event, informing it of the change (however it will also inform if itself updates the note, i.e. any update to the note). You can also listen to removal events:

```javascript
q2 = new EventSource(`_anki/_stream/remove_notes/${getNoteId()}`);
q2.addEventListener("message", console.log);
```

However I also noticed several issues along the way:
- For the update event, we'd need to figure out if the event originated from a change in the current view or not, or maybe just a good way to save and restore the current position 
- The server (?) only allows for 4 `EventSource` connections to be opened. Not sure whether this is because the media server cannot accept more connections, or it's a [HTTP/1.1 restriction](https://developer.mozilla.org/en-US/docs/Web/API/EventSource).
- Freeing the resources on the server works only suboptimal (it kinda has to be forced by emitting a few `update_note` events). Trying to release the resources with `q.close()` also yields an error message. It looks I'm implementing the protocol wrong.
- While I was working with the server in `qt/aqt/mediasrv.py`, I wondered whether this is a make-shift solution, and the media server / Backend server is eventually going to be moved to Rust?