### PR TITLE
Mathjax Cleanup

### DIFF
--- a/ts/editable/Mathjax.svelte
+++ b/ts/editable/Mathjax.svelte
@@ -3,7 +3,7 @@ Copyright: Ankitects Pty Ltd and contributors
 License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 -->
 <script lang="ts">
-    import { onMount, getContext } from "svelte";
+    import { onMount, onDestroy, getContext } from "svelte";
     import { nightModeKey } from "components/context-keys";
     import { convertMathjax } from "./mathjax";
 
@@ -22,17 +22,25 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     let encoded: string;
     let imageHeight: number;
 
-    $: {
-        encoded = encodeURIComponent(converted);
-        setTimeout(() => (imageHeight = image.getBoundingClientRect().height));
-    }
+    $: encoded = encodeURIComponent(converted);
 
     let image: HTMLImageElement;
 
+    const observer = new ResizeObserver(() => {
+        imageHeight = image.getBoundingClientRect().height;
+        setTimeout(() => image.dispatchEvent(new Event("resize")));
+    });
+
     onMount(() => {
+        observer.observe(image);
         if (autofocus) {
             image.click();
         }
+    });
+
+    onDestroy(() => {
+        observer.unobserve(image);
+        observer.disconnect();
     });
 </script>
 

--- a/ts/editable/Mathjax.svelte
+++ b/ts/editable/Mathjax.svelte
@@ -3,7 +3,7 @@ Copyright: Ankitects Pty Ltd and contributors
 License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 -->
 <script lang="ts">
-    import { onMount, onDestroy, getContext } from "svelte";
+    import { onMount, onDestroy, getContext, tick } from "svelte";
     import { nightModeKey } from "components/context-keys";
     import { convertMathjax } from "./mathjax";
 
@@ -26,8 +26,9 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
     let image: HTMLImageElement;
 
-    const observer = new ResizeObserver(() => {
+    const observer = new ResizeObserver(async () => {
         imageHeight = image.getBoundingClientRect().height;
+        await tick();
         setTimeout(() => image.dispatchEvent(new Event("resize")));
     });
 

--- a/ts/editable/mathjax.ts
+++ b/ts/editable/mathjax.ts
@@ -1,6 +1,10 @@
 // Copyright: Ankitects Pty Ltd and contributors
 // License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
+/* eslint
+@typescript-eslint/no-explicit-any: "off",
+ */
+
 import { mathIcon } from "./icons";
 
 const parser = new DOMParser();

--- a/ts/editable/mathjax.ts
+++ b/ts/editable/mathjax.ts
@@ -36,19 +36,25 @@ export function convertMathjax(
         return getEmptyIcon(style);
     }
 
-    const output = globalThis.MathJax.tex2svg(input);
-    const svg = output.children[0];
+    let output: Element;
+    try {
+        output = globalThis.MathJax.tex2svg(input);
+    } catch (e) {
+        return ["Mathjax Error", String(e)];
+    }
 
-    if (svg.viewBox.baseVal.height === 16) {
+    const svg = output.children[0] as SVGElement;
+
+    if ((svg as any).viewBox.baseVal.height === 16) {
         return getEmptyIcon(style);
     }
 
     let title = "";
 
     if (svg.innerHTML.includes("data-mjx-error")) {
-        svg.querySelector("rect").setAttribute("fill", "yellow");
-        svg.querySelector("text").setAttribute("color", "red");
-        title = svg.querySelector("title").innerHTML;
+        svg.querySelector("rect")?.setAttribute("fill", "yellow");
+        svg.querySelector("text")?.setAttribute("color", "red");
+        title = svg.querySelector("title")?.innerHTML ?? "";
     } else {
         svg.insertBefore(style, svg.children[0]);
     }

--- a/ts/editor/MathjaxHandle.svelte
+++ b/ts/editor/MathjaxHandle.svelte
@@ -36,19 +36,22 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         return image.closest("anki-mathjax")! as HTMLElement;
     }
 
-    function onEditorUpdate(event: CustomEvent) {
-        getComponent(activeImage!).dataset.mathjax = event.detail.mathjax;
+    const onImageResize = (resolve: () => void) => (): void => {
+        errorMessage = activeImage!.title;
+        updateSelection().then(resolve);
+    };
 
+    function onEditorUpdate(event: CustomEvent): Promise<void> {
         let selectionResolve: (value: void) => void;
-        const afterSelectionUpdate = new Promise((resolve) => {
+        const afterSelectionUpdate = new Promise((resolve: (value: void) => void) => {
             selectionResolve = resolve;
         });
 
-        setTimeout(async () => {
-            errorMessage = activeImage!.title;
-            await updateSelection();
-            selectionResolve();
-        });
+        const imageResize = onImageResize(selectionResolve!);
+
+        activeImage!.addEventListener("resize", imageResize, { once: true });
+        /* this updates the image in Mathjax.svelte */
+        getComponent(activeImage!).dataset.mathjax = event.detail.mathjax;
 
         return afterSelectionUpdate;
     }

--- a/ts/editor/MathjaxHandleEditor.svelte
+++ b/ts/editor/MathjaxHandleEditor.svelte
@@ -16,6 +16,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
     let codeMirror: CodeMirror.EditorFromTextArea;
     const changeTimer = new ChangeTimer();
+    const dispatch = createEventDispatcher();
 
     function onInput() {
         changeTimer.schedule(
@@ -24,12 +25,16 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         );
     }
 
+    function onBlur() {
+        changeTimer.fireImmediately();
+    }
+
     function openCodemirror(textarea: HTMLTextAreaElement): void {
         codeMirror = CodeMirror.fromTextArea(textarea, codeMirrorOptions);
         codeMirror.on("change", onInput);
+        codeMirror.on("blur", onBlur);
     }
 
-    const dispatch = createEventDispatcher();
     let textarea: HTMLTextAreaElement;
 
     onMount(() => {

--- a/ts/editor/change-timer.ts
+++ b/ts/editor/change-timer.ts
@@ -3,10 +3,16 @@
 
 export class ChangeTimer {
     private value: number | null = null;
+    private action: (() => void) | null = null;
+
+    constructor() {
+        this.fireImmediately = this.fireImmediately.bind(this);
+    }
 
     schedule(action: () => void, delay: number): void {
         this.clear();
-        this.value = setTimeout(action, delay);
+        this.action = action;
+        this.value = setTimeout(this.fireImmediately, delay);
     }
 
     clear(): void {
@@ -14,5 +20,14 @@ export class ChangeTimer {
             clearTimeout(this.value);
             this.value = null;
         }
+    }
+
+    fireImmediately(): void {
+        if (this.action) {
+            this.action();
+            this.action = null;
+        }
+
+        this.clear();
     }
 }

--- a/ts/editor/saving.ts
+++ b/ts/editor/saving.ts
@@ -29,12 +29,11 @@ export function saveNow(keepFocus: boolean): void {
         return;
     }
 
-    saveFieldTimer.clear();
-
     if (keepFocus) {
-        saveField(currentField, "key");
+        saveFieldTimer.fireImmediately();
     } else {
         // triggers onBlur, which saves
+        saveFieldTimer.clear();
         currentField.blur();
     }
 }

--- a/ts/lib/wrap.ts
+++ b/ts/lib/wrap.ts
@@ -38,7 +38,12 @@ export function wrapInternal(
         document.execCommand("inserthtml", false, new_);
     }
 
-    if (!span.innerHTML) {
+    if (
+        !span.innerHTML &&
+        /* ugly solution: treat <anki-mathjax> differently than other wraps */ !front.includes(
+            "<anki-mathjax"
+        )
+    ) {
         moveCursorPastPostfix(selection, back);
     }
 }


### PR DESCRIPTION
This fixes the bugs you mentioned in #1324.

> JS error /_anki/js/editor.js:54268 Uncaught (in promise) TypeError: t4.slice is not a function

This seemed to have been from the Mathjax code itself. I've wrapped the Mathjax compiler into a try/catch, but I haven't been able to recreate it myself.

I've done one ugly fix in 88fd31a. I'd much rather tidy this up by rewriting the wrapping (surrounding) code, basically reverse engineering `document.execCommand`.
You can have a look at it in #1377, but I've moved it into a different branch. While implementing it, I thought it we might be able to defer it until we've moved some Web components to Svelte components.
