### PR TITLE
set CardLayout fill_empty=False for add cards editor

### DIFF
--- a/qt/aqt/editor.py
+++ b/qt/aqt/editor.py
@@ -343,7 +343,7 @@ $editorToolbar.then(({{ toolbar }}) => toolbar.appendGroup({{
             self.note,
             ord=ord,
             parent=self.parentWindow,
-            fill_empty=self.addMode,
+            fill_empty=False,
         )
         if isWin:
             self.parentWindow.activateWindow()


### PR DESCRIPTION
In Add Cards dialog, I think the Card layout button is almost always used as a previewer. So displaying accurately may be more important than having placeholders.

The render is especially bad for card layouts using conditional fields like the following:
```
{{#Front-opt}}{{Front-opt}}{{/Front-opt}}
{{^Front-opt}}{{Vocab}}{{/Front-opt}}
```