### PR TITLE
In browser.table.model.flags, don't fetch rows

### DIFF
--- a/qt/aqt/browser/table/model.py
+++ b/qt/aqt/browser/table/model.py
@@ -291,7 +291,9 @@ class DataModel(QAbstractTableModel):
         return None
 
     def flags(self, index: QModelIndex) -> Qt.ItemFlags:
-        if self.get_row(index).is_deleted:
+        item = self.get_item(index)
+        row = self._rows.get(item)
+        if row and row.is_deleted:
             return Qt.ItemFlags(Qt.NoItemFlags)
         return cast(Qt.ItemFlags, Qt.ItemIsEnabled | Qt.ItemIsSelectable)
 


### PR DESCRIPTION
In the browser table, when `Ctrl + A` selecting all the cards, `flags()` is called for all rows . And because `flags` fetches its row, that makes selecting all rows an expensive operation.

This PR changes it so `flags` only uses cached rows. Because `table.StatusDelegate.paint` calls `model.get_cell()` which fetches row data, I don't think there will be any difference except when selecting items that are not painted.

It decreases the time taken by `flags` while selecting ~10000 notes from 4.7s to 0.51s.