### PR TITLE
Add hook for selecting a new note type in the add window

### DIFF
--- a/qt/aqt/addcards.py
+++ b/qt/aqt/addcards.py
@@ -148,6 +148,7 @@ class AddCards(QDialog):
         self.editor.loadNote(
             focusTo=min(self.editor.last_field_index or 0, len(new.fields) - 1)
         )
+        gui_hooks.add_cards_did_change_note_type(old.note_type(), new.note_type())
 
     def _load_new_note(self, sticky_fields_from: Optional[Note] = None) -> None:
         note = self._new_note()

--- a/qt/tools/genhooks_gui.py
+++ b/qt/tools/genhooks_gui.py
@@ -781,6 +781,12 @@ gui_hooks.webview_did_inject_style_into_page.append(mytest)
         return_type="str",
         doc="""Allows changing the history line in the add-card window.""",
     ),
+    Hook(
+        name="add_cards_did_change_note_type",
+        args=["old: anki.models.NoteType", "new: anki.models.NoteType"],
+        doc="""Executed after the user selects a new note type when adding
+        cards.""",
+    ),
     # Editing
     ###################
     Hook(


### PR DESCRIPTION
Use case: I have an add-on that uses a couple of note types that the user shouldn't normally add notes to directly (when they sync using my add-on, notes of those note types added directly within Anki get deleted), so I'd like to display a reminder when one of these note types is selected. I could imagine other add-ons might find it helpful to set up custom functionality in the editor when an appropriate note type was selected.

Most of the add-cards hook names appear to start with `add_cards_`, while one starts with `addcards_`, so I went with the most frequent one. Let me know if I guessed wrong.