### PR TITLE
Handle missing rows consistently and speed up selections

### DIFF
--- a/qt/aqt/browser/browser.py
+++ b/qt/aqt/browser/browser.py
@@ -619,8 +619,7 @@ class Browser(QMainWindow):
         if focus != self.form.tableView:
             return
 
-        nids = self.table.get_selected_note_ids()
-        self.table.to_row_of_unselected_note()
+        nids = self.table.to_row_of_unselected_note()
         remove_notes(parent=self, note_ids=nids).run_in_background()
 
     # legacy

--- a/qt/aqt/browser/browser.py
+++ b/qt/aqt/browser/browser.py
@@ -417,9 +417,7 @@ class Browser(QMainWindow):
         gui_hooks.editor_did_init.remove(add_preview_button)
 
     @ensure_editor_saved
-    def onRowChanged(
-        self, _current: Optional[QItemSelection], _previous: Optional[QItemSelection]
-    ) -> None:
+    def on_row_changed(self) -> None:
         """Update current note and hide/show editor."""
         if self._closeEventHasCleanedUp:
             return

--- a/qt/aqt/browser/browser.py
+++ b/qt/aqt/browser/browser.py
@@ -9,13 +9,7 @@ import aqt
 import aqt.forms
 from anki._legacy import deprecated
 from anki.cards import Card, CardId
-from anki.collection import (
-    Collection,
-    Config,
-    OpChanges,
-    OpChangesWithCount,
-    SearchNode,
-)
+from anki.collection import Collection, Config, OpChanges, SearchNode
 from anki.consts import *
 from anki.errors import NotFoundError
 from anki.lang import without_unicode_isolation
@@ -60,7 +54,6 @@ from aqt.utils import (
     saveState,
     showWarning,
     skip_if_selection_is_empty,
-    tooltip,
     tr,
 )
 
@@ -627,16 +620,8 @@ class Browser(QMainWindow):
             return
 
         nids = self.table.get_selected_note_ids()
-
-        def after_remove(changes: OpChangesWithCount) -> None:
-            tooltip(tr.browsing_cards_deleted(count=changes.count))
-            # select the next card if there is one
-            self.focusTo = self.editor.currentField
-            self.table.to_next_row()
-
-        remove_notes(parent=self, note_ids=nids).success(
-            after_remove
-        ).run_in_background()
+        self.table.to_row_of_unselected_note()
+        remove_notes(parent=self, note_ids=nids).run_in_background()
 
     # legacy
 

--- a/qt/aqt/browser/table/model.py
+++ b/qt/aqt/browser/table/model.py
@@ -119,6 +119,10 @@ class DataModel(QAbstractTableModel):
         )
         return row
 
+    def get_cached_row(self, index: QModelIndex) -> Optional[CellRow]:
+        """Get row if it is cached, regardless of staleness."""
+        return self._rows.get(self.get_item(index))
+
     # Reset
 
     def mark_cache_stale(self) -> None:
@@ -326,8 +330,10 @@ class DataModel(QAbstractTableModel):
         return None
 
     def flags(self, index: QModelIndex) -> Qt.ItemFlags:
-        if self.get_row(index).is_deleted:
-            return Qt.ItemFlags(Qt.NoItemFlags)
+        # shortcut for large selections (Ctrl+A) to avoid fetching large numbers of rows at once
+        if row := self.get_cached_row(index):
+            if row.is_deleted:
+                return Qt.ItemFlags(Qt.NoItemFlags)
         return cast(Qt.ItemFlags, Qt.ItemIsEnabled | Qt.ItemIsSelectable)
 
 

--- a/qt/aqt/browser/table/model.py
+++ b/qt/aqt/browser/table/model.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 import time
-from typing import Any, Dict, List, Optional, Sequence, Union, cast
+from typing import Any, Callable, Dict, List, Optional, Sequence, Union, cast
 
 import aqt
 from anki.cards import Card, CardId
@@ -32,7 +32,13 @@ class DataModel(QAbstractTableModel):
     _stale_cutoff -- A threshold to decide whether a cached row has gone stale.
     """
 
-    def __init__(self, col: Collection, state: ItemState) -> None:
+    def __init__(
+        self,
+        col: Collection,
+        state: ItemState,
+        row_state_will_change_callback: Callable,
+        row_state_changed_callback: Callable,
+    ) -> None:
         QAbstractTableModel.__init__(self)
         self.col: Collection = col
         self.columns: Dict[str, Column] = dict(
@@ -44,6 +50,8 @@ class DataModel(QAbstractTableModel):
         self._rows: Dict[int, CellRow] = {}
         self._block_updates = False
         self._stale_cutoff = 0.0
+        self._on_row_state_will_change = row_state_will_change_callback
+        self._on_row_state_changed = row_state_changed_callback
         self._want_tooltips = aqt.mw.pm.show_browser_table_tooltips()
 
     # Row Object Interface
@@ -59,15 +67,34 @@ class DataModel(QAbstractTableModel):
         if row := self._rows.get(item):
             if not self._block_updates and row.is_stale(self._stale_cutoff):
                 # need to refresh
-                self._rows[item] = self._fetch_row_from_backend(item)
-                return self._rows[item]
+                return self._fetch_row_and_update_cache(index, item, row)
             # return row, even if it's stale
             return row
         if self._block_updates:
             # blank row until we unblock
             return CellRow.placeholder(self.len_columns())
         # missing row, need to build
-        self._rows[item] = self._fetch_row_from_backend(item)
+        return self._fetch_row_and_update_cache(index, item, None)
+
+    def _fetch_row_and_update_cache(
+        self, index: QModelIndex, item: ItemId, old_row: Optional[CellRow]
+    ) -> CellRow:
+        """Fetch a row from the backend, add it to the cache and return it.
+        Thereby, handle callbacks if the row is being deleted or restored.
+        """
+        new_row = self._fetch_row_from_backend(item)
+        # row state has changed if existence of cached and fetched counterparts differ
+        # if the row was previously uncached, it is assumed to have existed
+        state_change = (
+            new_row.is_deleted
+            if old_row is None
+            else old_row.is_deleted != new_row.is_deleted
+        )
+        if state_change:
+            self._on_row_state_will_change(index, not new_row.is_deleted)
+        self._rows[item] = new_row
+        if state_change:
+            self._on_row_state_changed(index, not new_row.is_deleted)
         return self._rows[item]
 
     def _fetch_row_from_backend(self, item: ItemId) -> CellRow:

--- a/qt/aqt/browser/table/model.py
+++ b/qt/aqt/browser/table/model.py
@@ -80,7 +80,7 @@ class DataModel(QAbstractTableModel):
         self, index: QModelIndex, item: ItemId, old_row: Optional[CellRow]
     ) -> CellRow:
         """Fetch a row from the backend, add it to the cache and return it.
-        Thereby, handle callbacks if the row is being deleted or restored.
+        Then fire callbacks if the row is being deleted or restored.
         """
         new_row = self._fetch_row_from_backend(item)
         # row state has changed if existence of cached and fetched counterparts differ

--- a/qt/aqt/browser/table/model.py
+++ b/qt/aqt/browser/table/model.py
@@ -175,6 +175,8 @@ class DataModel(QAbstractTableModel):
 
     def get_card(self, index: QModelIndex) -> Optional[Card]:
         """Try to return the indicated, possibly deleted card."""
+        if not index.isValid():
+            return None
         try:
             return self._state.get_card(self.get_item(index))
         except NotFoundError:
@@ -182,6 +184,8 @@ class DataModel(QAbstractTableModel):
 
     def get_note(self, index: QModelIndex) -> Optional[Note]:
         """Try to return the indicated, possibly deleted note."""
+        if not index.isValid():
+            return None
         try:
             return self._state.get_note(self.get_item(index))
         except NotFoundError:

--- a/qt/aqt/browser/table/model.py
+++ b/qt/aqt/browser/table/model.py
@@ -184,6 +184,11 @@ class DataModel(QAbstractTableModel):
     def get_note_ids(self, indices: List[QModelIndex]) -> Sequence[NoteId]:
         return self._state.get_note_ids(self.get_items(indices))
 
+    def get_note_id(self, index: QModelIndex) -> Optional[NoteId]:
+        if nid_list := self._state.get_note_ids([self.get_item(index)]):
+            return nid_list[0]
+        return None
+
     # Get row numbers from items
 
     def get_item_row(self, item: ItemId) -> Optional[int]:

--- a/qt/aqt/browser/table/table.py
+++ b/qt/aqt/browser/table/table.py
@@ -384,10 +384,9 @@ class Table:
         if KeyboardModifiersPressed().shift or KeyboardModifiersPressed().control:
             # Current selection is modified. The number of added/removed rows is
             # usually smaller than the number of rows in the resulting selection.
-            self._len_selection += len(selected.indexes()) // self._model.len_columns()
-            self._len_selection -= (
-                len(deselected.indexes()) // self._model.len_columns()
-            )
+            self._len_selection += (
+                len(selected.indexes()) - len(deselected.indexes())
+            ) // self._model.len_columns()
         else:
             # New selection is created. Usually a single row or none at all.
             self._len_selection = len(self._view.selectionModel().selectedRows())

--- a/qt/aqt/browser/table/table.py
+++ b/qt/aqt/browser/table/table.py
@@ -207,6 +207,25 @@ class Table:
     def to_last_row(self) -> None:
         self._move_current_to_row(self._model.len_rows() - 1)
 
+    def to_row_of_unselected_note(self) -> None:
+        """Select and set focus to a row whose note is not selected,
+        starting with the nearest row below, then above the focused row.
+        If that's not possible, clear selection.
+        """
+        nids = self.get_selected_note_ids()
+        for row in range(self._current().row(), self.len()):
+            nid = self._model.get_note_id(self._model.index(row, 0))
+            if nid is not None and nid not in nids:
+                self._move_current_to_row(row)
+                return
+        for row in range(self._current().row() - 1, -1, -1):
+            nid = self._model.get_note_id(self._model.index(row, 0))
+            if nid is not None and nid not in nids:
+                self._move_current_to_row(row)
+                return
+        self.clear_selection()
+        self.clear_current()
+
     def clear_current(self) -> None:
         self._view.selectionModel().setCurrentIndex(
             QModelIndex(), QItemSelectionModel.NoUpdate

--- a/qt/aqt/browser/table/table.py
+++ b/qt/aqt/browser/table/table.py
@@ -78,13 +78,9 @@ class Table:
     # Get objects
 
     def get_current_card(self) -> Optional[Card]:
-        if not self.has_current():
-            return None
         return self._model.get_card(self._current())
 
     def get_current_note(self) -> Optional[Note]:
-        if not self.has_current():
-            return None
         return self._model.get_note(self._current())
 
     def get_single_selected_card(self) -> Optional[Card]:


### PR DESCRIPTION
Phew, that took some pains, but it should be working robustly now, even with deletions from outside the browser. I would appreciate some testing though.
My only gripe is with the introduced complexity. I've made an effort to add some comments. Please let me know where things are still unclear.

The changes from #1374 and #1381 are incorporated.

Do I have to add a legacy alias for `browser.onRowChanged()`?