### PR TITLE
Add the homepage property to manifest.json

### DIFF
--- a/ftl/qt/addons.ftl
+++ b/ftl/qt/addons.ftl
@@ -10,7 +10,6 @@ addons-config-validation-error = There was a problem with the provided configura
 addons-window-title = Add-ons
 addons-addon-has-no-configuration = Add-on has no configuration.
 addons-addon-installation-error = Add-on installation error
-addons-addon-was-not-downloaded-from-ankiweb = Add-on was not downloaded from AnkiWeb.
 addons-browse-addons = Browse Add-ons
 addons-changes-will-take-effect-when-anki = Changes will take effect when Anki is restarted.
 addons-check-for-updates = Check for Updates


### PR DESCRIPTION
This adds the `homepage` property to add-ons' manifest.json file to allow providing an add-on page as an alternative to an AnkiWeb page for add-ons installed locally. I saw the `homepage` property used in some of glutanimate's add-ons' manifests and thought that it's a good idea to use it for the View Add-on Page button when no AnkiWeb ID is available.
I also removed the `addons-addon-was-not-downloaded-from-ankiweb` string since it looks redundant because the View Add-on Page button is disabled when no add-on page is available.