### PR TITLE
Keep the list of duplicates up-to-date before tagging

### DIFF
--- a/qt/aqt/browser/find_duplicates.py
+++ b/qt/aqt/browser/find_duplicates.py
@@ -46,6 +46,7 @@ class FindDuplicatesDialog(QDialog):
         form.fields.addItems(fields)
         restore_combo_index_for_session(form.fields, fields, "findDupesFields")
         self._dupesButton: Optional[QPushButton] = None
+        self._dupes: List[Tuple[str, List[NoteId]]] = []
 
         # links
         form.webView.set_title("find duplicates")
@@ -76,11 +77,12 @@ class FindDuplicatesDialog(QDialog):
         self.show()
 
     def show_duplicates_report(self, dupes: List[Tuple[str, List[NoteId]]]) -> None:
+        self._dupes = dupes
         if not self._dupesButton:
             self._dupesButton = b = self.form.buttonBox.addButton(
                 tr.browsing_tag_duplicates(), QDialogButtonBox.ActionRole
             )
-            qconnect(b.clicked, lambda: self._tag_duplicates(dupes))
+            qconnect(b.clicked, lambda: self._tag_duplicates(self._dupes))
         text = ""
         groups = len(dupes)
         notes = sum(len(r[1]) for r in dupes)

--- a/qt/aqt/browser/find_duplicates.py
+++ b/qt/aqt/browser/find_duplicates.py
@@ -82,7 +82,7 @@ class FindDuplicatesDialog(QDialog):
             self._dupesButton = b = self.form.buttonBox.addButton(
                 tr.browsing_tag_duplicates(), QDialogButtonBox.ActionRole
             )
-            qconnect(b.clicked, lambda: self._tag_duplicates(self._dupes))
+            qconnect(b.clicked, lambda: self._tag_duplicates())
         text = ""
         groups = len(dupes)
         notes = sum(len(r[1]) for r in dupes)
@@ -106,12 +106,12 @@ class FindDuplicatesDialog(QDialog):
         text += "</ol>"
         self.form.webView.stdHtml(text, context=self)
 
-    def _tag_duplicates(self, dupes: List[Tuple[str, List[NoteId]]]) -> None:
-        if not dupes:
+    def _tag_duplicates(self) -> None:
+        if not self._dupes:
             return
 
         note_ids = set()
-        for _, nids in dupes:
+        for _, nids in self._dupes:
             note_ids.update(nids)
 
         add_tags_to_notes(

--- a/qt/aqt/browser/find_duplicates.py
+++ b/qt/aqt/browser/find_duplicates.py
@@ -82,7 +82,7 @@ class FindDuplicatesDialog(QDialog):
             self._dupesButton = b = self.form.buttonBox.addButton(
                 tr.browsing_tag_duplicates(), QDialogButtonBox.ActionRole
             )
-            qconnect(b.clicked, lambda: self._tag_duplicates())
+            qconnect(b.clicked, self._tag_duplicates)
         text = ""
         groups = len(dupes)
         notes = sum(len(r[1]) for r in dupes)


### PR DESCRIPTION
When you search duplicates, apparently Anki saves the first search result inside a lambda. If you press "Search" again with different settings, the "dupes" list does not update. If you then press "Tag Duplicates"  without reopening the window, Anki tags the wrong notes.

This pull request is supposed to fix it.