### PR TITLE
Fix svelte imports

### DIFF
--- a/ts/.prettierignore
+++ b/ts/.prettierignore
@@ -1,4 +1,5 @@
 licenses.json
 vendor
-i18n-generated.ts
+i18n-translate.ts
+i18n-modules.ts
 backend_proto.d.ts

--- a/ts/.prettierignore
+++ b/ts/.prettierignore
@@ -1,4 +1,4 @@
 licenses.json
 vendor
-*.svelte.d.ts
+i18n-generated.ts
 backend_proto.d.ts

--- a/ts/change-notetype/ChangeNotetypePage.svelte
+++ b/ts/change-notetype/ChangeNotetypePage.svelte
@@ -3,7 +3,7 @@ Copyright: Ankitects Pty Ltd and contributors
 License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 -->
 <script lang="ts">
-    import * as tr from "../lib/i18n";
+    import { tr } from "../lib/i18n";
     import NotetypeSelector from "./NotetypeSelector.svelte";
     import Mapper from "./Mapper.svelte";
     import { ChangeNotetypeState, MapContext } from "./lib";

--- a/ts/change-notetype/Mapper.svelte
+++ b/ts/change-notetype/Mapper.svelte
@@ -3,8 +3,8 @@ Copyright: Ankitects Pty Ltd and contributors
 License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 -->
 <script lang="ts">
-    import * as tr from "../lib/i18n";
     import MapperRow from "./MapperRow.svelte";
+    import { tr } from "../lib/i18n";
     import { ChangeNotetypeState, MapContext } from "./lib";
     import { slide } from "svelte/transition";
 

--- a/ts/change-notetype/SaveButton.svelte
+++ b/ts/change-notetype/SaveButton.svelte
@@ -3,7 +3,7 @@ Copyright: Ankitects Pty Ltd and contributors
 License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 -->
 <script lang="ts">
-    import * as tr from "../lib/i18n";
+    import { tr } from "../lib/i18n";
     import type { ChangeNotetypeState } from "./lib";
     import { withButton } from "../components/helpers";
 

--- a/ts/change-notetype/index.ts
+++ b/ts/change-notetype/index.ts
@@ -6,7 +6,7 @@
  */
 
 import { ChangeNotetypeState, getChangeNotetypeInfo, getNotetypeNames } from "./lib";
-import { setupI18n, ModuleName } from "../lib/i18n";
+import { setupI18n, tr } from "../lib/i18n";
 import { checkNightMode } from "../lib/nightmode";
 import ChangeNotetypePage from "./ChangeNotetypePage.svelte";
 import { nightModeKey } from "../components/context-keys";
@@ -20,7 +20,7 @@ export async function changeNotetypePage(
         getChangeNotetypeInfo(oldNotetypeId, newNotetypeId),
         getNotetypeNames(),
         setupI18n({
-            modules: [ModuleName.ACTIONS, ModuleName.CHANGE_NOTETYPE],
+            modules: [tr.ModuleName.ACTIONS, tr.ModuleName.CHANGE_NOTETYPE],
         }),
     ]);
 

--- a/ts/change-notetype/index.ts
+++ b/ts/change-notetype/index.ts
@@ -6,7 +6,7 @@
  */
 
 import { ChangeNotetypeState, getChangeNotetypeInfo, getNotetypeNames } from "./lib";
-import { setupI18n, tr } from "../lib/i18n";
+import { setupI18n, ModuleName } from "../lib/i18n";
 import { checkNightMode } from "../lib/nightmode";
 import ChangeNotetypePage from "./ChangeNotetypePage.svelte";
 import { nightModeKey } from "../components/context-keys";
@@ -20,7 +20,7 @@ export async function changeNotetypePage(
         getChangeNotetypeInfo(oldNotetypeId, newNotetypeId),
         getNotetypeNames(),
         setupI18n({
-            modules: [tr.ModuleName.ACTIONS, tr.ModuleName.CHANGE_NOTETYPE],
+            modules: [ModuleName.ACTIONS, ModuleName.CHANGE_NOTETYPE],
         }),
     ]);
 

--- a/ts/change-notetype/tsconfig.json
+++ b/ts/change-notetype/tsconfig.json
@@ -1,5 +1,6 @@
 {
     "extends": "../tsconfig.json",
+    "rootDirs": ["../../bazel-bin/ts/change-notetype"],
     "include": ["*"],
     "references": [
         { "path": "../lib" },

--- a/ts/components/tsconfig.json
+++ b/ts/components/tsconfig.json
@@ -1,5 +1,6 @@
 {
     "extends": "../tsconfig.json",
+    "rootDirs": ["../../bazel-bin/ts/components"],
     "include": ["*"],
     "references": [{ "path": "../lib" }, { "path": "../sveltelib" }]
 }

--- a/ts/congrats/CongratsPage.svelte
+++ b/ts/congrats/CongratsPage.svelte
@@ -6,9 +6,9 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     import type { Scheduler } from "../lib/proto";
     import { buildNextLearnMsg } from "./lib";
     import { bridgeLink } from "../lib/bridgecommand";
+    import { tr } from "../lib/i18n";
 
     export let info: Scheduler.CongratsInfoResponse;
-    import * as tr from "../lib/i18n";
 
     const congrats = tr.schedulingCongratulationsFinished();
     let nextLearnMsg: string;

--- a/ts/congrats/index.ts
+++ b/ts/congrats/index.ts
@@ -2,14 +2,14 @@
 // License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
 import { getCongratsInfo } from "./lib";
-import { setupI18n, tr } from "../lib/i18n";
+import { setupI18n, ModuleName } from "../lib/i18n";
 import { checkNightMode } from "../lib/nightmode";
 
 import CongratsPage from "./CongratsPage.svelte";
 
 export async function congrats(target: HTMLDivElement): Promise<void> {
     checkNightMode();
-    await setupI18n({ modules: [tr.ModuleName.SCHEDULING] });
+    await setupI18n({ modules: [ModuleName.SCHEDULING] });
     const info = await getCongratsInfo();
     const page = new CongratsPage({
         target,

--- a/ts/congrats/index.ts
+++ b/ts/congrats/index.ts
@@ -2,14 +2,14 @@
 // License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
 import { getCongratsInfo } from "./lib";
-import { setupI18n, ModuleName } from "../lib/i18n";
+import { setupI18n, tr } from "../lib/i18n";
 import { checkNightMode } from "../lib/nightmode";
 
 import CongratsPage from "./CongratsPage.svelte";
 
 export async function congrats(target: HTMLDivElement): Promise<void> {
     checkNightMode();
-    await setupI18n({ modules: [ModuleName.SCHEDULING] });
+    await setupI18n({ modules: [tr.ModuleName.SCHEDULING] });
     const info = await getCongratsInfo();
     const page = new CongratsPage({
         target,

--- a/ts/congrats/lib.ts
+++ b/ts/congrats/lib.ts
@@ -4,8 +4,7 @@
 import { Scheduler } from "../lib/proto";
 import { postRequest } from "../lib/postrequest";
 import { naturalUnit, unitAmount, unitName } from "../lib/time";
-
-import * as tr from "../lib/i18n";
+import { tr } from "../lib/i18n";
 
 export async function getCongratsInfo(): Promise<Scheduler.CongratsInfoResponse> {
     return Scheduler.CongratsInfoResponse.decode(

--- a/ts/congrats/tsconfig.json
+++ b/ts/congrats/tsconfig.json
@@ -1,5 +1,6 @@
 {
     "extends": "../tsconfig.json",
+    "rootDirs": ["../../bazel-bin/ts/congrats"],
     "include": ["*"],
     "references": [{ "path": "../lib" }]
 }

--- a/ts/deck-options/AdvancedOptions.svelte
+++ b/ts/deck-options/AdvancedOptions.svelte
@@ -3,7 +3,7 @@ Copyright: Ankitects Pty Ltd and contributors
 License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 -->
 <script lang="ts">
-    import * as tr from "../lib/i18n";
+    import { tr } from "../lib/i18n";
     import TitledContainer from "./TitledContainer.svelte";
     import Item from "../components/Item.svelte";
     import SpinBoxRow from "./SpinBoxRow.svelte";

--- a/ts/deck-options/AudioOptions.svelte
+++ b/ts/deck-options/AudioOptions.svelte
@@ -3,7 +3,7 @@ Copyright: Ankitects Pty Ltd and contributors
 License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 -->
 <script lang="ts">
-    import * as tr from "../lib/i18n";
+    import { tr } from "../lib/i18n";
     import TitledContainer from "./TitledContainer.svelte";
     import Item from "../components/Item.svelte";
     import SwitchRow from "./SwitchRow.svelte";

--- a/ts/deck-options/BuryOptions.svelte
+++ b/ts/deck-options/BuryOptions.svelte
@@ -3,10 +3,10 @@ Copyright: Ankitects Pty Ltd and contributors
 License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 -->
 <script lang="ts">
-    import * as tr from "../lib/i18n";
     import TitledContainer from "./TitledContainer.svelte";
     import Item from "../components/Item.svelte";
     import SwitchRow from "./SwitchRow.svelte";
+    import { tr } from "../lib/i18n";
     import type { DeckOptionsState } from "./lib";
 
     export let state: DeckOptionsState;

--- a/ts/deck-options/CardStateCustomizer.svelte
+++ b/ts/deck-options/CardStateCustomizer.svelte
@@ -3,7 +3,7 @@ Copyright: Ankitects Pty Ltd and contributors
 License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 -->
 <script lang="ts">
-    import * as tr from "../lib/i18n";
+    import { tr } from "../lib/i18n";
     import TooltipLabel from "./TooltipLabel.svelte";
     import RevertButton from "./RevertButton.svelte";
     import Row from "./Row.svelte";

--- a/ts/deck-options/ConfigSelector.svelte
+++ b/ts/deck-options/ConfigSelector.svelte
@@ -3,7 +3,7 @@ Copyright: Ankitects Pty Ltd and contributors
 License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 -->
 <script lang="ts">
-    import * as tr from "../lib/i18n";
+    import { tr } from "../lib/i18n";
     import { getContext } from "svelte";
     import { modalsKey } from "../components/context-keys";
     import type { DeckOptionsState, ConfigListEntry } from "./lib";

--- a/ts/deck-options/DailyLimits.svelte
+++ b/ts/deck-options/DailyLimits.svelte
@@ -3,7 +3,7 @@
     License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 -->
 <script lang="ts">
-    import * as tr from "../lib/i18n";
+    import { tr } from "../lib/i18n";
     import TitledContainer from "./TitledContainer.svelte";
     import Item from "../components/Item.svelte";
     import SpinBoxRow from "./SpinBoxRow.svelte";

--- a/ts/deck-options/DisplayOrder.svelte
+++ b/ts/deck-options/DisplayOrder.svelte
@@ -3,7 +3,7 @@ Copyright: Ankitects Pty Ltd and contributors
 License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 -->
 <script lang="ts">
-    import * as tr from "../lib/i18n";
+    import { tr } from "../lib/i18n";
     import TitledContainer from "./TitledContainer.svelte";
     import Item from "../components/Item.svelte";
     import EnumSelectorRow from "./EnumSelectorRow.svelte";

--- a/ts/deck-options/LapseOptions.svelte
+++ b/ts/deck-options/LapseOptions.svelte
@@ -3,7 +3,7 @@ Copyright: Ankitects Pty Ltd and contributors
 License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 -->
 <script lang="ts">
-    import * as tr from "../lib/i18n";
+    import { tr } from "../lib/i18n";
     import TitledContainer from "./TitledContainer.svelte";
     import Item from "../components/Item.svelte";
     import StepsInputRow from "./StepsInputRow.svelte";

--- a/ts/deck-options/NewOptions.svelte
+++ b/ts/deck-options/NewOptions.svelte
@@ -3,14 +3,15 @@ Copyright: Ankitects Pty Ltd and contributors
 License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 -->
 <script lang="ts">
-    import * as tr from "../lib/i18n";
     import TitledContainer from "./TitledContainer.svelte";
     import Item from "../components/Item.svelte";
     import StepsInputRow from "./StepsInputRow.svelte";
     import SpinBoxRow from "./SpinBoxRow.svelte";
     import EnumSelectorRow from "./EnumSelectorRow.svelte";
     import Warning from "./Warning.svelte";
+
     import type { DeckOptionsState } from "./lib";
+    import { tr } from "../lib/i18n";
 
     export let state: DeckOptionsState;
     export let api = {};

--- a/ts/deck-options/RevertButton.svelte
+++ b/ts/deck-options/RevertButton.svelte
@@ -3,7 +3,7 @@ Copyright: Ankitects Pty Ltd and contributors
 License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 -->
 <script lang="ts">
-    import * as tr from "../lib/i18n";
+    import { tr } from "../lib/i18n";
     import type Dropdown from "bootstrap/js/dist/dropdown";
     import WithDropdown from "../components/WithDropdown.svelte";
     import DropdownMenu from "../components/DropdownMenu.svelte";

--- a/ts/deck-options/SaveButton.svelte
+++ b/ts/deck-options/SaveButton.svelte
@@ -3,7 +3,7 @@ Copyright: Ankitects Pty Ltd and contributors
 License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 -->
 <script lang="ts">
-    import * as tr from "../lib/i18n";
+    import { tr } from "../lib/i18n";
     import { createEventDispatcher } from "svelte";
     import type { DeckOptionsState } from "./lib";
     import type Dropdown from "bootstrap/js/dist/dropdown";

--- a/ts/deck-options/SaveButton.svelte
+++ b/ts/deck-options/SaveButton.svelte
@@ -29,6 +29,12 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         }
     }
 
+    /// Treat text like HTML, merging multiple spaces and converting
+    /// newlines to spaces.
+    export function collapseWhitespace(s: string): string {
+        return s.replace(/\s+/g, " ");
+    }
+
     function removeConfig(): void {
         // show pop-up after dropdown has gone away
         setTimeout(() => {
@@ -41,7 +47,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
                     ? tr.deckConfigWillRequireFullSync() + " "
                     : "") +
                 tr.deckConfigConfirmRemoveName({ name: state.getCurrentName() });
-            if (confirm(tr.i18n.withCollapsedWhitespace(msg))) {
+            if (confirm(collapseWhitespace(msg))) {
                 try {
                     state.removeCurrentConfig();
                 } catch (err) {

--- a/ts/deck-options/TimerOptions.svelte
+++ b/ts/deck-options/TimerOptions.svelte
@@ -3,11 +3,11 @@ Copyright: Ankitects Pty Ltd and contributors
 License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 -->
 <script lang="ts">
-    import * as tr from "../lib/i18n";
     import TitledContainer from "./TitledContainer.svelte";
     import Item from "../components/Item.svelte";
     import SpinBoxRow from "./SpinBoxRow.svelte";
     import SwitchRow from "./SwitchRow.svelte";
+    import { tr } from "../lib/i18n";
     import type { DeckOptionsState } from "./lib";
 
     export let state: DeckOptionsState;

--- a/ts/deck-options/index.ts
+++ b/ts/deck-options/index.ts
@@ -8,7 +8,7 @@
 import "../sveltelib/export-runtime";
 
 import { getDeckOptionsInfo, DeckOptionsState } from "./lib";
-import { setupI18n, tr } from "../lib/i18n";
+import { setupI18n, ModuleName } from "../lib/i18n";
 import { checkNightMode } from "../lib/nightmode";
 import DeckOptionsPage from "./DeckOptionsPage.svelte";
 import { nightModeKey, touchDeviceKey, modalsKey } from "../components/context-keys";
@@ -21,9 +21,9 @@ export async function deckOptions(
         getDeckOptionsInfo(deckId),
         setupI18n({
             modules: [
-                tr.ModuleName.SCHEDULING,
-                tr.ModuleName.ACTIONS,
-                tr.ModuleName.DECK_CONFIG,
+                ModuleName.SCHEDULING,
+                ModuleName.ACTIONS,
+                ModuleName.DECK_CONFIG,
             ],
         }),
     ]);

--- a/ts/deck-options/index.ts
+++ b/ts/deck-options/index.ts
@@ -8,7 +8,7 @@
 import "../sveltelib/export-runtime";
 
 import { getDeckOptionsInfo, DeckOptionsState } from "./lib";
-import { setupI18n, ModuleName } from "../lib/i18n";
+import { setupI18n, tr } from "../lib/i18n";
 import { checkNightMode } from "../lib/nightmode";
 import DeckOptionsPage from "./DeckOptionsPage.svelte";
 import { nightModeKey, touchDeviceKey, modalsKey } from "../components/context-keys";
@@ -21,9 +21,9 @@ export async function deckOptions(
         getDeckOptionsInfo(deckId),
         setupI18n({
             modules: [
-                ModuleName.SCHEDULING,
-                ModuleName.ACTIONS,
-                ModuleName.DECK_CONFIG,
+                tr.ModuleName.SCHEDULING,
+                tr.ModuleName.ACTIONS,
+                tr.ModuleName.DECK_CONFIG,
             ],
         }),
     ]);

--- a/ts/deck-options/lib.ts
+++ b/ts/deck-options/lib.ts
@@ -9,7 +9,7 @@ import { DeckConfig } from "../lib/proto";
 import { postRequest } from "../lib/postrequest";
 import { Writable, writable, get, Readable, readable } from "svelte/store";
 import { isEqual, cloneDeep } from "lodash-es";
-import { i18n } from "../lib/i18n";
+import { localeCompare } from "../lib/i18n";
 import type { DynamicSvelteComponent } from "../sveltelib/dynamicComponent";
 
 export async function getDeckOptionsInfo(
@@ -278,9 +278,7 @@ export class DeckOptionsState {
                 useCount,
             };
         });
-        list.sort((a, b) =>
-            a.name.localeCompare(b.name, i18n.langs, { sensitivity: "base" })
-        );
+        list.sort((a, b) => localeCompare(a.name, b.name, { sensitivity: "base" }));
         return list;
     }
 

--- a/ts/deck-options/lib.ts
+++ b/ts/deck-options/lib.ts
@@ -9,7 +9,7 @@ import { DeckConfig } from "../lib/proto";
 import { postRequest } from "../lib/postrequest";
 import { Writable, writable, get, Readable, readable } from "svelte/store";
 import { isEqual, cloneDeep } from "lodash-es";
-import * as tr from "../lib/i18n";
+import { i18n } from "../lib/i18n";
 import type { DynamicSvelteComponent } from "../sveltelib/dynamicComponent";
 
 export async function getDeckOptionsInfo(
@@ -279,7 +279,7 @@ export class DeckOptionsState {
             };
         });
         list.sort((a, b) =>
-            a.name.localeCompare(b.name, tr.i18n.langs, { sensitivity: "base" })
+            a.name.localeCompare(b.name, i18n.langs, { sensitivity: "base" })
         );
         return list;
     }

--- a/ts/deck-options/strings.ts
+++ b/ts/deck-options/strings.ts
@@ -1,7 +1,7 @@
 // Copyright: Ankitects Pty Ltd and contributors
 // License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
-import * as tr from "../lib/i18n";
+import { tr } from "../lib/i18n";
 
 export const reviewMixChoices = (): string[] => [
     tr.deckConfigReviewMixMixWithReviews(),

--- a/ts/deck-options/tsconfig.json
+++ b/ts/deck-options/tsconfig.json
@@ -1,5 +1,6 @@
 {
     "extends": "../tsconfig.json",
+    "rootDirs": ["../../bazel-bin/ts/deck-options"],
     "include": ["*"],
     "references": [
         { "path": "../lib" },

--- a/ts/editable/tsconfig.json
+++ b/ts/editable/tsconfig.json
@@ -1,5 +1,6 @@
 {
     "extends": "../tsconfig.json",
+    "rootDirs": ["../../bazel-bin/ts/editable"],
     "include": ["*"],
     "references": [
         { "path": "../components" },

--- a/ts/editor/ClozeButton.svelte
+++ b/ts/editor/ClozeButton.svelte
@@ -3,12 +3,11 @@ Copyright: Ankitects Pty Ltd and contributors
 License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 -->
 <script lang="typescript">
-    import * as tr from "../lib/i18n";
-
     import IconButton from "../components/IconButton.svelte";
     import WithShortcut from "../components/WithShortcut.svelte";
     import OnlyEditable from "./OnlyEditable.svelte";
 
+    import { tr } from "../lib/i18n";
     import { withButton } from "../components/helpers";
     import { ellipseIcon } from "./icons";
     import { forEditorField } from ".";

--- a/ts/editor/ColorButtons.svelte
+++ b/ts/editor/ColorButtons.svelte
@@ -3,8 +3,6 @@ Copyright: Ankitects Pty Ltd and contributors
 License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 -->
 <script lang="typescript">
-    import * as tr from "../lib/i18n";
-
     import ButtonGroup from "../components/ButtonGroup.svelte";
     import ButtonGroupItem from "../components/ButtonGroupItem.svelte";
     import IconButton from "../components/IconButton.svelte";
@@ -13,6 +11,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     import WithColorHelper from "./WithColorHelper.svelte";
     import OnlyEditable from "./OnlyEditable.svelte";
 
+    import { tr } from "../lib/i18n";
     import { bridgeCommand } from "../lib/bridgecommand";
     import { withButton } from "../components/helpers";
     import { textColorIcon, highlightColorIcon, arrowIcon } from "./icons";

--- a/ts/editor/FormatBlockButtons.svelte
+++ b/ts/editor/FormatBlockButtons.svelte
@@ -3,8 +3,6 @@ Copyright: Ankitects Pty Ltd and contributors
 License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 -->
 <script lang="typescript">
-    import * as tr from "../lib/i18n";
-
     import ButtonGroup from "../components/ButtonGroup.svelte";
     import ButtonGroupItem from "../components/ButtonGroupItem.svelte";
     import IconButton from "../components/IconButton.svelte";
@@ -14,6 +12,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     import OnlyEditable from "./OnlyEditable.svelte";
     import CommandIconButton from "./CommandIconButton.svelte";
 
+    import { tr } from "../lib/i18n";
     import { getListItem } from "../lib/dom";
     import { getCurrentField, execCommand } from "./helpers";
     import {

--- a/ts/editor/FormatInlineButtons.svelte
+++ b/ts/editor/FormatInlineButtons.svelte
@@ -3,12 +3,11 @@ Copyright: Ankitects Pty Ltd and contributors
 License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 -->
 <script lang="typescript">
-    import * as tr from "../lib/i18n";
-
     import ButtonGroup from "../components/ButtonGroup.svelte";
     import ButtonGroupItem from "../components/ButtonGroupItem.svelte";
     import CommandIconButton from "./CommandIconButton.svelte";
 
+    import { tr } from "../lib/i18n";
     import {
         boldIcon,
         italicIcon,

--- a/ts/editor/ImageHandleFloatButtons.svelte
+++ b/ts/editor/ImageHandleFloatButtons.svelte
@@ -3,7 +3,7 @@ Copyright: Ankitects Pty Ltd and contributors
 License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 -->
 <script lang="typescript">
-    import * as tr from "../lib/i18n";
+    import { tr } from "../lib/i18n";
 
     import ButtonGroup from "../components/ButtonGroup.svelte";
     import ButtonGroupItem from "../components/ButtonGroupItem.svelte";

--- a/ts/editor/ImageHandleSizeSelect.svelte
+++ b/ts/editor/ImageHandleSizeSelect.svelte
@@ -3,7 +3,7 @@ Copyright: Ankitects Pty Ltd and contributors
 License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 -->
 <script lang="typescript">
-    import * as tr from "../lib/i18n";
+    import { tr } from "../lib/i18n";
 
     import ButtonGroup from "../components/ButtonGroup.svelte";
     import ButtonGroupItem from "../components/ButtonGroupItem.svelte";

--- a/ts/editor/MathjaxHandleInlineBlock.svelte
+++ b/ts/editor/MathjaxHandleInlineBlock.svelte
@@ -3,12 +3,11 @@ Copyright: Ankitects Pty Ltd and contributors
 License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 -->
 <script lang="typescript">
-    import * as tr from "../lib/i18n";
-
     import ButtonGroup from "../components/ButtonGroup.svelte";
     import ButtonGroupItem from "../components/ButtonGroupItem.svelte";
     import IconButton from "../components/IconButton.svelte";
 
+    import { tr } from "../lib/i18n";
     import { inlineIcon, blockIcon } from "./icons";
 
     export let activeImage: HTMLImageElement;

--- a/ts/editor/NoteTypeButtons.svelte
+++ b/ts/editor/NoteTypeButtons.svelte
@@ -4,7 +4,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 -->
 <script lang="typescript">
     import { bridgeCommand } from "../lib/bridgecommand";
-    import * as tr from "../lib/i18n";
+    import { tr } from "../lib/i18n";
     import { withButton } from "../components/helpers";
 
     import ButtonGroup from "../components/ButtonGroup.svelte";

--- a/ts/editor/PreviewButton.svelte
+++ b/ts/editor/PreviewButton.svelte
@@ -4,7 +4,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 -->
 <script lang="typescript">
     import { bridgeCommand } from "../lib/bridgecommand";
-    import * as tr from "../lib/i18n";
+    import { tr } from "../lib/i18n";
     import { withButton } from "../components/helpers";
 
     import WithShortcut from "../components/WithShortcut.svelte";

--- a/ts/editor/TemplateButtons.svelte
+++ b/ts/editor/TemplateButtons.svelte
@@ -3,7 +3,7 @@ Copyright: Ankitects Pty Ltd and contributors
 License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 -->
 <script lang="typescript">
-    import * as tr from "../lib/i18n";
+    import { tr } from "../lib/i18n";
     import { bridgeCommand } from "../lib/bridgecommand";
     import { fieldFocusedKey, inCodableKey } from "./context-keys";
 

--- a/ts/editor/index.ts
+++ b/ts/editor/index.ts
@@ -13,7 +13,7 @@ import type EditorToolbar from "./EditorToolbar.svelte";
 import type TagEditor from "./TagEditor.svelte";
 
 import { filterHTML } from "../html-filter";
-import { setupI18n, tr } from "../lib/i18n";
+import { setupI18n, ModuleName } from "../lib/i18n";
 import { isApplePlatform } from "../lib/platform";
 import { registerShortcut } from "../lib/shortcuts";
 import { bridgeCommand } from "../lib/bridgecommand";
@@ -200,10 +200,10 @@ export function setTags(tags: string[]): void {
 
 export const i18n = setupI18n({
     modules: [
-        tr.ModuleName.EDITING,
-        tr.ModuleName.KEYBOARD,
-        tr.ModuleName.ACTIONS,
-        tr.ModuleName.BROWSING,
+        ModuleName.EDITING,
+        ModuleName.KEYBOARD,
+        ModuleName.ACTIONS,
+        ModuleName.BROWSING,
     ],
 });
 

--- a/ts/editor/index.ts
+++ b/ts/editor/index.ts
@@ -13,7 +13,7 @@ import type EditorToolbar from "./EditorToolbar.svelte";
 import type TagEditor from "./TagEditor.svelte";
 
 import { filterHTML } from "../html-filter";
-import { setupI18n, ModuleName } from "../lib/i18n";
+import { setupI18n, tr } from "../lib/i18n";
 import { isApplePlatform } from "../lib/platform";
 import { registerShortcut } from "../lib/shortcuts";
 import { bridgeCommand } from "../lib/bridgecommand";
@@ -200,10 +200,10 @@ export function setTags(tags: string[]): void {
 
 export const i18n = setupI18n({
     modules: [
-        ModuleName.EDITING,
-        ModuleName.KEYBOARD,
-        ModuleName.ACTIONS,
-        ModuleName.BROWSING,
+        tr.ModuleName.EDITING,
+        tr.ModuleName.KEYBOARD,
+        tr.ModuleName.ACTIONS,
+        tr.ModuleName.BROWSING,
     ],
 });
 

--- a/ts/editor/label-container.ts
+++ b/ts/editor/label-container.ts
@@ -2,8 +2,7 @@
 // License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
 import type { EditorField } from "./editor-field";
-import * as tr from "../lib/i18n";
-
+import { tr } from "../lib/i18n";
 import { registerShortcut } from "../lib/shortcuts";
 import { bridgeCommand } from "./lib";
 import { appendInParentheses } from "./helpers";

--- a/ts/editor/tsconfig.json
+++ b/ts/editor/tsconfig.json
@@ -1,5 +1,6 @@
 {
     "extends": "../tsconfig.json",
+    "rootDirs": ["../../bazel-bin/ts/editor"],
     "include": ["*"],
     "references": [
         { "path": "../components" },

--- a/ts/graphs/AddedGraph.svelte
+++ b/ts/graphs/AddedGraph.svelte
@@ -13,6 +13,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     import GraphRangeRadios from "./GraphRangeRadios.svelte";
     import TableData from "./TableData.svelte";
 
+    import { tr } from "../lib/i18n";
     import { RevlogRange, GraphRange } from "./graph-helpers";
     import type { TableDatum, SearchEventMap } from "./graph-helpers";
     import type { HistogramData } from "./histogram-graph";
@@ -20,7 +21,6 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     import type { GraphData } from "./added";
 
     export let sourceData: Stats.GraphsResponse | null = null;
-    import * as tr from "../lib/i18n";
     export let preferences: PreferenceStore<Stats.GraphPreferences>;
 
     let histogramData = null as HistogramData | null;

--- a/ts/graphs/ButtonsGraph.svelte
+++ b/ts/graphs/ButtonsGraph.svelte
@@ -4,6 +4,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 -->
 <script lang="typescript">
     import type { Stats } from "../lib/proto";
+    import { tr } from "../lib/i18n";
 
     import Graph from "./Graph.svelte";
     import InputBox from "./InputBox.svelte";
@@ -15,7 +16,6 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     import { defaultGraphBounds, GraphRange, RevlogRange } from "./graph-helpers";
 
     export let sourceData: Stats.GraphsResponse | null = null;
-    import * as tr from "../lib/i18n";
     export let revlogRange: RevlogRange;
 
     let graphRange: GraphRange = GraphRange.Year;

--- a/ts/graphs/CalendarGraph.svelte
+++ b/ts/graphs/CalendarGraph.svelte
@@ -3,10 +3,10 @@ Copyright: Ankitects Pty Ltd and contributors
 License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 -->
 <script lang="typescript">
+    import { createEventDispatcher } from "svelte";
     import type { Stats } from "../lib/proto";
     import type { PreferenceStore } from "../sveltelib/preferences";
-
-    import { createEventDispatcher } from "svelte";
+    import { tr } from "../lib/i18n";
 
     import Graph from "./Graph.svelte";
     import InputBox from "./InputBox.svelte";
@@ -21,7 +21,6 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     export let sourceData: Stats.GraphsResponse;
     export let preferences: PreferenceStore<Stats.GraphPreferences>;
     export let revlogRange: RevlogRange;
-    import * as tr from "../lib/i18n";
     export let nightMode: boolean;
 
     let { calendarFirstDayOfWeek } = preferences;

--- a/ts/graphs/CardCounts.svelte
+++ b/ts/graphs/CardCounts.svelte
@@ -3,20 +3,19 @@ Copyright: Ankitects Pty Ltd and contributors
 License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 -->
 <script lang="typescript">
-    import { createEventDispatcher } from "svelte";
-    import type { Stats } from "../lib/proto";
-    import type { PreferenceStore } from "../sveltelib/preferences";
-
     import Graph from "./Graph.svelte";
     import InputBox from "./InputBox.svelte";
 
+    import { createEventDispatcher } from "svelte";
+    import type { Stats } from "../lib/proto";
+    import type { PreferenceStore } from "../sveltelib/preferences";
+    import { tr as trI18n } from "../lib/i18n";
     import { defaultGraphBounds } from "./graph-helpers";
     import type { SearchEventMap } from "./graph-helpers";
     import { gatherData, renderCards } from "./card-counts";
     import type { GraphData, TableDatum } from "./card-counts";
 
     export let sourceData: Stats.GraphsResponse;
-    import * as tr2 from "../lib/i18n";
     export let preferences: PreferenceStore<Stats.GraphPreferences>;
 
     let { cardCountsSeparateInactive, browserLinksSupported } = preferences;
@@ -36,8 +35,8 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         tableData = renderCards(svg as any, bounds, graphData);
     }
 
-    const label = tr2.statisticsCountsSeparateSuspendedBuriedCards();
-    const total = tr2.statisticsCountsTotalCards();
+    const label = trI18n.statisticsCountsSeparateSuspendedBuriedCards();
+    const total = trI18n.statisticsCountsTotalCards();
 </script>
 
 <Graph title={graphData.title}>

--- a/ts/graphs/EaseGraph.svelte
+++ b/ts/graphs/EaseGraph.svelte
@@ -4,10 +4,10 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 -->
 <script lang="typescript">
     import type { Stats } from "../lib/proto";
-    import * as tr from "../lib/i18n";
     import type { PreferenceStore } from "../sveltelib/preferences";
 
     import { createEventDispatcher } from "svelte";
+    import { tr } from "../lib/i18n";
 
     import HistogramGraph from "./HistogramGraph.svelte";
     import Graph from "./Graph.svelte";

--- a/ts/graphs/FutureDue.svelte
+++ b/ts/graphs/FutureDue.svelte
@@ -14,6 +14,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     import TableData from "./TableData.svelte";
     import type { PreferenceStore } from "../sveltelib/preferences";
 
+    import { tr } from "../lib/i18n";
     import type { HistogramData } from "./histogram-graph";
     import { GraphRange, RevlogRange } from "./graph-helpers";
     import type { TableDatum, SearchEventMap } from "./graph-helpers";
@@ -21,7 +22,6 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     import type { GraphData } from "./future-due";
 
     export let sourceData: Stats.GraphsResponse | null = null;
-    import * as tr from "../lib/i18n";
     export let preferences: PreferenceStore<Stats.GraphPreferences>;
 
     const dispatch = createEventDispatcher<SearchEventMap>();

--- a/ts/graphs/GraphRangeRadios.svelte
+++ b/ts/graphs/GraphRangeRadios.svelte
@@ -3,10 +3,10 @@ Copyright: Ankitects Pty Ltd and contributors
 License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 -->
 <script lang="typescript">
+    import { tr } from "../lib/i18n";
     import { RevlogRange, GraphRange } from "./graph-helpers";
     import { timeSpan, MONTH, YEAR } from "../lib/time";
 
-    import * as tr from "../lib/i18n";
     export let revlogRange: RevlogRange;
     export let graphRange: GraphRange;
     export let followRevlog: boolean = false;

--- a/ts/graphs/HourGraph.svelte
+++ b/ts/graphs/HourGraph.svelte
@@ -3,8 +3,6 @@ Copyright: Ankitects Pty Ltd and contributors
 License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 -->
 <script lang="typescript">
-    import type { Stats } from "../lib/proto";
-
     import Graph from "./Graph.svelte";
     import InputBox from "./InputBox.svelte";
     import AxisTicks from "./AxisTicks.svelte";
@@ -12,11 +10,13 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     import GraphRangeRadios from "./GraphRangeRadios.svelte";
     import CumulativeOverlay from "./CumulativeOverlay.svelte";
     import HoverColumns from "./HoverColumns.svelte";
+
+    import type { Stats } from "../lib/proto";
+    import { tr } from "../lib/i18n";
     import { defaultGraphBounds, RevlogRange, GraphRange } from "./graph-helpers";
     import { renderHours } from "./hours";
 
     export let sourceData: Stats.GraphsResponse | null = null;
-    import * as tr from "../lib/i18n";
     export let revlogRange: RevlogRange;
     let graphRange: GraphRange = GraphRange.Year;
 

--- a/ts/graphs/IntervalsGraph.svelte
+++ b/ts/graphs/IntervalsGraph.svelte
@@ -3,17 +3,16 @@ Copyright: Ankitects Pty Ltd and contributors
 License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 -->
 <script lang="typescript">
-    import { timeSpan, MONTH } from "../lib/time";
-
-    import type { Stats } from "../lib/proto";
-    import type { PreferenceStore } from "../sveltelib/preferences";
-    import { createEventDispatcher } from "svelte";
-
     import Graph from "./Graph.svelte";
     import InputBox from "./InputBox.svelte";
     import HistogramGraph from "./HistogramGraph.svelte";
     import TableData from "./TableData.svelte";
 
+    import { timeSpan, MONTH } from "../lib/time";
+    import { tr } from "../lib/i18n";
+    import type { Stats } from "../lib/proto";
+    import type { PreferenceStore } from "../sveltelib/preferences";
+    import { createEventDispatcher } from "svelte";
     import type { HistogramData } from "./histogram-graph";
     import {
         gatherIntervalData,
@@ -24,7 +23,6 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     import type { TableDatum, SearchEventMap } from "./graph-helpers";
 
     export let sourceData: Stats.GraphsResponse | null = null;
-    import * as tr from "../lib/i18n";
     export let preferences: PreferenceStore<Stats.GraphPreferences>;
 
     const dispatch = createEventDispatcher<SearchEventMap>();

--- a/ts/graphs/NoDataOverlay.svelte
+++ b/ts/graphs/NoDataOverlay.svelte
@@ -4,8 +4,10 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 -->
 <script lang="typescript">
     import type { GraphBounds } from "./graph-helpers";
+    import { tr } from "../lib/i18n";
+
     export let bounds: GraphBounds;
-    import * as tr from "../lib/i18n";
+
     const noData = tr.statisticsNoData();
 </script>
 

--- a/ts/graphs/RangeBox.svelte
+++ b/ts/graphs/RangeBox.svelte
@@ -3,11 +3,10 @@ Copyright: Ankitects Pty Ltd and contributors
 License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 -->
 <script lang="typescript">
-    import type { Writable } from "svelte/store";
-
     import InputBox from "./InputBox.svelte";
 
-    import * as tr from "../lib/i18n";
+    import type { Writable } from "svelte/store";
+    import { tr } from "../lib/i18n";
     import { RevlogRange, daysToRevlogRange } from "./graph-helpers";
 
     enum SearchRange {

--- a/ts/graphs/ReviewsGraph.svelte
+++ b/ts/graphs/ReviewsGraph.svelte
@@ -3,8 +3,6 @@ Copyright: Ankitects Pty Ltd and contributors
 License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 -->
 <script lang="typescript">
-    import type { Stats } from "../lib/proto";
-
     import Graph from "./Graph.svelte";
     import InputBox from "./InputBox.svelte";
     import NoDataOverlay from "./NoDataOverlay.svelte";
@@ -14,6 +12,8 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     import AxisTicks from "./AxisTicks.svelte";
     import HoverColumns from "./HoverColumns.svelte";
 
+    import type { Stats } from "../lib/proto";
+    import { tr } from "../lib/i18n";
     import { defaultGraphBounds, RevlogRange, GraphRange } from "./graph-helpers";
     import type { TableDatum } from "./graph-helpers";
     import { gatherData, renderReviews } from "./reviews";
@@ -21,7 +21,6 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
     export let sourceData: Stats.GraphsResponse | null = null;
     export let revlogRange: RevlogRange;
-    import * as tr from "../lib/i18n";
 
     let graphData: GraphData | null = null;
 

--- a/ts/graphs/TableData.svelte
+++ b/ts/graphs/TableData.svelte
@@ -4,12 +4,12 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 -->
 <script lang="typescript">
     import type { TableDatum } from "./graph-helpers";
-    import { i18n } from "../lib/i18n";
+    import { direction } from "../lib/i18n";
     export let tableData: TableDatum[];
 </script>
 
 <div>
-    <table dir={i18n.direction()}>
+    <table dir={direction()}>
         {#each tableData as { label, value }}
             <tr>
                 <td class="align-end">{label}:</td>

--- a/ts/graphs/added.ts
+++ b/ts/graphs/added.ts
@@ -19,10 +19,10 @@ import {
 import type { Bin } from "d3";
 import type { HistogramData } from "./histogram-graph";
 
+import { tr } from "../lib/i18n";
 import { dayLabel } from "../lib/time";
 import { GraphRange } from "./graph-helpers";
 import type { TableDatum, SearchDispatch } from "./graph-helpers";
-import * as tr from "../lib/i18n";
 
 export interface GraphData {
     daysAdded: number[];

--- a/ts/graphs/buttons.ts
+++ b/ts/graphs/buttons.ts
@@ -6,8 +6,6 @@
 @typescript-eslint/no-explicit-any: "off",
  */
 
-import { Stats } from "../lib/proto";
-
 import {
     interpolateRdYlGn,
     select,
@@ -19,6 +17,8 @@ import {
     axisLeft,
     sum,
 } from "d3";
+import { Stats } from "../lib/proto";
+import { tr } from "../lib/i18n";
 import { showTooltip, hideTooltip } from "./tooltip";
 import {
     GraphBounds,
@@ -26,7 +26,6 @@ import {
     GraphRange,
     millisecondCutoffForRange,
 } from "./graph-helpers";
-import * as tr from "../lib/i18n";
 
 type ButtonCounts = [number, number, number, number];
 

--- a/ts/graphs/calendar.ts
+++ b/ts/graphs/calendar.ts
@@ -29,7 +29,7 @@ import {
     SearchDispatch,
 } from "./graph-helpers";
 import { clickableClass } from "./graph-styles";
-import { tr, i18n } from "../lib/i18n";
+import { tr, weekdayLabel, toLocaleString } from "../lib/i18n";
 
 export interface GraphData {
     // indexed by day, where day is relative to today
@@ -154,7 +154,7 @@ export function renderCalendar(
         .interpolator((n) => interpolateBlues(cappedRange(n)!));
 
     function tooltipText(d: DayDatum): string {
-        const date = d.date.toLocaleString(i18n.langs, {
+        const date = toLocaleString(d.date, {
             weekday: "long",
             year: "numeric",
             month: "long",
@@ -171,7 +171,7 @@ export function renderCalendar(
         .selectAll("text")
         .data(sourceData.weekdayLabels)
         .join("text")
-        .text((d: number) => i18n.weekdayLabel(d))
+        .text((d: number) => weekdayLabel(d))
         .attr("width", x(-1)! - 2)
         .attr("height", height - 2)
         .attr("x", x(1)! - 3)

--- a/ts/graphs/calendar.ts
+++ b/ts/graphs/calendar.ts
@@ -29,8 +29,7 @@ import {
     SearchDispatch,
 } from "./graph-helpers";
 import { clickableClass } from "./graph-styles";
-import { i18n } from "../lib/i18n";
-import * as tr from "../lib/i18n";
+import { tr, i18n } from "../lib/i18n";
 
 export interface GraphData {
     // indexed by day, where day is relative to today

--- a/ts/graphs/card-counts.ts
+++ b/ts/graphs/card-counts.ts
@@ -6,6 +6,7 @@
 @typescript-eslint/no-explicit-any: "off",
  */
 
+import { tr } from "../lib/i18n";
 import { CardQueue, CardType } from "../lib/cards";
 import type { Stats, Cards } from "../lib/proto";
 import {
@@ -21,8 +22,6 @@ import {
     cumsum,
 } from "d3";
 import type { GraphBounds } from "./graph-helpers";
-
-import * as tr from "../lib/i18n";
 
 type Count = [string, number, boolean, string];
 export interface GraphData {

--- a/ts/graphs/ease.ts
+++ b/ts/graphs/ease.ts
@@ -16,11 +16,10 @@ import {
     interpolateRdYlGn,
 } from "d3";
 import type { Bin, ScaleLinear } from "d3";
+import { tr } from "../lib/i18n";
 import { CardType } from "../lib/cards";
 import type { HistogramData } from "./histogram-graph";
-
 import type { TableDatum, SearchDispatch } from "./graph-helpers";
-import * as tr from "../lib/i18n";
 
 export interface GraphData {
     eases: number[];

--- a/ts/graphs/future-due.ts
+++ b/ts/graphs/future-due.ts
@@ -17,13 +17,13 @@ import {
     interpolateGreens,
 } from "d3";
 import type { Bin } from "d3";
+import { tr } from "../lib/i18n";
 import { CardQueue } from "../lib/cards";
 import type { HistogramData } from "./histogram-graph";
 import { dayLabel } from "../lib/time";
 
 import { GraphRange } from "./graph-helpers";
 import type { TableDatum, SearchDispatch } from "./graph-helpers";
-import * as tr from "../lib/i18n";
 
 export interface GraphData {
     dueCounts: Map<number, number>;

--- a/ts/graphs/hours.ts
+++ b/ts/graphs/hours.ts
@@ -21,6 +21,7 @@ import {
     curveBasis,
 } from "d3";
 
+import { tr } from "../lib/i18n";
 import { showTooltip, hideTooltip } from "./tooltip";
 import {
     GraphBounds,
@@ -29,7 +30,6 @@ import {
     millisecondCutoffForRange,
 } from "./graph-helpers";
 import { oddTickClass } from "./graph-styles";
-import * as tr from "../lib/i18n";
 
 interface Hour {
     hour: number;

--- a/ts/graphs/index.ts
+++ b/ts/graphs/index.ts
@@ -3,7 +3,7 @@
 
 import type { SvelteComponent } from "svelte/internal";
 
-import { setupI18n, ModuleName } from "../lib/i18n";
+import { setupI18n, tr } from "../lib/i18n";
 import { checkNightMode } from "../lib/nightmode";
 
 import GraphsPage from "./GraphsPage.svelte";
@@ -33,16 +33,18 @@ export function graphs(
 ): void {
     const nightMode = checkNightMode();
 
-    setupI18n({ modules: [ModuleName.STATISTICS, ModuleName.SCHEDULING] }).then(() => {
-        new GraphsPage({
-            target,
-            props: {
-                graphs,
-                nightMode,
-                initialSearch: search,
-                initialDays: days,
-                controller,
-            },
-        });
-    });
+    setupI18n({ modules: [tr.ModuleName.STATISTICS, tr.ModuleName.SCHEDULING] }).then(
+        () => {
+            new GraphsPage({
+                target,
+                props: {
+                    graphs,
+                    nightMode,
+                    initialSearch: search,
+                    initialDays: days,
+                    controller,
+                },
+            });
+        }
+    );
 }

--- a/ts/graphs/index.ts
+++ b/ts/graphs/index.ts
@@ -3,7 +3,7 @@
 
 import type { SvelteComponent } from "svelte/internal";
 
-import { setupI18n, tr } from "../lib/i18n";
+import { setupI18n, ModuleName } from "../lib/i18n";
 import { checkNightMode } from "../lib/nightmode";
 
 import GraphsPage from "./GraphsPage.svelte";
@@ -33,18 +33,16 @@ export function graphs(
 ): void {
     const nightMode = checkNightMode();
 
-    setupI18n({ modules: [tr.ModuleName.STATISTICS, tr.ModuleName.SCHEDULING] }).then(
-        () => {
-            new GraphsPage({
-                target,
-                props: {
-                    graphs,
-                    nightMode,
-                    initialSearch: search,
-                    initialDays: days,
-                    controller,
-                },
-            });
-        }
-    );
+    setupI18n({ modules: [ModuleName.STATISTICS, ModuleName.SCHEDULING] }).then(() => {
+        new GraphsPage({
+            target,
+            props: {
+                graphs,
+                nightMode,
+                initialSearch: search,
+                initialDays: days,
+                controller,
+            },
+        });
+    });
 }

--- a/ts/graphs/intervals.ts
+++ b/ts/graphs/intervals.ts
@@ -18,12 +18,12 @@ import {
     interpolateBlues,
 } from "d3";
 import type { Bin } from "d3";
+import { tr } from "../lib/i18n";
+import { timeSpan } from "../lib/time";
 import { CardType } from "../lib/cards";
 import type { HistogramData } from "./histogram-graph";
 
 import type { TableDatum, SearchDispatch } from "./graph-helpers";
-import { timeSpan } from "../lib/time";
-import * as tr from "../lib/i18n";
 
 export interface IntervalGraphData {
     intervals: number[];

--- a/ts/graphs/reviews.ts
+++ b/ts/graphs/reviews.ts
@@ -32,10 +32,10 @@ import {
 } from "d3";
 import type { Bin } from "d3";
 
+import { tr } from "../lib/i18n";
 import type { TableDatum } from "./graph-helpers";
 import { GraphBounds, setDataAvailable, GraphRange } from "./graph-helpers";
 import { showTooltip, hideTooltip } from "./tooltip";
-import * as tr from "../lib/i18n";
 
 interface Reviews {
     learn: number;

--- a/ts/graphs/today.ts
+++ b/ts/graphs/today.ts
@@ -3,8 +3,7 @@
 
 import { Stats } from "../lib/proto";
 import { studiedToday } from "../lib/time";
-
-import * as tr from "../lib/i18n";
+import { tr } from "../lib/i18n";
 
 export interface TodayData {
     title: string;

--- a/ts/html-filter/tsconfig.json
+++ b/ts/html-filter/tsconfig.json
@@ -1,5 +1,6 @@
 {
     "extends": "../tsconfig.json",
+    "rootDirs": ["../../bazel-bin/ts/html-filter"],
     "include": ["*"],
     "references": [],
     "compilerOptions": {

--- a/ts/lib/BUILD.bazel
+++ b/ts/lib/BUILD.bazel
@@ -6,6 +6,10 @@ load("@rules_python//python:defs.bzl", "py_binary")
 load("@py_deps//:requirements.bzl", "requirement")
 load("//ts:jest.bzl", "jest_test")
 
+_generated = [
+    "i18n-generated.ts",
+]
+
 protobufjs_library(
     name = "backend_proto",
     proto = "//proto:backend_proto_lib",
@@ -35,9 +39,11 @@ genrule(
 
 typescript(
     name = "lib",
-    generated = [
-        ":i18n-generated.ts",
-    ],
+    srcs = glob(
+        ["*.ts"],
+        exclude = _generated,
+    ),
+    generated = [":" + file for file in _generated],
     deps = [
         ":backend_proto",
         "@npm//@fluent/bundle",
@@ -52,9 +58,9 @@ typescript(
 # Tests
 ################
 
-prettier_test()
+prettier_test(exclude = _generated)
 
-eslint_test()
+eslint_test(exclude = _generated)
 
 jest_test(
     deps = [

--- a/ts/lib/BUILD.bazel
+++ b/ts/lib/BUILD.bazel
@@ -25,7 +25,7 @@ py_binary(
 
 genrule(
     name = "fluent_gen",
-    outs = ["i18n.ts"],
+    outs = ["i18n-generated.ts"],
     cmd = "$(location genfluent) $(location //rslib/i18n:strings.json) $@",
     tools = [
         "genfluent",
@@ -36,7 +36,7 @@ genrule(
 typescript(
     name = "lib",
     generated = [
-        ":i18n.ts",
+        ":i18n-generated.ts",
     ],
     deps = [
         ":backend_proto",

--- a/ts/lib/BUILD.bazel
+++ b/ts/lib/BUILD.bazel
@@ -6,8 +6,13 @@ load("@rules_python//python:defs.bzl", "py_binary")
 load("@py_deps//:requirements.bzl", "requirement")
 load("//ts:jest.bzl", "jest_test")
 
-_generated = [
-    "i18n-generated.ts",
+_i18n_files = [
+    "i18n-translate.ts",
+    "i18n-modules.ts",
+]
+
+_generated = _i18n_files + [
+    "backend_proto.d.ts",
 ]
 
 protobufjs_library(
@@ -29,8 +34,8 @@ py_binary(
 
 genrule(
     name = "fluent_gen",
-    outs = ["i18n-generated.ts"],
-    cmd = "$(location genfluent) $(location //rslib/i18n:strings.json) $@",
+    outs = _i18n_files,
+    cmd = "$(location genfluent) $(location //rslib/i18n:strings.json) $(OUTS)",
     tools = [
         "genfluent",
         "//rslib/i18n:strings.json",

--- a/ts/lib/backend_proto.d.ts
+++ b/ts/lib/backend_proto.d.ts
@@ -1,0 +1,1 @@
+../../bazel-bin/ts/lib/backend_proto.d.ts

--- a/ts/lib/genfluent.py
+++ b/ts/lib/genfluent.py
@@ -7,7 +7,7 @@ from typing import List, Literal, TypedDict
 
 import stringcase
 
-strings_json, outfile = sys.argv[1:]
+strings_json, translate_out, modules_out = sys.argv[1:]
 modules = json.load(open(strings_json, encoding="utf8"))
 
 
@@ -101,17 +101,17 @@ def module_names() -> str:
     return buf
 
 
-out = ""
-
-out += methods()
-out += module_names()
-
-open(outfile, "wb").write(
-    (
-        """// Copyright: Ankitects Pty Ltd and contributors
+def write(outfile, out) -> None:
+    open(outfile, "wb").write(
+        (
+            f"""// Copyright: Ankitects Pty Ltd and contributors
 // License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
 """
-        + out
-    ).encode("utf8")
-)
+            + out
+        ).encode("utf8")
+    )
+
+
+write(translate_out, str(methods()))
+write(modules_out, str(module_names()))

--- a/ts/lib/genfluent.py
+++ b/ts/lib/genfluent.py
@@ -18,8 +18,7 @@ class Variable(TypedDict):
 
 def methods() -> str:
     out = [
-        'import { i18n } from "./i18n_helpers";',
-        'export { i18n, setupI18n } from "./i18n_helpers";',
+        'import { i18n } from "./i18n";',
     ]
     for module in modules:
         for translation in module["translations"]:

--- a/ts/lib/genfluent.py
+++ b/ts/lib/genfluent.py
@@ -18,7 +18,7 @@ class Variable(TypedDict):
 
 def methods() -> str:
     out = [
-        'import { i18n } from "./i18n";',
+        'import { translate } from "./i18n";',
     ]
     for module in modules:
         for translation in module["translations"]:
@@ -30,7 +30,7 @@ def methods() -> str:
                 f"""
 /** {doc} */
 export function {key}({arg_types}): string {{
-    return i18n.translate("{translation["key"]}"{args})
+    return translate("{translation["key"]}"{args})
 }}
 """
             )

--- a/ts/lib/i18n-generated.ts
+++ b/ts/lib/i18n-generated.ts
@@ -1,1 +1,0 @@
-../../bazel-bin/ts/lib/i18n-generated.ts

--- a/ts/lib/i18n-generated.ts
+++ b/ts/lib/i18n-generated.ts
@@ -1,0 +1,1 @@
+../../bazel-bin/ts/lib/i18n-generated.ts

--- a/ts/lib/i18n-modules.ts
+++ b/ts/lib/i18n-modules.ts
@@ -1,0 +1,1 @@
+../../bazel-bin/ts/lib/i18n-modules.ts

--- a/ts/lib/i18n-translate.ts
+++ b/ts/lib/i18n-translate.ts
@@ -1,0 +1,1 @@
+../../bazel-bin/ts/lib/i18n-translate.ts

--- a/ts/lib/i18n.ts
+++ b/ts/lib/i18n.ts
@@ -79,7 +79,7 @@ export class I18n {
 // global singleton
 export const i18n = new I18n();
 
-import type { ModuleName } from "./i18n";
+import type { ModuleName } from "./i18n-generated";
 
 export async function setupI18n(args: { modules: ModuleName[] }): Promise<void> {
     const resp = await fetch("/_anki/i18nResources", {
@@ -102,3 +102,5 @@ export async function setupI18n(args: { modules: ModuleName[] }): Promise<void> 
     }
     i18n.langs = json.langs;
 }
+
+export * as tr from "./i18n-generated";

--- a/ts/lib/i18n.ts
+++ b/ts/lib/i18n.ts
@@ -79,7 +79,7 @@ export class I18n {
 // global singleton
 export const i18n = new I18n();
 
-import type { ModuleName } from "./i18n-generated";
+import type { ModuleName } from "./i18n-modules";
 
 export async function setupI18n(args: { modules: ModuleName[] }): Promise<void> {
     const resp = await fetch("/_anki/i18nResources", {
@@ -103,4 +103,5 @@ export async function setupI18n(args: { modules: ModuleName[] }): Promise<void> 
     i18n.langs = json.langs;
 }
 
-export * as tr from "./i18n-generated";
+export { ModuleName } from "./i18n-modules";
+export * as tr from "./i18n-translate";

--- a/ts/lib/keys.ts
+++ b/ts/lib/keys.ts
@@ -1,7 +1,7 @@
 // Copyright: Ankitects Pty Ltd and contributors
 // License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
-import * as tr from "./i18n";
+import { tr } from "./i18n";
 import { isApplePlatform } from "./platform";
 
 // those are the modifiers that Anki works with

--- a/ts/lib/proto.ts
+++ b/ts/lib/proto.ts
@@ -2,6 +2,7 @@
 // License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
 import { anki } from "./backend_proto";
+
 import Cards = anki.cards;
 import DeckConfig = anki.deckconfig;
 import Notetypes = anki.notetypes;

--- a/ts/lib/time.ts
+++ b/ts/lib/time.ts
@@ -1,7 +1,7 @@
 // Copyright: Ankitects Pty Ltd and contributors
 // License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
-import * as tr from "./i18n";
+import { tr } from "./i18n";
 
 export const SECOND = 1.0;
 export const MINUTE = 60.0 * SECOND;

--- a/ts/lib/tsconfig.json
+++ b/ts/lib/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "extends": "../tsconfig.json",
-    "include": ["*", "../../bazel-bin/ts/lib"],
+    "include": ["*"],
+    "rootDirs": ["../../bazel-bin/ts/lib"],
     "references": [],
     "compilerOptions": {
         "types": ["jest"]

--- a/ts/lib/tsconfig.json
+++ b/ts/lib/tsconfig.json
@@ -1,6 +1,6 @@
 {
     "extends": "../tsconfig.json",
-    "include": ["*", "../../bazel-bin/ts/lib/*"],
+    "include": ["*", "../../bazel-bin/ts/lib"],
     "references": [],
     "compilerOptions": {
         "types": ["jest"]

--- a/ts/reviewer/tsconfig.json
+++ b/ts/reviewer/tsconfig.json
@@ -1,5 +1,6 @@
 {
     "extends": "../tsconfig.json",
+    "rootDirs": ["../../bazel-bin/ts/reviewer"],
     "include": ["*"],
     "references": [{ "path": "../lib" }]
 }

--- a/ts/sveltelib/tsconfig.json
+++ b/ts/sveltelib/tsconfig.json
@@ -1,5 +1,6 @@
 {
     "extends": "../tsconfig.json",
+    "rootDirs": ["../../bazel-bin/ts/sveltelib"],
     "include": ["*"],
     "references": [{ "path": "../lib" }]
 }

--- a/ts/tsconfig.json
+++ b/ts/tsconfig.json
@@ -32,11 +32,6 @@
         // "outDir": "dist",
         // "rootDir": "..",
         "rootDir": ".",
-        "rootDirs": [
-            ".",
-            // for VS code
-            "../bazel-bin/ts"
-        ],
         "baseUrl": ".",
         "paths": {},
         "types": [],


### PR DESCRIPTION
Moving to `ts_project` has broken types for me on both VS Code and Neovim. This is an error message:

> [ts 2607] [E] Element does not support attributes because type definitions
 ⇒  are missing for this Svelte Component or element cannot be used as such.
>
> Underlying error:
JSX element class does not support attributes because it does not have a
⇒  '$prop_def' property.
─────────────────────────────────
[ts 2786] [E] Type definitions are missing for this Svelte Component. It
⇒  needs a class definition with at least the property '$prop_def' which
⇒  should contain a map of input property definitions.
Example:
  class ComponentName { $prop_def: { propertyName: string; } }
If you are using Svelte 3.31+, use SvelteComponentTyped:
  import type { SvelteComponentTyped } from "svelte";
  class ComponentName extends SvelteComponentTyped<{propertyName: string;}> {}
> 
> Underlying error:
'ButtonGroup' cannot be used as a JSX component.
  Its instance type 'ButtonGroup__SvelteComponent_' is not a valid JSX
⇒  element.
    Property '$prop_def' is missing in type 'ButtonGroup__SvelteComponent_'
⇒  but required in type 'ElementClass'.

This PR fixes types for me. Obviously we should find a solution that fixes it for everybody :)

To fix the typings for svelte files, I had to move the `rootDirs` parameter inside the sub projects.
To fix the typings for `tr` and `backend_proto` I had to reinstate the symlinks you originally had added.

I also used the opportunity to rewrite `i18n` quite a bit. The old `i18n_helpers` is now the main `i18n` file. As the generated files are more difficult to handle, I thought it would make more sense, if the other subprojects depended on the one actual file, not on generated files. I also removed the singleton class and replaced it with ordinary functions.