### PR TITLE
Fix deck change after toggling sticky fields

### DIFF
--- a/qt/aqt/editor.py
+++ b/qt/aqt/editor.py
@@ -403,7 +403,9 @@ $editorToolbar.then(({{ toolbar }}) => toolbar.appendGroup({{
 
                 result.append(fld["sticky"])
 
-            update_notetype_legacy(parent=self.mw, notetype=model).run_in_background()
+            update_notetype_legacy(parent=self.mw, notetype=model).run_in_background(
+                initiator=self
+            )
 
             return result
 
@@ -416,7 +418,9 @@ $editorToolbar.then(({{ toolbar }}) => toolbar.appendGroup({{
             new_state = not fld["sticky"]
             fld["sticky"] = new_state
 
-            update_notetype_legacy(parent=self.mw, notetype=model).run_in_background()
+            update_notetype_legacy(parent=self.mw, notetype=model).run_in_background(
+                initiator=self
+            )
 
             return new_state
 


### PR DESCRIPTION
`AddCards.on_notetype_change` was being called by `AddCards.on_operation_did_execute` because `initiator` was not specified, causing the current deck to change if the "Change deck depending on note type" preferences option is enabled.