### PR TITLE
Mac bazelrc build tip

### DIFF
--- a/docs/mac.md
+++ b/docs/mac.md
@@ -38,6 +38,16 @@ $ ln -sf /usr/local/bin/{python3.9,python}
 This linking will not work if you're using the system Python from Big Sur,
 which is one of the reasons why we recommend using Python from python.org.
 
+But even so, if you still have a Python 2 binary on your system linked to 
+/usr/bin/python, it can happen that Bazel uses that, causing the build 
+process to error. In that case you can force Bazel to use the symlinked 
+/usr/local/python instead of /usr/bin/python by putting the following into 
+a file called user.bazelrc at the top of this repo before proceeding.
+
+```
+build --action_env=PYO3_PYTHON=/usr/local/bin/python
+```
+
 ## Running Anki during development
 
 From the top level of Anki's source folder:

--- a/docs/mac.md
+++ b/docs/mac.md
@@ -39,10 +39,11 @@ This linking will not work if you're using the system Python from Big Sur,
 which is one of the reasons why we recommend using Python from python.org.
 
 But even so, if you still have a Python 2 binary on your system linked to 
-/usr/bin/python, it can happen that Bazel uses that, causing the build 
-process to error. In that case you can force Bazel to use the symlinked 
-/usr/local/python instead of /usr/bin/python by putting the following into 
-a file called user.bazelrc at the top of this repo before proceeding.
+/usr/bin/python, it can happen that Bazel uses it and the build process 
+errors. In that case you might want to try forcing Bazel to use the 
+Python 3 binary by putting the following into a file called user.bazelrc at 
+the top of this repo (assuming /usr/local/bin/python links to your Python 
+3.9 binary).
 
 ```
 build --action_env=PYO3_PYTHON=/usr/local/bin/python


### PR DESCRIPTION
This PR contains a suggestion to add a tip from the Linux-specific build instructions to the Mac-specific build instructions as well. It helped me in getting over an issue I had trying to build Anki on MacOS Big Sur 11.6 with Bazel 4.2.1.

I followed the current Mac build instructions and downloaded Python 3.9 from python.org and symlinked it to /usr/local/bin/python. Despite that, Bazel still kept falling back to my system's Python 2 binary, which is hard-symlinked to /usr/bin/python. The only way to convince it was to follow the instruction from the Linux-specific build instructions and add `build --action_env=PYO3_PYTHON=/usr/local/bin/python` to the `user.bazelrc`.
