### PR TITLE
Fix invalid 'noteCards' browser column being used

### DIFF
--- a/pylib/anki/browser.py
+++ b/pylib/anki/browser.py
@@ -31,4 +31,4 @@ class BrowserConfig:
 
 class BrowserDefaults:
     CARD_COLUMNS = ["noteFld", "template", "cardDue", "deck"]
-    NOTE_COLUMNS = ["noteFld", "note", "noteCards", "noteTags"]
+    NOTE_COLUMNS = ["noteFld", "note", "template", "noteTags"]


### PR DESCRIPTION
I guess `noteCards` is a leftover from Rumo's work on the browser.

The column shows as added by an add-on.
![image](https://user-images.githubusercontent.com/41397710/136886550-b47c5419-8b22-4e6a-a89a-2533e83cac35.png)
