### PR TITLE
Increased max visible items from clayout_top.ui

### DIFF
--- a/qt/aqt/forms/clayout_top.ui
+++ b/qt/aqt/forms/clayout_top.ui
@@ -45,9 +45,12 @@
       <widget class="QComboBox" name="templatesBox">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-         <horstretch>10</horstretch>
+         <horstretch>30</horstretch>
          <verstretch>0</verstretch>
         </sizepolicy>
+       </property>
+       <property name="maxVisibleItems">
+        <number>30</number>
        </property>
       </widget>
      </item>


### PR DESCRIPTION
I was working with a big deck and I quite troublesome to organize things. Then, I increased its default size. I think 30 is a better value, even if you have like 50 fields because it would only hide 40% of them, instead of 80%.

Image for reference:
![image](https://user-images.githubusercontent.com/5332158/137042249-43235da5-4797-40fe-b2d2-d5ea5115294c.png)
