### PR TITLE
New cards: add reversed insertion order option

### DIFF
--- a/ftl/core/deck-config.ftl
+++ b/ftl/core/deck-config.ftl
@@ -60,6 +60,7 @@ deck-config-new-insertion-order-tooltip =
     this option will automatically update the existing position of new cards.
 deck-config-new-insertion-order-sequential = Sequential (oldest cards first)
 deck-config-new-insertion-order-random = Random
+deck-config-new-insertion-order-sequential-reversed = Sequential (newest cards first)
 
 ## Lapses section
 

--- a/proto/anki/deckconfig.proto
+++ b/proto/anki/deckconfig.proto
@@ -30,6 +30,7 @@ message DeckConfig {
     enum NewCardInsertOrder {
       NEW_CARD_INSERT_ORDER_DUE = 0;
       NEW_CARD_INSERT_ORDER_RANDOM = 1;
+      NEW_CARD_INSERT_ORDER_DUE_REVERSED = 2;
     }
     enum NewCardGatherPriority {
       NEW_CARD_GATHER_PRIORITY_DECK = 0;

--- a/rslib/src/deckconfig/schema11.rs
+++ b/rslib/src/deckconfig/schema11.rs
@@ -123,6 +123,7 @@ where
 pub enum NewCardOrderSchema11 {
     Random = 0,
     Due = 1,
+    DueReversed = 2,
 }
 
 impl Default for NewCardOrderSchema11 {
@@ -296,6 +297,7 @@ impl From<DeckConfSchema11> for DeckConfig {
                 new_card_insert_order: match c.new.order {
                     NewCardOrderSchema11::Random => NewCardInsertOrder::Random,
                     NewCardOrderSchema11::Due => NewCardInsertOrder::Due,
+                    NewCardOrderSchema11::DueReversed => NewCardInsertOrder::DueReversed,
                 } as i32,
                 new_card_gather_priority: c.new_gather_priority,
                 new_card_sort_order: c.new_sort_order,
@@ -366,6 +368,7 @@ impl From<DeckConfig> for DeckConfSchema11 {
                 order: match new_order {
                     NewCardInsertOrder::Random => NewCardOrderSchema11::Random,
                     NewCardInsertOrder::Due => NewCardOrderSchema11::Due,
+                    NewCardInsertOrder::DueReversed => NewCardOrderSchema11::DueReversed,
                 },
                 per_day: i.new_per_day,
                 other: new_other,

--- a/rslib/src/notetype/cardgen.rs
+++ b/rslib/src/notetype/cardgen.rs
@@ -315,6 +315,7 @@ impl Collection {
         {
             crate::deckconfig::NewCardInsertOrder::Random => Ok(random_position(next_pos)),
             crate::deckconfig::NewCardInsertOrder::Due => Ok(next_pos),
+            crate::deckconfig::NewCardInsertOrder::DueReversed => Ok(next_pos.wrapping_neg()),
         }
     }
 

--- a/rslib/src/scheduler/new.rs
+++ b/rslib/src/scheduler/new.rs
@@ -3,6 +3,8 @@
 
 use std::collections::{HashMap, HashSet};
 
+use std::cmp::Reverse;
+
 use rand::seq::SliceRandom;
 
 use crate::{
@@ -49,6 +51,7 @@ pub enum NewCardDueOrder {
     NoteId,
     Random,
     Preserve,
+    NoteIdReversed,
 }
 
 impl NewCardSorter {
@@ -86,6 +89,9 @@ fn nids_in_desired_order(cards: &[Card], order: NewCardDueOrder) -> Vec<NoteId> 
         match order {
             NewCardDueOrder::NoteId => {
                 nids.sort_unstable();
+            }
+            NewCardDueOrder::NoteIdReversed => {
+                nids.sort_unstable_by_key(|&num| Reverse(num));
             }
             NewCardDueOrder::Random => {
                 nids.shuffle(&mut rand::thread_rng());
@@ -240,6 +246,12 @@ mod test {
         assert_eq!(sorter.position(&c2), 5);
         assert_eq!(sorter.position(&c1), 7);
 
+        // NoteIdReversed
+        let sorter = NewCardSorter::new(&cards, 0, 1, NewCardDueOrder::NoteIdReversed);
+        assert_eq!(sorter.position(&c3), 2);
+        assert_eq!(sorter.position(&c2), 1);
+        assert_eq!(sorter.position(&c1), 0);
+
         // Random
         let mut c1_positions = HashSet::new();
         for _ in 1..100 {
@@ -258,6 +270,7 @@ impl From<NewCardInsertOrder> for NewCardDueOrder {
         match o {
             NewCardInsertOrder::Due => NewCardDueOrder::NoteId,
             NewCardInsertOrder::Random => NewCardDueOrder::Random,
+            NewCardInsertOrder::DueReversed => NewCardDueOrder::NoteIdReversed,
         }
     }
 }

--- a/ts/deck-options/NewOptions.svelte
+++ b/ts/deck-options/NewOptions.svelte
@@ -22,6 +22,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     const newInsertOrderChoices = [
         tr.deckConfigNewInsertionOrderSequential(),
         tr.deckConfigNewInsertionOrderRandom(),
+        tr.deckConfigNewInsertionOrderSequentialReversed(),
     ];
 
     let stepsExceedGraduatingInterval: string;


### PR DESCRIPTION
Hi! I want to be able to ask Anki to assign me my new cards in _reverse_ insertion order (that is, newest cards first).[0] This pull request makes that possible.

Potential problems:

1. I had to mess with the config a bit. I'm not familiar with Protobuf, so I don't really know what kinds of problems that could cause. I hope it should be fine (this doesn't change the structure or width of any field, it's just adding another accepted-value to some enum abstracting over an int). But maybe I'm wrong about that (maybe Protobuf does something clever where it automatically represents enums with the fewest number of bits necessary to cover all the options?).

2. The corresponding code isn't in AnkiDroid yet, and it would be bad if AnkiDroid broke for users who select this option on desktop. (I'd be happy to implement this on AnkiDroid too - I've [touched its deck-sorting code before](https://github.com/ankidroid/Anki-Android/pull/8173). But even if both support this feature, there's no way to guarantee that everyone updates both their desktop and mobile clients simultaneously.) Maybe the initial PR should just add sorting/insertion code, but shouldn't actually expose this option for selection in the deck config UI until both clients support it?

3. Maybe this use-case is too niche? Anki's a big program - maybe there's already some feature I don't know about that would solve my problem for me.

[0] The reason I want this is because sometimes I find myself adding huge amounts of material all at once, which builds up a backlog that would take weeks to work through. As I'm working through the backlog, I might find myself creating a handful of new cards each day. When that happens, I'd prefer to prioritize learning those new cards first, since they're relatively fresh in my mind. Right now, I _think_ the closest I can get to that is using random card order and relying on its gradually-increasing bias in favor of newly-added cards. But I'd prefer something more consistent/reliable.