### PR TITLE
focusField accepts a field or a number

### DIFF
--- a/ts/editor/index.ts
+++ b/ts/editor/index.ts
@@ -51,13 +51,13 @@ declare global {
         getRangeAt(n: number): Range;
     }
 }
-
 if (isApplePlatform()) {
     registerShortcut(() => bridgeCommand("paste"), "Control+Shift+V");
 }
 
-export function focusField(n: number): void {
-    const field = getEditorField(n);
+export function focusField(fieldOrOrd: number | EditorField): void {
+    const field =
+        fieldOrOrd instanceof EditorField ? fieldOrOrd : getEditorField(fieldOrOrd);
 
     if (field) {
         field.editingArea.focus();


### PR DESCRIPTION
My add-on multi-column window want to deal with field manipulation itself and then let use more or less standard anki
code. Ideally, reimplementing `getEditorField` and `forEditorField` would suffice if only I can get my version used everywhere.

The main difficulty consists in accessing methods such as `updateActiveButtons`, which can not simply be accessed
through the DOM. I no realize that if I can just allow my code to call `focusField` with the field I selected instead of
the number, this specific problem would be resolved.