### PR TITLE
Svelte build improvements

### DIFF
--- a/ts/card-info/BUILD.bazel
+++ b/ts/card-info/BUILD.bazel
@@ -16,15 +16,18 @@ compile_sass(
     ],
 )
 
-compile_svelte()
+_ts_deps = [
+    "//ts/components",
+    "//ts/lib",
+    "@npm//@fluent",
+]
+
+compile_svelte(deps = _ts_deps)
 
 typescript(
     name = "index",
-    deps = [
+    deps = _ts_deps + [
         ":svelte",
-        "//ts/components",
-        "//ts/lib",
-        "@npm//@fluent",
     ],
 )
 

--- a/ts/change-notetype/BUILD.bazel
+++ b/ts/change-notetype/BUILD.bazel
@@ -17,20 +17,23 @@ compile_sass(
     ],
 )
 
-compile_svelte()
+_ts_deps = [
+    "//ts/components",
+    "//ts/lib",
+    "//ts/sveltelib",
+    "@npm//@fluent",
+    "@npm//@types/jest",
+    "@npm//lodash-es",
+    "@npm//svelte",
+    "@npm//marked",
+]
+
+compile_svelte(deps = _ts_deps)
 
 typescript(
     name = "index",
-    deps = [
+    deps = _ts_deps + [
         ":svelte",
-        "//ts/components",
-        "//ts/lib",
-        "//ts/sveltelib",
-        "@npm//@fluent",
-        "@npm//@types/jest",
-        "@npm//lodash-es",
-        "@npm//svelte",
-        "@npm//svelte2tsx",
     ],
 )
 
@@ -47,12 +50,6 @@ esbuild(
         ":base_css",
         ":index",
         ":svelte",
-        "//ts/components",
-        "//ts/lib",
-        "//ts/sveltelib",
-        "@npm//bootstrap",
-        "@npm//marked",
-        "@npm//protobufjs",
     ],
 )
 

--- a/ts/components/BUILD.bazel
+++ b/ts/components/BUILD.bazel
@@ -3,20 +3,23 @@ load("//ts:prettier.bzl", "prettier_test")
 load("//ts:eslint.bzl", "eslint_test")
 load("//ts:typescript.bzl", "typescript")
 
+_ts_deps = [
+    "//ts/lib",
+    "//ts/sveltelib",
+    "@npm//@popperjs/core",
+    "@npm//@types/bootstrap",
+    "@npm//bootstrap",
+    "@npm//svelte",
+]
+
 compile_svelte(
-    deps = ["//sass/bootstrap"],
+    deps = _ts_deps + ["//sass/bootstrap"],
 )
 
 typescript(
     name = "components",
-    deps = [
+    deps = _ts_deps + [
         ":svelte",
-        "//ts/lib",
-        "//ts/sveltelib",
-        "@npm//@popperjs/core",
-        "@npm//@types/bootstrap",
-        "@npm//bootstrap",
-        "@npm//svelte",
     ],
 )
 

--- a/ts/congrats/BUILD.bazel
+++ b/ts/congrats/BUILD.bazel
@@ -1,7 +1,7 @@
 load("@npm//@bazel/typescript:index.bzl", "ts_library")
 load("//ts:prettier.bzl", "prettier_test")
 load("//ts:eslint.bzl", "eslint_test")
-load("//ts/svelte:svelte.bzl", "svelte", "svelte_check")
+load("//ts/svelte:svelte.bzl", "compile_svelte", "svelte_check")
 load("//ts:esbuild.bzl", "esbuild")
 load("//ts:compile_sass.bzl", "compile_sass")
 load("//ts:typescript.bzl", "typescript")
@@ -16,15 +16,14 @@ compile_sass(
     ],
 )
 
-svelte(
-    name = "CongratsPage",
-    entry_point = "CongratsPage.svelte",
+compile_svelte(
+    deps = ["//ts/lib"],
 )
 
 typescript(
     name = "index",
     deps = [
-        "CongratsPage",
+        ":svelte",
         "//ts/lib",
         "@npm//@fluent",
         "@npm//svelte",
@@ -41,9 +40,9 @@ esbuild(
     output_css = "congrats.css",
     visibility = ["//visibility:public"],
     deps = [
-        "CongratsPage",
         ":base_css",
         ":index",
+        ":svelte",
         "//ts/lib",
         "@npm//protobufjs",
     ],

--- a/ts/congrats/BUILD.bazel
+++ b/ts/congrats/BUILD.bazel
@@ -43,8 +43,6 @@ esbuild(
         ":base_css",
         ":index",
         ":svelte",
-        "//ts/lib",
-        "@npm//protobufjs",
     ],
 )
 

--- a/ts/deck-options/BUILD.bazel
+++ b/ts/deck-options/BUILD.bazel
@@ -18,25 +18,29 @@ compile_sass(
     ],
 )
 
+_ts_deps = [
+    "//ts/components",
+    "//ts/lib",
+    "//ts/sveltelib",
+    "@npm//@fluent",
+    "@npm//@popperjs",
+    "@npm//@types/jest",
+    "@npm//bootstrap-icons",
+    "@npm//lodash-es",
+    "@npm//svelte",
+    "@npm//marked",
+]
+
 compile_svelte(
-    deps = [
+    deps = _ts_deps + [
         "//sass/bootstrap",
     ],
 )
 
 typescript(
     name = "index",
-    deps = [
+    deps = _ts_deps + [
         ":svelte",
-        "//ts/components",
-        "//ts/lib",
-        "//ts/sveltelib",
-        "@npm//@fluent",
-        "@npm//@popperjs",
-        "@npm//@types/jest",
-        "@npm//bootstrap-icons",
-        "@npm//lodash-es",
-        "@npm//svelte",
     ],
 )
 
@@ -50,15 +54,9 @@ esbuild(
     output_css = "deck-options.css",
     visibility = ["//visibility:public"],
     deps = [
-        "index",
         ":base_css",
+        ":index",
         ":svelte",
-        "//ts/components",
-        "//ts/lib",
-        "//ts/sveltelib",
-        "@npm//bootstrap",
-        "@npm//marked",
-        "@npm//protobufjs",
     ],
 )
 

--- a/ts/graphs/BUILD.bazel
+++ b/ts/graphs/BUILD.bazel
@@ -15,20 +15,25 @@ compile_sass(
     ],
 )
 
-compile_svelte()
+_ts_deps = [
+    "//ts/lib",
+    "//ts/sveltelib",
+    "@npm//@fluent",
+    "@npm//@types/d3",
+    "@npm//@types/lodash",
+    "@npm//d3",
+    "@npm//lodash-es",
+    "@npm//svelte",
+]
+
+compile_svelte(
+    deps = _ts_deps,
+)
 
 typescript(
     name = "index",
-    deps = [
+    deps = _ts_deps + [
         ":svelte",
-        "//ts/lib",
-        "//ts/sveltelib",
-        "@npm//@fluent",
-        "@npm//@types/d3",
-        "@npm//@types/lodash",
-        "@npm//d3",
-        "@npm//lodash-es",
-        "@npm//svelte",
     ],
 )
 

--- a/ts/reviewer/BUILD.bazel
+++ b/ts/reviewer/BUILD.bazel
@@ -28,8 +28,6 @@ esbuild(
     visibility = ["//visibility:public"],
     deps = [
         ":reviewer_ts",
-        "//ts/lib",
-        "@npm//protobufjs",
     ],
 )
 
@@ -39,8 +37,6 @@ esbuild(
     visibility = ["//visibility:public"],
     deps = [
         ":reviewer_ts",
-        "//ts/lib",
-        "@npm//protobufjs",
     ],
 )
 

--- a/ts/svelte/BUILD.bazel
+++ b/ts/svelte/BUILD.bazel
@@ -1,28 +1,25 @@
 load("@build_bazel_rules_nodejs//:index.bzl", "nodejs_binary")
-load("@npm//@bazel/typescript:index.bzl", "ts_library")
+load("//ts:typescript.bzl", "typescript")
 
 _deps = [
     "@npm//@bazel/worker",
+    "@npm//@types/node",
     "@npm//sass",
     "@npm//svelte",
     "@npm//svelte-preprocess",
     "@npm//svelte2tsx",
     "@npm//typescript",
-    "@npm//@types/node",
 ]
 
-ts_library(
-    name = "svelte_bin_ts",
+typescript(
+    name = "svelte_worker_ts",
     srcs = ["svelte.ts"],
-    tsconfig = "//ts:tsconfig_bin",
     deps = _deps,
 )
 
 nodejs_binary(
     name = "svelte_bin",
-    data = ["svelte_bin_ts"] + _deps,
-    entry_point = ":svelte.ts",
-    # should fix .js files being not found on subsequent worker requests
-    templated_args = ["--bazel_patch_module_resolver"],
+    data = [":svelte_worker_ts"] + _deps,
+    entry_point = ":svelte.js",
     visibility = ["//visibility:public"],
 )

--- a/ts/svelte/svelte.ts
+++ b/ts/svelte/svelte.ts
@@ -8,7 +8,7 @@ import { svelte2tsx } from "svelte2tsx";
 import preprocess from "svelte-preprocess";
 import { basename } from "path";
 import * as ts from "typescript";
-import * as svelte from "svelte/compiler.js";
+import * as svelte from "svelte/compiler";
 
 const parsedCommandLine: ts.ParsedCommandLine = {
     fileNames: [],

--- a/ts/svelte/svelte.ts
+++ b/ts/svelte/svelte.ts
@@ -10,20 +10,19 @@ import { basename } from "path";
 import * as ts from "typescript";
 import * as svelte from "svelte/compiler.js";
 
-let parsedCommandLine: ts.ParsedCommandLine = {
+const parsedCommandLine: ts.ParsedCommandLine = {
     fileNames: [],
     errors: [],
     options: {
         jsx: ts.JsxEmit.Preserve,
         declaration: true,
         emitDeclarationOnly: true,
-        skipLibCheck: true,
+        // noEmitOnError: true,
+        paths: {
+            "*": ["*", "external/npm/node_modules/*"],
+        },
     },
 };
-
-// We avoid hitting the filesystem for ts/d.ts files after initial startup - the
-// .ts file we generate can be injected directly into our cache, and Bazel
-// should restart us if the Svelte or TS typings change.
 
 interface FileContent {
     text: string;
@@ -43,17 +42,17 @@ function getFileContent(path: string): FileContent {
     return content;
 }
 
-function updateFileContent(path: string, text: string): void {
-    let content = fileContent.get(path);
+function updateFileContent(input: InputFile): void {
+    let content = fileContent.get(input.path);
     if (content) {
-        content.text = text;
+        content.text = input.data;
         content.version += 1;
     } else {
         content = {
-            text,
+            text: input.data,
             version: 0,
         };
-        fileContent.set(path, content);
+        fileContent.set(input.path, content);
     }
 }
 
@@ -65,7 +64,6 @@ const languageServiceHost: ts.LanguageServiceHost = {
         return getFileContent(path).version.toString();
     },
     getScriptSnapshot: (path: string): ts.IScriptSnapshot | undefined => {
-        // if (!ts.sys.fileExists(fileName)) {
         const text = getFileContent(path).text;
         return {
             getText: (start: number, end: number) => {
@@ -78,7 +76,7 @@ const languageServiceHost: ts.LanguageServiceHost = {
             },
             getLength: () => text.length,
             getChangeRange: (
-                oldSnapshot: ts.IScriptSnapshot
+                _oldSnapshot: ts.IScriptSnapshot
             ): ts.TextChangeRange | undefined => {
                 return undefined;
             },
@@ -90,14 +88,29 @@ const languageServiceHost: ts.LanguageServiceHost = {
 
 const languageService = ts.createLanguageService(languageServiceHost);
 
-function compile(tsPath: string, tsLibs: string[]) {
-    parsedCommandLine.fileNames = [tsPath, ...tsLibs];
+async function emitTypings(svelte: SvelteTsxFile[], deps: InputFile[]): Promise<void> {
+    const allFiles = [...svelte, ...deps];
+    allFiles.forEach(updateFileContent);
+    parsedCommandLine.fileNames = allFiles.map((i) => i.path);
     const program = languageService.getProgram()!;
     const tsHost = ts.createCompilerHost(parsedCommandLine.options);
     const createdFiles = {};
-    tsHost.writeFile = (fileName, contents) => (createdFiles[fileName] = contents);
-    program.emit(undefined /* all files */, tsHost.writeFile);
-    return createdFiles[parsedCommandLine.fileNames[0].replace(".tsx", ".d.ts")];
+    const cwd = ts.sys.getCurrentDirectory().replace(/\\/g, "/");
+    tsHost.writeFile = (fileName, contents) => {
+        // tsc makes some paths absolute for some reason
+        if (fileName.startsWith(cwd)) {
+            fileName = fileName.substring(cwd.length + 1);
+        }
+        createdFiles[fileName] = contents;
+    };
+    const result = program.emit(undefined /* all files */, tsHost.writeFile);
+    // for (const diag of result.diagnostics) {
+    //     console.log(diag.messageText);
+    // }
+
+    for (const file of svelte) {
+        await writeFile(file.realDtsPath, createdFiles[file.virtualDtsPath]);
+    }
 }
 
 function writeFile(file, data): Promise<void> {
@@ -124,26 +137,8 @@ function readFile(file) {
     });
 }
 
-async function writeDts(tsPath, dtsPath, tsLibs) {
-    const dtsSource = compile(tsPath, tsLibs);
-    await writeFile(dtsPath, dtsSource);
-}
-
-function writeTs(svelteSource, sveltePath, tsPath): void {
-    let tsSource = svelte2tsx(svelteSource, {
-        filename: sveltePath,
-        isTsFile: true,
-        mode: "dts",
-    });
-    let codeLines = tsSource.code.split("\n");
-    updateFileContent(tsPath, codeLines.join("\n"));
-}
-
-async function writeJs(
-    source: string,
-    inputFilename: string,
-    outputJsPath: string,
-    outputCssPath: string,
+async function compileSingleSvelte(
+    input: SvelteInput,
     binDir: string,
     genDir: string
 ): Promise<void> {
@@ -162,14 +157,14 @@ async function writeJs(
     });
 
     try {
-        const processed = await svelte.preprocess(source, preprocessOptions, {
-            filename: inputFilename,
+        const processed = await svelte.preprocess(input.data, preprocessOptions, {
+            filename: input.path,
         });
         const result = svelte.compile(processed.toString!(), {
             format: "esm",
             css: false,
             generate: "dom",
-            filename: outputJsPath,
+            filename: input.mjsPath,
         });
         // warnings are an error
         if (result.warnings.length > 0) {
@@ -177,27 +172,123 @@ async function writeJs(
         }
         // write out the css file
         const outputCss = result.css.code ?? "";
-        await writeFile(outputCssPath, outputCss);
+        await writeFile(input.cssPath, outputCss);
         // if it was non-empty, prepend a reference to it in the js file, so that
         // it's included in the bundled .css when bundling
         const outputSource =
-            (outputCss ? `import "./${basename(outputCssPath)}";` : "") +
+            (outputCss ? `import "./${basename(input.cssPath)}";` : "") +
             result.js.code;
-        await writeFile(outputJsPath, outputSource);
+        await writeFile(input.mjsPath, outputSource);
     } catch (err) {
         console.log(`compile failed: ${err}`);
         return;
     }
 }
 
-async function compileSvelte(args) {
-    const [sveltePath, mjsPath, dtsPath, cssPath, binDir, genDir, ...tsLibs] = args;
-    const svelteSource = (await readFile(sveltePath)) as string;
+interface Args {
+    binDir: string;
+    genDir: string;
+    svelteFiles: SvelteInput[];
+    dependencies: InputFile[];
+}
 
-    const mockTsPath = sveltePath + ".tsx";
-    writeTs(svelteSource, sveltePath, mockTsPath);
-    await writeDts(mockTsPath, dtsPath, tsLibs);
-    await writeJs(svelteSource, sveltePath, mjsPath, cssPath, binDir, genDir);
+interface InputFile {
+    path: string;
+    data: string;
+}
+
+interface SvelteInput extends InputFile {
+    dtsPath: string;
+    cssPath: string;
+    mjsPath: string;
+}
+
+async function extractArgsAndData(args: string[]): Promise<Args> {
+    const [binDir, genDir, ...rest] = args;
+    const [svelteFiles, dependencies] = await extractSvelteAndDeps(rest);
+    return {
+        binDir,
+        genDir,
+        svelteFiles,
+        dependencies,
+    };
+}
+
+async function extractSvelteAndDeps(
+    files: string[]
+): Promise<[SvelteInput[], InputFile[]]> {
+    const svelte: SvelteInput[] = [];
+    const deps: InputFile[] = [];
+    files.reverse();
+    while (files.length) {
+        const file = files.pop()!;
+        const data = (await readFile(file)) as string;
+        if (file.endsWith(".svelte")) {
+            svelte.push({
+                path: file,
+                data,
+                dtsPath: files.pop()!,
+                cssPath: files.pop()!,
+                mjsPath: files.pop()!,
+            });
+        } else {
+            deps.push({ path: remapBinToSrcDir(file), data });
+        }
+    }
+    return [svelte, deps];
+}
+
+/// Our generated .tsx files sit in the bin dir,  but .ts files
+/// may be coming from the source folder, which breaks ./foo imports.
+/// Adjust the path to make it appear they're all in the same folder.
+function remapBinToSrcDir(file: string): string {
+    return file.replace(new RegExp("bazel-out/[-_a-z]+/bin/"), "");
+}
+
+/// Generate Svelte .mjs/.css files.
+async function compileSvelte(
+    svelte: SvelteInput[],
+    binDir: string,
+    genDir: string
+): Promise<void> {
+    for (const file of svelte) {
+        await compileSingleSvelte(file, binDir, genDir);
+    }
+}
+
+interface SvelteTsxFile extends InputFile {
+    // relative to src folder
+    virtualDtsPath: string;
+    // must go to bazel-out
+    realDtsPath: string;
+}
+
+function generateTsxFiles(svelteFiles: SvelteInput[]): SvelteTsxFile[] {
+    return svelteFiles.map((file) => {
+        const data = svelte2tsx(file.data, {
+            filename: file.path,
+            isTsFile: true,
+            mode: "dts",
+        }).code;
+        const path = file.path.replace(".svelte", ".svelte.tsx");
+        return {
+            path,
+            data,
+            virtualDtsPath: path.replace(".tsx", ".d.ts"),
+            realDtsPath: file.dtsPath,
+        };
+    });
+}
+
+async function compileSvelteAndGenerateTypings(argsList: string[]): Promise<boolean> {
+    const args = await extractArgsAndData(argsList);
+
+    // mjs/css
+    await compileSvelte(args.svelteFiles, args.binDir, args.genDir);
+
+    // d.ts
+    const tsxFiles = generateTsxFiles(args.svelteFiles);
+    await emitTypings(tsxFiles, args.dependencies);
 
     return true;
 }
@@ -206,12 +297,12 @@ function main() {
     if (worker.runAsWorker(process.argv)) {
         console.log = worker.log;
         worker.log("Svelte running as a Bazel worker");
-        worker.runWorkerLoop(compileSvelte);
+        worker.runWorkerLoop(compileSvelteAndGenerateTypings);
     } else {
         const paramFile = process.argv[2].replace(/^@/, "");
         const commandLineArgs = fs.readFileSync(paramFile, "utf-8").trim().split("\n");
         console.log("Svelte running as a standalone process");
-        compileSvelte(commandLineArgs);
+        compileSvelteAndGenerateTypings(commandLineArgs);
     }
 }
 

--- a/ts/svelte/tsconfig.json
+++ b/ts/svelte/tsconfig.json
@@ -1,0 +1,13 @@
+{
+    "extends": "../tsconfig.json",
+    "include": ["*"],
+    "references": [],
+    "compilerOptions": {
+        // ignore missing optional modules like postcss
+        "skipLibCheck": true,
+        // ensure node can run the resulting code
+        "noEmitHelpers": false,
+        "importHelpers": false,
+        "module": "commonjs",
+    }
+}


### PR DESCRIPTION
1. All Svelte files in a package are compiled in one step now, which
ensures that properties that use types from a different Svelte file in the
same package are typed correctly. The single-file svelte() has been removed,
and compile_svelte() may be renamed to svelte() in the future.

2. The .ts files in the same package are included as part of the Svelte
compilation, so that types imported imported from .ts files in the
same package work.

3. Dependencies passed into the rule are now loaded into the TypeScript
compiler, so that properties referencing types from different packages
work. We'll need to update our compile_svelte() lines to list the
dependencies. For example, before this change:

```
% cat bazel-bin/ts/congrats/CongratsPage.svelte.d.ts
import { SvelteComponentTyped } from "svelte";
declare const __propDef: {
    props: {
        info: any;
    };
...
```

After adding //ts/lib to the deps of compile_svelte() in ts/congrats:

```
% cat bazel-bin/ts/congrats/CongratsPage.svelte.d.ts
import { SvelteComponentTyped } from "svelte";
import type { Scheduler } from "../lib/proto";
declare const __propDef: {
    props: {
        info: Scheduler.CongratsInfoResponse;
    };
...
```