### PR TITLE
Make field state badges more discernible

### DIFF
--- a/ts/editor/PlainTextBadge.svelte
+++ b/ts/editor/PlainTextBadge.svelte
@@ -27,7 +27,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     );
 </script>
 
-<span on:click|stopPropagation={toggle}>
+<span class:highlighted={!off} on:click|stopPropagation={toggle}>
     <Badge
         tooltip="{tr.editingHtmlEditor()} ({getPlatformString(keyCombination)})"
         iconSize={80}>{@html icon}</Badge
@@ -36,10 +36,13 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
 <style lang="scss">
     span {
-        opacity: 0.6;
+        opacity: 0.4;
 
-        &:hover {
+        &.highlighted {
             opacity: 1;
+        }
+        &:hover {
+            opacity: 0.8;
         }
     }
 </style>

--- a/ts/editor/RichTextBadge.svelte
+++ b/ts/editor/RichTextBadge.svelte
@@ -15,16 +15,19 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     $: icon = off ? richTextOff : richTextOn;
 </script>
 
-<span on:click|stopPropagation={toggle}>
+<span class:highlighted={off} on:click|stopPropagation={toggle}>
     <Badge iconSize={80}>{@html icon}</Badge>
 </span>
 
 <style lang="scss">
     span {
-        opacity: 0.6;
+        opacity: 0.4;
 
-        &:hover {
+        &.highlighted {
             opacity: 1;
+        }
+        &:hover {
+            opacity: 0.8;
         }
     }
 </style>

--- a/ts/editor/StickyBadge.svelte
+++ b/ts/editor/StickyBadge.svelte
@@ -29,7 +29,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     onMount(() => registerShortcut(toggleSticky, keyCombination, editorField.element));
 </script>
 
-<span on:click|stopPropagation={toggleSticky}>
+<span class:highlighted={active} on:click|stopPropagation={toggleSticky}>
     <Badge
         tooltip="{tr.editingToggleSticky()} ({getPlatformString(keyCombination)})"
         widthMultiplier={0.7}>{@html icon}</Badge
@@ -38,10 +38,13 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
 <style lang="scss">
     span {
-        opacity: 0.6;
+        opacity: 0.4;
 
-        &:hover {
+        &.highlighted {
             opacity: 1;
+        }
+        &:hover {
+            opacity: 0.8;
         }
     }
 </style>


### PR DESCRIPTION
https://forums.ankiweb.net/t/poll-icon-for-sticky-pinned-frozen-fields/7910/4

Adds class `highlighted` to badge containers when toggled to a presumably less frequently used state. This approach should avoid as much visual clutter as possible, while also making the different states more discernible.

Highlighting works via opacity changes:
- `default`: 0.4
- `highlighted`: 1
- `hover`: 0.8 (this makes hovering visible both on highlighted and non-highlighted badges)

![image](https://user-images.githubusercontent.com/62722460/139234196-31fc24ee-fc97-44e7-9bb2-8c3a0dac7c26.png) ![image](https://user-images.githubusercontent.com/62722460/139236258-50809a66-5b9d-4af8-816e-e66933703895.png)
