### PR TITLE
Remove data/ prefix from data folder in mediasrv.py

### DIFF
--- a/qt/aqt/mediasrv.py
+++ b/qt/aqt/mediasrv.py
@@ -210,7 +210,7 @@ def _builtin_data(path: str) -> bytes:
 def _handle_builtin_file_request(request: BundledFileRequest) -> Response:
     path = request.path
     mimetype = _mime_for_path(path)
-    data_path = f"data/web/{path}"
+    data_path = f"web/{path}"
     try:
         data = _builtin_data(data_path)
         return Response(data, mimetype=mimetype)


### PR DESCRIPTION
b5e9eba26f71a65c6e165 broke the media server for me.

When using `./scripts/ts-run`, [this](https://github.com/ankitects/anki/blob/16ad0137f7ee9c2796d356c643861d744b153324/scripts/ts-run#L9) already adds `/data` as a suffix, which is why all the media requests failed. I'm now entirely sure which location should be corrected, but I was guessing `mediasrv.py`.