### PR TITLE
Consider setting "no-non-null-assertion: off" by default

### DIFF
--- a/ts/.eslintrc.js
+++ b/ts/.eslintrc.js
@@ -11,6 +11,7 @@ module.exports = {
         "prefer-const": "warn",
         "no-nested-ternary": "warn",
         "@typescript-eslint/ban-ts-comment": "warn",
+        "@typescript-eslint/no-non-null-assertion": "off",
         "@typescript-eslint/no-unused-vars": [
             "warn",
             { argsIgnorePattern: "^_", varsIgnorePattern: "^_" },

--- a/ts/change-notetype/lib.ts
+++ b/ts/change-notetype/lib.ts
@@ -1,10 +1,6 @@
 // Copyright: Ankitects Pty Ltd and contributors
 // License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
-/* eslint
-@typescript-eslint/no-non-null-assertion: "off",
- */
-
 import { Notetypes } from "../lib/proto";
 import { postRequest } from "../lib/postrequest";
 import { readable, Readable } from "svelte/store";

--- a/ts/deck-options/TextInputModal.svelte
+++ b/ts/deck-options/TextInputModal.svelte
@@ -3,9 +3,6 @@ Copyright: Ankitects Pty Ltd and contributors
 License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 -->
 <script lang="ts">
-    /* eslint
-    @typescript-eslint/no-non-null-assertion: "off",
-    */
     import { onMount, onDestroy, getContext } from "svelte";
     import { nightModeKey, modalsKey } from "../components/context-keys";
     import Modal from "bootstrap/js/dist/modal";

--- a/ts/deck-options/lib.ts
+++ b/ts/deck-options/lib.ts
@@ -1,10 +1,6 @@
 // Copyright: Ankitects Pty Ltd and contributors
 // License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
-/* eslint
-@typescript-eslint/no-non-null-assertion: "off",
- */
-
 import { DeckConfig } from "../lib/proto";
 import { postRequest } from "../lib/postrequest";
 import { Writable, writable, get, Readable, readable } from "svelte/store";

--- a/ts/editable/mathjax-element.ts
+++ b/ts/editable/mathjax-element.ts
@@ -2,7 +2,6 @@
 // License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
 /* eslint
-@typescript-eslint/no-non-null-assertion: "off",
 @typescript-eslint/no-explicit-any: "off",
  */
 

--- a/ts/editor/index.ts
+++ b/ts/editor/index.ts
@@ -5,7 +5,6 @@ import "./legacy.css";
 import "./editor-base.css";
 
 /* eslint
-@typescript-eslint/no-non-null-assertion: "off",
 @typescript-eslint/no-explicit-any: "off",
  */
 

--- a/ts/graphs/added.ts
+++ b/ts/graphs/added.ts
@@ -2,7 +2,6 @@
 // License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
 /* eslint
-@typescript-eslint/no-non-null-assertion: "off",
 @typescript-eslint/no-explicit-any: "off",
  */
 

--- a/ts/graphs/buttons.ts
+++ b/ts/graphs/buttons.ts
@@ -2,7 +2,6 @@
 // License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
 /* eslint
-@typescript-eslint/no-non-null-assertion: "off",
 @typescript-eslint/no-explicit-any: "off",
  */
 

--- a/ts/graphs/calendar.ts
+++ b/ts/graphs/calendar.ts
@@ -1,10 +1,6 @@
 // Copyright: Ankitects Pty Ltd and contributors
 // License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
-/* eslint
-@typescript-eslint/no-non-null-assertion: "off",
- */
-
 import { Stats } from "../lib/proto";
 import {
     interpolateBlues,

--- a/ts/graphs/card-counts.ts
+++ b/ts/graphs/card-counts.ts
@@ -2,7 +2,6 @@
 // License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
 /* eslint
-@typescript-eslint/no-non-null-assertion: "off",
 @typescript-eslint/no-explicit-any: "off",
  */
 

--- a/ts/graphs/ease.ts
+++ b/ts/graphs/ease.ts
@@ -2,7 +2,6 @@
 // License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
 /* eslint
-@typescript-eslint/no-non-null-assertion: "off",
 @typescript-eslint/no-explicit-any: "off",
  */
 

--- a/ts/graphs/future-due.ts
+++ b/ts/graphs/future-due.ts
@@ -2,7 +2,6 @@
 // License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
 /* eslint
-@typescript-eslint/no-non-null-assertion: "off",
 @typescript-eslint/no-explicit-any: "off",
  */
 

--- a/ts/graphs/graph-helpers.ts
+++ b/ts/graphs/graph-helpers.ts
@@ -2,7 +2,6 @@
 // License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
 /* eslint
-@typescript-eslint/no-non-null-assertion: "off",
 @typescript-eslint/no-explicit-any: "off",
 @typescript-eslint/ban-ts-comment: "off" */
 

--- a/ts/graphs/histogram-graph.ts
+++ b/ts/graphs/histogram-graph.ts
@@ -2,7 +2,6 @@
 // License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
 /* eslint
-@typescript-eslint/no-non-null-assertion: "off",
 @typescript-eslint/no-explicit-any: "off",
  */
 

--- a/ts/graphs/hours.ts
+++ b/ts/graphs/hours.ts
@@ -2,7 +2,6 @@
 // License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
 /* eslint
-@typescript-eslint/no-non-null-assertion: "off",
 @typescript-eslint/no-explicit-any: "off",
  */
 

--- a/ts/graphs/intervals.ts
+++ b/ts/graphs/intervals.ts
@@ -2,7 +2,6 @@
 // License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
 /* eslint
-@typescript-eslint/no-non-null-assertion: "off",
 @typescript-eslint/no-explicit-any: "off",
  */
 

--- a/ts/graphs/reviews.ts
+++ b/ts/graphs/reviews.ts
@@ -2,7 +2,6 @@
 // License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
 /* eslint
-@typescript-eslint/no-non-null-assertion: "off",
 @typescript-eslint/no-explicit-any: "off",
  */
 

--- a/ts/lib/dom.ts
+++ b/ts/lib/dom.ts
@@ -1,10 +1,6 @@
 // Copyright: Ankitects Pty Ltd and contributors
 // License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
-/* eslint
-@typescript-eslint/no-non-null-assertion: "off",
- */
-
 export function nodeIsElement(node: Node): node is Element {
     return node.nodeType === Node.ELEMENT_NODE;
 }

--- a/ts/lib/promise.ts
+++ b/ts/lib/promise.ts
@@ -1,10 +1,6 @@
 // Copyright: Ankitects Pty Ltd and contributors
 // License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
-/* eslint
-@typescript-eslint/no-non-null-assertion: "off",
- */
-
 export function promiseWithResolver<T>(): [Promise<T>, (value: T) => void] {
     let resolve: (object: T) => void;
     const promise = new Promise<T>((res) => (resolve = res));

--- a/ts/lib/wrap.ts
+++ b/ts/lib/wrap.ts
@@ -1,10 +1,6 @@
 // Copyright: Ankitects Pty Ltd and contributors
 // License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
-/* eslint
-@typescript-eslint/no-non-null-assertion: "off",
- */
-
 function wrappedExceptForWhitespace(text: string, front: string, back: string): string {
     const match = text.match(/^(\s*)([^]*?)(\s*)$/)!;
     return match[1] + front + match[2] + back + match[3];

--- a/ts/reviewer/index.ts
+++ b/ts/reviewer/index.ts
@@ -2,7 +2,6 @@
 // License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
 /* eslint
-@typescript-eslint/no-non-null-assertion: "off",
 @typescript-eslint/no-explicit-any: "off",
  */
 

--- a/ts/sveltelib/node-store.ts
+++ b/ts/sveltelib/node-store.ts
@@ -1,10 +1,6 @@
 // Copyright: Ankitects Pty Ltd and contributors
 // License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
-/* eslint
-@typescript-eslint/no-non-null-assertion: "off",
-*/
-
 import type { Writable, Subscriber, Unsubscriber, Updater } from "svelte/store";
 import { noop } from "../lib/functional";
 


### PR DESCRIPTION
Whenever I use a non-null assertion, I will typically turn off eslint for it. While it is not _clean_ when it comes to typing, I'd consider it on the same level as upcasting using `as Obj`, which we also don't restrict.

Comparing non-null-assertion with using `any`: `any` is a magic trick, that allows us to do anything, which is why we should restrict it, whereas non-null-assertion still has very clear semantics.

Altogether I'd vote for turning off the error altogether.