### PR TITLE
Fix invalid path in cargo-env.bat

### DIFF
--- a/cargo/README.md
+++ b/cargo/README.md
@@ -12,6 +12,10 @@ After updating dependencies in ../rslib/Cargo.toml, change to this
 folder and run python update.py to update the external Bazel repositories
 to point to the updated deps.
 
+Note: cargo-raze does not currently work when run from Windows, and nobody
+has investigated why yet. For now, you'll need a Mac or Linux machine, or
+will need to run update.py from within WSL.
+
 A couple of crates need extra work to build with Bazel, and are listed
 in ../Cargo.toml. For example:
 

--- a/qt/package/build.bat
+++ b/qt/package/build.bat
@@ -1,6 +1,7 @@
-:: ensure wheels are built
+:: ensure wheels are built and set up Rust env
 pushd ..\..
 call scripts\build || exit /b
+call scripts\cargo-env
 set ROOT=%CD%
 popd
 
@@ -16,6 +17,5 @@ if not exist %VENV% (
 
 :: run the rest of the build in Python
 FOR /F "tokens=*" %%g IN ('call ..\..\bazel.bat info output_base --ui_event_filters=-INFO') do (SET BAZEL_EXTERNAL=%%g/external)
-call %ROOT%\scripts\cargo-env
 call ..\..\bazel.bat query @pyqt515//:*
 %VENV%\scripts\python build.py %ROOT% %BAZEL_EXTERNAL% || exit /b

--- a/scripts/cargo-env.bat
+++ b/scripts/cargo-env.bat
@@ -1,2 +1,4 @@
-FOR /F "tokens=*" %%g IN ('call ..\bazel.bat info output_base --ui_event_filters=-INFO') do (SET BAZEL_EXTERNAL=%%g/external)
+rem Run this from the repo root folder
+
+FOR /F "tokens=*" %%g IN ('call bazel.bat info output_base --ui_event_filters=-INFO') do (SET BAZEL_EXTERNAL=%%g/external)
 set PATH=%BAZEL_EXTERNAL%\rust_windows_x86_64\bin;%PATH%

--- a/scripts/cargo-env.bat
+++ b/scripts/cargo-env.bat
@@ -1,2 +1,2 @@
-FOR /F "tokens=*" %%g IN ('call ..\..\bazel.bat info output_base --ui_event_filters=-INFO') do (SET BAZEL_EXTERNAL=%%g/external)
+FOR /F "tokens=*" %%g IN ('call ..\bazel.bat info output_base --ui_event_filters=-INFO') do (SET BAZEL_EXTERNAL=%%g/external)
 set PATH=%BAZEL_EXTERNAL%\rust_windows_x86_64\bin;%PATH%


### PR DESCRIPTION
**Unrelated**: cargo-raze is failing for me with the following error message on Windows when running cargo/update.py:
```
Error: Failed to create symlink for generating metadata

Caused by:
    Cannot create a file when that file already exists. (os error 183)

```

Do you have any pointers about how to fix this?