### PR TITLE
Fix incorrect card count in timebox after undo

### DIFF
--- a/pylib/anki/collection.py
+++ b/pylib/anki/collection.py
@@ -114,6 +114,7 @@ class Collection(DeprecatedNamesMixin):
         self.tags = TagManager(self)
         self.conf = ConfigManager(self)
         self._load_scheduler()
+        self._startReps = 0  # pylint: disable=invalid-name
 
     def name(self) -> Any:
         return os.path.splitext(os.path.basename(self.path))[0]

--- a/pylib/anki/collection.py
+++ b/pylib/anki/collection.py
@@ -992,6 +992,7 @@ class Collection(DeprecatedNamesMixin):
         type = ("new", "lrn", "rev")[idx]
         self.sched._updateStats(card, type, -1)
         self.sched.reps -= 1
+        self._startReps -= 1
 
         # and refresh the queues
         self.sched.reset()


### PR DESCRIPTION

Minimal steps to reproduce:
1. Add a card
2. Do a single repetition, then return to the deck list (reps=1, startReps=0)
3. Go to the reviewer again and undo the last review before rating another card (reps=0, startReps=1)
4. Wait for the timebox time limit to pass, then rate the current card (reps=1, startReps=1). The timebox dialog will incorrectly report studying 0 cards.
