### PR TITLE
Fix duplicate conflicting add-on names being shown

### DIFF
--- a/qt/aqt/addons.py
+++ b/qt/aqt/addons.py
@@ -53,7 +53,7 @@ class AbortAddonImport(Exception):
 @dataclass
 class InstallOk:
     name: str
-    conflicts: list[str]
+    conflicts: set[str]
     compatible: bool
 
 
@@ -354,14 +354,12 @@ class AddonManager:
                 all_conflicts[other_dir].append(addon.dir_name)
         return all_conflicts
 
-    def _disableConflicting(self, dir: str, conflicts: list[str] = None) -> list[str]:
+    def _disableConflicting(self, dir: str, conflicts: list[str] = None) -> set[str]:
         conflicts = conflicts or self.addonConflicts(dir)
 
         installed = self.allAddons()
-        found = [d for d in conflicts if d in installed and self.isEnabled(d)]
-        found.extend(self.allAddonConflicts().get(dir, []))
-        if not found:
-            return []
+        found = {d for d in conflicts if d in installed and self.isEnabled(d)}
+        found.update(self.allAddonConflicts().get(dir, []))
 
         for package in found:
             self.toggleEnabled(package, enable=False)


### PR DESCRIPTION
A conflicting add-on's name could be listed twice when installing another add-on if both add-ons list each other in their conflicts list.
![image](https://user-images.githubusercontent.com/41397710/141658063-6cf03ba3-cafc-4dc0-8ba9-1a7ec5b75ad9.png)
