### PR TITLE
Add hotkey to save add-on config

### DIFF
--- a/qt/aqt/addons.py
+++ b/qt/aqt/addons.py
@@ -1484,6 +1484,8 @@ class ConfigEditor(QDialog):
             QDialogButtonBox.StandardButton.RestoreDefaults
         )
         qconnect(restore.clicked, self.onRestoreDefaults)
+        ok = self.form.buttonBox.button(QDialogButtonBox.StandardButton.Ok)
+        ok.setShortcut(QKeySequence("Ctrl+Return"))
         self.setupFonts()
         self.updateHelp()
         self.updateText(self.conf)


### PR DESCRIPTION
This just adds the handy "Ctrl+Return" hotkey to save add-ons' configs.