### PR TITLE
docs: Install pip in venv

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -24,6 +24,7 @@ python.org or from your distro.
 
 ```
 $ python3.9 -m venv ~/pyenv
+$ curl https://bootstrap.pypa.io/get-pip.py -o - | ~/pyenv/bin/python -
 $ ~/pyenv/bin/pip install --upgrade pip
 $ ~/pyenv/bin/pip install aqt[qt6]
 ```


### PR DESCRIPTION
Running the build instructions in a fresh environment failed, because pip was missing in pyenv/bin. With this instruction, pip can be installed to this folder.