### PR TITLE
Remove all_names in notetypechooser

### DIFF
--- a/qt/aqt/notetypechooser.py
+++ b/qt/aqt/notetypechooser.py
@@ -103,7 +103,7 @@ class NotetypeChooser(QHBoxLayout):
         qconnect(edit.clicked, self.onEdit)
 
         def nameFunc() -> list[str]:
-            return sorted(self.mw.col.models.all_names())
+            return sorted(n.name for n in self.mw.col.models.all_names_and_ids())
 
         ret = StudyDeck(
             self.mw,


### PR DESCRIPTION
The only purpose is to stop having warning in my console because all_names is deprecated