### PR TITLE
Fix memory leak in AnkiWebView

### DIFF
--- a/qt/aqt/about.py
+++ b/qt/aqt/about.py
@@ -91,6 +91,15 @@ def show(mw: aqt.AnkiQt) -> QDialog:
     abt.buttonBox.addButton(btn, QDialogButtonBox.ButtonRole.ActionRole)
     abt.buttonBox.button(QDialogButtonBox.StandardButton.Ok).setFocus()
 
+    # WebView cleanup
+    ######################################################################
+
+    def on_dialog_destroyed() -> None:
+        abt.label.cleanup()
+        abt.label = None
+
+    qconnect(dialog.destroyed, on_dialog_destroyed)
+
     # WebView contents
     ######################################################################
     abouttext = "<center><img src='/_anki/imgs/anki-logo-thin.png'></center>"

--- a/qt/aqt/browser/card_info.py
+++ b/qt/aqt/browser/card_info.py
@@ -77,6 +77,7 @@ class CardInfoDialog(QDialog):
     def reject(self) -> None:
         if self._on_close:
             self._on_close()
+        self.web.cleanup()
         self.web = None
         saveGeom(self, self.GEOMETRY_KEY)
         return QDialog.reject(self)

--- a/qt/aqt/browser/previewer.py
+++ b/qt/aqt/browser/previewer.py
@@ -120,6 +120,7 @@ class Previewer(QDialog):
     def _on_close(self) -> None:
         self._open = False
         self._close_callback()
+        self._web.cleanup()
         self._web = None
 
     def _setup_web_view(self) -> None:

--- a/qt/aqt/changenotetype.py
+++ b/qt/aqt/changenotetype.py
@@ -65,6 +65,7 @@ class ChangeNotetypeDialog(QDialog):
         self.setWindowTitle(tr.browsing_change_notetype())
 
     def reject(self) -> None:
+        self.web.cleanup()
         self.web = None
         saveGeom(self, self.TITLE)
         QDialog.reject(self)

--- a/qt/aqt/clayout.py
+++ b/qt/aqt/clayout.py
@@ -825,6 +825,7 @@ class CardLayout(QDialog):
         av_player.stop_and_clear_queue()
         saveGeom(self, "CardLayout")
         saveSplitter(self.mainArea, "CardLayoutMainArea")
+        self.preview_web.cleanup()
         self.preview_web = None
         self.model = None
         self.rendered_card = None

--- a/qt/aqt/deckoptions.py
+++ b/qt/aqt/deckoptions.py
@@ -60,6 +60,7 @@ class DeckOptionsDialog(QDialog):
         gui_hooks.deck_options_did_load(self)
 
     def reject(self) -> None:
+        self.web.cleanup()
         self.web = None
         saveGeom(self, self.TITLE)
         QDialog.reject(self)

--- a/qt/aqt/editor.py
+++ b/qt/aqt/editor.py
@@ -586,6 +586,7 @@ noteEditorPromise.then(noteEditor => noteEditor.toolbar.toolbar.appendGroup({{
     def cleanup(self) -> None:
         self.set_note(None)
         # prevent any remaining evalWithCallback() events from firing after C++ object deleted
+        self.web.cleanup()
         self.web = None
 
     # legacy

--- a/qt/aqt/emptycards.py
+++ b/qt/aqt/emptycards.py
@@ -36,6 +36,7 @@ class EmptyCardsDialog(QDialog):
     def __init__(self, mw: aqt.main.AnkiQt, report: EmptyCardsReport) -> None:
         super().__init__(mw)
         self.mw = mw.weakref()
+        self.mw.garbage_collect_on_dialog_finish(self)
         self.report = report
         self.form = aqt.forms.emptycards.Ui_Dialog()
         self.form.setupUi(self)
@@ -58,6 +59,8 @@ class EmptyCardsDialog(QDialog):
         self.form.webview.stdHtml(style + html, context=self)
 
         def on_finished(code: Any) -> None:
+            self.form.webview.cleanup()
+            self.form.webview = None
             saveGeom(self, "emptycards")
 
         qconnect(self.finished, on_finished)

--- a/qt/aqt/stats.py
+++ b/qt/aqt/stats.py
@@ -54,6 +54,7 @@ class NewDeckStats(QDialog):
         self.activateWindow()
 
     def reject(self) -> None:
+        self.form.web.cleanup()
         self.form.web = None
         saveGeom(self, self.name)
         aqt.dialogs.markClosed("NewDeckStats")
@@ -144,6 +145,7 @@ class DeckStats(QDialog):
         self.activateWindow()
 
     def reject(self) -> None:
+        self.form.web.cleanup()
         self.form.web = None
         saveGeom(self, self.name)
         aqt.dialogs.markClosed("DeckStats")

--- a/qt/aqt/webview.py
+++ b/qt/aqt/webview.py
@@ -671,7 +671,7 @@ document.head.appendChild(style);
         self._domReady = False
         self._page.setContent(cast(QByteArray, bytes("", "ascii")))
 
-    def __del__(self) -> None:
+    def cleanup(self) -> None:
         try:
             from aqt import mw
         except ImportError:


### PR DESCRIPTION
Since commit f2173fddb04a95a3eff17494c9845736997131e4, a memory leak occurs every time all sub-windows with `AnkiWebView` inside are opened and closed.
<details>
 <summary>Screenshot of Task Manager (627f910635893f8205f7004572ba2ac7f3d987b8 on Win10, after opening and closing sub-windows several times)</summary>

![anki-taskmanager](https://user-images.githubusercontent.com/47855854/143674837-3a1af220-ff99-4203-8080-bd1994ced1e0.png)
</details>

Currently, `on_theme_did_change` is added to `gui_hooks.theme_did_change` when `AnkiWebView` is initialized, and it is removed from the list when the finalizer function (`__del__()`) is called. However, at the point when the parent widget of `AnkiWebView` is deleted, the reference to `AnkiWebView` still remains in `gui_hooks.theme_did_change`, so the finalizer is not called and the object continues to exist until Anki shuts down.