### PR TITLE
Add missing editorToolbar export

### DIFF
--- a/ts/editor/index.ts
+++ b/ts/editor/index.ts
@@ -93,3 +93,4 @@ async function setupNoteEditor(): Promise<NoteEditorAPI> {
 }
 
 export const noteEditorPromise = setupNoteEditor();
+export { editorToolbar } from "./EditorToolbar.svelte";


### PR DESCRIPTION
This fixes preview and add-on buttons not showing due to a deletion in https://github.com/ankitects/anki/commit/610ef8f04396db124909975b6842178f1116e77f#r60989499 which I believe was accidental @hgiesel?

(I put it below the noteEditorPromise export because I figured it makes more sense there.)
