### PR TITLE
Fix custom CSS not being applied to scrollbars in night mode

### DIFF
--- a/qt/aqt/data/web/css/webview.scss
+++ b/qt/aqt/data/web/css/webview.scss
@@ -33,6 +33,6 @@ h1 {
     margin-bottom: 0.2em;
 }
 
-.nightMode {
+.night-mode {
     @include scrollbar.night-mode;
 }

--- a/sass/base.scss
+++ b/sass/base.scss
@@ -41,7 +41,7 @@ body {
     overscroll-behavior: none;
 }
 
-.nightMode {
+.night-mode {
     @include scrollbar.night-mode;
 }
 

--- a/sass/scrollbar.scss
+++ b/sass/scrollbar.scss
@@ -5,7 +5,7 @@
 @use "fusion-vars";
 
 @mixin night-mode {
-    &::-webkit-scrollbar {
+    ::-webkit-scrollbar {
         background-color: var(--window-bg);
 
         &:horizontal {
@@ -17,7 +17,7 @@
         }
     }
 
-    &::-webkit-scrollbar-thumb {
+    ::-webkit-scrollbar-thumb {
         background: fusion-vars.$button-hover-bg;
         border-radius: 8px;
 
@@ -30,7 +30,7 @@
         }
     }
 
-    &::-webkit-scrollbar-corner {
+    ::-webkit-scrollbar-corner {
         background-color: var(--window-bg);
     }
 }

--- a/ts/components/ButtonToolbar.svelte
+++ b/ts/components/ButtonToolbar.svelte
@@ -110,12 +110,6 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 </div>
 
 <style lang="scss">
-    @use "sass/scrollbar";
-
-    .nightMode {
-        @include scrollbar.night-mode;
-    }
-
     .button-toolbar {
         flex-wrap: var(--buttons-wrap);
         padding-left: 0.15rem;

--- a/ts/editable/editable-base.scss
+++ b/ts/editable/editable-base.scss
@@ -2,10 +2,6 @@
 
 * {
     max-width: 100%;
-
-    :host(.nightMode) & {
-        @include scrollbar.night-mode;
-    }
 }
 
 p {
@@ -20,4 +16,8 @@ p {
 
 [hidden] {
     display: none;
+}
+
+:host(.night-mode) {
+    @include scrollbar.night-mode;
 }

--- a/ts/editor/RichTextInput.svelte
+++ b/ts/editor/RichTextInput.svelte
@@ -245,6 +245,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 >
     <div
         class:hidden
+        class:night-mode={$pageTheme.isDark}
         use:attachShadow
         use:attachStyles
         use:attachContentEditable={{ stylesDidLoad }}


### PR DESCRIPTION
This fixes one of the issues listed in #1516, where custom CSS is not applied to scrollbars in some windows when night mode is enabled.

In this PR, `night-mode` class of the shadow root elements are toggled to apply custom CSS to the horizontal scroll bars of individual fields in the editor as well.
<details>
 <summary>Screenshots (left/top images: dcfc6d73a2718330ac60e03ad8d3a7bb3f5aeb83, right/bottom: with this PR adapted)</summary>

![pr-editor](https://user-images.githubusercontent.com/47855854/144709117-461de612-fbf8-421f-9597-f266b491bb5d.png)

![pr-change-notetype](https://user-images.githubusercontent.com/47855854/144709127-f36f420c-2c25-4954-9c06-20d2f583d3e9.png)

![pr-stats](https://user-images.githubusercontent.com/47855854/144709136-4f9bbebf-bed3-4a82-ad4f-7e4c5dc7d608.png)

![pr-card-info](https://user-images.githubusercontent.com/47855854/144709143-7ca82a17-3eb9-4f47-a9ed-4d0512e834b1.png)
</details>