### PR TITLE
Flip arrows of Bootstrap-styled `<select>`s for RTL langs

### DIFF
--- a/qt/aqt/theme.py
+++ b/qt/aqt/theme.py
@@ -11,9 +11,7 @@ import sys
 from ctypes import CDLL
 from dataclasses import dataclass
 
-import anki
 import aqt
-from anki.lang import is_rtl
 from anki.utils import is_lin, is_mac, is_win
 from aqt import QApplication, colors, gui_hooks
 from aqt.qt import (
@@ -141,8 +139,6 @@ class ThemeManager:
             classes.extend(["nightMode", "night_mode"])
             if self.macos_dark_mode():
                 classes.append("macos-dark-mode")
-        if is_rtl(anki.lang.current_lang):
-            classes.append("rtl")
         return " ".join(classes)
 
     def body_classes_for_card_ord(

--- a/qt/aqt/theme.py
+++ b/qt/aqt/theme.py
@@ -11,7 +11,9 @@ import sys
 from ctypes import CDLL
 from dataclasses import dataclass
 
+import anki
 import aqt
+from anki.lang import is_rtl
 from anki.utils import is_lin, is_mac, is_win
 from aqt import QApplication, colors, gui_hooks
 from aqt.qt import (
@@ -139,6 +141,8 @@ class ThemeManager:
             classes.extend(["nightMode", "night_mode"])
             if self.macos_dark_mode():
                 classes.append("macos-dark-mode")
+        if is_rtl(anki.lang.current_lang):
+            classes.append("rtl")
         return " ".join(classes)
 
     def body_classes_for_card_ord(

--- a/qt/aqt/webview.py
+++ b/qt/aqt/webview.py
@@ -638,6 +638,7 @@ html {{ {font} }}
     def inject_dynamic_style_and_show(self) -> None:
         "Add dynamic styling, and reveal."
         css = self.standard_css()
+        body_class = theme_manager.body_class()
 
         def after_style(arg: Any) -> None:
             gui_hooks.webview_did_inject_style_into_page(self)
@@ -648,6 +649,7 @@ html {{ {font} }}
 const style = document.createElement('style');
 style.innerHTML = `{css}`;
 document.head.appendChild(style);
+document.body.classList.add(...`{body_class}`.split(" "));
 """,
             after_style,
         )

--- a/qt/aqt/webview.py
+++ b/qt/aqt/webview.py
@@ -438,10 +438,9 @@ div[contenteditable="true"]:focus {{
 
         window_bg_day = self.get_window_bg_color(False).name()
         window_bg_night = self.get_window_bg_color(True).name()
-        body_bg = window_bg_night if theme_manager.night_mode else window_bg_day
 
         return f"""
-body {{ zoom: {zoom}; background-color: --window-bg; }}
+body {{ zoom: {zoom}; background-color: var(--window-bg); }}
 html {{ {font} }}
 {button_style}
 :root {{ --window-bg: {window_bg_day} }}

--- a/qt/aqt/webview.py
+++ b/qt/aqt/webview.py
@@ -440,13 +440,8 @@ div[contenteditable="true"]:focus {{
         window_bg_night = self.get_window_bg_color(True).name()
         body_bg = window_bg_night if theme_manager.night_mode else window_bg_day
 
-        if is_rtl(anki.lang.current_lang):
-            lang_dir = "rtl"
-        else:
-            lang_dir = "ltr"
-
         return f"""
-body {{ zoom: {zoom}; background-color: --window-bg; direction: {lang_dir}; }}
+body {{ zoom: {zoom}; background-color: --window-bg; }}
 html {{ {font} }}
 {button_style}
 :root {{ --window-bg: {window_bg_day} }}
@@ -496,9 +491,14 @@ html {{ {font} }}
         else:
             doc_class = ""
 
+        if is_rtl(anki.lang.current_lang):
+            lang_dir = "rtl"
+        else:
+            lang_dir = "ltr"
+
         html = f"""
 <!doctype html>
-<html class="{doc_class}">
+<html class="{doc_class}" dir="{lang_dir}">
 <head>
     <title>{self.title}</title>
 {head}
@@ -638,7 +638,6 @@ html {{ {font} }}
     def inject_dynamic_style_and_show(self) -> None:
         "Add dynamic styling, and reveal."
         css = self.standard_css()
-        body_class = theme_manager.body_class()
 
         def after_style(arg: Any) -> None:
             gui_hooks.webview_did_inject_style_into_page(self)
@@ -649,7 +648,6 @@ html {{ {font} }}
 const style = document.createElement('style');
 style.innerHTML = `{css}`;
 document.head.appendChild(style);
-document.body.classList.add(...`{body_class}`.split(" "));
 """,
             after_style,
         )

--- a/sass/base.scss
+++ b/sass/base.scss
@@ -69,7 +69,7 @@ samp {
     --base-font-size: 14px;
 }
 
-.rtl {
+[dir=rtl] {
     .form-select {
         /* flip <select>'s arrow */
         background-position: left .75rem center;

--- a/sass/base.scss
+++ b/sass/base.scss
@@ -68,3 +68,10 @@ samp {
 .isLin {
     --base-font-size: 14px;
 }
+
+.rtl {
+    .form-select {
+        /* flip <select>'s arrow */
+        background-position: left .75rem center;
+    }
+}

--- a/ts/lib/i18n/utils.ts
+++ b/ts/lib/i18n/utils.ts
@@ -88,4 +88,6 @@ export async function setupI18n(args: { modules: ModuleName[] }): Promise<void> 
 
     setBundles(newBundles);
     langs = json.langs;
+
+    document.dir = direction();
 }


### PR DESCRIPTION
Bootstrap's `form-select` class was causing the arrows not to flip automatically as you said in https://github.com/ankitects/anki/pull/1521#issuecomment-985875363

Instead of duplicating styles across all places where `<select>` is used, I chose to add the `rtl` class to `body` and put the fix in `base.scss`.