### PR TITLE
Fix error on previewer close

### DIFF
--- a/qt/aqt/browser/previewer.py
+++ b/qt/aqt/browser/previewer.py
@@ -114,10 +114,6 @@ class Previewer(QDialog):
         elif self._state == "answer":
             replay_audio(self.card(), False)
 
-    def close(self) -> None:
-        self._on_close()
-        super().close()
-
     def _on_close(self) -> None:
         self._open = False
         self._close_callback()


### PR DESCRIPTION
`_on_close` was being called twice, causing an error when the destroyed `_web` is accessed again.

Surfaced after https://github.com/ankitects/anki/pull/1510