### PR TITLE
Block {,max-}{width,height} from being copied

### DIFF
--- a/ts/html-filter/styling.ts
+++ b/ts/html-filter/styling.ts
@@ -25,6 +25,10 @@ const stylingInternal: BlockProperties = [
     "background-color",
     "font-size",
     "font-family",
+    "width",
+    "height",
+    "max-width",
+    "max-height",
 ];
 
 const allowPropertiesBlockValues =


### PR DESCRIPTION
Closes #1515.

Btw, I noticed that when pasting images on GitHub, they also allow you to edit the `width` property, similar to how it works in Anki now. Seems like we are on the right track with that feature.