### PR TITLE
Update about.py

### DIFF
--- a/qt/aqt/about.py
+++ b/qt/aqt/about.py
@@ -223,6 +223,7 @@ def show(mw: aqt.AnkiQt) -> QDialog:
             "Hikaru Yoshiga",
             "Matthias Metelka",
             "Sergio Quintero",
+            "Nicholas Flint",
         )
     )
 

--- a/qt/aqt/about.py
+++ b/qt/aqt/about.py
@@ -218,6 +218,10 @@ def show(mw: aqt.AnkiQt) -> QDialog:
             "RumovZ",
             "学习骇客",
             "ready-research",
+            "Henrik Giesel",
+            "Yoonchae Lee",
+            "Hikaru Yoshiga",
+            "Matthias Metelka",
         )
     )
 

--- a/qt/aqt/about.py
+++ b/qt/aqt/about.py
@@ -222,6 +222,7 @@ def show(mw: aqt.AnkiQt) -> QDialog:
             "Yoonchae Lee",
             "Hikaru Yoshiga",
             "Matthias Metelka",
+            "Sergio Quintero",
         )
     )
 


### PR DESCRIPTION
I noticed some important contributors (and I) can't show off with their name on the Anki About screen yet.
@hgiesel @BlueGreenMagick @hikaru-y I can't force anyone into this, so just react to this comment with
- :+1: if you **want** to get added with this PR (or don't have anything against it)
- :-1: if you **don't** want to get added with this PR

and then I mark this PR as ready.

(I used the names from `CONTRIBUTORS`)
@abdnh I think your initials are already on the list, correct me if I'm wrong ^^