### PR TITLE
Add .aac files to editor

### DIFF
--- a/qt/aqt/editor.py
+++ b/qt/aqt/editor.py
@@ -57,6 +57,7 @@ from aqt.webview import AnkiWebView
 pics = ("jpg", "jpeg", "png", "tif", "tiff", "gif", "svg", "webp", "ico")
 audio = (
     "3gp",
+    "aac",
     "avi",
     "flac",
     "flv",


### PR DESCRIPTION
.aac audio files work as expected, but Anki doesn't recognize them by default when attaching files.