### PR TITLE
The importer list have a Hook

### DIFF
--- a/pylib/anki/importing/__init__.py
+++ b/pylib/anki/importing/__init__.py
@@ -3,6 +3,7 @@
 
 from typing import Any, Callable, Sequence, Type, Union
 
+from anki import hooks
 from anki.collection import Collection
 from anki.importing.anki2 import Anki2Importer
 from anki.importing.apkg import AnkiPackageImporter
@@ -15,7 +16,7 @@ from anki.lang import TR
 
 
 def importers(col: Collection) -> Sequence[tuple[str, type[Importer]]]:
-    return (
+    importers = [
         (col.tr.importing_text_separated_by_tabs_or_semicolons(), TextImporter),
         (
             col.tr.importing_packaged_anki_deckcollection_apkg_colpkg_zip(),
@@ -24,4 +25,6 @@ def importers(col: Collection) -> Sequence[tuple[str, type[Importer]]]:
         (col.tr.importing_mnemosyne_20_deck_db(), MnemosyneImporter),
         (col.tr.importing_supermemo_xml_export_xml(), SupermemoXmlImporter),
         (col.tr.importing_pauker_18_lesson_paugz(), PaukerImporter),
-    )
+    ]
+    hooks.importing_importers(importers)
+    return importers

--- a/pylib/tools/genhooks.py
+++ b/pylib/tools/genhooks.py
@@ -93,6 +93,13 @@ hooks = [
         doc="""Allows changing the number of rev card for this deck (without
         considering descendants).""",
     ),
+    Hook(
+        name="importing_importers",
+        args=["importers: list[tuple[str, Any]]"],
+        doc="""Allows updating the list of importers.
+        The resulting list is not saved and should be changed each time the
+        filter is called.""",
+    ),
     # obsolete
     Hook(
         name="deck_added",

--- a/pylib/tools/genhooks.py
+++ b/pylib/tools/genhooks.py
@@ -98,7 +98,11 @@ hooks = [
         args=["importers: list[tuple[str, Any]]"],
         doc="""Allows updating the list of importers.
         The resulting list is not saved and should be changed each time the
-        filter is called.""",
+        filter is called.
+        
+        NOTE: Updates to the import/export code are expected in the coming 
+        months, and this hook may be replaced with another solution at that 
+        time. Tracked on https://github.com/ankitects/anki/issues/1018""",
     ),
     # obsolete
     Hook(


### PR DESCRIPTION
Previously, add-on 175027074 simply edited the list once. It became impossible
since the list became a function. Hence I need a filter to add the list here.

@kelciour (nice to meet you by the way), you may be interested by it too (at
least if I believe efb1ce46d4b6982833b0ed324b9d105ba83ba394 )

I would have preferred to use `anki.importing.base.Importer` instead of
`Any`. However, this leads to
> Name "anki.importing.base.Importer" is not defined  [name-defined]
when I run test.

Helps to solve this would be welcomed. Otherwise, I believe keeping "Any" is acceptable