### PR TITLE
Parse Markdown inside HTML tags in config.md

### DIFF
--- a/qt/aqt/addons.py
+++ b/qt/aqt/addons.py
@@ -613,7 +613,7 @@ class AddonManager:
         path = os.path.join(self.addonsFolder(dir), "config.md")
         if os.path.exists(path):
             with open(path, encoding="utf-8") as f:
-                return markdown.markdown(f.read())
+                return markdown.markdown(f.read(), extensions=["md_in_html"])
         else:
             return ""
 


### PR DESCRIPTION
My use case for this is to wrap a config.md written in Arabic with a RTL div (with [`markdown="1"`](https://python-markdown.github.io/extensions/md_in_html/#1) set).
