### PR TITLE
Add setField to OldEditorAdapter

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -88,6 +88,7 @@ Ren Tatsumoto <tatsu@autistici.org>
 lolilolicon <lolilolicon@gmail.com>
 Gesa Stupperich <gesa.stupperich@gmail.com>
 git9527 <github.com/git9527>
+Matthew Hayes <matthew.terence.hayes@gmail.com>
 
 ********************
 

--- a/ts/editor/OldEditorAdapter.svelte
+++ b/ts/editor/OldEditorAdapter.svelte
@@ -115,6 +115,10 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         fieldNames = newFieldNames;
     }
 
+    export function setField(index: number, fieldContent: string): void {
+        fieldStores[index].set(fieldContent);
+    }
+
     let fieldDescriptions: string[] = [];
     export function setDescriptions(fs: string[]): void {
         fieldDescriptions = fs;

--- a/ts/editor/index.ts
+++ b/ts/editor/index.ts
@@ -74,6 +74,7 @@ async function setupNoteEditor(): Promise<NoteEditorAPI> {
     });
 
     Object.assign(globalThis, {
+        setField: noteEditor.setField,
         setFields: noteEditor.setFields,
         setDescriptions: noteEditor.setDescriptions,
         setFonts: noteEditor.setFonts,


### PR DESCRIPTION
I developed a plugin called [Cloze Anything](https://ankiweb.net/shared/info/330680661) that supports an alternative JavaScript-based cloze implementation.  One of the requirements the plugin has is the ability to update another field in the editor (besides the one being edited) based on certain conditions.  Previously the plugin was able to use `web.eval` to set individual fields in the editor, ex: 

```
editor.web.eval("""$("#f" + %d).html(%s)""" % (f["ord"], json.dumps(field_content)))
```

This stopped working at some point in recent releases.  As an alternative, I've had to switch to using `setFields`.  However this isn't optimal.  There are two cases where I need to update other fields.  One is for a `blur` event and the other is for a `key` event.  For a `blur` event, using `setFields` works fine (although it's overkill because I only need to update one field).  But for the `key` event, `setFields` doesn't work well because it resets the focus of the field being edited.  What I really need is the ability to set the value of just one field.

Here I've added a `setField` function, based on the implementation I saw for `setFields`.  I tested this new function in my plugin [here](https://github.com/matthayes/anki_cloze_anything/commit/8841ca96a9f6a15dc009839c20706460fadd87aa).

Is there a better way to achieve this besides adding this new function?  I tried searching the Python code for `eval` calls doing something similar and I couldn't find anything.