### PR TITLE
Add surround to OldEditorAdapter

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -88,6 +88,7 @@ Ren Tatsumoto <tatsu@autistici.org>
 lolilolicon <lolilolicon@gmail.com>
 Gesa Stupperich <gesa.stupperich@gmail.com>
 git9527 <github.com/git9527>
+Matthew Hayes <matthew.terence.hayes@gmail.com>
 
 ********************
 

--- a/ts/editor/OldEditorAdapter.svelte
+++ b/ts/editor/OldEditorAdapter.svelte
@@ -115,6 +115,10 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         fieldNames = newFieldNames;
     }
 
+    export function surround(before: string, after: string): void {
+        get(activeInput)?.surround(before, after);
+    }
+
     let fieldDescriptions: string[] = [];
     export function setDescriptions(fs: string[]): void {
         fieldDescriptions = fs;

--- a/ts/editor/index.ts
+++ b/ts/editor/index.ts
@@ -87,6 +87,7 @@ async function setupNoteEditor(): Promise<NoteEditorAPI> {
         activateStickyShortcuts: noteEditor.activateStickyShortcuts,
         focusIfField: noteEditor.focusIfField,
         setNoteId: noteEditor.setNoteId,
+        surround: noteEditor.surround,
     });
 
     return api as NoteEditorAPI;


### PR DESCRIPTION
The [Cloze Anything](https://github.com/matthayes/anki_cloze_anything) plugin I created has been using the `wrap` JavaScript function.  It appears this is being removed in 2.1.50, which will break the plugin.  To fix this, I've added `surround` to the OldEditorAdapter.  I've demonstrated using this fix [here](https://github.com/matthayes/anki_cloze_anything/commit/080e5b73eb5f0363a77fc9737852ea685d74f3b1).