### PR TITLE
Rework field copying when switching notetypes

### DIFF
--- a/qt/aqt/addcards.py
+++ b/qt/aqt/addcards.py
@@ -148,15 +148,27 @@ class AddCards(QMainWindow):
         if old:
             old_fields = list(old.keys())
             new_fields = list(new.keys())
+            copied_fields = set()
             for n, f in enumerate(new.note_type()["flds"]):
                 field_name = f["name"]
-                # copy identical fields
-                if field_name in old_fields:
+                # copy identical non-empty fields
+                if field_name in old_fields and old[field_name]:
                     new[field_name] = old[field_name]
-                elif n < len(old_fields):
-                    # set non-identical fields by field index
-                    if old_fields[n] not in new_fields:
-                        new.fields[n] = old.fields[n]
+                    copied_fields.add(field_name)
+            new_idx = 0
+            for old_idx, old_field in enumerate(old_fields):
+                # skip previously copied identical fields in new note
+                while (
+                    new_idx < len(new_fields) and new_fields[new_idx] in copied_fields
+                ):
+                    new_idx += 1
+                if new_idx >= len(new_fields):
+                    break
+                # copy non-empty old fields
+                if not old_field in copied_fields and old.fields[old_idx]:
+                    new.fields[new_idx] = old.fields[old_idx]
+                    new_idx += 1
+
             new.tags = old.tags
 
         # and update editor state


### PR DESCRIPTION
This PR tweaks the way Anki copies fields when switching notetypes in the Add screen:
- Copy identical fields as before, but maintain a list of copied fields and only add non-empty ones to it.
- Instead of setting remaining fields by their indices, assign remaining non-empty old fields to new fields sequentially

This results in less fields being lost when switching notetypes, while admittedly making the behavior less obvious.