### PR TITLE
New TTS/AV tag handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,6 +54,7 @@ dependencies = [
  "bytes",
  "chrono",
  "coarsetime",
+ "criterion",
  "env_logger",
  "flate2",
  "fluent",
@@ -223,6 +224,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
+dependencies = [
+ "lazy_static",
+ "memchr",
+ "regex-automata",
+ "serde",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -239,6 +252,15 @@ name = "bytes"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
+
+[[package]]
+name = "cast"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c24dab4283a142afa2fdca129b80ad2c6284e073930f964c3a1293c225ee39a"
+dependencies = [
+ "rustc_version",
+]
 
 [[package]]
 name = "cc"
@@ -263,6 +285,17 @@ dependencies = [
  "num-traits",
  "time",
  "winapi",
+]
+
+[[package]]
+name = "clap"
+version = "2.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
+dependencies = [
+ "bitflags",
+ "textwrap",
+ "unicode-width",
 ]
 
 [[package]]
@@ -336,6 +369,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1604dafd25fba2fe2d5895a9da139f8dc9b319a5fe5354ca137cbbce4e178d10"
+dependencies = [
+ "atty",
+ "cast",
+ "clap",
+ "criterion-plot",
+ "csv",
+ "itertools",
+ "lazy_static",
+ "num-traits",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_cbor",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d00996de9f2f7559f7f4dc286073197f83e92256a59ed395f9aac01fe717da57"
+dependencies = [
+ "cast",
+ "itertools",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -343,6 +412,30 @@ checksum = "06ed27e177f16d65f0f0c22a213e17c696ace5dd64b14258b52f9417ccb52db4"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6455c0ca19f0d2fbf751b908d5c55c1f5cbc65e03c4225427254b46890bdde1e"
+dependencies = [
+ "cfg-if",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ec02e091aa634e2c3ada4a392989e7c3116673ef0ac5b72232439094d73b7fd"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "lazy_static",
+ "memoffset",
+ "scopeguard",
 ]
 
 [[package]]
@@ -380,6 +473,28 @@ checksum = "dfae75de57f2b2e85e8768c3ea840fd159c8f33e2b6522c7835b7abac81be16e"
 dependencies = [
  "quote",
  "syn",
+]
+
+[[package]]
+name = "csv"
+version = "1.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22813a6dc45b335f9bade10bf7271dc477e81113e89eb251a0bc2a8a81c536e1"
+dependencies = [
+ "bstr",
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b2466559f260f48ad25fe6317b3c8dac77b5bdb5763ac7d9d6103530663bc90"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -757,6 +872,12 @@ dependencies = [
  "tokio-util",
  "tracing",
 ]
+
+[[package]]
+name = "half"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
 
 [[package]]
 name = "hashbrown"
@@ -1167,6 +1288,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 
 [[package]]
+name = "memoffset"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1342,6 +1472,12 @@ name = "once_cell"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
+
+[[package]]
+name = "oorandom"
+version = "11.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
 name = "openssl"
@@ -1579,6 +1715,34 @@ name = "pkg-config"
 version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12295df4f294471248581bc09bef3c38a5e46f1e36d6a37353621a0c6c357e1f"
+
+[[package]]
+name = "plotters"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a3fd9ec30b9749ce28cd91f255d569591cdf937fe280c312143e3c4bad6f2a"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d88417318da0eaf0fdcdb51a0ee6c3bed624333bff8f946733049380be67ac1c"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521fa9638fa597e1dc53e9412a4f9cefb01187ee1f7413076f9e6749e2885ba9"
+dependencies = [
+ "plotters-backend",
+]
 
 [[package]]
 name = "ppv-lite86"
@@ -1837,6 +2001,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c06aca804d41dbc8ba42dfd964f0d01334eceb64314b9ecf7c5fad5188a06d90"
+dependencies = [
+ "autocfg",
+ "crossbeam-deque",
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d78120e2c850279833f1dd3582f730c4ab53ed95aeaaaa862a2a5c71b1656d8e"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-utils",
+ "lazy_static",
+ "num_cpus",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1865,6 +2054,12 @@ dependencies = [
  "memchr",
  "regex-syntax",
 ]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
 
 [[package]]
 name = "regex-syntax"
@@ -2121,6 +2316,16 @@ dependencies = [
  "chrono",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "serde_cbor"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bef2ebfde456fb76bbcf9f59315333decc4fda0b2b44b420243c11e0f5ec1f5"
+dependencies = [
+ "half",
+ "serde",
 ]
 
 [[package]]
@@ -2424,6 +2629,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "textwrap"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+dependencies = [
+ "unicode-width",
+]
+
+[[package]]
 name = "thin-slice"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2474,6 +2688,16 @@ name = "tinystr"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29738eedb4388d9ea620eeab9384884fc3f06f586a2eddb56bedc5885126c7c1"
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
 
 [[package]]
 name = "tinyvec"

--- a/ftl/core/errors.ftl
+++ b/ftl/core/errors.ftl
@@ -9,3 +9,8 @@ errors-100-tags-max =
     is no need to select child tags if you have selected a parent tag.
 errors-multiple-notetypes-selected = Please select notes from only one notetype.
 errors-please-check-database = Please use the Check Database action, then try again.
+
+## Card Rendering
+
+errors-bad-directive = Error in directive '{ $directive }': { $error }
+errors-option-not-set = '{ $option }' not set

--- a/rslib/Cargo.toml
+++ b/rslib/Cargo.toml
@@ -11,6 +11,19 @@ build = "build/main.rs"
 name = "anki"
 path = "src/lib.rs"
 
+[features]
+bench = ["criterion"]
+links = ["linkcheck"]
+
+[[test]]
+name = "links"
+required-features = ["links"]
+
+[[bench]]
+name = "benchmark"
+harness = false
+required-features = ["bench"]
+
 # After updating anything below, run ../cargo/update.py
 
 [build-dependencies]
@@ -18,7 +31,6 @@ prost-build = "0.9.0"
 
 [dev-dependencies]
 env_logger = "0.9.0"
-linkcheck = { git = "https://github.com/ankitects/linkcheck.git", rev = "2f20798ce521cc594d510d4e417e76d5eac04d4b" }
 tokio = { version = "1.12.0", features = ["macros"] }
 
 [dependencies]
@@ -26,6 +38,9 @@ tokio = { version = "1.12.0", features = ["macros"] }
 unicase = "=2.6.0"
 
 anki_i18n = { path="i18n" }
+
+criterion = { version = "0.3.5", optional = true }
+linkcheck = { git = "https://github.com/ankitects/linkcheck.git", rev = "2f20798ce521cc594d510d4e417e76d5eac04d4b", optional = true }
 
 nom = "7.0.0"
 proc-macro-nested = "0.1.7"

--- a/rslib/bench.sh
+++ b/rslib/bench.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+cargo criterion --bench benchmark --features bench

--- a/rslib/benches/benchmark.rs
+++ b/rslib/benches/benchmark.rs
@@ -1,3 +1,6 @@
+// Copyright: Ankitects Pty Ltd and contributors
+// License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
+
 use anki::card_rendering::anki_tag_benchmark;
 use criterion::{criterion_group, criterion_main, Criterion};
 

--- a/rslib/benches/benchmark.rs
+++ b/rslib/benches/benchmark.rs
@@ -1,0 +1,9 @@
+use anki::card_rendering::anki_tag_benchmark;
+use criterion::{criterion_group, criterion_main, Criterion};
+
+pub fn criterion_benchmark(c: &mut Criterion) {
+    c.bench_function("anki_tag_parse", |b| b.iter(|| anki_tag_benchmark()));
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/rslib/src/backend/cardrendering.rs
+++ b/rslib/src/backend/cardrendering.rs
@@ -22,7 +22,7 @@ impl CardRenderingService for Backend {
         &self,
         input: pb::ExtractAvTagsRequest,
     ) -> Result<pb::ExtractAvTagsResponse> {
-        let out = extract_av_tags(&input.text, input.question_side, self.i18n());
+        let out = extract_av_tags(input.text, input.question_side, self.i18n());
         Ok(pb::ExtractAvTagsResponse {
             text: out.0,
             av_tags: out.1,
@@ -117,7 +117,7 @@ impl CardRenderingService for Backend {
     }
 
     fn strip_av_tags(&self, input: pb::String) -> Result<pb::String> {
-        Ok(strip_av_tags(&input.val).into())
+        Ok(strip_av_tags(input.val).into())
     }
 
     fn render_markdown(&self, input: pb::RenderMarkdownRequest) -> Result<pb::String> {

--- a/rslib/src/browser_table.rs
+++ b/rslib/src/browser_table.rs
@@ -9,7 +9,7 @@ use strum::{Display, EnumIter, EnumString, IntoEnumIterator};
 use crate::{
     backend_proto as pb,
     card::{CardQueue, CardType},
-    card_rendering::extract_av_tags,
+    card_rendering::prettify_av_tags,
     notetype::{CardTemplate, NotetypeKind},
     prelude::*,
     scheduler::{timespan::time_span, timing::SchedTimingToday},
@@ -271,7 +271,7 @@ impl RenderContext {
                 } => current_text,
             })
             .join("");
-        let question = extract_av_tags(&qnodes_text, true, &col.tr).0;
+        let question = prettify_av_tags(&qnodes_text);
 
         Ok(RenderContext {
             question,
@@ -411,7 +411,7 @@ impl RowContext {
                 } => current_text,
             })
             .join("");
-        let answer = extract_av_tags(&answer, false, &self.tr).0;
+        let answer = prettify_av_tags(&answer);
         html_to_text_line(
             if let Some(stripped) = answer.strip_prefix(&render_context.question) {
                 stripped

--- a/rslib/src/browser_table.rs
+++ b/rslib/src/browser_table.rs
@@ -9,11 +9,12 @@ use strum::{Display, EnumIter, EnumString, IntoEnumIterator};
 use crate::{
     backend_proto as pb,
     card::{CardQueue, CardType},
+    card_rendering::extract_av_tags,
     notetype::{CardTemplate, NotetypeKind},
     prelude::*,
     scheduler::{timespan::time_span, timing::SchedTimingToday},
     template::RenderedNode,
-    text::{extract_av_tags, html_to_text_line},
+    text::html_to_text_line,
 };
 
 #[derive(Debug, PartialEq, Clone, Copy, Display, EnumIter, EnumString)]
@@ -270,7 +271,7 @@ impl RenderContext {
                 } => current_text,
             })
             .join("");
-        let question = extract_av_tags(&qnodes_text, true).0.to_string();
+        let question = extract_av_tags(&qnodes_text, true, &col.tr).0;
 
         Ok(RenderContext {
             question,
@@ -410,7 +411,7 @@ impl RowContext {
                 } => current_text,
             })
             .join("");
-        let answer = extract_av_tags(&answer, false).0;
+        let answer = extract_av_tags(&answer, false, &self.tr).0;
         html_to_text_line(
             if let Some(stripped) = answer.strip_prefix(&render_context.question) {
                 stripped

--- a/rslib/src/browser_table.rs
+++ b/rslib/src/browser_table.rs
@@ -271,7 +271,7 @@ impl RenderContext {
                 } => current_text,
             })
             .join("");
-        let question = prettify_av_tags(&qnodes_text);
+        let question = prettify_av_tags(qnodes_text);
 
         Ok(RenderContext {
             question,
@@ -411,7 +411,7 @@ impl RowContext {
                 } => current_text,
             })
             .join("");
-        let answer = prettify_av_tags(&answer);
+        let answer = prettify_av_tags(answer);
         html_to_text_line(
             if let Some(stripped) = answer.strip_prefix(&render_context.question) {
                 stripped

--- a/rslib/src/card_rendering/mod.rs
+++ b/rslib/src/card_rendering/mod.rs
@@ -56,17 +56,17 @@ impl<'iter, 'nodes> IntoIterator for &'iter CardNodes<'nodes> {
 enum Node<'a> {
     Text(&'a str),
     SoundOrVideo(&'a str),
-    Tag(Tag<'a>),
+    Directive(Directive<'a>),
 }
 
 #[derive(Debug, PartialEq)]
-enum Tag<'a> {
-    Tts(TtsTag<'a>),
-    Other(OtherTag<'a>),
+enum Directive<'a> {
+    Tts(TtsDirective<'a>),
+    Other(OtherDirective<'a>),
 }
 
 #[derive(Debug, PartialEq)]
-struct TtsTag<'a> {
+struct TtsDirective<'a> {
     content: &'a str,
     lang: &'a str,
     voices: Vec<&'a str>,
@@ -76,7 +76,7 @@ struct TtsTag<'a> {
 }
 
 #[derive(Debug, PartialEq)]
-struct OtherTag<'a> {
+struct OtherDirective<'a> {
     name: &'a str,
     content: &'a str,
     options: HashMap<&'a str, &'a str>,
@@ -84,7 +84,7 @@ struct OtherTag<'a> {
 
 #[cfg(feature = "bench")]
 #[inline]
-pub fn anki_tag_benchmark() {
+pub fn anki_directive_benchmark() {
     CardNodes::parse("[anki:foo bar=baz][/anki:foo][anki:tts lang=jp_JP voices=Alice,Bob speed=0.5 cloze_blank= bar=baz][/anki:tts]");
 }
 

--- a/rslib/src/card_rendering/mod.rs
+++ b/rslib/src/card_rendering/mod.rs
@@ -82,6 +82,33 @@ struct OtherTag<'a> {
     options: HashMap<&'a str, &'a str>,
 }
 
+impl TtsTag<'_> {
+    pub(crate) fn new<'a>(content: &'a str, options: Vec<(&'a str, &'a str)>) -> TtsTag<'a> {
+        let mut options: HashMap<&str, &str> = options.into_iter().collect();
+        let lang = options.remove("lang").unwrap_or_default();
+        let voices = options
+            .remove("voices")
+            .unwrap_or_default()
+            .split(',')
+            .collect();
+        let speed = options
+            .remove("speed")
+            .unwrap_or_default()
+            .parse()
+            .unwrap_or(1.0);
+        let blank = options.remove("cloze_blank");
+
+        TtsTag {
+            content,
+            lang,
+            voices,
+            speed,
+            blank,
+            options,
+        }
+    }
+}
+
 #[cfg(feature = "bench")]
 #[inline]
 pub fn anki_tag_benchmark() {

--- a/rslib/src/card_rendering/mod.rs
+++ b/rslib/src/card_rendering/mod.rs
@@ -82,33 +82,6 @@ struct OtherTag<'a> {
     options: HashMap<&'a str, &'a str>,
 }
 
-impl TtsTag<'_> {
-    pub(crate) fn new<'a>(content: &'a str, options: Vec<(&'a str, &'a str)>) -> TtsTag<'a> {
-        let mut options: HashMap<&str, &str> = options.into_iter().collect();
-        let lang = options.remove("lang").unwrap_or_default();
-        let voices = options
-            .remove("voices")
-            .unwrap_or_default()
-            .split(',')
-            .collect();
-        let speed = options
-            .remove("speed")
-            .unwrap_or_default()
-            .parse()
-            .unwrap_or(1.0);
-        let blank = options.remove("cloze_blank");
-
-        TtsTag {
-            content,
-            lang,
-            voices,
-            speed,
-            blank,
-            options,
-        }
-    }
-}
-
 #[cfg(feature = "bench")]
 #[inline]
 pub fn anki_tag_benchmark() {

--- a/rslib/src/card_rendering/mod.rs
+++ b/rslib/src/card_rendering/mod.rs
@@ -1,0 +1,112 @@
+// Copyright: Ankitects Pty Ltd and contributors
+// License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
+
+use std::collections::HashMap;
+
+use crate::backend_proto as pb;
+use crate::prelude::*;
+
+mod parser;
+mod writer;
+
+pub fn strip_av_tags(txt: &str) -> String {
+    CardNodes::parse(txt).write_without_av_tags()
+}
+
+pub fn extract_av_tags(txt: &str, question_side: bool, tr: &I18n) -> (String, Vec<pb::AvTag>) {
+    CardNodes::parse(txt).write_and_extract_av_tags(question_side, tr)
+}
+
+#[derive(Debug, PartialEq)]
+struct CardNodes<'a>(Vec<Node<'a>>);
+
+impl<'iter, 'nodes> IntoIterator for &'iter CardNodes<'nodes> {
+    type Item = &'iter Node<'nodes>;
+    type IntoIter = std::slice::Iter<'iter, Node<'nodes>>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.iter()
+    }
+}
+
+#[derive(Debug, PartialEq)]
+enum Node<'a> {
+    Text(&'a str),
+    SoundOrVideo(&'a str),
+    Tag(Tag<'a>),
+}
+
+#[derive(Debug, PartialEq)]
+enum Tag<'a> {
+    Tts(TtsTag<'a>),
+    Other(OtherTag<'a>),
+}
+
+#[derive(Debug, PartialEq)]
+struct TtsTag<'a> {
+    content: &'a str,
+    lang: &'a str,
+    voices: Vec<&'a str>,
+    speed: f32,
+    blank: Option<&'a str>,
+    options: HashMap<&'a str, &'a str>,
+}
+
+#[derive(Debug, PartialEq)]
+struct OtherTag<'a> {
+    name: &'a str,
+    content: &'a str,
+    options: HashMap<&'a str, &'a str>,
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    /// Strip av tags and assert equality with input or separately passed output.
+    macro_rules! assert_av_stripped {
+        ($input:expr) => {
+            assert_eq!($input, strip_av_tags($input));
+        };
+        ($input:expr, $output:expr) => {
+            assert_eq!(strip_av_tags($input), $output);
+        };
+    }
+
+    #[test]
+    fn av_stripping() {
+        assert_av_stripped!("foo [sound:bar] baz", "foo  baz");
+        assert_av_stripped!("[anki:tts bar=baz]spam[/anki:tts]", "");
+        assert_av_stripped!("[anki:foo bar=baz]spam[/anki:foo]");
+    }
+
+    #[test]
+    fn av_extracting() {
+        let tr = I18n::template_only();
+        let (txt, tags) = extract_av_tags(
+            "foo [sound:bar.mp3] baz [anki:tts][...][/anki:tts]",
+            true,
+            &tr,
+        );
+        assert_eq!(
+            (txt.as_str(), tags),
+            (
+                "foo [anki:play:q:0] baz [anki:play:q:1]",
+                vec![
+                    pb::AvTag {
+                        value: Some(pb::av_tag::Value::SoundOrVideo("bar.mp3".to_string()))
+                    },
+                    pb::AvTag {
+                        value: Some(pb::av_tag::Value::Tts(pb::TtsTag {
+                            field_text: tr.card_templates_blank().to_string(),
+                            lang: "".to_string(),
+                            voices: vec![],
+                            speed: 1.0,
+                            other_args: vec![],
+                        }))
+                    }
+                ],
+            ),
+        );
+    }
+}

--- a/rslib/src/card_rendering/mod.rs
+++ b/rslib/src/card_rendering/mod.rs
@@ -17,6 +17,10 @@ pub fn extract_av_tags(txt: &str, question_side: bool, tr: &I18n) -> (String, Ve
     CardNodes::parse(txt).write_and_extract_av_tags(question_side, tr)
 }
 
+pub fn prettify_av_tags(txt: &str) -> String {
+    CardNodes::parse(txt).write_with_pretty_av_tags()
+}
+
 #[derive(Debug, PartialEq)]
 struct CardNodes<'a>(Vec<Node<'a>>);
 

--- a/rslib/src/card_rendering/mod.rs
+++ b/rslib/src/card_rendering/mod.rs
@@ -113,7 +113,7 @@ mod test {
     fn av_extracting() {
         let tr = I18n::template_only();
         let (txt, tags) = extract_av_tags(
-            "foo [sound:bar.mp3] baz [anki:tts][...][/anki:tts]",
+            "foo [sound:bar.mp3] baz [anki:tts lang=en_US][...][/anki:tts]",
             true,
             &tr,
         );
@@ -128,13 +128,25 @@ mod test {
                     pb::AvTag {
                         value: Some(pb::av_tag::Value::Tts(pb::TtsTag {
                             field_text: tr.card_templates_blank().to_string(),
-                            lang: "".to_string(),
+                            lang: "en_US".to_string(),
                             voices: vec![],
                             speed: 1.0,
                             other_args: vec![],
                         }))
                     }
                 ],
+            ),
+        );
+
+        assert_eq!(
+            extract_av_tags("[anki:tts]foo[/anki:tts]", true, &tr),
+            (
+                format!(
+                    "[{}]",
+                    tr.errors_bad_directive("anki:tts", tr.errors_option_not_set("lang"))
+                        .to_owned()
+                ),
+                vec![],
             ),
         );
     }

--- a/rslib/src/card_rendering/mod.rs
+++ b/rslib/src/card_rendering/mod.rs
@@ -3,8 +3,7 @@
 
 use std::collections::HashMap;
 
-use crate::backend_proto as pb;
-use crate::prelude::*;
+use crate::{backend_proto as pb, prelude::*};
 
 mod parser;
 mod writer;
@@ -81,6 +80,12 @@ struct OtherTag<'a> {
     name: &'a str,
     content: &'a str,
     options: HashMap<&'a str, &'a str>,
+}
+
+#[cfg(feature = "bench")]
+#[inline]
+pub fn anki_tag_benchmark() {
+    CardNodes::parse("[anki:foo bar=baz][/anki:foo][anki:tts lang=jp_JP voices=Alice,Bob speed=0.5 cloze_blank= bar=baz][/anki:tts]");
 }
 
 #[cfg(test)]

--- a/rslib/src/card_rendering/parser.rs
+++ b/rslib/src/card_rendering/parser.rs
@@ -5,8 +5,7 @@ use std::collections::HashMap;
 
 use nom::{
     branch::alt,
-    bytes::complete::is_not,
-    bytes::complete::tag,
+    bytes::complete::{is_not, tag},
     character::complete::{anychar, multispace0},
     combinator::{map, not, recognize, success, value},
     multi::{many0, many1},

--- a/rslib/src/card_rendering/parser.rs
+++ b/rslib/src/card_rendering/parser.rs
@@ -88,7 +88,7 @@ fn node(s: &str) -> IResult<Node> {
     alt((text_node, sound_node, tag_node))(s)
 }
 
-/// A sound tag `[sound:ressource]`, where `ressource` is pointing to a sound or video file.
+/// A sound tag `[sound:resource]`, where `resource` is pointing to a sound or video file.
 fn sound_node(s: &str) -> IResult<Node> {
     map(
         delimited(tag("[sound:"), is_not("]"), tag("]")),

--- a/rslib/src/card_rendering/parser.rs
+++ b/rslib/src/card_rendering/parser.rs
@@ -1,0 +1,261 @@
+// Copyright: Ankitects Pty Ltd and contributors
+// License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
+
+use std::collections::HashMap;
+
+use nom::{
+    branch::alt,
+    bytes::complete::is_not,
+    bytes::complete::tag,
+    character::complete::{anychar, multispace0},
+    combinator::{map, not, recognize, success, value},
+    multi::{many0, many1},
+    sequence::{delimited, pair, preceded, separated_pair, terminated, tuple},
+};
+
+use super::{CardNodes, Node, OtherTag, Tag, TtsTag};
+
+type IResult<'a, O> = nom::IResult<&'a str, O>;
+
+impl<'a> CardNodes<'a> {
+    pub(super) fn parse(mut txt: &'a str) -> Self {
+        let mut nodes = Vec::new();
+        while let Ok((remaining, node)) = node(txt) {
+            txt = remaining;
+            nodes.push(node);
+        }
+
+        Self(nodes)
+    }
+}
+
+impl<'a> Tag<'a> {
+    fn new(name: &'a str, options: Vec<(&'a str, &'a str)>, content: &'a str) -> Self {
+        match name {
+            "tts" => {
+                let mut lang = "";
+                let mut voices = vec![];
+                let mut speed = 1.0;
+                let mut blank = None;
+                let mut other_options = HashMap::new();
+
+                for option in options {
+                    match option.0 {
+                        "lang" => lang = option.1,
+                        "voices" => voices = option.1.split(',').collect(),
+                        "speed" => speed = option.1.parse().unwrap_or(1.0),
+                        "cloze_blank" => blank = Some(option.1),
+                        _ => {
+                            other_options.insert(option.0, option.1);
+                        }
+                    }
+                }
+
+                Self::Tts(TtsTag {
+                    content,
+                    lang,
+                    voices,
+                    speed,
+                    blank,
+                    options: other_options,
+                })
+            }
+            _ => Self::Other(OtherTag {
+                name,
+                content,
+                options: options.into_iter().collect(),
+            }),
+        }
+    }
+}
+
+/// Consume 0 or more of anything in " \t\r\n" after `parser`.
+fn trailing_whitespace0<'parser, 's, P, O>(parser: P) -> impl FnMut(&'s str) -> IResult<O>
+where
+    P: FnMut(&'s str) -> IResult<O> + 'parser,
+{
+    terminated(parser, multispace0)
+}
+
+/// Parse until char in `arr` is found. Always succeeds.
+fn is_not0<'parser, 'arr: 'parser, 's: 'parser>(
+    arr: &'arr str,
+) -> impl FnMut(&'s str) -> IResult<&'s str> + 'parser {
+    alt((is_not(arr), success("")))
+}
+
+fn node(s: &str) -> IResult<Node> {
+    alt((text_node, sound_node, tag_node))(s)
+}
+
+/// A sound tag `[sound:ressource]`, where `ressource` is pointing to a sound or video file.
+fn sound_node(s: &str) -> IResult<Node> {
+    map(
+        delimited(tag("[sound:"), is_not("]"), tag("]")),
+        Node::SoundOrVideo,
+    )(s)
+}
+
+/// An Anki tag `[anki:tag...]...[/anki:tag]`.
+fn tag_node(s: &str) -> IResult<Node> {
+    /// Match the start of an opening tag and return its name.
+    fn name(s: &str) -> IResult<&str> {
+        preceded(tag("[anki:"), is_not("] \t\r\n"))(s)
+    }
+
+    /// Return a parser to match an opening `name` tag and return its options.
+    fn opening_parser<'name, 's: 'name>(
+        name: &'name str,
+    ) -> impl FnMut(&'s str) -> IResult<Vec<(&str, &str)>> + 'name {
+        /// List of whitespace-separated `key=val` tuples, where `val` may be empty.
+        fn options(s: &str) -> IResult<Vec<(&str, &str)>> {
+            fn key(s: &str) -> IResult<&str> {
+                is_not("] \t\r\n=")(s)
+            }
+
+            fn val(s: &str) -> IResult<&str> {
+                alt((
+                    delimited(tag("\""), is_not0("\""), tag("\"")),
+                    is_not0("] \t\r\n\""),
+                ))(s)
+            }
+
+            many0(trailing_whitespace0(separated_pair(key, tag("="), val)))(s)
+        }
+
+        delimited(
+            pair(tag("[anki:"), trailing_whitespace0(tag(name))),
+            options,
+            tag("]"),
+        )
+    }
+
+    /// Return a parser to match a closing `name` tag.
+    fn closing_parser<'parser, 'name: 'parser, 's: 'parser>(
+        name: &'name str,
+    ) -> impl FnMut(&'s str) -> IResult<()> + 'parser {
+        value((), tuple((tag("[/anki:"), tag(name), tag("]"))))
+    }
+
+    /// Return a parser to match and return anything until a closing `name` tag is found.
+    fn content_parser<'parser, 'name: 'parser, 's: 'parser>(
+        name: &'name str,
+    ) -> impl FnMut(&'s str) -> IResult<&str> + 'parser {
+        recognize(many0(pair(not(closing_parser(name)), anychar)))
+    }
+
+    let (_, tag_name) = name(s)?;
+    map(
+        terminated(
+            pair(opening_parser(tag_name), content_parser(tag_name)),
+            closing_parser(tag_name),
+        ),
+        |(options, content)| Node::Tag(Tag::new(tag_name, options, content)),
+    )(s)
+}
+
+fn text_node(s: &str) -> IResult<Node> {
+    map(
+        recognize(many1(pair(not(alt((sound_node, tag_node))), anychar))),
+        Node::Text,
+    )(s)
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    macro_rules! assert_parsed_nodes {
+        ($txt:expr $(, $node:expr)*) => {
+            assert_eq!(CardNodes::parse($txt), CardNodes(vec![$($node),*]));
+        }
+    }
+
+    #[test]
+    fn parsing() {
+        use Node::*;
+
+        // empty
+        assert_parsed_nodes!("");
+
+        // text
+        assert_parsed_nodes!("foo", Text("foo"));
+        // broken sound/tags are just text as well
+        assert_parsed_nodes!("[sound:]", Text("[sound:]"));
+        assert_parsed_nodes!("[anki:][/anki:]", Text("[anki:][/anki:]"));
+        assert_parsed_nodes!("[anki:foo][/anki:bar]", Text("[anki:foo][/anki:bar]"));
+
+        // sound
+        assert_parsed_nodes!("[sound:foo]", SoundOrVideo("foo"));
+        assert_parsed_nodes!(
+            "foo [sound:bar] baz",
+            Text("foo "),
+            SoundOrVideo("bar"),
+            Text(" baz")
+        );
+        assert_parsed_nodes!(
+            "[sound:foo][sound:bar]",
+            SoundOrVideo("foo"),
+            SoundOrVideo("bar")
+        );
+
+        // tags
+        assert_parsed_nodes!(
+            "[anki:foo]bar[/anki:foo]",
+            Tag(super::Tag::Other(OtherTag {
+                name: "foo",
+                content: "bar",
+                options: HashMap::new()
+            }))
+        );
+        assert_parsed_nodes!(
+            "[anki:foo bar=baz][/anki:foo]",
+            Tag(super::Tag::Other(OtherTag {
+                name: "foo",
+                content: "",
+                options: [("bar", "baz")].into_iter().collect(),
+            }))
+        );
+        // unquoted white space separates options, "]" terminates
+        assert_parsed_nodes!(
+            "[anki:foo\na=b\tc=d e=f][/anki:foo]",
+            Tag(super::Tag::Other(OtherTag {
+                name: "foo",
+                content: "",
+                options: [("a", "b"), ("c", "d"), ("e", "f")].into_iter().collect(),
+            }))
+        );
+        assert_parsed_nodes!(
+            "[anki:foo a=\"b \t\n c ]\"][/anki:foo]",
+            Tag(super::Tag::Other(OtherTag {
+                name: "foo",
+                content: "",
+                options: [("a", "b \t\n c ]")].into_iter().collect(),
+            }))
+        );
+
+        // tts tags
+        assert_parsed_nodes!(
+            "[anki:tts lang=jp_JP voices=Alice,Bob speed=0.5 cloze_blank= bar=baz][/anki:tts]",
+            Tag(super::Tag::Tts(TtsTag {
+                content: "",
+                lang: "jp_JP",
+                voices: vec!["Alice", "Bob"],
+                speed: 0.5,
+                blank: Some(""),
+                options: [("bar", "baz")].into_iter().collect(),
+            }))
+        );
+        assert_parsed_nodes!(
+            "[anki:tts speed=foo][/anki:tts]",
+            Tag(super::Tag::Tts(TtsTag {
+                content: "",
+                lang: "",
+                voices: vec![],
+                speed: 1.0,
+                blank: None,
+                options: HashMap::new(),
+            }))
+        );
+    }
+}

--- a/rslib/src/card_rendering/parser.rs
+++ b/rslib/src/card_rendering/parser.rs
@@ -1,8 +1,6 @@
 // Copyright: Ankitects Pty Ltd and contributors
 // License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
-use std::collections::HashMap;
-
 use nom::{
     branch::alt,
     bytes::complete::{is_not, tag},
@@ -31,34 +29,7 @@ impl<'a> CardNodes<'a> {
 impl<'a> Tag<'a> {
     fn new(name: &'a str, options: Vec<(&'a str, &'a str)>, content: &'a str) -> Self {
         match name {
-            "tts" => {
-                let mut lang = "";
-                let mut voices = vec![];
-                let mut speed = 1.0;
-                let mut blank = None;
-                let mut other_options = HashMap::new();
-
-                for option in options {
-                    match option.0 {
-                        "lang" => lang = option.1,
-                        "voices" => voices = option.1.split(',').collect(),
-                        "speed" => speed = option.1.parse().unwrap_or(1.0),
-                        "cloze_blank" => blank = Some(option.1),
-                        _ => {
-                            other_options.insert(option.0, option.1);
-                        }
-                    }
-                }
-
-                Self::Tts(TtsTag {
-                    content,
-                    lang,
-                    voices,
-                    speed,
-                    blank,
-                    options: other_options,
-                })
-            }
+            "tts" => Self::Tts(TtsTag::new(content, options)),
             _ => Self::Other(OtherTag {
                 name,
                 content,
@@ -162,6 +133,8 @@ fn text_node(s: &str) -> IResult<Node> {
 
 #[cfg(test)]
 mod test {
+    use std::collections::HashMap;
+
     use super::*;
 
     macro_rules! assert_parsed_nodes {

--- a/rslib/src/card_rendering/writer.rs
+++ b/rslib/src/card_rendering/writer.rs
@@ -1,0 +1,210 @@
+// Copyright: Ankitects Pty Ltd and contributors
+// License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
+
+use std::fmt::Write as _;
+
+use super::{CardNodes, Node, OtherTag, Tag, TtsTag};
+use crate::prelude::*;
+use crate::{
+    backend_proto as pb,
+    text::{decode_entities, strip_html_for_tts},
+};
+
+impl<'a> CardNodes<'a> {
+    pub(super) fn write_without_av_tags(&self) -> String {
+        AvStripper::new().write(self)
+    }
+
+    pub(super) fn write_and_extract_av_tags(
+        &self,
+        question_side: bool,
+        tr: &I18n,
+    ) -> (String, Vec<pb::AvTag>) {
+        let mut extractor = AvExtractor::new(question_side, tr);
+        (extractor.write(self), extractor.tags)
+    }
+}
+
+trait Write {
+    fn write<'iter, 'nodes: 'iter, T>(&mut self, nodes: T) -> String
+    where
+        T: IntoIterator<Item = &'iter Node<'nodes>>,
+    {
+        let mut buf = String::new();
+        for node in nodes {
+            match &node {
+                Node::Text(s) => self.write_text(&mut buf, s),
+                Node::SoundOrVideo(r) => self.write_sound(&mut buf, r),
+                Node::Tag(tag) => self.write_tag(&mut buf, tag),
+            };
+        }
+        buf
+    }
+
+    fn write_text(&mut self, buf: &mut String, txt: &str) {
+        buf.push_str(txt);
+    }
+
+    fn write_sound(&mut self, buf: &mut String, ressource: &str) {
+        write!(buf, "[sound:{}]", ressource).unwrap();
+    }
+
+    fn write_tag(&mut self, buf: &mut String, tag: &Tag) {
+        match tag {
+            Tag::Tts(tag) => self.write_tts_tag(buf, tag),
+            Tag::Other(tag) => self.write_other_tag(buf, tag),
+        };
+    }
+
+    fn write_tts_tag(&mut self, buf: &mut String, tag: &TtsTag) {
+        write!(buf, "[anki:tts").unwrap();
+
+        for (key, val) in [
+            ("lang", tag.lang),
+            ("voices", &tag.voices.join(",")),
+            ("speed", &tag.speed.to_string()),
+        ] {
+            self.write_tag_option(buf, key, val);
+        }
+        if let Some(blank) = tag.blank {
+            self.write_tag_option(buf, "cloze_blank", blank);
+        }
+        for (key, val) in &tag.options {
+            self.write_tag_option(buf, key, val);
+        }
+
+        write!(buf, "]{}[/anki:tts]", tag.content).unwrap();
+    }
+
+    fn write_other_tag(&mut self, buf: &mut String, tag: &OtherTag) {
+        write!(buf, "[anki:{}", tag.name).unwrap();
+        for (key, val) in &tag.options {
+            self.write_tag_option(buf, key, val);
+        }
+        buf.push(']');
+        self.write_tag_content(buf, tag.content);
+        write!(buf, "[/anki:{}]", tag.name).unwrap();
+    }
+
+    fn write_tag_option(&mut self, buf: &mut String, key: &str, val: &str) {
+        if val.contains::<&[char]>(&[']', ' ', '\t', '\r', '\n']) {
+            write!(buf, " {}=\"{}\"", key, val).unwrap();
+        } else {
+            write!(buf, " {}={}", key, val).unwrap();
+        }
+    }
+
+    fn write_tag_content(&mut self, buf: &mut String, content: &str) {
+        buf.push_str(content);
+    }
+}
+
+struct AvStripper;
+
+impl AvStripper {
+    fn new() -> Self {
+        Self {}
+    }
+}
+
+impl Write for AvStripper {
+    fn write_sound(&mut self, _buf: &mut String, _ressource: &str) {}
+
+    fn write_tts_tag(&mut self, _buf: &mut String, _tag: &TtsTag) {}
+}
+
+struct AvExtractor<'a> {
+    side: char,
+    tags: Vec<pb::AvTag>,
+    tr: &'a I18n,
+}
+
+impl<'a> AvExtractor<'a> {
+    fn new(question_side: bool, tr: &'a I18n) -> Self {
+        Self {
+            side: if question_side { 'q' } else { 'a' },
+            tags: vec![],
+            tr,
+        }
+    }
+
+    fn write_play_tag(&self, buf: &mut String) {
+        write!(buf, "[anki:play:{}:{}]", self.side, self.tags.len()).unwrap();
+    }
+
+    fn transform_tts_content(&self, tag: &TtsTag) -> String {
+        strip_html_for_tts(tag.content).replace(
+            "[...]",
+            tag.blank.unwrap_or(&self.tr.card_templates_blank()),
+        )
+    }
+}
+
+impl Write for AvExtractor<'_> {
+    fn write_sound(&mut self, buf: &mut String, ressource: &str) {
+        self.write_play_tag(buf);
+        self.tags.push(pb::AvTag {
+            value: Some(pb::av_tag::Value::SoundOrVideo(
+                decode_entities(ressource).into(),
+            )),
+        });
+    }
+
+    fn write_tts_tag(&mut self, buf: &mut String, tag: &TtsTag) {
+        self.write_play_tag(buf);
+        self.tags.push(pb::AvTag {
+            value: Some(pb::av_tag::Value::Tts(pb::TtsTag {
+                field_text: self.transform_tts_content(tag),
+                lang: tag.lang.into(),
+                voices: tag.voices.iter().map(ToString::to_string).collect(),
+                speed: tag.speed,
+                other_args: tag
+                    .options
+                    .iter()
+                    .map(|(key, val)| format!("{}={}", key, val))
+                    .collect(),
+            })),
+        });
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    struct Writer;
+    impl Write for Writer {}
+    impl Writer {
+        fn new() -> Self {
+            Self {}
+        }
+    }
+
+    /// Parse input, write it out, and assert equality with input or separately
+    /// passed output.
+    macro_rules! roundtrip {
+        ($input:expr) => {
+            assert_eq!($input, Writer::new().write(&CardNodes::parse($input)));
+        };
+        ($input:expr, $output:expr) => {
+            assert_eq!(Writer::new().write(&CardNodes::parse($input)), $output);
+        };
+    }
+
+    #[test]
+    fn writing() {
+        roundtrip!("foo");
+        roundtrip!("[sound:foo]");
+        roundtrip!("[anki:foo bar=baz]spam[/anki:foo]");
+
+        // normalizing (not currently exposed)
+        roundtrip!(
+            "[anki:foo\nbar=baz ][/anki:foo]",
+            "[anki:foo bar=baz][/anki:foo]"
+        );
+        roundtrip!(
+            "[anki:tts][/anki:tts]",
+            "[anki:tts lang= voices= speed=1][/anki:tts]"
+        );
+    }
+}

--- a/rslib/src/card_rendering/writer.rs
+++ b/rslib/src/card_rendering/writer.rs
@@ -45,8 +45,8 @@ trait Write {
         buf.push_str(txt);
     }
 
-    fn write_sound(&mut self, buf: &mut String, ressource: &str) {
-        write!(buf, "[sound:{}]", ressource).unwrap();
+    fn write_sound(&mut self, buf: &mut String, resource: &str) {
+        write!(buf, "[sound:{}]", resource).unwrap();
     }
 
     fn write_tag(&mut self, buf: &mut String, tag: &Tag) {
@@ -108,7 +108,7 @@ impl AvStripper {
 }
 
 impl Write for AvStripper {
-    fn write_sound(&mut self, _buf: &mut String, _ressource: &str) {}
+    fn write_sound(&mut self, _buf: &mut String, _resource: &str) {}
 
     fn write_tts_tag(&mut self, _buf: &mut String, _tag: &TtsTag) {}
 }
@@ -141,11 +141,11 @@ impl<'a> AvExtractor<'a> {
 }
 
 impl Write for AvExtractor<'_> {
-    fn write_sound(&mut self, buf: &mut String, ressource: &str) {
+    fn write_sound(&mut self, buf: &mut String, resource: &str) {
         self.write_play_tag(buf);
         self.tags.push(pb::AvTag {
             value: Some(pb::av_tag::Value::SoundOrVideo(
-                decode_entities(ressource).into(),
+                decode_entities(resource).into(),
             )),
         });
     }

--- a/rslib/src/card_rendering/writer.rs
+++ b/rslib/src/card_rendering/writer.rs
@@ -23,6 +23,10 @@ impl<'a> CardNodes<'a> {
         let mut extractor = AvExtractor::new(question_side, tr);
         (extractor.write(self), extractor.tags)
     }
+
+    pub(super) fn write_with_pretty_av_tags(&self) -> String {
+        AvPrettifier::new().write(self)
+    }
 }
 
 trait Write {
@@ -165,6 +169,24 @@ impl Write for AvExtractor<'_> {
                     .collect(),
             })),
         });
+    }
+}
+
+struct AvPrettifier;
+
+impl AvPrettifier {
+    fn new() -> Self {
+        Self {}
+    }
+}
+
+impl Write for AvPrettifier {
+    fn write_sound(&mut self, buf: &mut String, resource: &str) {
+        write!(buf, "🔉{}🔉", resource).unwrap();
+    }
+
+    fn write_tts_tag(&mut self, buf: &mut String, tag: &TtsTag) {
+        write!(buf, "💬{}💬", tag.content).unwrap();
     }
 }
 

--- a/rslib/src/lib.rs
+++ b/rslib/src/lib.rs
@@ -8,6 +8,7 @@ pub mod backend;
 mod backend_proto;
 pub mod browser_table;
 pub mod card;
+pub mod card_rendering;
 pub mod cloze;
 pub mod collection;
 pub mod config;

--- a/rslib/src/template.rs
+++ b/rslib/src/template.rs
@@ -443,7 +443,6 @@ fn render_into(
                             .as_slice(),
                         key,
                         context,
-                        tr,
                     ),
                     None => {
                         // unknown field encountered


### PR DESCRIPTION
Closes #1507. Closes #1537. All squashed in two commits, sorry.
I'll leave notes on some implementation details. In addition, here are a few remaining points from #1507.

1. > Should we implement error handling like for the search syntax? I'd normally say we can always add it later if necessary. However, without error messages, I wonder how we can reserve certain characters like ". If we just refuse to evaluate a tag containing such characters, the user might never figure out what the problem is.

2. > Or we use a convention, e.g. "only tags starting with a bang can be nested".

     (Does not need to be implemented yet, but probably should be documented in advance.)

3. > It would also be great to have some catchy name for these environments, because a tag is already a concept both in Anki and nom.