### PR TITLE
Make Hard use current step's interval if it's not the first one

### DIFF
--- a/pylib/anki/scheduler/v2.py
+++ b/pylib/anki/scheduler/v2.py
@@ -645,14 +645,18 @@ limit ?"""
         return int(delay * 60)
 
     def _delayForRepeatingGrade(self, conf: QueueConfig, left: int) -> Any:
-        # halfway between last and next
         delay1 = self._delayForGrade(conf, left)
-        if len(conf["delays"]) > 1:
-            delay2 = self._delayForGrade(conf, left - 1)
-        else:
-            delay2 = delay1 * 2
-        avg = (delay1 + max(delay1, delay2)) // 2
-        return avg
+        # first step?
+        if len(conf["delays"]) == left % 1000:
+            # halfway between last and next to avoid same interval with Again
+            if len(conf["delays"]) > 1:
+                delay2 = self._delayForGrade(conf, left - 1)
+            else:
+                # no next step, use dummy
+                delay2 = delay1 * 2
+            avg = (delay1 + max(delay1, delay2)) // 2
+            return avg
+        return delay1
 
     def _lrnConf(self, card: Card) -> Any:
         if card.type in (CARD_TYPE_REV, CARD_TYPE_RELEARNING):

--- a/pylib/tests/test_schedv2.py
+++ b/pylib/tests/test_schedv2.py
@@ -585,7 +585,7 @@ def test_nextIvl():
     assert ni(c, 4) == 4 * 86400
     col.sched.answerCard(c, 3)
     assert ni(c, 1) == 30
-    assert ni(c, 2) == (180 + 600) // 2
+    assert ni(c, 2) == 180
     assert ni(c, 3) == 600
     assert ni(c, 4) == 4 * 86400
     col.sched.answerCard(c, 3)


### PR DESCRIPTION
Closes #1555.
The Rust tests show nicely how the intervals for different buttons remain distinct.