### PR TITLE
Add "X-GNOME-SingleWindow=true" to the desktop file

### DIFF
--- a/qt/package/lin/anki.desktop
+++ b/qt/package/lin/anki.desktop
@@ -10,3 +10,4 @@ Terminal=false
 Type=Application
 Version=1.0
 MimeType=application/x-apkg;application/x-anki;application/x-ankiaddon;
+X-GNOME-SingleWindow=true


### PR DESCRIPTION
Since this commit (https://github.com/KDE/plasma-workspace/commit/ebd2acd98ecdb9d115b01bd01f532390376152f7),
Plasma Desktop will check "X-GNOME-SingleWindow" property to determine
whether to show "Open New Window" action in the context menu of a task.

Anki cannot launch a new instance or open a new window, so add the
property and set it to true to hide the action.