### PR TITLE
Increment sched.reps for preview cards in V2

### DIFF
--- a/pylib/anki/scheduler/v2.py
+++ b/pylib/anki/scheduler/v2.py
@@ -462,11 +462,12 @@ limit ?"""
         card.flush()
 
     def _answerCard(self, card: Card, ease: int) -> None:
+        self.reps += 1
+
         if self._previewingCard(card):
             self._answerCardPreview(card, ease)
             return
 
-        self.reps += 1
         card.reps += 1
 
         new_delta = 0


### PR DESCRIPTION
This is to make the timebox dialog report the correct count. The V3 scheduler already does that.

Minor question: I'm curious where `sched.reps` is actually reset to 0 between review sessions?