### PR TITLE
Fix padding and alignment inside revlog table

### DIFF
--- a/ts/card-info/Revlog.svelte
+++ b/ts/card-info/Revlog.svelte
@@ -77,111 +77,97 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 </script>
 
 {#if revlog.length > 0}
-    <table class="revlog-table">
-        <tr>
-            <th class="left">{tr2.cardStatsReviewLogDate()}</th>
-            <th class="center hidden-xs">{tr2.cardStatsReviewLogType()}</th>
-            <th class="center">{tr2.cardStatsReviewLogRating()}</th>
-            <th class="center">{tr2.cardStatsInterval()}</th>
-            <th class="center hidden-xs">{tr2.cardStatsEase()}</th>
-            <th class="center">{tr2.cardStatsReviewLogTimeTaken()}</th>
-        </tr>
-        <tr>
-            <td
-                ><div class="column">
-                    {#each revlogRows as row, _index}
-                        <div><b>{row.date}</b> @ {row.time}</div>
-                    {/each}
-                </div></td
-            >
-            <td class="hidden-xs"
-                ><div class="centered-cell">
-                    <div class="column">
-                        {#each revlogRows as row, _index}
-                            <div class={row.reviewKindClass}>
-                                {row.reviewKind}
-                            </div>
-                        {/each}
+    <div class="revlog-table">
+        <div class="column">
+            <div class="column-head">{tr2.cardStatsReviewLogDate()}</div>
+            <div class="column-content">
+                {#each revlogRows as row, _index}
+                    <div><b>{row.date}</b> @ {row.time}</div>
+                {/each}
+            </div>
+        </div>
+        <div class="column hidden-xs">
+            <div class="column-head">{tr2.cardStatsReviewLogType()}</div>
+            <div class="column-content">
+                {#each revlogRows as row, _index}
+                    <div class={row.reviewKindClass}>
+                        {row.reviewKind}
                     </div>
-                </div></td
-            >
-            <td
-                ><div class="centered-cell">
-                    <div class="column">
-                        {#each revlogRows as row, _index}
-                            <div class={row.ratingClass}>{row.rating}</div>
-                        {/each}
-                    </div>
-                </div></td
-            >
-            <td
-                ><div class="centered-cell">
-                    <div class="column column-right">
-                        {#each revlogRows as row, _index}
-                            <div>{row.interval}</div>
-                        {/each}
-                    </div>
-                </div></td
-            >
-            <td class="hidden-xs"
-                ><div class="centered-cell">
-                    <div class="column">
-                        {#each revlogRows as row, _index}
-                            <div>{row.ease}</div>
-                        {/each}
-                    </div>
-                </div></td
-            >
-            <td
-                ><div class="centered-cell">
-                    <div class="column column-right">
-                        {#each revlogRows as row, _index}
-                            <div>{row.takenSecs}</div>
-                        {/each}
-                    </div>
-                </div></td
-            >
-        </tr>
-    </table>
+                {/each}
+            </div>
+        </div>
+        <div class="column">
+            <div class="column-head">{tr2.cardStatsReviewLogRating()}</div>
+            <div class="column-content">
+                {#each revlogRows as row, _index}
+                    <div class={row.ratingClass}>{row.rating}</div>
+                {/each}
+            </div>
+        </div>
+        <div class="column">
+            <div class="column-head">{tr2.cardStatsInterval()}</div>
+            <div class="column-content right">
+                {#each revlogRows as row, _index}
+                    <div>{row.interval}</div>
+                {/each}
+            </div>
+        </div>
+        <div class="column hidden-xs">
+            <div class="column-head">{tr2.cardStatsEase()}</div>
+            <div class="column-content">
+                {#each revlogRows as row, _index}
+                    <div>{row.ease}</div>
+                {/each}
+            </div>
+        </div>
+        <div class="column">
+            <div class="column-head">{tr2.cardStatsReviewLogTimeTaken()}</div>
+            <div class="column-content right">
+                {#each revlogRows as row, _index}
+                    <div>{row.takenSecs}</div>
+                {/each}
+            </div>
+        </div>
+    </div>
 {/if}
 
-<style>
-    .column > div:empty::after {
-        /* prevent collapsing of empty rows */
-        content: "\00a0";
-    }
-
-    .left {
-        text-align: start;
-    }
-
-    .center {
-        text-align: center;
-    }
-
+<style lang="scss">
     .revlog-table {
         width: 100%;
-        border-spacing: 1em 0;
-        border-collapse: collapse;
+        max-width: 50em;
+        display: flex;
+        flex-direction: row;
+        justify-content: space-between;
+        align-items: center;
+        gap: 0.5em;
         white-space: nowrap;
     }
 
-    .centered-cell {
-        display: flex;
-        flex-direction: row;
-        justify-content: center;
-        align-items: center;
-    }
-
     .column {
-        display: inline-flex;
+        display: flex;
         flex-direction: column;
         justify-content: center;
         align-items: center;
     }
 
-    .column-right {
-        align-items: flex-end;
+    .column-head {
+        font-weight: bold;
+    }
+
+    .column-content {
+        display: inline-flex;
+        flex-direction: column;
+        justify-content: center;
+        align-items: center;
+
+        &.right {
+            align-items: flex-end;
+        }
+
+        > div:empty::after {
+            /* prevent collapsing of empty rows */
+            content: "\00a0";
+        }
     }
 
     .revlog-learn {

--- a/ts/card-info/Revlog.svelte
+++ b/ts/card-info/Revlog.svelte
@@ -88,67 +88,71 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         </tr>
         <tr>
             <td
-                ><table class="left">
+                ><div class="column">
                     {#each revlogRows as row, _index}
-                        <tr><td><b>{row.date}</b> @ {row.time}</td></tr>
+                        <div><b>{row.date}</b> @ {row.time}</div>
                     {/each}
-                </table></td
+                </div></td
             >
             <td class="hidden-xs"
-                ><table class="center-table center">
-                    {#each revlogRows as row, _index}
-                        <tr
-                            ><td class={row.reviewKindClass}>
+                ><div class="centered-cell">
+                    <div class="column">
+                        {#each revlogRows as row, _index}
+                            <div class={row.reviewKindClass}>
                                 {row.reviewKind}
-                            </td></tr
-                        >
-                    {/each}
-                </table></td
+                            </div>
+                        {/each}
+                    </div>
+                </div></td
             >
             <td
-                ><table class="center-table center">
-                    {#each revlogRows as row, _index}
-                        <tr><td class={row.ratingClass}>{row.rating}</td></tr>
-                    {/each}
-                </table></td
+                ><div class="centered-cell">
+                    <div class="column">
+                        {#each revlogRows as row, _index}
+                            <div class={row.ratingClass}>{row.rating}</div>
+                        {/each}
+                    </div>
+                </div></td
             >
             <td
-                ><table class="center-table right">
-                    {#each revlogRows as row, _index}
-                        <tr><td>{row.interval}</td></tr>
-                    {/each}
-                </table></td
+                ><div class="centered-cell">
+                    <div class="column column-right">
+                        {#each revlogRows as row, _index}
+                            <div>{row.interval}</div>
+                        {/each}
+                    </div>
+                </div></td
             >
             <td class="hidden-xs"
-                ><table class="center-table center">
-                    {#each revlogRows as row, _index}
-                        <tr><td>{row.ease}</td></tr>
-                    {/each}
-                </table></td
+                ><div class="centered-cell">
+                    <div class="column">
+                        {#each revlogRows as row, _index}
+                            <div>{row.ease}</div>
+                        {/each}
+                    </div>
+                </div></td
             >
             <td
-                ><table class="center-table right">
-                    {#each revlogRows as row, _index}
-                        <tr><td>{row.takenSecs}</td></tr>
-                    {/each}
-                </table></td
+                ><div class="centered-cell">
+                    <div class="column column-right">
+                        {#each revlogRows as row, _index}
+                            <div>{row.takenSecs}</div>
+                        {/each}
+                    </div>
+                </div></td
             >
         </tr>
     </table>
 {/if}
 
 <style>
-    td:empty::after {
-        /* prevent collapsing of empty cells */
+    .column > div:empty::after {
+        /* prevent collapsing of empty rows */
         content: "\00a0";
     }
 
     .left {
         text-align: start;
-    }
-
-    .right {
-        text-align: end;
     }
 
     .center {
@@ -162,9 +166,22 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         white-space: nowrap;
     }
 
-    .center-table {
-        margin-left: auto;
-        margin-right: auto;
+    .centered-cell {
+        display: flex;
+        flex-direction: row;
+        justify-content: center;
+        align-items: center;
+    }
+
+    .column {
+        display: inline-flex;
+        flex-direction: column;
+        justify-content: center;
+        align-items: center;
+    }
+
+    .column-right {
+        align-items: flex-end;
     }
 
     .revlog-learn {

--- a/ts/card-info/Revlog.svelte
+++ b/ts/card-info/Revlog.svelte
@@ -94,11 +94,11 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
                     {/each}
                 </table></td
             >
-            <td
+            <td class="hidden-xs"
                 ><table class="center-table center">
                     {#each revlogRows as row, _index}
                         <tr
-                            ><td class="hidden-xs {row.reviewKindClass}">
+                            ><td class={row.reviewKindClass}>
                                 {row.reviewKind}
                             </td></tr
                         >
@@ -119,10 +119,10 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
                     {/each}
                 </table></td
             >
-            <td
+            <td class="hidden-xs"
                 ><table class="center-table center">
                     {#each revlogRows as row, _index}
-                        <tr><td class="hidden-xs">{row.ease}</td></tr>
+                        <tr><td>{row.ease}</td></tr>
                     {/each}
                 </table></td
             >

--- a/ts/card-info/Revlog.svelte
+++ b/ts/card-info/Revlog.svelte
@@ -82,26 +82,67 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
             <th class="left">{tr2.cardStatsReviewLogDate()}</th>
             <th class="center hidden-xs">{tr2.cardStatsReviewLogType()}</th>
             <th class="center">{tr2.cardStatsReviewLogRating()}</th>
-            <th class="right">{tr2.cardStatsInterval()}</th>
+            <th class="center">{tr2.cardStatsInterval()}</th>
             <th class="center hidden-xs">{tr2.cardStatsEase()}</th>
-            <th class="right">{tr2.cardStatsReviewLogTimeTaken()}</th>
+            <th class="center">{tr2.cardStatsReviewLogTimeTaken()}</th>
         </tr>
-        {#each revlogRows as row, _index}
-            <tr>
-                <td class="left"><b>{row.date}</b> @ {row.time}</td>
-                <td class="center hidden-xs {row.reviewKindClass}">
-                    {row.reviewKind}
-                </td>
-                <td class="center {row.ratingClass}">{row.rating}</td>
-                <td class="right">{row.interval}</td>
-                <td class="center hidden-xs">{row.ease}</td>
-                <td class="right">{row.takenSecs}</td>
-            </tr>
-        {/each}
+        <tr>
+            <td
+                ><table class="left">
+                    {#each revlogRows as row, _index}
+                        <tr><td><b>{row.date}</b> @ {row.time}</td></tr>
+                    {/each}
+                </table></td
+            >
+            <td
+                ><table class="center-table center">
+                    {#each revlogRows as row, _index}
+                        <tr
+                            ><td class="hidden-xs {row.reviewKindClass}">
+                                {row.reviewKind}
+                            </td></tr
+                        >
+                    {/each}
+                </table></td
+            >
+            <td
+                ><table class="center-table center">
+                    {#each revlogRows as row, _index}
+                        <tr><td class={row.ratingClass}>{row.rating}</td></tr>
+                    {/each}
+                </table></td
+            >
+            <td
+                ><table class="center-table right">
+                    {#each revlogRows as row, _index}
+                        <tr><td>{row.interval}</td></tr>
+                    {/each}
+                </table></td
+            >
+            <td
+                ><table class="center-table center">
+                    {#each revlogRows as row, _index}
+                        <tr><td class="hidden-xs">{row.ease}</td></tr>
+                    {/each}
+                </table></td
+            >
+            <td
+                ><table class="center-table right">
+                    {#each revlogRows as row, _index}
+                        <tr><td>{row.takenSecs}</td></tr>
+                    {/each}
+                </table></td
+            >
+        </tr>
     </table>
 {/if}
 
 <style>
+    td:empty::after {
+        /* prevent collapsing of empty cells */
+        content: "\00a0";
+    }
+
     .left {
         text-align: start;
     }
@@ -118,6 +159,12 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         width: 100%;
         border-spacing: 1em 0;
         border-collapse: collapse;
+        white-space: nowrap;
+    }
+
+    .center-table {
+        margin-left: auto;
+        margin-right: auto;
     }
 
     .revlog-learn {

--- a/ts/card-info/Revlog.svelte
+++ b/ts/card-info/Revlog.svelte
@@ -139,7 +139,6 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         flex-direction: row;
         justify-content: space-between;
         align-items: center;
-        gap: 0.5em;
         white-space: nowrap;
     }
 
@@ -148,6 +147,10 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         flex-direction: column;
         justify-content: center;
         align-items: center;
+
+        &:not(:last-child) {
+            margin-right: 0.5em;
+        }
     }
 
     .column-head {


### PR DESCRIPTION
This addresses https://github.com/ankitects/anki/issues/1516#issuecomment-1004420601 by using nested tables to have both, evenly padded columns and aligned units. Some remarks:

- The first column is still left-aligned to ensure alignment with the other stats above. It can be seen as a kind of row header, so I think the additional right padding is tolerable.
- The sub-tables would wrap independently, so wrapping has to be disabled. However, I'd argue that this is for the best anyway. The content is pretty limited for all cells, regardless of localisation, and if a row doesn't fit the window, it breaks at some odd positions, like between a value and its unit. That makes it extremely hard to read, so it's better to have a horizontal scrollbar in my opinion.