### PR TITLE
Change X-GNOME-SingleWindow key to SingleMainWindow

### DIFF
--- a/qt/package/lin/anki.desktop
+++ b/qt/package/lin/anki.desktop
@@ -10,4 +10,6 @@ Terminal=false
 Type=Application
 Version=1.0
 MimeType=application/x-apkg;application/x-anki;application/x-ankiaddon;
+#should be removed eventually as it was upstreamed as to be an XDG specification called SingleMainWindow
 X-GNOME-SingleWindow=true
+SingleMainWindow=true


### PR DESCRIPTION
X-GNOME-SingleWindow was upstreamed to be an XDG spec with the name
"SingleMainWindow" in
https://gitlab.freedesktop.org/xdg/xdg-specs/-/merge_requests/53