### PR TITLE
Fix IME input after tab

### DIFF
--- a/ts/domlib/index.ts
+++ b/ts/domlib/index.ts
@@ -1,5 +1,7 @@
 // Copyright: Ankitects Pty Ltd and contributors
 // License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
-export * as location from "./location";
-export * as surround from "./surround";
+export * from "./location";
+export * from "./surround";
+export * from "./move-nodes";
+export * from "./place-caret";

--- a/ts/editable/ContentEditable.svelte
+++ b/ts/editable/ContentEditable.svelte
@@ -12,7 +12,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     import actionList from "../sveltelib/action-list";
     import contentEditableAPI, {
         saveLocation,
-        prepareFocusHandling,
+        initialFocusHandling,
         preventBuiltinContentEditableShortcuts,
     } from "./content-editable";
     import type { ContentEditableAPI } from "./content-editable";
@@ -40,7 +40,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     contenteditable="true"
     use:resolve
     use:saveLocation
-    use:prepareFocusHandling
+    use:initialFocusHandling
     use:preventBuiltinContentEditableShortcuts
     use:mirrorAction={mirrorOptions}
     use:managerAction={{}}

--- a/ts/editable/content-editable.ts
+++ b/ts/editable/content-editable.ts
@@ -17,17 +17,27 @@ function flushLocation(): void {
     }
 }
 
+function safePlaceCaretAfterContent(editable: HTMLElement): void {
+    /**
+     * Workaround: If you try to invoke an IME after calling
+     * `placeCaretAfterContent` on a cE element, the IME will immediately
+     * end and the input character will be duplicated
+     */
+    placeCaretAfterContent(editable);
+    restoreSelection(editable, saveSelection(editable)!);
+}
+
 function onFocus(location: SelectionLocation | null): () => void {
     return function (this: HTMLElement): void {
         if (!location) {
-            placeCaretAfterContent(this);
+            safePlaceCaretAfterContent(this);
             return;
         }
 
         try {
             restoreSelection(this, location);
         } catch {
-            placeCaretAfterContent(this);
+            safePlaceCaretAfterContent(this);
         }
     };
 }

--- a/ts/editor/OldEditorAdapter.svelte
+++ b/ts/editor/OldEditorAdapter.svelte
@@ -29,7 +29,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     const currentField = writable<EditorFieldAPI | null>(null);
 
     function updateFocus() {
-        get(activeInput)?.moveCaretToEnd();
+        /* get(activeInput)?.moveCaretToEnd(); */
     }
 
     registerShortcut(

--- a/ts/editor/OldEditorAdapter.svelte
+++ b/ts/editor/OldEditorAdapter.svelte
@@ -8,7 +8,6 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     import type { PlainTextInputAPI } from "./PlainTextInput.svelte";
     import type { EditorToolbarAPI } from "./EditorToolbar.svelte";
 
-    import { registerShortcut } from "../lib/shortcuts";
     import contextProperty from "../sveltelib/context-property";
     import { writable, get } from "svelte/store";
 
@@ -27,15 +26,6 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
     const activeInput = writable<RichTextInputAPI | PlainTextInputAPI | null>(null);
     const currentField = writable<EditorFieldAPI | null>(null);
-
-    function updateFocus() {
-        /* get(activeInput)?.moveCaretToEnd(); */
-    }
-
-    registerShortcut(
-        () => document.addEventListener("focusin", updateFocus, { once: true }),
-        "Shift?+Tab",
-    );
 </script>
 
 <script lang="ts">
@@ -67,6 +57,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     import { onMount, onDestroy } from "svelte";
     import type { Writable } from "svelte/store";
     import { bridgeCommand } from "../lib/bridgecommand";
+    import { registerShortcut } from "../lib/shortcuts";
     import { isApplePlatform } from "../lib/platform";
     import { ChangeTimer } from "./change-timer";
     import { alertIcon } from "./icons";

--- a/ts/editor/RichTextInput.svelte
+++ b/ts/editor/RichTextInput.svelte
@@ -110,7 +110,6 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         /* we need createContextualFragment so that customElements are initialized */
         const fragment = range.createContextualFragment(adjustInputHTML(html));
         adjustInputFragment(fragment);
-
         nodes.setUnprocessed(fragment);
     }
 

--- a/ts/editor/mathjax-overlay/MathjaxHandle.svelte
+++ b/ts/editor/mathjax-overlay/MathjaxHandle.svelte
@@ -40,6 +40,8 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     let selectAll = false;
 
     function placeHandle(after: boolean): void {
+        flushLocation();
+
         if (after) {
             (mathjaxElement as any).placeCaretAfter();
         } else {
@@ -48,7 +50,6 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     }
 
     async function resetHandle(): Promise<void> {
-        flushLocation();
         selectAll = false;
 
         if (activeImage && mathjaxElement) {

--- a/ts/sveltelib/mirror-dom.ts
+++ b/ts/sveltelib/mirror-dom.ts
@@ -110,7 +110,7 @@ function getDOMMirror(): DOMMirrorAPI {
 
         return {
             destroy() {
-                // observer.disconnect();
+                observer.disconnect();
 
                 removeFocus();
                 removeBlur?.();

--- a/ts/sveltelib/mirror-dom.ts
+++ b/ts/sveltelib/mirror-dom.ts
@@ -39,6 +39,7 @@ function cloneNode(node: Node): DocumentFragment {
  * Allows you to keep an element's inner HTML bidirectionally
  * in sync with a store containing a DocumentFragment.
  * While the element has focus, this connection is tethered.
+ * In practice, this will sync changes from PlainTextInput to RichTextInput.
  */
 function getDOMMirror(): DOMMirrorAPI {
     const allowResubscription = writable(true);

--- a/ts/sveltelib/mirror-dom.ts
+++ b/ts/sveltelib/mirror-dom.ts
@@ -23,7 +23,6 @@ interface DOMMirrorAPI {
     preventResubscription(): () => void;
 }
 
-
 function cloneNode(node: Node): DocumentFragment {
     /**
      * Creates a deep clone
@@ -80,7 +79,11 @@ function getDOMMirror(): DOMMirrorAPI {
             mirrorToElement(cloneNode(fragment));
         }
 
-        const { subscribe, unsubscribe } = storeSubscribe(store, mirrorFromFragment, false);
+        const { subscribe, unsubscribe } = storeSubscribe(
+            store,
+            mirrorFromFragment,
+            false,
+        );
 
         /* do not update when focused as it will reset caret */
         const removeFocus = on(element, "focus", unsubscribe);

--- a/ts/sveltelib/node-store.ts
+++ b/ts/sveltelib/node-store.ts
@@ -15,12 +15,13 @@ export function nodeStore<T extends Node>(
     const subscribers: Set<Subscriber<T>> = new Set();
 
     function setUnprocessed(newNode: T): void {
-        if (!node || !node.isEqualNode(newNode)) {
-            node = newNode;
+        if (node && node.isEqualNode(newNode)) {
+            return;
+        }
 
-            for (const subscriber of subscribers) {
-                subscriber(node);
-            }
+        node = newNode;
+        for (const subscriber of subscribers) {
+            subscriber(node);
         }
     }
 

--- a/ts/sveltelib/store-subscribe.ts
+++ b/ts/sveltelib/store-subscribe.ts
@@ -8,7 +8,9 @@ interface StoreAccessors {
     unsubscribe: () => void;
 }
 
-// Prevent double subscriptions / unsubscriptions
+/**
+ * Helper function to prevent double (un)subscriptions
+ */
 function storeSubscribe<T>(
     store: Readable<T>,
     callback: (value: T) => void,


### PR DESCRIPTION
This PR adresses the bug reported [here](https://forums.ankiweb.net/t/anki-2-1-50-beta/15608/124). As it is mentioned in the post, it only happens in Qt6.
I've figured out the issue of the bug: It happens when trying to type after the caret has been placed programmatically at the end of the node (`placeCaretAfterContent` in ts/domlib/place-caret).
I'm not entirely sure how to circumvent it yet.