### PR TITLE
Use consistent colors across years in calendar graph.

### DIFF
--- a/ts/graphs/calendar.ts
+++ b/ts/graphs/calendar.ts
@@ -98,6 +98,9 @@ export function renderCalendar(
     let maxCount = 0;
     for (const [day, count] of sourceData.reviewCount.entries()) {
         const date = new Date(now.getTime() + day * 86400 * 1000);
+        if (count > maxCount) {
+            maxCount = count;
+        }
         if (date.getFullYear() != targetYear) {
             continue;
         }
@@ -105,9 +108,6 @@ export function renderCalendar(
         const weekDay = timeDay.count(sourceData.timeFunction(date), date);
         const yearDay = timeDay.count(timeYear(date), date);
         dayMap.set(yearDay, { day, count, weekNumber, weekDay, date } as DayDatum);
-        if (count > maxCount) {
-            maxCount = count;
-        }
     }
 
     if (!maxCount) {


### PR DESCRIPTION
With the turn of the year, I noticed that the calendar graph changes palette when flipping between years, limiting it's usefulness for comparing review activity over time where multiple years are involved. The issue is demonstrated in the two screenshots below, where you can see a similar level of reviews being much lighter in 2021 due to more activity earlier in the year.

 
![image](https://user-images.githubusercontent.com/1860011/148762879-43ad4239-e031-4ba9-b4da-c1043946193a.png)
![image](https://user-images.githubusercontent.com/1860011/148762905-df6b7899-8325-442b-b815-efc04d180249.png)

This pull request fixes that. I never filed a bug report as I wanted to confirm the issue in the latest code and once I had built, it was a really simple fix. Here's a screenshot of 2022 under the fix.

![image](https://user-images.githubusercontent.com/1860011/148763095-7a18b047-c224-4fa6-a784-8f38858d7872.png)

As you can see, my review activity is much more in line with what was seen at the end of 2021.
