### PR TITLE
fix: AttributeError: 'QMouseEvent' object has no attribute 'pos'

### DIFF
--- a/qt/aqt/browser/sidebar/tree.py
+++ b/qt/aqt/browser/sidebar/tree.py
@@ -311,7 +311,10 @@ class SidebarTreeView(QTreeView):
 
     def dropEvent(self, event: QDropEvent) -> None:
         model = self.model()
-        pos = self.getPos(event)
+        if qtmajor == 5:
+            pos = event.pos()  # type: ignore
+        else:
+            pos = event.position().toPoint()
         target_item = model.item_for_index(self.indexAt(pos))
         if self.handle_drag_drop(self._selected_items(), target_item):
             event.acceptProposedAction()
@@ -322,16 +325,12 @@ class SidebarTreeView(QTreeView):
             self.tool == SidebarTool.SEARCH
             and event.button() == Qt.MouseButton.LeftButton
         ):
-            pos = self.getPos(event)
+            if qtmajor == 5:
+                pos = event.pos()  # type: ignore
+            else:
+                pos = event.position().toPoint()
             if (index := self.currentIndex()) == self.indexAt(pos):
                 self._on_search(index)
-
-    def getPos(self, event: QSinglePointEvent) -> QPoint:
-        if qtmajor == 5:
-            pos = event.pos()  # type: ignore
-        else:
-            pos = event.position().toPoint()
-        return pos
 
     def keyPressEvent(self, event: QKeyEvent) -> None:
         index = self.currentIndex()

--- a/qt/aqt/browser/sidebar/tree.py
+++ b/qt/aqt/browser/sidebar/tree.py
@@ -311,10 +311,7 @@ class SidebarTreeView(QTreeView):
 
     def dropEvent(self, event: QDropEvent) -> None:
         model = self.model()
-        if qtmajor == 5:
-            pos = event.pos()  # type: ignore
-        else:
-            pos = event.position().toPoint()
+        pos = self.getPos(event)
         target_item = model.item_for_index(self.indexAt(pos))
         if self.handle_drag_drop(self._selected_items(), target_item):
             event.acceptProposedAction()
@@ -325,8 +322,16 @@ class SidebarTreeView(QTreeView):
             self.tool == SidebarTool.SEARCH
             and event.button() == Qt.MouseButton.LeftButton
         ):
-            if (index := self.currentIndex()) == self.indexAt(event.pos()):
+            pos = self.getPos(event)
+            if (index := self.currentIndex()) == self.indexAt(pos):
                 self._on_search(index)
+
+    def getPos(self, event: QSinglePointEvent) -> QPoint:
+        if qtmajor == 5:
+            pos = event.pos()  # type: ignore
+        else:
+            pos = event.position().toPoint()
+        return pos
 
     def keyPressEvent(self, event: QKeyEvent) -> None:
         index = self.currentIndex()


### PR DESCRIPTION
```
Caught exception:
Traceback (most recent call last):
  File "D:\Python\Python39\lib\site-packages\aqt\browser\sidebar\tree.py", line 328, in mouseReleaseEvent
    if (index := self.currentIndex()) == self.indexAt(event.pos()):
d
```