### PR TITLE
Selectively disable zoom

### DIFF
--- a/qt/aqt/main.py
+++ b/qt/aqt/main.py
@@ -869,12 +869,14 @@ title="{}" {}>{}</button>""".format(
         # toolbar
         tweb = self.toolbarWeb = AnkiWebView(title="top toolbar")
         tweb.setFocusPolicy(Qt.FocusPolicy.WheelFocus)
+        tweb.disable_zoom()
         self.toolbar = aqt.toolbar.Toolbar(self, tweb)
         # main area
         self.web = MainWebView(self)
         # bottom area
         sweb = self.bottomWeb = AnkiWebView(title="bottom toolbar")
         sweb.setFocusPolicy(Qt.FocusPolicy.WheelFocus)
+        sweb.disable_zoom()
         # add in a layout
         self.mainLayout = QVBoxLayout()
         self.mainLayout.setContentsMargins(0, 0, 0, 0)

--- a/qt/aqt/utils.py
+++ b/qt/aqt/utils.py
@@ -1002,6 +1002,22 @@ def no_arg_trigger(func: Callable) -> Callable:
     return pyqtSlot()(func)  # type: ignore
 
 
+def is_zoom_event(evt: QEvent) -> bool:
+    """If the event will trigger zoom.
+
+    Includes zoom by pinching, Ctrl-scrolling, and Meta-scrolling,
+    where scrolling may be triggered by mouse wheel or gesture.
+    """
+
+    return isinstance(evt, QNativeGestureEvent) or (
+        isinstance(evt, QWheelEvent)
+        and (
+            (is_mac and KeyboardModifiersPressed().meta)
+            or KeyboardModifiersPressed().control
+        )
+    )
+
+
 class KeyboardModifiersPressed:
     "Util for type-safe checks of currently-pressed modifier keys."
 
@@ -1021,6 +1037,10 @@ class KeyboardModifiersPressed:
     @property
     def alt(self) -> bool:
         return bool(self._modifiers & Qt.KeyboardModifier.AltModifier)
+
+    @property
+    def meta(self) -> bool:
+        return bool(self._modifiers & Qt.KeyboardModifier.MetaModifier)
 
 
 # add-ons attempting to import isMac from this module :-(

--- a/qt/aqt/webview.py
+++ b/qt/aqt/webview.py
@@ -13,7 +13,7 @@ from anki.utils import is_lin, is_mac, is_win
 from aqt import colors, gui_hooks
 from aqt.qt import *
 from aqt.theme import theme_manager
-from aqt.utils import KeyboardModifiersPressed, askUser, openLink, showInfo, tr
+from aqt.utils import askUser, is_zoom_event, openLink, showInfo, tr
 
 serverbaseurl = re.compile(r"^.+:\/\/[^\/]+")
 
@@ -260,12 +260,8 @@ class AnkiWebView(QWebEngineView):
         self._disable_zoom = True
 
     def eventFilter(self, obj: QObject, evt: QEvent) -> bool:
-        # disable pinch to zoom gesture
-        if self._disable_zoom:
-            if isinstance(evt, QNativeGestureEvent) or (
-                isinstance(evt, QWheelEvent) and KeyboardModifiersPressed().control
-            ):
-                return True
+        if self._disable_zoom and is_zoom_event(evt):
+            return True
 
         if (
             isinstance(evt, QMouseEvent)

--- a/qt/aqt/webview.py
+++ b/qt/aqt/webview.py
@@ -13,7 +13,7 @@ from anki.utils import is_lin, is_mac, is_win
 from aqt import colors, gui_hooks
 from aqt.qt import *
 from aqt.theme import theme_manager
-from aqt.utils import askUser, openLink, showInfo, tr
+from aqt.utils import KeyboardModifiersPressed, askUser, openLink, showInfo, tr
 
 serverbaseurl = re.compile(r"^.+:\/\/[^\/]+")
 
@@ -241,6 +241,7 @@ class AnkiWebView(QWebEngineView):
         self._pendingActions: list[tuple[str, Sequence[Any]]] = []
         self.requiresCol = True
         self.setPage(self._page)
+        self._disable_zoom = False
 
         self.resetHandlers()
         self._filterSet = False
@@ -255,18 +256,25 @@ class AnkiWebView(QWebEngineView):
     def set_title(self, title: str) -> None:
         self.title = title  # type: ignore[assignment]
 
+    def disable_zoom(self) -> None:
+        self._disable_zoom = True
+
     def eventFilter(self, obj: QObject, evt: QEvent) -> bool:
         # disable pinch to zoom gesture
-        if isinstance(evt, QNativeGestureEvent):
-            return True
-        elif (
+        if self._disable_zoom:
+            if isinstance(evt, QNativeGestureEvent) or (
+                isinstance(evt, QWheelEvent) and KeyboardModifiersPressed().control
+            ):
+                return True
+
+        if (
             isinstance(evt, QMouseEvent)
             and evt.type() == QEvent.Type.MouseButtonRelease
         ):
             if evt.button() == Qt.MouseButton.MiddleButton and is_lin:
                 self.onMiddleClickPaste()
                 return True
-            return False
+
         return False
 
     def set_open_links_externally(self, enable: bool) -> None:


### PR DESCRIPTION
This disables zoom for the top and bottom bars in the main view. Unlike the previous eventfilter, it also disables zooming via scrolling.

- Would be great if this could be tested by a mac user. It is my understanding that zooming can also be done on a mac by holding <kbd>Control</kbd> and a two finger swipe. This should also be disabled.
- I've kept the filter for `QNativeGestureEvent`, but isn't that a bit unspecific? Are there no other gestures we also end up disabling?
- I couldn't reproduce any of the issues described in #985.