### PR TITLE
Fix bug when selecting text next to frame by clicking three times

### DIFF
--- a/ts/editable/frame-element.ts
+++ b/ts/editable/frame-element.ts
@@ -8,7 +8,7 @@ import {
     hasBlockAttribute,
 } from "../lib/dom";
 import { on } from "../lib/events";
-import { getSelection } from "../lib/cross-browser";
+import { getSelection, isSelectionCollapsed } from "../lib/cross-browser";
 import { moveChildOutOfElement } from "../domlib/move-nodes";
 import { placeCaretBefore, placeCaretAfter } from "../domlib/place-caret";
 import {
@@ -238,7 +238,10 @@ function checkIfInsertingLineBreakAdjacentToBlockFrame() {
 
         const selection = getSelection(frame)!;
 
-        if (selection.anchorNode === frame.framedElement && selection.isCollapsed) {
+        if (
+            selection.anchorNode === frame.framedElement &&
+            isSelectionCollapsed(selection)
+        ) {
             frame.insertLineBreak(selection.anchorOffset);
         }
     }

--- a/ts/editable/frame-handle.ts
+++ b/ts/editable/frame-handle.ts
@@ -3,7 +3,7 @@
 
 import { nodeIsText, nodeIsElement, elementIsEmpty } from "../lib/dom";
 import { on } from "../lib/events";
-import { getSelection } from "../lib/cross-browser";
+import { getSelection, isSelectionCollapsed } from "../lib/cross-browser";
 import { moveChildOutOfElement } from "../domlib/move-nodes";
 import { placeCaretAfter } from "../domlib/place-caret";
 import type { FrameElement } from "./frame-element";
@@ -277,7 +277,10 @@ export function checkWhetherMovingIntoHandle(): void {
     for (const handle of handles) {
         const selection = getSelection(handle)!;
 
-        if (selection.anchorNode === handle.firstChild && selection.isCollapsed) {
+        if (
+            selection.anchorNode === handle.firstChild &&
+            isSelectionCollapsed(selection)
+        ) {
             handle.notifyMoveIn(selection.anchorOffset);
         }
     }

--- a/ts/lib/cross-browser.ts
+++ b/ts/lib/cross-browser.ts
@@ -2,11 +2,6 @@
 // License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
 /**
- * NOTES:
- * - Avoid using selection.isCollapsed: will always return true in shadow root in Gecko
- */
-
-/**
  * Gecko has no .getSelection on ShadowRoot, only .activeElement
  */
 export function getSelection(element: Node): Selection | null {
@@ -28,4 +23,13 @@ export function getRange(selection: Selection): Range | null {
     const rangeCount = selection.rangeCount;
 
     return rangeCount === 0 ? null : selection.getRangeAt(rangeCount - 1);
+}
+
+/**
+ * Avoid using selection.isCollapsed: it will always return
+ * true in shadow root in Gecko
+ * (this bug seems to also happens in Blink)
+ */
+export function isSelectionCollapsed(selection: Selection): boolean {
+    return getRange(selection)!.collapsed;
 }


### PR DESCRIPTION
You can recreate the bug when selecting text which is next to Mathjax element by tripple-clicking.