### PR TITLE
Fix the caret flushing behavior when moving out of a Mathjax element

### DIFF
--- a/ts/editable/ContentEditable.svelte
+++ b/ts/editable/ContentEditable.svelte
@@ -10,9 +10,8 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     import type { Writable } from "svelte/store";
     import { updateAllState } from "../components/WithState.svelte";
     import actionList from "../sveltelib/action-list";
-    import contentEditableAPI, {
-        saveLocation,
-        initialFocusHandling,
+    import {
+        customFocusHandling,
         preventBuiltinContentEditableShortcuts,
     } from "./content-editable";
     import type { ContentEditableAPI } from "./content-editable";
@@ -33,14 +32,15 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
     export let api: Partial<ContentEditableAPI>;
 
-    Object.assign(api, contentEditableAPI);
+    const { setupFocusHandling, flushCaret } = customFocusHandling();
+
+    Object.assign(api, { flushCaret });
 </script>
 
 <anki-editable
     contenteditable="true"
     use:resolve
-    use:saveLocation
-    use:initialFocusHandling
+    use:setupFocusHandling
     use:preventBuiltinContentEditableShortcuts
     use:mirrorAction={mirrorOptions}
     use:managerAction={{}}

--- a/ts/editable/content-editable.ts
+++ b/ts/editable/content-editable.ts
@@ -9,16 +9,6 @@ import { isApplePlatform } from "../lib/platform";
 import { bridgeCommand } from "../lib/bridgecommand";
 import type { SelectionLocation } from "../domlib/location";
 
-const locationEvents: (() => void)[] = [];
-
-function flushLocation(): void {
-    let removeEvent: (() => void) | undefined;
-
-    while ((removeEvent = locationEvents.pop())) {
-        removeEvent();
-    }
-}
-
 function safePlaceCaretAfterContent(editable: HTMLElement): void {
     /**
      * Workaround: If you try to invoke an IME after calling
@@ -44,37 +34,48 @@ function onFocus(location: SelectionLocation | null): () => void {
     };
 }
 
-function onBlur(this: HTMLElement): void {
-    prepareFocusHandling(this, saveSelection(this));
-}
+export function customFocusHandling() {
+    const focusHandlingEvents: (() => void)[] = [];
 
-function prepareFocusHandling(
-    editable: HTMLElement,
-    latestLocation: SelectionLocation | null = null,
-): void {
-    const removeOnFocus = on(editable, "focus", onFocus(latestLocation), {
-        once: true,
-    });
+    function flushEvents(): void {
+        let removeEvent: (() => void) | undefined;
 
-    locationEvents.push(
-        removeOnFocus,
-        on(editable, "pointerdown", removeOnFocus, { once: true }),
-    );
-}
+        while ((removeEvent = focusHandlingEvents.pop())) {
+            removeEvent();
+        }
+    }
 
-export function initialFocusHandling(editable: HTMLElement): void {
-    prepareFocusHandling(editable);
-}
+    function prepareFocusHandling(
+        editable: HTMLElement,
+        latestLocation: SelectionLocation | null = null,
+    ): void {
+        const off = on(editable, "focus", onFocus(latestLocation), { once: true });
 
-/* Must execute before DOMMirror */
-export function saveLocation(editable: HTMLElement): { destroy(): void } {
-    const removeOnBlur = on(editable, "blur", onBlur);
+        focusHandlingEvents.push(off, on(editable, "pointerdown", off, { once: true }));
+    }
+
+    /**
+     * Must execute before DOMMirror.
+     */
+    function onBlur(this: HTMLElement): void {
+        prepareFocusHandling(this, saveSelection(this));
+    }
+
+    function setupFocusHandling(editable: HTMLElement): { destroy(): void } {
+        prepareFocusHandling(editable);
+        const off = on(editable, "blur", onBlur);
+
+        return {
+            destroy() {
+                flushEvents();
+                off();
+            },
+        };
+    }
 
     return {
-        destroy() {
-            removeOnBlur();
-            flushLocation();
-        },
+        setupFocusHandling,
+        flushCaret: flushEvents,
     };
 }
 
@@ -91,11 +92,5 @@ export function preventBuiltinContentEditableShortcuts(editable: HTMLElement): v
 /** API */
 
 export interface ContentEditableAPI {
-    flushLocation(): void;
+    flushCaret(): void;
 }
-
-const contentEditableApi: ContentEditableAPI = {
-    flushLocation,
-};
-
-export default contentEditableApi;

--- a/ts/editable/content-editable.ts
+++ b/ts/editable/content-editable.ts
@@ -34,7 +34,12 @@ function onFocus(location: SelectionLocation | null): () => void {
     };
 }
 
-export function customFocusHandling() {
+interface CustomFocusHandlingAPI {
+    setupFocusHandling(element: HTMLElement): { destroy(): void };
+    flushCaret(): void;
+}
+
+export function customFocusHandling(): CustomFocusHandlingAPI {
     const focusHandlingEvents: (() => void)[] = [];
 
     function flushEvents(): void {
@@ -92,5 +97,10 @@ export function preventBuiltinContentEditableShortcuts(editable: HTMLElement): v
 /** API */
 
 export interface ContentEditableAPI {
+    /**
+     * Can be used to turn off the caret restoring functionality of
+     * the ContentEditable. Can be used when you want to set the caret
+     * yourself.
+     */
     flushCaret(): void;
 }

--- a/ts/editor/mathjax-overlay/MathjaxHandle.svelte
+++ b/ts/editor/mathjax-overlay/MathjaxHandle.svelte
@@ -16,7 +16,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     import { Mathjax } from "../../editable/mathjax-element";
 
     const { container, api } = getRichTextInput();
-    const { flushLocation, preventResubscription } = api;
+    const { flushCaret, preventResubscription } = api;
 
     const code = writable("");
 
@@ -40,7 +40,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     let selectAll = false;
 
     function placeHandle(after: boolean): void {
-        flushLocation();
+        flushCaret();
 
         if (after) {
             (mathjaxElement as any).placeCaretAfter();


### PR DESCRIPTION
You could recreate this bug by going into a Mathjax element, moving out with the arrow keys, and then tabbing to the next field: the caret would always be set to the start of the field.