### PR TITLE
Add dark mode detection fix for users without gnome schema

### DIFF
--- a/qt/aqt/theme.py
+++ b/qt/aqt/theme.py
@@ -369,6 +369,11 @@ def get_linux_dark_mode() -> bool:
         print(e)
         return False
 
+    except subprocess.CalledProcessError as e:
+        # gsettings is installed, but cannot return a value
+        print(e)
+        return False
+    
     return "-dark" in process.stdout.lower()
 
 

--- a/qt/aqt/theme.py
+++ b/qt/aqt/theme.py
@@ -373,7 +373,7 @@ def get_linux_dark_mode() -> bool:
         # gsettings is installed, but cannot return a value
         print(e)
         return False
-    
+
     return "-dark" in process.stdout.lower()
 
 


### PR DESCRIPTION
EDIT: sorry I forgot to add my name to the CONTRIBUTORS file, since my code is so trifling you can consider it public domain. Taking attribution, acknowledgement, etc. would just be comical here lmao

Hello, I was trying to install Anki on my new Gentoo installation when I encountered this bug, although it was luckily an easy fix. As I'm running a fairly minimal distro, I'm just using Xorg server with dwm as my window manager, but it seems the existing code tries to use `gsettings` to detect dark mode on Linux. Maybe it's down to a mistake on my part, but this naturally didn't work, as I don't have a GNOME desktop*; the result of the subprocess that Anki tries to spawn on my system is:

```
$ gsettings get org.gnome.desktop.interface gtk-theme
No such schema “org.gnome.desktop.interface”
```
I included a check to also except any error if `gsettings` _is_ installed (like on my system), but can't provide any proper output.
Hope this can be of use to you.

* At least, I assume that's what the code's checking for.

(The comment I wrote on my fork's commit.):
On some systems, the result of the `gsettings get org.gnome.desktop.interface gtk-theme` command is `No such schema “org.gnome.desktop.interface”`, which causes Anki to fail to find a value, subsequently crashing on some Linux systems.