### PR TITLE
Remove outdated info about VS Code

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -179,10 +179,8 @@ pip in the virtual environment, and run `pip install -r pip/requirements.txt` to
 all of Anki's dependencies into the environment, so that code completion works for them.
 Then run `pip install pyqt6 pyqt6-webengine` to install PyQt.
 
-Visual Studio Code + the Python extension does support code completion, but
-currently seems to frequently freeze for multiple seconds while pinning the CPU
-at 100%. Switching from the default Jedi language server to Pylance improves the
-CPU usage, but Pylance doesn't do a great job understanding the type annotations.
+Visual Studio Code + the Python extension does support code completion, but Pylance 
+doesn't do a great job understanding the type annotations.
 
 ## Rust editing
 


### PR DESCRIPTION
Pylance is now the default for Python on VS Code, so it should no longer be necessary to suggest switching to it.

I haven't used PyCharm so maybe there is something I'm missing, but for the record I haven't had any issues with Pylance understanding the type annotations. Maybe it's worth checking if this is still true? It's pretty new so it may have had improvements since this was written.