### PR TITLE
qt/aqt/webview: handle opening href with target=_blank

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -91,6 +91,7 @@ git9527 <github.com/git9527>
 Vova Selin <vselin12@gmail.com>
 qxo <49526356@qq.com>
 Spooghetti420 <github.com/spooghetti420>
+Danish Prakash <github.com/danishprakash>
 
 ********************
 

--- a/qt/aqt/webview.py
+++ b/qt/aqt/webview.py
@@ -259,6 +259,11 @@ class AnkiWebView(QWebEngineView):
     def disable_zoom(self) -> None:
         self._disable_zoom = True
 
+    def createWindow(self, windowType: QWebEnginePage.WebWindowType) -> QWebEngineView:
+        # intercept opening a new window (hrefs
+        # with target="_blank") and return view
+        return AnkiWebView()
+
     def eventFilter(self, obj: QObject, evt: QEvent) -> bool:
         if self._disable_zoom and is_gesture_or_zoom_event(evt):
             return True


### PR DESCRIPTION
Turns out, if using `target="_blank"`, the `createWindow` method is called and not `acceptNavigationRequest`. But similar to `acceptNavigationRequest`, we're supposed to override `createWindow` and handle the behavior accordingly. I was trying to extract the URL and invoke the `openLink` method, but this turned out to be the preferred approach as per the community.

Note: I was only able to test this on GNU/Linux.

From https://doc.qt.io/qt-5/qwebengineview.html#createWindow:
```
This function is called from the createWindow() method of the associated QWebEnginePage each 
time the page wants to create a new window of the given type. For example, when a JavaScript 
request to open a document in a new window is issued.
```

Fixes #1339