### PR TITLE
Tweak search highlight color in the templates screen

### DIFF
--- a/qt/aqt/clayout.py
+++ b/qt/aqt/clayout.py
@@ -240,6 +240,7 @@ class CardLayout(QDialog):
 
     def setup_edit_area(self) -> None:
         tform = self.tform
+        editor = tform.edit_area
 
         tform.front_button.setText(tr.card_templates_front_template())
         tform.back_button.setText(tr.card_templates_back_template())
@@ -247,28 +248,28 @@ class CardLayout(QDialog):
         tform.groupBox.setTitle(tr.card_templates_template_box())
 
         cnt = self.mw.col.models.use_count(self.model)
-        self.tform.changes_affect_label.setText(
+        tform.changes_affect_label.setText(
             self.col.tr.card_templates_changes_will_affect_notes(count=cnt)
         )
 
-        qconnect(tform.edit_area.textChanged, self.write_edits_to_template_and_redraw)
+        qconnect(editor.textChanged, self.write_edits_to_template_and_redraw)
         qconnect(tform.front_button.clicked, self.on_editor_toggled)
         qconnect(tform.back_button.clicked, self.on_editor_toggled)
         qconnect(tform.style_button.clicked, self.on_editor_toggled)
 
         self.current_editor_index = 0
-        self.tform.edit_area.setAcceptRichText(False)
-        self.tform.edit_area.setFont(QFont("Courier"))
+        editor.setAcceptRichText(False)
+        editor.setFont(QFont("Courier"))
         tab_width = self.fontMetrics().horizontalAdvance(" " * 4)
-        self.tform.edit_area.setTabStopDistance(tab_width)
+        editor.setTabStopDistance(tab_width)
 
-        palette = tform.edit_area.palette()
+        palette = editor.palette()
         palette.setColor(
             QPalette.ColorGroup.Inactive,
             QPalette.ColorRole.Highlight,
             QColor("#4169e1" if theme_manager.night_mode else "#FFFF80"),
         )
-        tform.edit_area.setPalette(palette)
+        editor.setPalette(palette)
 
         widg = tform.search_edit
         widg.setPlaceholderText("Search")

--- a/qt/aqt/clayout.py
+++ b/qt/aqt/clayout.py
@@ -222,6 +222,7 @@ class CardLayout(QDialog):
         left = QWidget()
         tform = self.tform = aqt.forms.template.Ui_Form()
         tform.setupUi(left)
+        self.setup_edit_area()
         split.addWidget(left)
         split.setCollapsible(0, False)
 
@@ -233,7 +234,6 @@ class CardLayout(QDialog):
         pform.preview_back.setText(tr.card_templates_back_preview())
         pform.preview_box.setTitle(tr.card_templates_preview_box())
 
-        self.setup_edit_area()
         self.setup_preview()
         split.addWidget(right)
         split.setCollapsible(1, False)
@@ -261,6 +261,14 @@ class CardLayout(QDialog):
         self.tform.edit_area.setFont(QFont("Courier"))
         tab_width = self.fontMetrics().horizontalAdvance(" " * 4)
         self.tform.edit_area.setTabStopDistance(tab_width)
+
+        palette = tform.edit_area.palette()
+        palette.setColor(
+            QPalette.ColorGroup.Inactive,
+            QPalette.ColorRole.Highlight,
+            QColor("#4169e1" if theme_manager.night_mode else "#FFFF80"),
+        )
+        tform.edit_area.setPalette(palette)
 
         widg = tform.search_edit
         widg.setPlaceholderText("Search")

--- a/qt/aqt/clayout.py
+++ b/qt/aqt/clayout.py
@@ -269,6 +269,11 @@ class CardLayout(QDialog):
             QPalette.ColorRole.Highlight,
             QColor("#4169e1" if theme_manager.night_mode else "#FFFF80"),
         )
+        palette.setColor(
+            QPalette.ColorGroup.Inactive,
+            QPalette.ColorRole.HighlightedText,
+            QColor("#ffffff" if theme_manager.night_mode else "#000000"),
+        )
         editor.setPalette(palette)
 
         widg = tform.search_edit


### PR DESCRIPTION
The default highlight color was hard to see, especially in light mode.

Before:
![Screenshot 2022-01-24 193816](https://user-images.githubusercontent.com/41397710/150825279-8e067e15-38b6-49f8-97a7-f3d933856096.png)
![Screenshot 2022-01-24 193834](https://user-images.githubusercontent.com/41397710/150825287-59c10654-23a6-4483-a0cd-27cbb7a16318.png)

After:
![Screenshot 2022-01-24 184610](https://user-images.githubusercontent.com/41397710/150823800-dc97046d-bd4e-4d1a-8a99-226ea28bd459.png)
![Screenshot 2022-01-24 184544](https://user-images.githubusercontent.com/41397710/150823824-983ad1bd-dc9f-4771-a760-f508d7bae84b.png)

Using `QPalette.ColorGroup.Inactive` will also cause normally selected text to have the highlight background color if the template editor is not focused, but this is the simplest solution I could think of.

![image](https://user-images.githubusercontent.com/41397710/150824302-63caef86-0174-4c6f-9c06-68a41f52da94.png)


I had to move the setup_edit_area() call because it was preventing the palette change to take effect for some reason.