### PR TITLE
Fix button focus highlight on Windows

### DIFF
--- a/qt/aqt/data/web/css/reviewer-bottom.scss
+++ b/qt/aqt/data/web/css/reviewer-bottom.scss
@@ -52,11 +52,25 @@ button {
 .focus {
     outline: 5px auto var(--focus-color);
 
+    .nightMode & {
+        outline: unset;
+        box-shadow: 0 0 0 2px var(--focus-color);
+    }
+
     #innertable:focus-within & {
         outline: unset;
 
+        .nightMode & {
+            box-shadow: unset;
+        }
+
         &:focus {
             outline: 5px auto var(--focus-color);
+
+            .nightMode & {
+                outline: unset;
+                box-shadow: 0 0 0 2px var(--focus-color);
+            }
         }
     }
 }

--- a/qt/aqt/webview.py
+++ b/qt/aqt/webview.py
@@ -413,8 +413,9 @@ class AnkiWebView(QWebEngineView):
         if is_win:
             # T: include a font for your language on Windows, eg: "Segoe UI", "MS Mincho"
             family = tr.qt_misc_segoe_ui()
-            button_style = "button { font-family:%s; }" % family
-            button_style += "\n:focus { outline: 1px solid %s; }" % color_hl
+            button_style = f"""
+button {{ font-family: {family}; }}
+button:focus {{ outline: 5px auto {color_hl}; }}"""
             font = f"font-size:12px;font-family:{family};"
         elif is_mac:
             family = "Helvetica"

--- a/sass/buttons.scss
+++ b/sass/buttons.scss
@@ -1,5 +1,13 @@
 @use "fusion-vars";
 
+:root {
+    --focus-color: #0078d7;
+
+    .isMac {
+        --focus-color: rgba(0 103 244 / 0.247);
+    }
+}
+
 .isWin {
     button {
         font-size: 12px;
@@ -39,6 +47,11 @@
 
         border-radius: 5px;
         padding: 3px 10px 3px;
+
+        &:focus {
+            outline: unset;
+            box-shadow: 0 0 0 2px var(--focus-color);
+        }
     }
 
     button:hover {


### PR DESCRIPTION
Fixes the issue described in https://github.com/ankitects/anki/issues/1567 and a similar one for the reviewer buttons at the bottom.
Before:
![grafik](https://user-images.githubusercontent.com/48286681/150836566-ee4acbdc-7ac0-4277-b341-67d6e7c67ae3.png) ![grafik](https://user-images.githubusercontent.com/48286681/150836555-c045e07a-dd4e-46d0-a243-784a806a40c0.png) ![grafik](https://user-images.githubusercontent.com/48286681/150836637-1219a472-e2b3-4cef-b7bf-3201f3346c87.png) ![grafik](https://user-images.githubusercontent.com/48286681/150836676-c95bcb55-0a60-4a9a-967b-3f0b962271c1.png)
After:
![grafik](https://user-images.githubusercontent.com/48286681/150869477-55c34086-d228-4328-b182-cc2a6a20f4f7.png) ![grafik](https://user-images.githubusercontent.com/48286681/150869367-a3828f4a-6864-4fb2-9cd2-0fdab766e79a.png) ![grafik](https://user-images.githubusercontent.com/48286681/150869391-2b973b60-0293-487b-9a66-a580a59e6c70.png) ![grafik](https://user-images.githubusercontent.com/48286681/150869434-85c07a44-057e-418a-b14b-7ebd3258ca8b.png)

This took me forever and I still don't fully understand the interplay of the three files, so most likely someone will have to clean things up. I've probably broken things for other systems, and didn't do things how they're supposed to be done. (E.g. `--focus-color` is declared twice now, but I assumed there was a reason it's not in `_vars.scss`.)

Heads-up, @hgiesel.