### PR TITLE
Fix active field not being updated after some operation

### DIFF
--- a/qt/aqt/browser/browser.py
+++ b/qt/aqt/browser/browser.py
@@ -154,7 +154,7 @@ class Browser(QMainWindow):
                     except NotFoundError:
                         self.editor.set_note(None)
                         return
-                    self.editor.set_note(note)
+                    self.editor.set_note(note, refocus=True)
 
         if changes.browser_table and changes.card:
             self.card = self.table.get_single_selected_card()

--- a/qt/aqt/editcurrent.py
+++ b/qt/aqt/editcurrent.py
@@ -49,7 +49,7 @@ class EditCurrent(QDialog):
                 self.cleanup_and_close()
                 return
 
-            self.editor.set_note(note)
+            self.editor.set_note(note, refocus=True)
 
     def cleanup_and_close(self) -> None:
         gui_hooks.operation_did_execute.remove(self.on_operation_did_execute)

--- a/qt/aqt/editor.py
+++ b/qt/aqt/editor.py
@@ -467,20 +467,24 @@ uiPromise.then(noteEditor => noteEditor.toolbar.toolbar.appendGroup({{
     ######################################################################
 
     def set_note(
-        self, note: Note | None, hide: bool = True, focusTo: int | None = None
+        self,
+        note: Note | None,
+        hide: bool = True,
+        focusTo: int | None = None,
+        refocus: bool = False,
     ) -> None:
         "Make NOTE the current note."
         self.note = note
         self.currentField = None
         if self.note:
-            self.loadNote(focusTo=focusTo)
+            self.loadNote(focusTo=focusTo, refocus=refocus)
         elif hide:
             self.widget.hide()
 
     def loadNoteKeepingFocus(self) -> None:
         self.loadNote(self.currentField)
 
-    def loadNote(self, focusTo: int | None = None) -> None:
+    def loadNote(self, focusTo: int | None = None, refocus: bool = False) -> None:
         if not self.note:
             return
 
@@ -523,6 +527,11 @@ uiPromise.then(noteEditor => noteEditor.toolbar.toolbar.appendGroup({{
         if self.addMode:
             sticky = [field["sticky"] for field in self.note.note_type()["flds"]]
             js += " setSticky(%s);" % json.dumps(sticky)
+
+        # update active field after changes are made to the note text
+        # from outside the webview
+        if refocus:
+            js += "refocusField();"
 
         js = gui_hooks.editor_will_load_note(js, self.note, self)
         self.web.evalWithCallback(f"uiPromise.then(() => {{ {js} }})", oncallback)

--- a/ts/editor/OldEditorAdapter.svelte
+++ b/ts/editor/OldEditorAdapter.svelte
@@ -209,6 +209,10 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         return false;
     }
 
+    export function refocusField(): void {
+        $activeInput?.refocus();
+    }
+
     let richTextInputs: RichTextInput[] = [];
     $: richTextInputs = richTextInputs.filter(Boolean);
 
@@ -259,6 +263,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
             setClozeHint,
             saveNow: saveFieldNow,
             focusIfField,
+            refocusField,
             setNoteId,
             wrap,
             ...oldEditorAdapter,


### PR DESCRIPTION
Fixes #1628.

The issue occurs not only when undoing, but also when performing a "Find and Replace".