### PR TITLE
Add forget card to review context "more" menu

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -92,6 +92,7 @@ Vova Selin <vselin12@gmail.com>
 qxo <49526356@qq.com>
 Spooghetti420 <github.com/spooghetti420>
 Danish Prakash <github.com/danishprakash>
+Araceli Yanez <github.com/aracelix>
 
 ********************
 

--- a/qt/aqt/reviewer.py
+++ b/qt/aqt/reviewer.py
@@ -30,6 +30,7 @@ from aqt.operations.scheduling import (
     answer_card,
     bury_cards,
     bury_notes,
+    forget_cards,
     set_due_date_dialog,
     suspend_cards,
     suspend_note,
@@ -459,6 +460,7 @@ class Reviewer:
             ("-", self.bury_current_card),
             ("!", self.suspend_current_note),
             ("@", self.suspend_current_card),
+            ("Ctrl+Alt+N", self.forget_current_card),
             ("Ctrl+Alt+E", self.on_create_copy),
             ("Ctrl+Delete", self.delete_current_note),
             ("Ctrl+Shift+D", self.on_set_due),
@@ -915,6 +917,7 @@ time = %(time)d;
                 ],
             ],
             [tr.studying_bury_card(), "-", self.bury_current_card],
+            [tr.actions_forget_card(), "Ctrl+Alt+N", self.forget_current_card],
             [
                 tr.actions_with_ellipsis(action=tr.actions_set_due_date()),
                 "Ctrl+Shift+D",
@@ -1051,6 +1054,12 @@ time = %(time)d;
     def bury_current_card(self) -> None:
         bury_cards(parent=self.mw, card_ids=[self.card.id],).success(
             lambda res: tooltip(tr.studying_cards_buried(count=res.count))
+        ).run_in_background()
+
+    def forget_current_card(self) -> None:
+        forget_cards(
+            parent=self.mw,
+            card_ids=[self.card.id],
         ).run_in_background()
 
     def on_create_copy(self) -> None:


### PR DESCRIPTION
I hope I did this correctly. Development notes say that there is a transition from python to rust for the business logic - forgetting cards seems like business logic...what I did in this PR is reference `forget_cards` from `scheduling.py` in the context menu:

https://github.com/ankitects/anki/blob/0c81bbce04c1998b92ed0c1fa08d1cd5d13f3f56/qt/aqt/operations/scheduling.py#L66-L75

Which looks like it eventually calls the rust backend?
https://github.com/ankitects/anki/blob/0c81bbce04c1998b92ed0c1fa08d1cd5d13f3f56/pylib/anki/scheduler/base.py#L162-L164

Re: tests, it seemed like there were tests for `forget_cards` already, but didn't see anything specifically for the review view. I did check that clicking the menu and using the shortcut both work to forget a card. Let me know if that's not enough/expected. 