### PR TITLE
Add callback and non-blocking option to StudyDeck

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -92,6 +92,7 @@ Vova Selin <vselin12@gmail.com>
 qxo <49526356@qq.com>
 Spooghetti420 <github.com/spooghetti420>
 Danish Prakash <github.com/danishprakash>
+Sam Bradshaw <samjr.bradshaw@gmail.com>
 
 ********************
 

--- a/qt/aqt/modelchooser.py
+++ b/qt/aqt/modelchooser.py
@@ -79,7 +79,18 @@ class ModelChooser(QHBoxLayout):
         def nameFunc() -> list[str]:
             return [nt.name for nt in self.deck.models.all_names_and_ids()]
 
-        ret = StudyDeck(
+        def callback(ret):
+            if not ret.name:
+                return
+            m = self.deck.models.by_name(ret.name)
+            self.deck.conf["curModel"] = m["id"]
+            cdeck = self.deck.decks.current()
+            cdeck["mid"] = m["id"]
+            self.deck.decks.save(cdeck)
+            gui_hooks.current_note_type_did_change(current)
+            self.mw.reset()
+
+        StudyDeck(
             self.mw,
             names=nameFunc,
             accept=tr.actions_choose(),
@@ -90,16 +101,8 @@ class ModelChooser(QHBoxLayout):
             buttons=[edit],
             cancel=True,
             geomKey="selectModel",
+            callback=callback,
         )
-        if not ret.name:
-            return
-        m = self.deck.models.by_name(ret.name)
-        self.deck.conf["curModel"] = m["id"]
-        cdeck = self.deck.decks.current()
-        cdeck["mid"] = m["id"]
-        self.deck.decks.save(cdeck)
-        gui_hooks.current_note_type_did_change(current)
-        self.mw.reset()
 
     def updateModels(self) -> None:
         self.models.setText(self.deck.models.current()["name"].replace("&", "&&"))

--- a/qt/aqt/modelchooser.py
+++ b/qt/aqt/modelchooser.py
@@ -79,7 +79,7 @@ class ModelChooser(QHBoxLayout):
         def nameFunc() -> list[str]:
             return [nt.name for nt in self.deck.models.all_names_and_ids()]
 
-        def callback(ret):
+        def callback(ret: StudyDeck) -> None:
             if not ret.name:
                 return
             m = self.deck.models.by_name(ret.name)

--- a/qt/aqt/studydeck.py
+++ b/qt/aqt/studydeck.py
@@ -36,7 +36,7 @@ class StudyDeck(QDialog):
         dyn: bool = False,
         buttons: Optional[list[Union[str, QPushButton]]] = None,
         geomKey: str = "default",
-        callback: Union[Callable, bool] = False,
+        callback: Callable = None,
     ) -> None:
         QDialog.__init__(self, parent or mw)
         self.mw = mw

--- a/qt/aqt/studydeck.py
+++ b/qt/aqt/studydeck.py
@@ -36,7 +36,7 @@ class StudyDeck(QDialog):
         dyn: bool = False,
         buttons: Optional[list[Union[str, QPushButton]]] = None,
         geomKey: str = "default",
-        callback: Callable = None,
+        callback: Callable | None = None,
     ) -> None:
         QDialog.__init__(self, parent or mw)
         self.mw = mw

--- a/qt/aqt/studydeck.py
+++ b/qt/aqt/studydeck.py
@@ -36,7 +36,7 @@ class StudyDeck(QDialog):
         dyn: bool = False,
         buttons: Optional[list[Union[str, QPushButton]]] = None,
         geomKey: str = "default",
-        callback: Callable | None = None,
+        callback: Union[Callable, None] = None,
     ) -> None:
         QDialog.__init__(self, parent or mw)
         self.mw = mw

--- a/qt/aqt/studydeck.py
+++ b/qt/aqt/studydeck.py
@@ -36,6 +36,7 @@ class StudyDeck(QDialog):
         dyn: bool = False,
         buttons: Optional[list[Union[str, QPushButton]]] = None,
         geomKey: str = "default",
+        callback: Union[Callable, bool] = False,
     ) -> None:
         QDialog.__init__(self, parent or mw)
         self.mw = mw
@@ -87,7 +88,11 @@ class StudyDeck(QDialog):
         self.show()
         # redraw after show so position at center correct
         self.redraw("", current)
-        self.exec()
+        self.callback = callback
+        if callback:
+            self.open()
+        else:
+            self.exec()
 
     def eventFilter(self, obj: QObject, evt: QEvent) -> bool:
         if isinstance(evt, QKeyEvent) and evt.type() == QEvent.Type.KeyPress:
@@ -152,6 +157,8 @@ class StudyDeck(QDialog):
             showInfo(tr.decks_please_select_something())
             return
         self.name = self.names[self.form.list.currentRow()]
+        if callable(self.callback):
+            self.callback(self)
         QDialog.accept(self)
 
     def reject(self) -> None:

--- a/qt/aqt/studydeck.py
+++ b/qt/aqt/studydeck.py
@@ -157,7 +157,7 @@ class StudyDeck(QDialog):
             showInfo(tr.decks_please_select_something())
             return
         self.name = self.names[self.form.list.currentRow()]
-        if callable(self.callback):
+        if self.callback:
             self.callback(self)
         QDialog.accept(self)
 


### PR DESCRIPTION
### Background

QDialog has a few different ways of displaying itself, including:

```
QDialog.exec() # runs in own loop, blocks program until finished
QDialog.open() # non-blocking
```

 The blocking version is useful if your function needs to get a value out of QDialog, but this causes issues because:
- If QDialog causes an error, it will also cause an error in the function that called it (or simply hang)
- Other code might need to run in the background, e.g. an add-on that makes a selection from the dialog

A similar problem exists with QMenu, and ideally all subclasses of QDialog and QMenu will be changed to their respective non-blocking options, but StudyDeck is known to be causing issues (see #987) already. However, since existing code (and likely add-ons as well) relies on QDialogs being blocking, this will cause issues if the behaviour is changed.

### Fix

A `callback` kwarg is added to StudyDeck, accepting a callable and defaulting to `None`, and the class is modified so that:
- if `callback == None` the class retains its old, blocking, behaviour. As this is the default, existing code that calls StudyDeck will be unaffected. 
- if a callable is passed to callback, the callable is called with the StudyDeck instance as its only argument by `StudyDeck.accept`. New code that requires the result of StudyDeck should use this behaviour.

This option allows existing code (and addons) to be updated while preserving legacy behaviour in the interim. Once the new behaviour is confirmed to be suitable, a depreciation warning can be added to emit when values of the instance (usually `StudyDeck.name`) are referenced after the dialog has been closed to warn add-ons of the need to update, and eventually the blocking option can be removed.

Changes have been tested in MacOS (Apple, PyQt6) and StudyDeck is confirmed to behave normally when called using either approach.

If this approach is successful for StudyDeck, the same changes should be made to other objects that block the main loop.