### PR TITLE
Make dialogs non-blocking

### DIFF
--- a/qt/aqt/browser/browser.py
+++ b/qt/aqt/browser/browser.py
@@ -673,6 +673,13 @@ class Browser(QMainWindow):
         cids = self.table.get_selected_card_ids()
         did = self.mw.col.db.scalar("select did from cards where id = ?", cids[0])
         current = self.mw.col.decks.get(did)["name"]
+
+        def callback(ret: StudyDeck) -> None:
+            if not ret.name:
+                return
+            did = self.col.decks.id(ret.name)
+            set_card_deck(parent=self, card_ids=cids, deck_id=did).run_in_background()
+
         ret = StudyDeck(
             self.mw,
             current=current,
@@ -680,12 +687,8 @@ class Browser(QMainWindow):
             title=tr.browsing_change_deck(),
             help=HelpPage.BROWSING,
             parent=self,
+            callback=callback,
         )
-        if not ret.name:
-            return
-        did = self.col.decks.id(ret.name)
-
-        set_card_deck(parent=self, card_ids=cids, deck_id=did).run_in_background()
 
     # legacy
 

--- a/qt/aqt/browser/browser.py
+++ b/qt/aqt/browser/browser.py
@@ -680,7 +680,7 @@ class Browser(QMainWindow):
             did = self.col.decks.id(ret.name)
             set_card_deck(parent=self, card_ids=cids, deck_id=did).run_in_background()
 
-        ret = StudyDeck(
+        StudyDeck(
             self.mw,
             current=current,
             accept=tr.browsing_move_cards(),

--- a/qt/aqt/customstudy.py
+++ b/qt/aqt/customstudy.py
@@ -32,10 +32,9 @@ class CustomStudy(QDialog):
         self.created_custom_study = False
         f.setupUi(self)
         disable_help_button(self)
-        self.setWindowModality(Qt.WindowModality.WindowModal)
         self.setupSignals()
         f.radioNew.click()
-        self.exec()
+        self.open()
 
     def setupSignals(self) -> None:
         f = self.form

--- a/qt/aqt/deckchooser.py
+++ b/qt/aqt/deckchooser.py
@@ -91,7 +91,17 @@ class DeckChooser(QHBoxLayout):
         from aqt.studydeck import StudyDeck
 
         current = self.selected_deck_name()
-        ret = StudyDeck(
+
+        def callback(ret: StudyDeck) -> None:
+            if not ret.name:
+                return
+            new_selected_deck_id = self.mw.col.decks.by_name(ret.name)["id"]
+            if self.selected_deck_id != new_selected_deck_id:
+                self.selected_deck_id = new_selected_deck_id
+                if func := self.on_deck_changed:
+                    func(new_selected_deck_id)
+
+        StudyDeck(
             self.mw,
             current=current,
             accept=tr.actions_choose(),
@@ -100,13 +110,8 @@ class DeckChooser(QHBoxLayout):
             cancel=False,
             parent=self._widget,
             geomKey="selectDeck",
+            callback=callback,
         )
-        if ret.name:
-            new_selected_deck_id = self.mw.col.decks.by_name(ret.name)["id"]
-            if self.selected_deck_id != new_selected_deck_id:
-                self.selected_deck_id = new_selected_deck_id
-                if func := self.on_deck_changed:
-                    func(new_selected_deck_id)
 
     def on_operation_did_execute(
         self, changes: OpChanges, handler: object | None

--- a/qt/aqt/deckchooser.py
+++ b/qt/aqt/deckchooser.py
@@ -107,7 +107,7 @@ class DeckChooser(QHBoxLayout):
             accept=tr.actions_choose(),
             title=tr.qt_misc_choose_deck(),
             help=HelpPage.EDITING,
-            cancel=False,
+            cancel=True,
             parent=self._widget,
             geomKey="selectDeck",
             callback=callback,

--- a/qt/aqt/deckconf.py
+++ b/qt/aqt/deckconf.py
@@ -40,7 +40,6 @@ class DeckConf(QDialog):
         self.mw.checkpoint(tr.actions_options())
         self.setupCombos()
         self.setupConfs()
-        self.setWindowModality(Qt.WindowModality.WindowModal)
         qconnect(
             self.form.buttonBox.helpRequested, lambda: openHelp(HelpPage.DECK_OPTIONS)
         )
@@ -58,8 +57,7 @@ class DeckConf(QDialog):
         # qt doesn't size properly with altered fonts otherwise
         restoreGeom(self, "deckconf", adjustSize=True)
         gui_hooks.deck_conf_will_show(self)
-        self.show()
-        self.exec()
+        self.open()
         saveGeom(self, "deckconf")
 
     def setupCombos(self) -> None:

--- a/qt/aqt/main.py
+++ b/qt/aqt/main.py
@@ -1447,7 +1447,9 @@ title="{}" {}>{}</button>""".format(
                 lambda out: self.moveToState("overview")
             ).run_in_background()
 
-        StudyDeck(self, dyn=True, current=self.col.decks.current()["name"], callback=callback)
+        StudyDeck(
+            self, dyn=True, current=self.col.decks.current()["name"], callback=callback
+        )
 
     def onEmptyCards(self) -> None:
         show_empty_cards(self)

--- a/qt/aqt/main.py
+++ b/qt/aqt/main.py
@@ -1439,13 +1439,15 @@ title="{}" {}>{}</button>""".format(
     def onStudyDeck(self) -> None:
         from aqt.studydeck import StudyDeck
 
-        ret = StudyDeck(self, dyn=True, current=self.col.decks.current()["name"])
-        if ret.name:
-            # fixme: this is silly, it should be returning an ID
+        def callback(ret: StudyDeck) -> None:
+            if not ret.name:
+                return
             deck_id = self.col.decks.id(ret.name)
             set_current_deck(parent=self, deck_id=deck_id).success(
                 lambda out: self.moveToState("overview")
             ).run_in_background()
+
+        StudyDeck(self, dyn=True, current=self.col.decks.current()["name"], callback=callback)
 
     def onEmptyCards(self) -> None:
         show_empty_cards(self)

--- a/qt/aqt/models.py
+++ b/qt/aqt/models.py
@@ -48,7 +48,7 @@ class Models(QDialog):
         parent = parent or mw
         self.fromMain = fromMain
         self.selected_notetype_id = selected_notetype_id
-        QDialog.__init__(self, parent, Qt.WindowType.Window)
+        QDialog.__init__(self, parent or mw)
         self.col = mw.col.weakref()
         assert self.col
         self.mm = self.col.models

--- a/qt/aqt/models.py
+++ b/qt/aqt/models.py
@@ -61,7 +61,7 @@ class Models(QDialog):
         self.models: Sequence[NotetypeNameIdUseCount] = []
         self.setupModels()
         restoreGeom(self, "models")
-        self.exec()
+        self.show()
 
     # Models
     ##########################################################################

--- a/qt/aqt/notetypechooser.py
+++ b/qt/aqt/notetypechooser.py
@@ -112,7 +112,7 @@ class NotetypeChooser(QHBoxLayout):
             if (id := notetype["id"]) != self._selected_notetype_id:
                 self.selected_notetype_id = id
 
-        ret = StudyDeck(
+        StudyDeck(
             self.mw,
             names=nameFunc,
             accept=tr.actions_choose(),

--- a/qt/aqt/notetypechooser.py
+++ b/qt/aqt/notetypechooser.py
@@ -105,6 +105,13 @@ class NotetypeChooser(QHBoxLayout):
         def nameFunc() -> list[str]:
             return sorted(n.name for n in self.mw.col.models.all_names_and_ids())
 
+        def callback(ret: StudyDeck) -> None:
+            if not ret.name:
+                return
+            notetype = self.mw.col.models.by_name(ret.name)
+            if (id := notetype["id"]) != self._selected_notetype_id:
+                self.selected_notetype_id = id
+
         ret = StudyDeck(
             self.mw,
             names=nameFunc,
@@ -116,13 +123,8 @@ class NotetypeChooser(QHBoxLayout):
             buttons=[edit],
             cancel=True,
             geomKey="selectModel",
+            callback=callback,
         )
-        if not ret.name:
-            return
-
-        notetype = self.mw.col.models.by_name(ret.name)
-        if (id := notetype["id"]) != self._selected_notetype_id:
-            self.selected_notetype_id = id
 
     @property
     def selected_notetype_id(self) -> NotetypeId:

--- a/qt/aqt/studydeck.py
+++ b/qt/aqt/studydeck.py
@@ -81,7 +81,7 @@ class StudyDeck(QDialog):
         self.ok = self.form.buttonBox.addButton(
             accept or tr.decks_study(), QDialogButtonBox.ButtonRole.AcceptRole
         )
-        self.setWindowModality(Qt.WindowModality.WindowModal)
+        self.setModal(True)
         qconnect(self.form.buttonBox.helpRequested, lambda: openHelp(help))
         qconnect(self.form.filter.textEdited, self.redraw)
         qconnect(self.form.list.itemDoubleClicked, self.accept)
@@ -90,7 +90,7 @@ class StudyDeck(QDialog):
         self.redraw("", current)
         self.callback = callback
         if callback:
-            self.open()
+            self.show()
         else:
             self.exec()
 

--- a/ts/editor/HandleSelection.svelte
+++ b/ts/editor/HandleSelection.svelte
@@ -3,7 +3,7 @@ Copyright: Ankitects Pty Ltd and contributors
 License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 -->
 <script lang="ts">
-    import { createEventDispatcher } from "svelte";
+    import { createEventDispatcher, onMount } from "svelte";
 
     export let container: HTMLElement;
     export let image: HTMLImageElement;
@@ -43,10 +43,13 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
     const dispatch = createEventDispatcher();
 
+    let selectionRef: HTMLDivElement;
     function initSelection(selection: HTMLDivElement): void {
         setSelection();
-        dispatch("mount", { selection });
+        selectionRef = selection;
     }
+
+    onMount(() => dispatch("mount", { selection: selectionRef }));
 </script>
 
 <div


### PR DESCRIPTION
This makes two main changes:
- implements the callback option for StudyDeck for the remaining callers from #987 
- switches CustomStudy, DeckConf, Models dialogs to be non-blocking via open()

Notes:
- open() causes the dialog to be modal, preventing interaction with the rest of the program, but is non-blocking, whereas exec() blocks the main loop until the dialog exits
- self.setWindowModality(Qt.WindowModality.WindowModal) has been removed since open makes the dialog modal
- There are some other dialogs to be changed to non-blocking, and the QMenus, but these three are fair straightforward as they are unlikely to be called in a way that expects them to be blocking in the same way as StudyDeck
- As discussed in #987 the use of blocking dialogs can cause issues with add-ons that rely on being able to run while the dialog is open, perhaps because they implement a method to interact with the UI and therefore the dialog. The use of exec has also been identified as causing other problems
- The possibility that an add-on relies on being blocked while a dialog is open can't be ruled out other than when trying to get a return value, but it seems unlikely for these dialogs