### PR TITLE
Fix ValueError when exported files have wrong mtime

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -94,6 +94,7 @@ Spooghetti420 <github.com/spooghetti420>
 Danish Prakash <github.com/danishprakash>
 Araceli Yanez <github.com/aracelix>
 Sam Bradshaw <samjr.bradshaw@gmail.com>
+gnnoh <gerongfenh@gmail.com>
 
 ********************
 

--- a/pylib/anki/exporting.py
+++ b/pylib/anki/exporting.py
@@ -340,7 +340,7 @@ class AnkiPackageExporter(AnkiExporter):
 
     def exportInto(self, path: str) -> None:
         # open a zip file
-        z = zipfile.ZipFile(path, "w", zipfile.ZIP_DEFLATED, allowZip64=True)
+        z = zipfile.ZipFile(path, "w", zipfile.ZIP_DEFLATED, allowZip64=True, strict_timestamps=False)
         media = self.doExport(z, path)
         # media map
         z.writestr("media", json.dumps(media))

--- a/pylib/anki/exporting.py
+++ b/pylib/anki/exporting.py
@@ -340,7 +340,9 @@ class AnkiPackageExporter(AnkiExporter):
 
     def exportInto(self, path: str) -> None:
         # open a zip file
-        z = zipfile.ZipFile(path, "w", zipfile.ZIP_DEFLATED, allowZip64=True, strict_timestamps=False)
+        z = zipfile.ZipFile(
+            path, "w", zipfile.ZIP_DEFLATED, allowZip64=True, strict_timestamps=False
+        )
         media = self.doExport(z, path)
         # media map
         z.writestr("media", json.dumps(media))


### PR DESCRIPTION
Set the `strict_timestamps` argument to `False`, so the media files which have a wrong mtime(like `1970-01-01 00:00:00`) can be normally added to the zipfile instead of raising an error.