### PR TITLE
Add option to ignore accents in search by default

### DIFF
--- a/ftl/core/preferences.ftl
+++ b/ftl/core/preferences.ftl
@@ -42,4 +42,4 @@ preferences-theme-follow-system = Follow System
 preferences-theme-light = Light
 preferences-theme-dark = Dark
 preferences-v3-scheduler = V3 scheduler
-preferences-ignore-accents-in-search = Ignore accents in search
+preferences-ignore-accents-in-search = Ignore accents in search (slower)

--- a/ftl/core/preferences.ftl
+++ b/ftl/core/preferences.ftl
@@ -42,3 +42,4 @@ preferences-theme-follow-system = Follow System
 preferences-theme-light = Light
 preferences-theme-dark = Dark
 preferences-v3-scheduler = V3 scheduler
+preferences-ignore-accents-in-search = Ignore accents in search

--- a/proto/anki/config.proto
+++ b/proto/anki/config.proto
@@ -40,6 +40,7 @@ message ConfigKey {
     PASTE_IMAGES_AS_PNG = 15;
     PASTE_STRIPS_FORMATTING = 16;
     NORMALIZE_NOTE_TEXT = 17;
+    IGNORE_ACCENTS_IN_SEARCH = 18;
   }
   enum String {
     SET_DUE_BROWSER = 0;
@@ -110,6 +111,7 @@ message Preferences {
     bool paste_images_as_png = 2;
     bool paste_strips_formatting = 3;
     string default_search_text = 4;
+    bool ignore_accents_in_search = 5;
   }
 
   Scheduling scheduling = 1;

--- a/qt/aqt/forms/preferences.ui
+++ b/qt/aqt/forms/preferences.ui
@@ -90,6 +90,13 @@
         </widget>
        </item>
        <item>
+        <widget class="QCheckBox" name="ignore_accents_in_search">
+         <property name="text">
+          <string>preferences_ignore_accents_in_search</string>
+         </property>
+        </widget>
+       </item>
+       <item>
         <widget class="QComboBox" name="useCurrent">
          <item>
           <property name="text">

--- a/qt/aqt/preferences.py
+++ b/qt/aqt/preferences.py
@@ -91,6 +91,7 @@ class Preferences(QDialog):
             0 if editing.adding_defaults_to_current_deck else 1
         )
         form.paste_strips_formatting.setChecked(editing.paste_strips_formatting)
+        form.ignore_accents_in_search.setChecked(editing.ignore_accents_in_search)
         form.pastePNG.setChecked(editing.paste_images_as_png)
         form.default_search_text.setText(editing.default_search_text)
 
@@ -116,6 +117,9 @@ class Preferences(QDialog):
         editing.paste_images_as_png = self.form.pastePNG.isChecked()
         editing.paste_strips_formatting = self.form.paste_strips_formatting.isChecked()
         editing.default_search_text = self.form.default_search_text.text()
+        editing.ignore_accents_in_search = (
+            self.form.ignore_accents_in_search.isChecked()
+        )
 
         def after_prefs_update(changes: OpChanges) -> None:
             self.mw.apply_collection_options()

--- a/rslib/src/backend/config.rs
+++ b/rslib/src/backend/config.rs
@@ -31,6 +31,7 @@ impl From<BoolKeyProto> for BoolKey {
             BoolKeyProto::PasteImagesAsPng => BoolKey::PasteImagesAsPng,
             BoolKeyProto::PasteStripsFormatting => BoolKey::PasteStripsFormatting,
             BoolKeyProto::NormalizeNoteText => BoolKey::NormalizeNoteText,
+            BoolKeyProto::IgnoreAccentsInSearch => BoolKey::IgnoreAccentsInSearch,
         }
     }
 }

--- a/rslib/src/config/bool.rs
+++ b/rslib/src/config/bool.rs
@@ -26,6 +26,7 @@ pub enum BoolKey {
     PasteStripsFormatting,
     PreviewBothSides,
     Sched2021,
+    IgnoreAccentsInSearch,
 
     #[strum(to_string = "normalize_note_text")]
     NormalizeNoteText,

--- a/rslib/src/preferences.rs
+++ b/rslib/src/preferences.rs
@@ -132,6 +132,7 @@ impl Collection {
             paste_images_as_png: self.get_config_bool(BoolKey::PasteImagesAsPng),
             paste_strips_formatting: self.get_config_bool(BoolKey::PasteStripsFormatting),
             default_search_text: self.get_config_string(StringKey::DefaultSearchText),
+            ignore_accents_in_search: self.get_config_bool(BoolKey::IgnoreAccentsInSearch),
         })
     }
 
@@ -144,6 +145,7 @@ impl Collection {
         self.set_config_bool_inner(BoolKey::PasteImagesAsPng, s.paste_images_as_png)?;
         self.set_config_bool_inner(BoolKey::PasteStripsFormatting, s.paste_strips_formatting)?;
         self.set_config_string_inner(StringKey::DefaultSearchText, &s.default_search_text)?;
+        self.set_config_bool_inner(BoolKey::IgnoreAccentsInSearch, s.ignore_accents_in_search)?;
         Ok(())
     }
 }

--- a/rslib/src/search/sqlwriter.rs
+++ b/rslib/src/search/sqlwriter.rs
@@ -117,7 +117,14 @@ impl SqlWriter<'_> {
         use normalize_to_nfc as norm;
         match node {
             // note fields related
-            SearchNode::UnqualifiedText(text) => self.write_unqualified(&self.norm_note(text)),
+            SearchNode::UnqualifiedText(text) => {
+                let text = &self.norm_note(text);
+                if self.col.get_config_bool(BoolKey::IgnoreAccentsInSearch) {
+                    self.write_no_combining(text)
+                } else {
+                    self.write_unqualified(text)
+                }
+            }
             SearchNode::SingleField { field, text, is_re } => {
                 self.write_field(&norm(field), &self.norm_note(text), *is_re)?
             }

--- a/rslib/src/search/sqlwriter.rs
+++ b/rslib/src/search/sqlwriter.rs
@@ -587,8 +587,20 @@ impl SqlWriter<'_> {
         self.args.push(format!(r"(?i){}", word));
     }
 
+    fn write_regex_nc(&mut self, word: &str) {
+        let word = &without_combining(word);
+        self.sql
+            .push_str("coalesce(without_combining(n.flds), n.flds) regexp ?");
+        self.args.push(format!(r"(?i){}", word));
+    }
+
     fn write_word_boundary(&mut self, word: &str) {
-        self.write_regex(&format!(r"\b{}\b", to_re(word)));
+        let re = format!(r"\b{}\b", to_re(word));
+        if self.col.get_config_bool(BoolKey::IgnoreAccentsInSearch) {
+            self.write_regex_nc(&re);
+        } else {
+            self.write_regex(&re);
+        }
     }
 }
 


### PR DESCRIPTION
This PR adds a preferences option to ignore accents in unqualified and word boundary searches by default. The "Ignore accents in browser search" add-on supports ignoring accents in unqualified search, but it doesn't work with `w:` as far as I know.

Regarding demand of this feature, the add-on seems quite popular and there are requests to [make this use case easier](https://anki.tenderapp.com/discussions/ankidesktop/41875-proposal-card-browser-search-change-default-search-behaviour-in-respect-to-accents-nc-syntax-as-default) than having to type `nc:` before every search, or to [extend it to word boundary searches](https://forums.ankiweb.net/t/ignore-accent-and-case-while-searching/17305).

I didn't look much into implementing this for field searches. Maybe it can be implemented in the future if there is demand.

Perhaps the Fluent string can be improved to communicate the extent of the feature more clearly.