### PR TITLE
Fix new deck not being selected

### DIFF
--- a/qt/aqt/studydeck.py
+++ b/qt/aqt/studydeck.py
@@ -1,7 +1,9 @@
 # Copyright: Ankitects Pty Ltd and contributors
 # License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
-from typing import Optional
+from __future__ import annotations
+
+from typing import Callable
 
 import aqt
 import aqt.forms
@@ -28,17 +30,17 @@ class StudyDeck(QDialog):
     def __init__(
         self,
         mw: aqt.AnkiQt,
-        names: Callable = None,
-        accept: str = None,
-        title: str = None,
+        names: Callable[[], list[str]] | None = None,
+        accept: str | None = None,
+        title: str | None = None,
         help: HelpPageArgument = HelpPage.KEYBOARD_SHORTCUTS,
-        current: Optional[str] = None,
+        current: str | None = None,
         cancel: bool = True,
-        parent: Optional[QWidget] = None,
+        parent: QWidget | None = None,
         dyn: bool = False,
-        buttons: Optional[list[Union[str, QPushButton]]] = None,
+        buttons: list[str | QPushButton] | None = None,
         geomKey: str = "default",
-        callback: Union[Callable, None] = None,
+        callback: Callable[[StudyDeck], None] | None = None,
     ) -> None:
         QDialog.__init__(self, parent or mw)
         self.mw = mw
@@ -79,7 +81,7 @@ class StudyDeck(QDialog):
         else:
             self.nameFunc = names
             self.origNames = names()
-        self.name: Optional[str] = None
+        self.name: str | None = None
         self.ok = self.form.buttonBox.addButton(
             accept or tr.decks_study(), QDialogButtonBox.ButtonRole.AcceptRole
         )
@@ -121,7 +123,7 @@ class StudyDeck(QDialog):
                 return True
         return False
 
-    def redraw(self, filt: str, focus: Optional[str] = None) -> None:
+    def redraw(self, filt: str, focus: str | None = None) -> None:
         self.filt = filt
         self.focus = focus
         self.names = [n for n in self.origNames if self._matches(n, filt)]

--- a/qt/aqt/studydeck.py
+++ b/qt/aqt/studydeck.py
@@ -42,7 +42,7 @@ class StudyDeck(QDialog):
         geomKey: str = "default",
         callback: Callable[[StudyDeck], None] | None = None,
     ) -> None:
-        QDialog.__init__(self, parent or mw)
+        super().__init__(parent or mw)
         self.mw = mw
         self.form = aqt.forms.studydeck.Ui_Dialog()
         self.form.setupUi(self)
@@ -163,12 +163,12 @@ class StudyDeck(QDialog):
         self.name = self.names[self.form.list.currentRow()]
         if self.callback:
             self.callback(self)
-        QDialog.accept(self)
+        super().accept()
 
     def reject(self) -> None:
         saveGeom(self, self.geomKey)
         gui_hooks.state_did_reset.remove(self.onReset)
-        QDialog.reject(self)
+        super().reject()
 
     def onAddDeck(self) -> None:
         row = self.form.list.currentRow()
@@ -184,7 +184,7 @@ class StudyDeck(QDialog):
             # make sure we clean up reset hook when manually exiting
             gui_hooks.state_did_reset.remove(self.onReset)
 
-            QDialog.accept(self)
+            super().accept()
 
         if diag := add_deck_dialog(parent=self, default_text=default):
             diag.success(success).run_in_background()

--- a/qt/aqt/studydeck.py
+++ b/qt/aqt/studydeck.py
@@ -162,6 +162,9 @@ class StudyDeck(QDialog):
             showInfo(tr.decks_please_select_something())
             return
         self.name = self.names[self.form.list.currentRow()]
+        self.accept_with_callback()
+
+    def accept_with_callback(self) -> None:
         if self.callback:
             self.callback(self)
         super().accept()
@@ -176,7 +179,7 @@ class StudyDeck(QDialog):
         def success(out: OpChangesWithId) -> None:
             deck = self.mw.col.decks.get(DeckId(out.id))
             self.name = deck["name"]
-            super().accept()
+            self.accept_with_callback()
 
         if diag := add_deck_dialog(parent=self, default_text=default):
             diag.success(success).run_in_background()

--- a/qt/aqt/studydeck.py
+++ b/qt/aqt/studydeck.py
@@ -42,7 +42,9 @@ class StudyDeck(QDialog):
         geomKey: str = "default",
         callback: Callable[[StudyDeck], None] | None = None,
     ) -> None:
-        super().__init__(parent or mw)
+        super().__init__(parent)
+        if not parent:
+            mw.garbage_collect_on_dialog_finish(self)
         self.mw = mw
         self.form = aqt.forms.studydeck.Ui_Dialog()
         self.form.setupUi(self)

--- a/qt/aqt/studydeck.py
+++ b/qt/aqt/studydeck.py
@@ -49,7 +49,6 @@ class StudyDeck(QDialog):
         self.form = aqt.forms.studydeck.Ui_Dialog()
         self.form.setupUi(self)
         self.form.filter.installEventFilter(self)
-        self.cancel = cancel
         gui_hooks.state_did_reset.append(self.onReset)
         self.geomKey = f"studyDeck-{geomKey}"
         restoreGeom(self, self.geomKey)
@@ -84,7 +83,7 @@ class StudyDeck(QDialog):
             self.nameFunc = names
             self.origNames = names()
         self.name: str | None = None
-        self.ok = self.form.buttonBox.addButton(
+        self.form.buttonBox.addButton(
             accept or tr.decks_study(), QDialogButtonBox.ButtonRole.AcceptRole
         )
         self.setModal(True)


### PR DESCRIPTION
This will do the following:
1. Fix the issue: https://forums.ankiweb.net/t/new-deck-is-not-selected-anymore/17712
1. Explicitly delete `StudyDeck` widget after closing the dialog to release memory when `parent` is `None`.
    - Memory will not be automatically released until Anki is closed with the current approach of setting `mw` as parent when `parent` is `None`.
1. Minor refactoring and tidyups in studydeck.py