### PR TITLE
Match deck name truncation behavior to prevent long deck names from obscuring stats

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -95,6 +95,7 @@ Danish Prakash <github.com/danishprakash>
 Araceli Yanez <github.com/aracelix>
 Sam Bradshaw <samjr.bradshaw@gmail.com>
 gnnoh <gerongfenh@gmail.com>
+Sachin Govind <sachin.govind.too@gmail.com>
 
 ********************
 

--- a/qt/aqt/data/web/css/deckbrowser.scss
+++ b/qt/aqt/data/web/css/deckbrowser.scss
@@ -41,6 +41,8 @@ body {
 
 .decktd {
     min-width: 15em;
+    max-width: calc(100vw - 300px);
+    overflow:hidden;
 }
 
 .count {

--- a/qt/aqt/data/web/css/deckbrowser.scss
+++ b/qt/aqt/data/web/css/deckbrowser.scss
@@ -42,7 +42,7 @@ body {
 .decktd {
     min-width: 15em;
     max-width: calc(100vw - 300px);
-    overflow:hidden;
+    overflow: hidden;
 }
 
 .count {


### PR DESCRIPTION
When deck names are very long, they have no limit as to how much is displayed, resulting in the long deck name obscuring the stats on the right-hand side of the screen by pushing them off to the side. This issue is not present at https://ankiweb.net/decks/. 

For example, here is AnkiWeb truncating the name of a long deck so that stats are still visible:
![image](https://user-images.githubusercontent.com/62180448/155424448-d04f99b6-a871-48a2-bf5d-fd8d24b43304.png)

Here is the desktop client's current handling of a long deck name:
<img width="440" alt="image" src="https://user-images.githubusercontent.com/62180448/155424691-2ae6944f-db10-44a3-aa72-ef20071e206d.png">
The stats are pushed off to the side. This is undesirable functionality and does not match AnkiWeb's handling. 

This pull request addresses the issue in the desktop client by matching AnkiWeb's handling of the deck name - truncating it if it's too long. This is accomplished by computing an appropriate maximum width for the deck name table cell and truncating anything larger than the cell size. 

The new behavior of the desktop client:
<img width="414" alt="image" src="https://user-images.githubusercontent.com/62180448/155424947-94f28377-e032-4b88-be84-cda188d442cb.png">

The computation is done based on the current window size and adapts as the window is resized. 