### PR TITLE
Using the Rust backend in the editor

### DIFF
--- a/qt/aqt/mediasrv.py
+++ b/qt/aqt/mediasrv.py
@@ -472,7 +472,9 @@ exposed_backend_list = [
     # NotesService
     "get_field_names",
     "get_note",
+    "new_note",
     # NotetypesService
+    "get_notetype",
     "get_notetype_names",
     "get_change_notetype_info",
     # StatsService

--- a/ts/change-notetype/change-notetype-base.scss
+++ b/ts/change-notetype/change-notetype-base.scss
@@ -23,7 +23,8 @@ html {
     overflow-x: hidden;
 }
 
-html, body { 
+html,
+body {
     height: 100%;
 }
 

--- a/ts/editor/BrowserEditor.svelte
+++ b/ts/editor/BrowserEditor.svelte
@@ -3,25 +3,21 @@ Copyright: Ankitects Pty Ltd and contributors
 License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 -->
 <script lang="ts">
+    import { onMount } from "svelte";
+
     import ButtonGroupItem from "../components/ButtonGroupItem.svelte";
-    import type { NoteEditorAPI } from "./NoteEditor.svelte";
-    import NoteEditor from "./NoteEditor.svelte";
+    import NoteEditingEditor from "./NoteEditingEditor.svelte";
     import PreviewButton from "./PreviewButton.svelte";
 
-    const api: Partial<NoteEditorAPI> = {};
-    let noteEditor: NoteEditor;
+    export let uiResolve: () => void;
 
-    export let uiResolve: (api: NoteEditorAPI) => void;
-
-    $: if (noteEditor) {
-        uiResolve(api as NoteEditorAPI);
-    }
+    onMount(uiResolve);
 </script>
 
-<NoteEditor bind:this={noteEditor} {api}>
+<NoteEditingEditor>
     <svelte:fragment slot="notetypeButtons">
         <ButtonGroupItem>
             <PreviewButton />
         </ButtonGroupItem>
     </svelte:fragment>
-</NoteEditor>
+</NoteEditingEditor>

--- a/ts/editor/CodeMirror.svelte
+++ b/ts/editor/CodeMirror.svelte
@@ -15,11 +15,11 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 </script>
 
 <script lang="ts">
-    import { createEventDispatcher, getContext, onMount } from "svelte";
+    import { createEventDispatcher, onMount } from "svelte";
     import type { Writable } from "svelte/store";
 
-    import { directionKey } from "../lib/context-keys";
     import { promiseWithResolver } from "../lib/promise";
+    import { directionProperty } from "../sveltelib/context-property";
     import { pageTheme } from "../sveltelib/theme";
     import {
         darkTheme,
@@ -49,7 +49,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         editor.setOption(key, value);
     }
 
-    const direction = getContext<Writable<"ltr" | "rtl">>(directionKey);
+    const direction = directionProperty.get();
 
     let apiPartial: Partial<CodeMirrorAPI>;
     export { apiPartial as api };

--- a/ts/editor/EditingArea.svelte
+++ b/ts/editor/EditingArea.svelte
@@ -46,32 +46,32 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 </script>
 
 <script lang="ts">
-    import { setContext as svelteSetContext, tick } from "svelte";
+    import { tick } from "svelte";
+    import { createEventDispatcher } from "svelte";
     import { writable } from "svelte/store";
 
-    import { fontFamilyKey, fontSizeKey } from "../lib/context-keys";
     import FocusTrap from "./FocusTrap.svelte";
 
-    export let fontFamily: string;
-    const fontFamilyStore = writable(fontFamily);
-    $: $fontFamilyStore = fontFamily;
-    svelteSetContext(fontFamilyKey, fontFamilyStore);
+    let input = "";
+    const content: Writable<string> = writable(input);
 
-    export let fontSize: number;
-    const fontSizeStore = writable(fontSize);
-    $: $fontSizeStore = fontSize;
-    svelteSetContext(fontSizeKey, fontSizeStore);
+    export { input as content };
 
-    export let content: Writable<string>;
+    $: $content = input ?? "";
+
+    const dispatch = createEventDispatcher();
+
+    $: dispatch("contentupdate", $content);
 
     let editingArea: HTMLElement;
     let focusTrap: FocusTrap;
 
-    const inputsStore = writable<EditingInputAPI[]>([]);
-    $: editingInputs = $inputsStore;
+    const editingInputs = writable<EditingInputAPI[]>([]);
 
     function getAvailableInput(): EditingInputAPI | undefined {
-        return editingInputs.find((input) => input.focusable);
+        return $editingInputs.find(
+            (input: EditingInputAPI): boolean => input.focusable,
+        );
     }
 
     function focusEditingInputIfAvailable(): boolean {
@@ -92,7 +92,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     }
 
     $: {
-        $inputsStore;
+        $editingInputs;
         /**
          * Triggers when all editing inputs are hidden,
          * the editor field has focus, and then some
@@ -126,8 +126,9 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         }
     }
 
-    // Prevents editor field being entirely deselected when
-    // closing active field.
+    /**
+     * Prevents editor field being entirely deselected when closing active field.
+     */
     async function trapFocusOnBlurOut(event: FocusEvent): Promise<void> {
         if (event.relatedTarget) {
             return;
@@ -141,7 +142,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
         let focusableInput: FocusableInputAPI | null = null;
 
-        const focusableInputs = editingInputs.filter(
+        const focusableInputs = $editingInputs.filter(
             (input: EditingInputAPI): boolean => input.focusable,
         );
 
@@ -165,9 +166,9 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     let apiPartial: Partial<EditingAreaAPI>;
     export { apiPartial as api };
 
-    const api = Object.assign(apiPartial, {
+    const api: EditingAreaAPI = Object.assign(apiPartial, {
         content,
-        editingInputs: inputsStore,
+        editingInputs,
         focus,
         refocus,
     });

--- a/ts/editor/HandleLabel.svelte
+++ b/ts/editor/HandleLabel.svelte
@@ -3,13 +3,27 @@ Copyright: Ankitects Pty Ltd and contributors
 License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 -->
 <script lang="ts">
-    import { getContext } from "svelte";
-    import { createEventDispatcher, onMount } from "svelte";
-    import type { Readable } from "svelte/store";
+    import { afterUpdate, createEventDispatcher, onMount } from "svelte";
 
-    import { directionKey } from "../lib/context-keys";
+    import { directionProperty } from "../sveltelib/context-property";
 
-    const direction = getContext<Readable<"ltr" | "rtl">>(directionKey);
+    let dimensions: HTMLDivElement;
+    let overflowFix = 0;
+
+    const direction = directionProperty.get();
+
+    function updateOverflow(dimensions: HTMLDivElement): void {
+        const boundingClientRect = dimensions.getBoundingClientRect();
+        const overflow =
+            $direction === "ltr"
+                ? boundingClientRect.x
+                : window.innerWidth - boundingClientRect.x - boundingClientRect.width;
+
+        overflowFix = Math.min(0, overflowFix + overflow, overflow);
+    }
+
+    afterUpdate(() => updateOverflow(dimensions));
+
     const dispatch = createEventDispatcher();
 
     onMount(() => dispatch("mount"));

--- a/ts/editor/LabelContainer.svelte
+++ b/ts/editor/LabelContainer.svelte
@@ -2,20 +2,7 @@
 Copyright: Ankitects Pty Ltd and contributors
 License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 -->
-<script lang="ts">
-    import { getContext } from "svelte";
-    import type { Readable } from "svelte/store";
-
-    import { directionKey } from "../lib/context-keys";
-
-    const direction = getContext<Readable<"ltr" | "rtl">>(directionKey);
-</script>
-
-<div
-    class="label-container"
-    class:rtl={$direction === "rtl"}
-    on:mousedown|preventDefault
->
+<div class="label-container" on:mousedown|preventDefault>
     <slot />
 </div>
 
@@ -32,9 +19,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         border-radius: 5px 5px 0 0;
 
         padding: 0px 6px;
-    }
 
-    .rtl {
-        direction: rtl;
+        direction: var(--editor-field-direction);
     }
 </style>

--- a/ts/editor/NoteEditingEditor.svelte
+++ b/ts/editor/NoteEditingEditor.svelte
@@ -1,0 +1,40 @@
+<!--
+Copyright: Ankitects Pty Ltd and contributors
+License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
+-->
+<script lang="ts">
+    import { abortable, Notes, notes, Notetypes, notetypes } from "../lib/proto";
+    import NoteEditor from "./NoteEditor.svelte";
+
+    let notetype: Notetypes.Notetype;
+    let note: Notes.Note;
+
+    let noteId: number;
+    let handle: AbortController;
+
+    async function setNoteId(nid: number): Promise<void> {
+        // Abort previous fetch (if it is still in process)
+        handle?.abort();
+
+        handle = abortable();
+        const nextNote = await notes.getNote(Notes.NoteId.create({ nid }));
+        const ntid = nextNote.notetypeId;
+
+        handle = abortable();
+        const nextNotetype = await notetypes.getNotetype(
+            Notetypes.NotetypeId.create({ ntid }),
+        );
+
+        [notetype, note, noteId] = [nextNotetype, nextNote, nid];
+    }
+
+    function getNoteId(): number {
+        return noteId;
+    }
+
+    Object.assign(globalThis, { setNoteId, getNoteId });
+</script>
+
+<NoteEditor {notetype} {note}>
+    <slot name="notetypeButtons" slot="notetypeButtons" />
+</NoteEditor>

--- a/ts/editor/NoteEditor.svelte
+++ b/ts/editor/NoteEditor.svelte
@@ -7,10 +7,10 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
     import type { HooksAPI } from "../lib/hooks";
     import { Notes, Notetypes } from "../lib/proto";
+    import type { TagEditorAPI } from "../tag-editor";
     import type { EditingInputAPI } from "./EditingArea.svelte";
     import type { EditorToolbarAPI } from "./editor-toolbar";
     import type { EditorFieldAPI } from "./EditorField.svelte";
-    import type { TagEditorAPI } from "./tag-editor";
 
     interface OnLoadNoteInput {
         note: Notes.Note;

--- a/ts/editor/NoteEditor.svelte
+++ b/ts/editor/NoteEditor.svelte
@@ -5,15 +5,25 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 <script context="module" lang="ts">
     import type { Writable } from "svelte/store";
 
+    import type { HooksAPI } from "../lib/hooks";
+    import { Notes, Notetypes } from "../lib/proto";
     import type { EditingInputAPI } from "./EditingArea.svelte";
     import type { EditorToolbarAPI } from "./editor-toolbar";
     import type { EditorFieldAPI } from "./EditorField.svelte";
+    import type { TagEditorAPI } from "./tag-editor";
+
+    interface OnLoadNoteInput {
+        note: Notes.Note;
+        notetype: Notetypes.Notetype;
+    }
 
     export interface NoteEditorAPI {
-        fields: EditorFieldAPI[];
         focusedField: Writable<EditorFieldAPI | null>;
         focusedInput: Writable<EditingInputAPI | null>;
         toolbar: EditorToolbarAPI;
+        fields: EditorFieldAPI[];
+        tagEditor: TagEditorAPI;
+        onLoadNote: HooksAPI<OnLoadNoteInput>;
     }
 
     import { registerPackage } from "../lib/runtime-require";
@@ -34,20 +44,22 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 </script>
 
 <script lang="ts">
-    import { onMount, tick } from "svelte";
-    import { get, writable } from "svelte/store";
+    import { createEventDispatcher, onMount } from "svelte";
+    import { writable } from "svelte/store";
 
     import Absolute from "../components/Absolute.svelte";
     import Badge from "../components/Badge.svelte";
     import StickyContainer from "../components/StickyContainer.svelte";
     import { bridgeCommand } from "../lib/bridgecommand";
+    import { noop } from "../lib/functional";
+    import { hooks } from "../lib/hooks";
+    import type { Callback } from "../lib/typing";
     import { TagEditor } from "../tag-editor";
     import { ChangeTimer } from "./change-timer";
     import DecoratedElements from "./DecoratedElements.svelte";
     import { clearableArray } from "./destroyable";
     import DuplicateLink from "./DuplicateLink.svelte";
-    import { EditorToolbar } from "./editor-toolbar";
-    import type { FieldData } from "./EditorField.svelte";
+    import { EditorToolbar, RichTextClozeButtons } from "./editor-toolbar";
     import EditorField from "./EditorField.svelte";
     import Fields from "./Fields.svelte";
     import FieldsEditor from "./FieldsEditor.svelte";
@@ -62,146 +74,108 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     import { editingInputIsRichText, RichTextInput } from "./rich-text-input";
     import RichTextBadge from "./RichTextBadge.svelte";
 
-    function quoteFontFamily(fontFamily: string): string {
-        // generic families (e.g. sans-serif) must not be quoted
-        if (!/^[-a-z]+$/.test(fontFamily)) {
-            fontFamily = `"${fontFamily}"`;
-        }
-        return fontFamily;
-    }
+    export let notetype: Notetypes.Notetype;
+    export let note: Notes.Note;
 
     const size = 1.6;
     const wrap = true;
 
-    const fieldStores: Writable<string>[] = [];
-    let fieldNames: string[] = [];
-    export function setFields(fs: [string, string][]): void {
-        // this is a bit of a mess -- when moving to Rust calls, we should make
-        // sure to have two backend endpoints for:
-        // * the note, which can be set through this view
-        // * the fieldname, font, etc., which cannot be set
+    let fieldsData: [Notetypes.Notetype.Field, string][] = [];
+    const tags = writable<string[]>([]);
 
-        const newFieldNames: string[] = [];
-
-        for (const [index, [fieldName]] of fs.entries()) {
-            newFieldNames[index] = fieldName;
-        }
-
-        for (let i = fieldStores.length; i < newFieldNames.length; i++) {
-            const newStore = writable("");
-            fieldStores[i] = newStore;
-            newStore.subscribe((value) => updateField(i, value));
-        }
-
-        for (
-            let i = fieldStores.length;
-            i > newFieldNames.length;
-            i = fieldStores.length
-        ) {
-            fieldStores.pop();
-        }
-
-        for (const [index, [, fieldContent]] of fs.entries()) {
-            fieldStores[index].set(fieldContent);
-        }
-
-        fieldNames = newFieldNames;
-    }
-
-    let fieldDescriptions: string[] = [];
-    export function setDescriptions(fs: string[]): void {
-        fieldDescriptions = fs;
-    }
-
-    let fonts: [string, number, boolean][] = [];
     let richTextsHidden: boolean[] = [];
     let plainTextsHidden: boolean[] = [];
+
+    function zip<T, U>(first: T[], second: U[]): [T, U][] {
+        return first.map((t: T, index: number) => [t, second[index]]);
+    }
+
+    const [onLoadNote, runLoadNote] = hooks<OnLoadNoteInput>();
+
+    function loadEditor(notetype: Notetypes.Notetype, note: Notes.Note): void {
+        // For now we won't await the hook
+        runLoadNote({ notetype, note });
+
+        fieldsData = zip(notetype.fields, note.fields);
+        $tags = note.tags;
+
+        richTextsHidden = note.fields.map(
+            (_, index) => richTextsHidden[index] ?? false,
+        );
+        plainTextsHidden = note.fields.map(
+            (_, index) => plainTextsHidden[index] ?? true,
+        );
+
+        $focusedInput?.refocus();
+    }
+
+    $: if (notetype && note) {
+        loadEditor(notetype, note);
+    }
+
     const fields = clearableArray<EditorFieldAPI>();
 
-    export function setFonts(fs: [string, number, boolean][]): void {
-        fonts = fs;
-
-        richTextsHidden = fonts.map((_, index) => richTextsHidden[index] ?? false);
-        plainTextsHidden = fonts.map((_, index) => plainTextsHidden[index] ?? true);
-    }
-
-    export function focusField(index: number | null): void {
-        tick().then(() => {
-            if (typeof index === "number") {
-                if (!(index in fields)) {
-                    return;
-                }
-
-                fields[index].editingArea?.refocus();
-            } else {
-                $focusedInput?.refocus();
+    async function focusField(index: number | null): Promise<void> {
+        if (typeof index === "number") {
+            if (!(index in fields)) {
+                return;
             }
-        });
-    }
 
-    const tags = writable<string[]>([]);
-    export function setTags(ts: string[]): void {
-        $tags = ts;
-    }
-
-    let noteId: number | null = null;
-    export function setNoteId(ntid: number): void {
-        // TODO this is a hack, because it requires the NoteEditor to know implementation details of the PlainTextInput.
-        // It should be refactored once we work on our own Undo stack
-        for (const pi of plainTextInputs) {
-            pi.api.codeMirror.editor.then((editor) => editor.clearHistory());
+            fields[index].editingArea?.refocus();
+        } else {
+            $focusedInput?.refocus();
         }
-        noteId = ntid;
-    }
-
-    function getNoteId(): number | null {
-        return noteId;
     }
 
     let cols: ("dupe" | "")[] = [];
-    export function setBackgrounds(cls: ("dupe" | "")[]): void {
+    function setBackgrounds(cls: ("dupe" | "")[]): void {
         cols = cls;
     }
 
     let hint: string = "";
-    export function setClozeHint(hnt: string): void {
+    function setClozeHint(hnt: string): void {
         hint = hnt;
     }
-
-    $: fieldsData = fieldNames.map((name, index) => ({
-        name,
-        description: fieldDescriptions[index],
-        fontFamily: quoteFontFamily(fonts[index][0]),
-        fontSize: fonts[index][1],
-        direction: fonts[index][2] ? "rtl" : "ltr",
-    })) as FieldData[];
 
     function saveTags({ detail }: CustomEvent): void {
         bridgeCommand(`saveTags:${JSON.stringify(detail.tags)}`);
     }
 
     const fieldSave = new ChangeTimer();
+    let fieldBlur: Callback = noop;
 
     function updateField(index: number, content: string): void {
-        fieldSave.schedule(
-            () => bridgeCommand(`key:${index}:${getNoteId()}:${content}`),
-            600,
-        );
+        fieldSave.schedule(() => {
+            // This correctly updates the stached content,
+            // so that fieldsData matches with the content store.
+            fieldsData[index][1] = content;
+            fieldsData = fieldsData;
+
+            bridgeCommand(`key:${index}:${globalThis.getNoteId()}:${content}`);
+            dispatch("contentupdate", { index, content });
+        }, 600);
+
+        fieldBlur = () =>
+            bridgeCommand(
+                `blur:${index}:${globalThis.getNoteId()}:${fieldsData[index][1]}`,
+            );
     }
 
-    export function saveFieldNow(): void {
+    const dispatch = createEventDispatcher();
+
+    function saveFieldNow(): void {
         /* this will always be a key save */
         fieldSave.fireImmediately();
     }
 
-    export function saveOnPageHide() {
+    function saveOnPageHide() {
         if (document.visibilityState === "hidden") {
             // will fire on session close and minimize
             saveFieldNow();
         }
     }
 
-    export function focusIfField(x: number, y: number): boolean {
+    function focusIfField(x: number, y: number): boolean {
         const elements = document.elementsFromPoint(x, y);
         const first = elements[0];
 
@@ -220,10 +194,30 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     let plainTextInputs: PlainTextInput[] = [];
     $: plainTextInputs = plainTextInputs.filter(Boolean);
 
+    function resetPlainTextHistory(): void {
+        for (const pi of plainTextInputs) {
+            pi.api?.codeMirror.editor.then((editor) => editor.clearHistory());
+        }
+    }
+
     const toolbar: Partial<EditorToolbarAPI> = {};
+    const tagEditor: Partial<TagEditorAPI> = {};
+
+    let isCloze: boolean;
+    $: isCloze = notetype?.config!.kind === Notetypes.Notetype.Config.Kind.KIND_CLOZE;
 
     import { wrapInternal } from "../lib/wrap";
     import * as oldEditorAdapter from "./old-editor-adapter";
+
+    Object.assign(globalThis, {
+        focusField,
+        setBackgrounds,
+        setClozeHint,
+        saveNow: saveFieldNow,
+        resetPlainTextHistory,
+        focusIfField,
+        ...oldEditorAdapter,
+    });
 
     onMount(() => {
         function wrap(before: string, after: string): void {
@@ -237,19 +231,12 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         }
 
         Object.assign(globalThis, {
-            setFields,
-            setDescriptions,
-            setFonts,
             focusField,
-            setTags,
             setBackgrounds,
             setClozeHint,
             saveNow: saveFieldNow,
             focusIfField,
-            getNoteId,
-            setNoteId,
             wrap,
-            ...oldEditorAdapter,
         });
 
         document.addEventListener("visibilitychange", saveOnPageHide);
@@ -268,6 +255,8 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         focusedInput,
         toolbar: toolbar as EditorToolbarAPI,
         fields,
+        tagEditor: tagEditor as TagEditorAPI,
+        onLoadNote,
     };
 
     setContextProperty(api);
@@ -286,6 +275,12 @@ the AddCards dialog) should be implemented in the user of this component.
     <FieldsEditor>
         <EditorToolbar {size} {wrap} api={toolbar}>
             <slot slot="notetypeButtons" name="notetypeButtons" />
+
+            <svelte:fragment slot="extraButtonGroups">
+                {#if isCloze}
+                    <RichTextClozeButtons />
+                {/if}
+            </svelte:fragment>
         </EditorToolbar>
 
         {#if hint}
@@ -301,10 +296,10 @@ the AddCards dialog) should be implemented in the user of this component.
 
         <Fields>
             <DecoratedElements>
-                {#each fieldsData as field, index}
+                {#each fieldsData as [field, content], index}
                     <EditorField
                         {field}
-                        content={fieldStores[index]}
+                        {content}
                         api={fields[index]}
                         on:focusin={() => {
                             $focusedField = fields[index];
@@ -312,12 +307,10 @@ the AddCards dialog) should be implemented in the user of this component.
                         }}
                         on:focusout={() => {
                             $focusedField = null;
-                            bridgeCommand(
-                                `blur:${index}:${getNoteId()}:${get(
-                                    fieldStores[index],
-                                )}`,
-                            );
+                            fieldBlur();
                         }}
+                        on:contentupdate={({ detail: content }) =>
+                            updateField(index, content)}
                         --label-color={cols[index] === "dupe"
                             ? "var(--flag1-bg)"
                             : "transparent"}
@@ -382,7 +375,7 @@ the AddCards dialog) should be implemented in the user of this component.
     </FieldsEditor>
 
     <StickyContainer --gutter-block="0.1rem" --sticky-borders="1px 0 0" class="d-flex">
-        <TagEditor {tags} on:tagsupdate={saveTags} />
+        <TagEditor {tags} api={tagEditor} on:tagsupdate={saveTags} />
     </StickyContainer>
 </div>
 

--- a/ts/editor/ReviewerEditor.svelte
+++ b/ts/editor/ReviewerEditor.svelte
@@ -3,17 +3,13 @@ Copyright: Ankitects Pty Ltd and contributors
 License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 -->
 <script lang="ts">
-    import type { NoteEditorAPI } from "./NoteEditor.svelte";
-    import NoteEditor from "./NoteEditor.svelte";
+    import { onMount } from "svelte";
 
-    const api: Partial<NoteEditorAPI> = {};
-    let noteEditor: NoteEditor;
+    import NoteEditingEditor from "./NoteEditingEditor.svelte";
 
-    export let uiResolve: (api: NoteEditorAPI) => void;
+    export let uiResolve: () => void;
 
-    $: if (noteEditor) {
-        uiResolve(api as NoteEditorAPI);
-    }
+    onMount(uiResolve);
 </script>
 
-<NoteEditor bind:this={noteEditor} {api} />
+<NoteEditingEditor />

--- a/ts/editor/editor-base.scss
+++ b/ts/editor/editor-base.scss
@@ -13,6 +13,7 @@ html {
     overflow: hidden;
 }
 
-html, body {
+html,
+body {
     height: 100%;
 }

--- a/ts/editor/editor-toolbar/EditorToolbar.svelte
+++ b/ts/editor/editor-toolbar/EditorToolbar.svelte
@@ -58,7 +58,6 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     import BlockButtons from "./BlockButtons.svelte";
     import InlineButtons from "./InlineButtons.svelte";
     import NotetypeButtons from "./NotetypeButtons.svelte";
-    import RichTextClozeButtons from "./RichTextClozeButtons.svelte";
     import TemplateButtons from "./TemplateButtons.svelte";
 
     export let size: number;
@@ -81,7 +80,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         blockButtons,
         templateButtons,
         removeFormats,
-    } as EditorToolbarAPI);
+    });
 
     setContextProperty(api);
 </script>
@@ -107,9 +106,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
                 <TemplateButtons api={templateButtons} />
             </Item>
 
-            <Item id="cloze">
-                <RichTextClozeButtons />
-            </Item>
+            <slot name="extraButtonGroups" />
         </DynamicallySlottable>
     </ButtonToolbar>
 </StickyContainer>

--- a/ts/editor/editor-toolbar/index.ts
+++ b/ts/editor/editor-toolbar/index.ts
@@ -3,4 +3,4 @@
 
 export type { EditorToolbarAPI } from "./EditorToolbar.svelte";
 export { default as EditorToolbar, editorToolbar } from "./EditorToolbar.svelte";
-export { default as ClozeButtons } from "./EditorToolbar.svelte";
+export { default as RichTextClozeButtons } from "./RichTextClozeButtons.svelte";

--- a/ts/editor/image-overlay/FloatButtons.svelte
+++ b/ts/editor/image-overlay/FloatButtons.svelte
@@ -3,19 +3,17 @@ Copyright: Ankitects Pty Ltd and contributors
 License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 -->
 <script lang="ts">
-    import { getContext } from "svelte";
     import { createEventDispatcher } from "svelte";
-    import type { Readable } from "svelte/store";
 
     import ButtonGroup from "../../components/ButtonGroup.svelte";
     import IconButton from "../../components/IconButton.svelte";
-    import { directionKey } from "../../lib/context-keys";
     import * as tr from "../../lib/ftl";
+    import { directionProperty } from "../../sveltelib/context-property";
     import { floatLeftIcon, floatNoneIcon, floatRightIcon } from "./icons";
 
     export let image: HTMLImageElement;
 
-    const direction = getContext<Readable<"ltr" | "rtl">>(directionKey);
+    const direction = directionProperty.get();
     const [inlineStartIcon, inlineEndIcon] =
         $direction === "ltr"
             ? [floatLeftIcon, floatRightIcon]

--- a/ts/editor/image-overlay/SizeSelect.svelte
+++ b/ts/editor/image-overlay/SizeSelect.svelte
@@ -3,13 +3,12 @@ Copyright: Ankitects Pty Ltd and contributors
 License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 -->
 <script lang="ts">
-    import { createEventDispatcher, getContext } from "svelte";
-    import type { Readable } from "svelte/store";
+    import { createEventDispatcher } from "svelte";
 
     import ButtonGroup from "../../components/ButtonGroup.svelte";
     import IconButton from "../../components/IconButton.svelte";
-    import { directionKey } from "../../lib/context-keys";
     import * as tr from "../../lib/ftl";
+    import { directionProperty } from "../../sveltelib/context-property";
     import { sizeActual, sizeClear, sizeMinimized } from "./icons";
 
     export let isSizeConstrained: boolean;
@@ -18,8 +17,8 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
     $: icon = isSizeConstrained ? sizeMinimized : sizeActual;
 
-    const direction = getContext<Readable<"ltr" | "rtl">>(directionKey);
     const dispatch = createEventDispatcher();
+    const direction = directionProperty.get();
 </script>
 
 <ButtonGroup size={1.6}>

--- a/ts/editor/rich-text-input/RichTextStyles.svelte
+++ b/ts/editor/rich-text-input/RichTextStyles.svelte
@@ -3,11 +3,8 @@ Copyright: Ankitects Pty Ltd and contributors
 License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 -->
 <script lang="ts">
-    import { getContext } from "svelte";
-    import type { Readable } from "svelte/store";
-
-    import { directionKey, fontFamilyKey, fontSizeKey } from "../../lib/context-keys";
     import { promiseWithResolver } from "../../lib/promise";
+    import { context as editorFieldContext } from "../EditorField.svelte";
     import type { StyleLinkType, StyleObject } from "./CustomStyles.svelte";
     import CustomStyles from "./CustomStyles.svelte";
 
@@ -28,9 +25,24 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     });
 
     export let color: string;
-    const fontFamily = getContext<Readable<string>>(fontFamilyKey);
-    const fontSize = getContext<Readable<number>>(fontSizeKey);
-    const direction = getContext<Readable<"ltr" | "rtl">>(directionKey);
+
+    const { field } = editorFieldContext.get();
+
+    let fontFamily: string;
+    let fontSize: number;
+    let rtl: boolean;
+    let direction: "ltr" | "rtl";
+
+    $: ({ fontName: fontFamily, fontSize, rtl } = $field.config!);
+    $: direction = rtl ? "rtl" : "ltr";
+
+    function quoteFontFamily(fontFamily: string): string {
+        // generic families (e.g. sans-serif) must not be quoted
+        if (!/^[-a-z]+$/.test(fontFamily)) {
+            fontFamily = `"${fontFamily}"`;
+        }
+        return fontFamily;
+    }
 
     async function setStyling(property: string, value: unknown): Promise<void> {
         const rule = await userBaseRule;
@@ -38,9 +50,9 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     }
 
     $: setStyling("color", color);
-    $: setStyling("fontFamily", $fontFamily);
-    $: setStyling("fontSize", $fontSize + "px");
-    $: setStyling("direction", $direction);
+    $: setStyling("fontFamily", quoteFontFamily(fontFamily));
+    $: setStyling("fontSize", fontSize + "px");
+    $: setStyling("direction", direction);
 
     const styles = [
         {

--- a/ts/lib/context-keys.ts
+++ b/ts/lib/context-keys.ts
@@ -1,6 +1,0 @@
-// Copyright: Ankitects Pty Ltd and contributors
-// License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
-
-export const fontFamilyKey = Symbol("fontFamily");
-export const fontSizeKey = Symbol("fontSize");
-export const directionKey = Symbol("direction");

--- a/ts/lib/hooks.ts
+++ b/ts/lib/hooks.ts
@@ -1,0 +1,43 @@
+// Copyright: Ankitects Pty Ltd and contributors
+// License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
+
+import { removeItem } from "./helpers";
+import type { Callback } from "./typing";
+
+type HookCallback<T> = (input: T) => void | Promise<void>;
+
+export interface HooksAPI<T> {
+    hook(callback: HookCallback<T>): Callback;
+}
+
+type RunHooks<T> = (input: T) => Promise<void>;
+
+export function hooks<T>(): [HooksAPI<T>, RunHooks<T>] {
+    const hooksList: HookCallback<T>[] = [];
+
+    function hook(callback: HookCallback<T>): Callback {
+        hooksList.push(callback);
+        return () => removeItem(hooksList, callback);
+    }
+
+    async function run(input: T): Promise<void> {
+        const promises: (void | Promise<void>)[] = [];
+
+        for (const hook of hooksList) {
+            try {
+                const result = hook(input);
+                promises.push(result);
+            } catch (error) {
+                console.log("Hook failed: ", error);
+            }
+        }
+
+        await Promise.allSettled(promises);
+    }
+
+    const hooksApi = {
+        hook,
+    };
+
+    return [hooksApi, run];
+}

--- a/ts/lib/ui.ts
+++ b/ts/lib/ui.ts
@@ -4,7 +4,7 @@
 import { promiseWithResolver } from "./promise";
 import { registerPackage } from "./runtime-require";
 
-const [loaded, uiResolve] = promiseWithResolver();
+const [loaded, uiResolve] = promiseWithResolver<void>();
 
 registerPackage("anki/ui", {
     loaded,

--- a/ts/sveltelib/context-property.ts
+++ b/ts/sveltelib/context-property.ts
@@ -44,3 +44,10 @@ function contextProperty<T>(
 }
 
 export default contextProperty;
+
+// Global context properties
+import type { Readable } from "svelte/store";
+
+const directionKey = Symbol("direction");
+export const [directionProperty, setDirectionProperty] =
+    contextProperty<Readable<"ltr" | "rtl">>(directionKey);

--- a/ts/tag-editor/TagEditor.svelte
+++ b/ts/tag-editor/TagEditor.svelte
@@ -2,9 +2,16 @@
 Copyright: Ankitects Pty Ltd and contributors
 License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 -->
+<script context="module" lang="ts">
+    import type { Writable } from "svelte/store";
+
+    export interface TagEditorAPI {
+        tags: Writable<string[]>;
+    }
+</script>
+
 <script lang="ts">
     import { createEventDispatcher, tick } from "svelte";
-    import type { Writable } from "svelte/store";
     import { writable } from "svelte/store";
 
     import { execCommand } from "../domlib";
@@ -30,6 +37,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         tagTypes = tags.map(
             (tag: string): TagType => attachId(replaceWithUnicodeSeparator(tag)),
         );
+        saveTags();
     }
 
     $: tagsToTagTypes($tags);
@@ -379,6 +387,13 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     $: assumedRows = Math.floor(height / badgeHeight);
     $: shortenTags = shortenTags || assumedRows > 2;
     $: anyTagsSelected = tagTypes.some((tag) => tag.selected);
+
+    let apiPartial: Partial<TagEditorAPI> = {};
+    export { apiPartial as api };
+
+    Object.assign(apiPartial, {
+        tags,
+    }) as TagEditorAPI;
 </script>
 
 <div class="tag-editor-area" on:focusout={deselectIfLeave} bind:offsetHeight={height}>

--- a/ts/tag-editor/index.ts
+++ b/ts/tag-editor/index.ts
@@ -1,4 +1,5 @@
 // Copyright: Ankitects Pty Ltd and contributors
 // License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
+export type { TagEditorAPI } from "./TagEditor.svelte";
 export { default as TagEditor } from "./TagEditor.svelte";


### PR DESCRIPTION
So far a draft. It works well, but there is an issue in the editor in the browser. You will notice that going up and down will make the editor noticeably lag. The problem is that were sequentially getting 1. the note, and then 2. the notetype.

1. I think we should cater the backend more to the individual views. Right now we have e.g. `NotesService`, `NotetypesService`, etc., i.e. the services are oriented on the data objects in Anki. But to have a responsive UI, we should fit some endpoints directly to what the front-end needs.

Two other points causing me a headache:

2. It seems like protobufjs has very unhelpful/damaging typing. You must have noticed it already, when you wrote the deck options screen, e.g. statements like this:

```typescript
this.defaults = data.defaults!.config! as DeckConfig.DeckConfig.Config;
```

It seems like, when the type of `data.defaults` should theoretically be `Deck.DeckConfig` (which is its type at runtime), it actually is `Deck.IDeckConfig | null | undefined`, and so on. At that point I would actually prefer everything to be `any`, rather than wrong types that require type assertions and casting all the time.

Do you know the reason for this? Is this really an oversight on the side of protobufjs? Or is this something within our grasp?

3. I cannot use `async` functions in svelte files. It gives me an error like so:

```
compile failed: Cannot declare same variable name which is imported inside <script context="module"> (22:9)
20:
21: <script lang="ts">var _a;
22: import { __awaiter } from "tslib";
             ^
23: import { onMount, tick } from "svelte";
24: import { get, writable } from "svelte/store";
```

Do you have any clue what causes this? If no, my first guess is that there's something wrong with the logic in `ts/svelte/svelte.ts`. Does that seem right?
