### PR TITLE
Consider using --force-message for ts/protobuf.bzl

### DIFF
--- a/ts/card-info/CardInfo.svelte
+++ b/ts/card-info/CardInfo.svelte
@@ -6,7 +6,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     import Container from "../components/Container.svelte";
     import Row from "../components/Row.svelte";
     import type { Stats } from "../lib/proto";
-    import { stats as statsService } from "../lib/proto";
+    import { Cards, stats as statsService } from "../lib/proto";
     import CardInfoPlaceholder from "./CardInfoPlaceholder.svelte";
     import CardStats from "./CardStats.svelte";
     import Revlog from "./Revlog.svelte";
@@ -19,7 +19,9 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
     async function updateStats(cardId: number): Promise<void> {
         const requestedCardId = cardId;
-        const cardStats = await statsService.cardStats({ cid: requestedCardId });
+        const cardStats = await statsService.cardStats(
+            Cards.CardId.create({ cid: requestedCardId }),
+        );
 
         /* Skip if another update has been triggered in the meantime. */
         if (requestedCardId === cardId) {

--- a/ts/change-notetype/index.ts
+++ b/ts/change-notetype/index.ts
@@ -5,7 +5,7 @@ import "./change-notetype-base.css";
 
 import { ModuleName, setupI18n } from "../lib/i18n";
 import { checkNightMode } from "../lib/nightmode";
-import { empty, notetypes } from "../lib/proto";
+import { empty, Notetypes, notetypes } from "../lib/proto";
 import ChangeNotetypePage from "./ChangeNotetypePage.svelte";
 import { ChangeNotetypeState } from "./lib";
 
@@ -18,10 +18,12 @@ export async function setupChangeNotetypePage(
     oldNotetypeId: number,
     newNotetypeId: number,
 ): Promise<ChangeNotetypePage> {
-    const changeNotetypeInfo = notetypes.getChangeNotetypeInfo({
-        oldNotetypeId,
-        newNotetypeId,
-    });
+    const changeNotetypeInfo = notetypes.getChangeNotetypeInfo(
+        Notetypes.GetChangeNotetypeInfoRequest.create({
+            oldNotetypeId,
+            newNotetypeId,
+        }),
+    );
     const [names, info] = await Promise.all([notetypeNames, changeNotetypeInfo, i18n]);
 
     checkNightMode();

--- a/ts/change-notetype/lib.ts
+++ b/ts/change-notetype/lib.ts
@@ -144,10 +144,12 @@ export class ChangeNotetypeState {
         this.info_.input().newNotetypeId = this.notetypeNames.entries[idx].id!;
         this.notetypesSetter(this.buildNotetypeList());
         const { oldNotetypeId, newNotetypeId } = this.info_.input();
-        const newInfo = await notetypes.getChangeNotetypeInfo({
-            oldNotetypeId,
-            newNotetypeId,
-        });
+        const newInfo = await notetypes.getChangeNotetypeInfo(
+            Notetypes.GetChangeNotetypeInfoRequest.create({
+                oldNotetypeId,
+                newNotetypeId,
+            }),
+        );
 
         this.info_ = new ChangeNotetypeInfoWrapper(newInfo);
         this.info_.unusedItems(MapContext.Field);

--- a/ts/deck-options/index.ts
+++ b/ts/deck-options/index.ts
@@ -11,7 +11,7 @@ import "./deck-options-base.css";
 import { modalsKey, touchDeviceKey } from "../components/context-keys";
 import { ModuleName, setupI18n } from "../lib/i18n";
 import { checkNightMode } from "../lib/nightmode";
-import { deckConfig } from "../lib/proto";
+import { deckConfig, Decks } from "../lib/proto";
 import DeckOptionsPage from "./DeckOptionsPage.svelte";
 import { DeckOptionsState } from "./lib";
 
@@ -26,7 +26,7 @@ const i18n = setupI18n({
 
 export async function setupDeckOptions(did: number): Promise<DeckOptionsPage> {
     const [info] = await Promise.all([
-        deckConfig.getDeckConfigsForUpdate({ did }),
+        deckConfig.getDeckConfigsForUpdate(Decks.DeckId.create({ did })),
         i18n,
     ]);
 

--- a/ts/deck-options/lib.test.ts
+++ b/ts/deck-options/lib.test.ts
@@ -306,10 +306,7 @@ test("aux data", () => {
     expect(out.configs!.length).toBe(2);
     const json = out.configs!.map(
         (c) =>
-            JSON.parse(new TextDecoder().decode((c.config as any).other)) as Record<
-                string,
-                unknown
-            >,
+            JSON.parse(new TextDecoder().decode((c.config!).other))
     );
     expect(json).toStrictEqual([
         // other deck comes first

--- a/ts/deck-options/lib.test.ts
+++ b/ts/deck-options/lib.test.ts
@@ -304,9 +304,8 @@ test("aux data", () => {
     // ensure changes serialize
     const out = state.dataForSaving(true);
     expect(out.configs!.length).toBe(2);
-    const json = out.configs!.map(
-        (c) =>
-            JSON.parse(new TextDecoder().decode((c.config!).other))
+    const json = out.configs!.map((c) =>
+        JSON.parse(new TextDecoder().decode(c.config!.other)),
     );
     expect(json).toStrictEqual([
         // other deck comes first

--- a/ts/deck-options/lib.ts
+++ b/ts/deck-options/lib.ts
@@ -51,11 +51,11 @@ export class DeckOptionsState {
 
     constructor(targetDeckId: number, data: DeckConfig.DeckConfigsForUpdate) {
         this.targetDeckId = targetDeckId;
-        this.currentDeck =
-            data.currentDeck as DeckConfig.DeckConfigsForUpdate.CurrentDeck;
+        this.currentDeck = data.currentDeck!;
         this.defaults = data.defaults!.config!;
         this.configs = data.allConfig.map((config) => {
-            const configInner = config.config as DeckConfig.DeckConfig;
+            const configInner = config.config!;
+
             return {
                 config: configInner,
                 useCount: config.useCount!,
@@ -290,20 +290,21 @@ export class DeckOptionsState {
 
 function bytesToObject(bytes: Uint8Array): Record<string, unknown> {
     if (!bytes.length) {
-        return {} as Record<string, unknown>;
+        return {};
     }
 
     let obj: Record<string, unknown>;
+
     try {
-        obj = JSON.parse(new TextDecoder().decode(bytes)) as Record<string, unknown>;
+        obj = JSON.parse(new TextDecoder().decode(bytes));
     } catch (err) {
         console.log(`invalid json in deck config`);
-        return {} as Record<string, unknown>;
+        return {};
     }
 
     if (obj.constructor !== Object) {
         console.log(`invalid object in deck config`);
-        return {} as Record<string, unknown>;
+        return {};
     }
 
     return obj;

--- a/ts/deck-options/lib.ts
+++ b/ts/deck-options/lib.ts
@@ -28,15 +28,14 @@ export interface ConfigListEntry {
     current: boolean;
 }
 
-type ConfigInner = DeckConfig.DeckConfig.Config;
 export class DeckOptionsState {
-    readonly currentConfig: Writable<ConfigInner>;
+    readonly currentConfig: Writable<DeckConfig.DeckConfig.Config>;
     readonly currentAuxData: Writable<Record<string, unknown>>;
     readonly configList: Readable<ConfigListEntry[]>;
     readonly parentLimits: Readable<ParentLimits>;
     readonly cardStateCustomizer: Writable<string>;
     readonly currentDeck: DeckConfig.DeckConfigsForUpdate.CurrentDeck;
-    readonly defaults: ConfigInner;
+    readonly defaults: DeckConfig.DeckConfig.Config;
     readonly addonComponents: Writable<DynamicSvelteComponent[]>;
     readonly v3Scheduler: boolean;
     readonly haveAddons: boolean;
@@ -54,7 +53,7 @@ export class DeckOptionsState {
         this.targetDeckId = targetDeckId;
         this.currentDeck =
             data.currentDeck as DeckConfig.DeckConfigsForUpdate.CurrentDeck;
-        this.defaults = data.defaults!.config! as ConfigInner;
+        this.defaults = data.defaults!.config!;
         this.configs = data.allConfig.map((config) => {
             const configInner = config.config as DeckConfig.DeckConfig;
             return {
@@ -136,7 +135,7 @@ export class DeckOptionsState {
         const config = DeckConfig.DeckConfig.create({
             id: 0,
             name: uniqueName,
-            config: cloneDeep(source),
+            config: DeckConfig.DeckConfig.Config.create(cloneDeep(source)),
         });
         const configWithCount = { config, useCount: 0 };
         this.configs.push(configWithCount);
@@ -195,10 +194,14 @@ export class DeckOptionsState {
     }
 
     async save(applyToChildren: boolean): Promise<void> {
-        await deckConfig.updateDeckConfigs(this.dataForSaving(applyToChildren));
+        await deckConfig.updateDeckConfigs(
+            DeckConfig.UpdateDeckConfigsRequest.create(
+                this.dataForSaving(applyToChildren),
+            ),
+        );
     }
 
-    private onCurrentConfigChanged(config: ConfigInner): void {
+    private onCurrentConfigChanged(config: DeckConfig.DeckConfig.Config): void {
         const configOuter = this.configs[this.selectedIdx].config;
         if (!isEqual(config, configOuter.config)) {
             configOuter.config = config;
@@ -240,13 +243,13 @@ export class DeckOptionsState {
     }
 
     /// Returns a copy of the currently selected config.
-    private getCurrentConfig(): ConfigInner {
-        return cloneDeep(this.configs[this.selectedIdx].config.config as ConfigInner);
+    private getCurrentConfig(): DeckConfig.DeckConfig.Config {
+        return cloneDeep(this.configs[this.selectedIdx].config.config!);
     }
 
     /// Extra data associated with current config (for add-ons)
     private getCurrentAuxData(): Record<string, unknown> {
-        const conf = this.configs[this.selectedIdx].config.config as ConfigInner;
+        const conf = this.configs[this.selectedIdx].config.config!;
         return bytesToObject(conf.other);
     }
 

--- a/ts/editor/tag-editor/TagEditor.svelte
+++ b/ts/editor/tag-editor/TagEditor.svelte
@@ -8,7 +8,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
     import ButtonToolbar from "../../components/ButtonToolbar.svelte";
     import StickyContainer from "../../components/StickyContainer.svelte";
-    import { tags as tagsService } from "../../lib/proto";
+    import { Tags, tags as tagsService } from "../../lib/proto";
     import { execCommand } from "../helpers";
     import Tag from "./Tag.svelte";
     import TagEditMode from "./TagEditMode.svelte";
@@ -56,7 +56,9 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     let autocompleteDisabled: boolean = false;
 
     async function fetchSuggestions(input: string): Promise<string[]> {
-        const { tags } = await tagsService.completeTag({ input, matchLimit: 500 });
+        const { tags } = await tagsService.completeTag(
+            Tags.CompleteTagRequest.create({ input, matchLimit: 500 }),
+        );
         return tags;
     }
 

--- a/ts/graphs/WithGraphData.svelte
+++ b/ts/graphs/WithGraphData.svelte
@@ -5,8 +5,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 <script lang="ts">
     import type { Writable } from "svelte/store";
 
-    import { Stats } from "../lib/proto";
-    import { empty, stats } from "../lib/proto";
+    import { empty, Stats, stats } from "../lib/proto";
     import useAsync from "../sveltelib/async";
     import useAsyncReactive from "../sveltelib/asyncReactive";
     import type { PreferenceRaw } from "../sveltelib/preferences";
@@ -21,7 +20,8 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         error: graphError,
         value: graphValue,
     } = useAsyncReactive(
-        () => stats.graphs({ search: $search, days: $days }),
+        () =>
+            stats.graphs(Stats.GraphsRequest.create({ search: $search, days: $days })),
         [search, days],
     );
 
@@ -33,7 +33,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         getPreferences(
             () => stats.getGraphPreferences(empty),
             async (input: Stats.IGraphPreferences): Promise<void> => {
-                stats.setGraphPreferences(input);
+                stats.setGraphPreferences(Stats.GraphPreferences.create(input));
             },
             Stats.GraphPreferences.toObject.bind(Stats.GraphPreferences) as (
                 preferences: Stats.GraphPreferences,

--- a/ts/lib/i18n/utils.ts
+++ b/ts/lib/i18n/utils.ts
@@ -5,7 +5,7 @@ import "intl-pluralrules";
 
 import { FluentBundle, FluentResource } from "@fluent/bundle";
 
-import { i18n } from "../proto";
+import { I18n, i18n } from "../proto";
 import { firstLanguage, setBundles } from "./bundles";
 import type { ModuleName } from "./modules";
 
@@ -75,7 +75,7 @@ export function withoutUnicodeIsolation(s: string): string {
 }
 
 export async function setupI18n(args: { modules: ModuleName[] }): Promise<void> {
-    const resources = await i18n.i18nResources(args);
+    const resources = await i18n.i18nResources(I18n.I18nResourcesRequest.create(args));
     const json = JSON.parse(new TextDecoder().decode(resources.json));
 
     const newBundles: FluentBundle[] = [];

--- a/ts/lib/proto.ts
+++ b/ts/lib/proto.ts
@@ -23,7 +23,7 @@ import Tags = anki.tags;
 
 export { Cards, Collection, Decks, Generic, Notes };
 
-export const empty = Generic.Empty.encode(Generic.Empty.create()).finish();
+export const empty = Generic.Empty.create();
 
 async function serviceCallback(
     method: rpc.ServiceMethod<Message<any>, Message<any>>,

--- a/ts/protobuf.bzl
+++ b/ts/protobuf.bzl
@@ -79,6 +79,7 @@ def protobufjs_library(name, proto, **kwargs):
             "--wrap=default",
             #"--strict-long",  # Force usage of Long type with int64 fields
             "--force-number",
+            "--force-message",
             "--out=$@",
             "$(execpaths %s)" % proto_target,
         ],
@@ -96,6 +97,7 @@ def protobufjs_library(name, proto, **kwargs):
             "--wrap=default",
             #"--strict-long",  # Force usage of Long type with int64 fields
             "--force-number",
+            "--force-message",
             "--out=$@",
             "$(execpaths %s)" % proto_target,
         ],


### PR DESCRIPTION
This would force us to be more explicit when providing input for the protobuf services, and avoids as have to cast the type when consuming output.

The first is arguable, but the second is much more ergonomic.
This means we don't have cast from `IOurType` to `OurType` anymore, but non-null assertion is still needed (which makes sense after reading your explanation [here](https://github.com/ankitects/anki/pull/1691#issuecomment-1051474992))