### PR TITLE
Fix Mathjax sometimes being deleted even though it's not selected

### DIFF
--- a/ts/editable/frame-element.ts
+++ b/ts/editable/frame-element.ts
@@ -34,18 +34,16 @@ function restoreFrameHandles(mutations: MutationRecord[]): void {
 
             // In some rare cases, nodes might be inserted into the frame itself.
             // For example after using execCommand.
-            const placement = node.compareDocumentPosition(framed);
+            const placement = framed.compareDocumentPosition(node);
 
-            if (placement & Node.DOCUMENT_POSITION_FOLLOWING) {
-                referenceNode = moveChildOutOfElement(frameElement, node, "afterend");
-                continue;
-            } else if (placement & Node.DOCUMENT_POSITION_PRECEDING) {
+            if (placement & Node.DOCUMENT_POSITION_PRECEDING) {
                 referenceNode = moveChildOutOfElement(
                     frameElement,
                     node,
                     "beforebegin",
                 );
-                continue;
+            } else if (placement & Node.DOCUMENT_POSITION_FOLLOWING) {
+                referenceNode = moveChildOutOfElement(frameElement, node, "afterend");
             }
         }
 
@@ -257,7 +255,7 @@ document.addEventListener("selectionchange", onSelectionChange);
  * <anki-frame>
  *     <frame-handle-start> </frame-handle-start>
  *     <your-element ... />
- *     <frame-handle-end> </frame-handle-start>
+ *     <frame-handle-end> </frame-handle-end>
  * </anki-frame>
  */
 export function frameElement(element: HTMLElement, block: boolean): FrameElement {

--- a/ts/editable/frame-handle.ts
+++ b/ts/editable/frame-handle.ts
@@ -297,6 +297,11 @@ function checkWhetherSelectingHandle(selection: Selection, handle: FrameHandle):
 export function checkHandles(): void {
     for (const handle of handles) {
         const selection = getSelection(handle)!;
+
+        if (selection.rangeCount === 0) {
+            return;
+        }
+
         checkWhetherMovingIntoHandle(selection, handle);
         checkWhetherSelectingHandle(selection, handle);
     }


### PR DESCRIPTION
To recreate the old bug, have an inline Mathjax element as the last thing in a field, then do a tripple click behind it, and then press delete. There's no visual indication around the Mathjax to indicate that it's going to be delete, however it is deleted.

After this PR, it is not.