### PR TITLE
Add a flag to allow loading the fields dialog in a web view

### DIFF
--- a/qt/aqt/data/web/pages/BUILD.bazel
+++ b/qt/aqt/data/web/pages/BUILD.bazel
@@ -6,6 +6,7 @@ _pages = [
     "deck-options",
     "change-notetype",
     "card-info",
+    "fields",
 ]
 
 [copy_files_into_group(

--- a/qt/aqt/fields.py
+++ b/qt/aqt/fields.py
@@ -48,19 +48,21 @@ class FieldDialog(QDialog):
         )
 
         if os.getenv("ANKI_EXPERIMENTAL_FIELDS_WEB"):
-            self.form = aqt.forms.fields_web.Ui_Dialog()
-            self.form.setupUi(self)
-            self.form.webview.set_title("fields")
+            form = aqt.forms.fields_web.Ui_Dialog()
+            form.setupUi(self)
+
+            self.webview = form.webview
+            self.webview.set_title("fields")
 
             self.show()
             self.refresh()
-            self.form.webview.set_bridge_command(self._on_bridge_cmd, self)
+            self.webview.set_bridge_command(self._on_bridge_cmd, self)
             self.activateWindow()
 
         else:
             self.form = aqt.forms.fields.Ui_Dialog()
             self.form.setupUi(self)
-            self.form.webview = None
+            self.webview = None
 
             disable_help_button(self)
             self.form.buttonBox.button(
@@ -83,7 +85,7 @@ class FieldDialog(QDialog):
             self.exec()
 
     def refresh(self) -> None:
-        self.form.webview.load_ts_page("fields")
+        self.webview.load_ts_page("fields")
 
     def _on_bridge_cmd(self, cmd: str) -> bool:
         return False
@@ -267,9 +269,9 @@ class FieldDialog(QDialog):
             self.change_tracker.mark_basic()
 
     def reject(self) -> None:
-        if self.form.webview:
-            self.form.webview.cleanup()
-            self.form.webview = None
+        if self.webview:
+            self.webview.cleanup()
+            self.webview = None
 
         if self.change_tracker.changed():
             if not askUser("Discard changes?"):

--- a/qt/aqt/forms/__init__.py
+++ b/qt/aqt/forms/__init__.py
@@ -20,6 +20,7 @@ from . import edithtml
 from . import emptycards
 from . import exporting
 from . import fields
+from . import fields_web
 from . import finddupes
 from . import findreplace
 from . import getaddons

--- a/qt/aqt/forms/fields_web.py
+++ b/qt/aqt/forms/fields_web.py
@@ -1,0 +1,1 @@
+../../../.bazel/bin/qt/aqt/forms/fields_web_qt6.py

--- a/qt/aqt/forms/fields_web.ui
+++ b/qt/aqt/forms/fields_web.ui
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Dialog</class>
+ <widget class="QDialog" name="Dialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>400</width>
+    <height>300</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string notr="true">Dialog</string>
+  </property>
+  <property name="windowIcon">
+   <iconset resource="icons.qrc">
+    <normaloff>:/icons/anki.png</normaloff>:/icons/anki.png</iconset>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <property name="spacing">
+    <number>0</number>
+   </property>
+   <property name="margin">
+    <number>0</number>
+   </property>
+   <item>
+    <widget class="AnkiWebView" name="webview" native="true">
+     <property name="url" stdset="0">
+      <url>
+       <string notr="true">about:blank</string>
+      </url>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>AnkiWebView</class>
+   <extends>QWidget</extends>
+   <header location="global">aqt/webview</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
+ <resources>
+  <include location="icons.qrc"/>
+ </resources>
+</ui>

--- a/ts/fields/BUILD.bazel
+++ b/ts/fields/BUILD.bazel
@@ -1,0 +1,73 @@
+load("//ts:prettier.bzl", "prettier_test")
+load("//ts:eslint.bzl", "eslint_test")
+load("//ts/svelte:svelte.bzl", "compile_svelte", "svelte_check")
+load("//ts:esbuild.bzl", "esbuild")
+load("//ts:generate_page.bzl", "generate_page")
+load("//ts:compile_sass.bzl", "compile_sass")
+load("//ts:typescript.bzl", "typescript")
+
+generate_page(page = "fields")
+
+compile_sass(
+    srcs = ["fields-base.scss"],
+    group = "base_css",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//sass:base_lib",
+        "//sass:scrollbar_lib",
+        "//sass/bootstrap",
+    ],
+)
+
+_ts_deps = [
+    "//ts/components",
+    "//ts/lib",
+    "//ts/sveltelib",
+    "@npm//svelte",
+]
+
+compile_svelte(deps = _ts_deps)
+
+typescript(
+    name = "index",
+    deps = _ts_deps + [
+        ":svelte",
+    ],
+)
+
+esbuild(
+    name = "fields",
+    args = {
+        "loader": {".svg": "text"},
+    },
+    entry_point = "index.ts",
+    output_css = "fields.css",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":base_css",
+        ":index",
+        ":svelte",
+    ],
+)
+
+# Tests
+################
+
+prettier_test()
+
+eslint_test()
+
+svelte_check(
+    name = "svelte_check",
+    srcs = glob([
+        "*.ts",
+        "*.svelte",
+    ]) + [
+        "//sass:button_mixins_lib",
+        "//sass/bootstrap",
+        "@npm//@types/bootstrap",
+        "@npm//@types/lodash-es",
+        "@npm//@types/marked",
+        "//ts/components",
+    ],
+)

--- a/ts/fields/FieldsPage.svelte
+++ b/ts/fields/FieldsPage.svelte
@@ -1,0 +1,8 @@
+<!--
+jopyright: Ankitects Pty Ltd and contributors
+License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
+-->
+<script lang="ts">
+</script>
+
+<div>Fields</div>

--- a/ts/fields/fields-base.scss
+++ b/ts/fields/fields-base.scss
@@ -1,0 +1,29 @@
+@use "sass/vars";
+@use "sass/bootstrap-dark";
+
+@import "sass/base";
+
+@import "sass/bootstrap/scss/alert";
+@import "sass/bootstrap/scss/buttons";
+@import "sass/bootstrap/scss/button-group";
+@import "sass/bootstrap/scss/close";
+@import "sass/bootstrap/scss/grid";
+@import "sass/bootstrap-forms";
+
+.night-mode {
+    @include bootstrap-dark.night-mode;
+}
+
+body {
+    width: min(100vw, 70em);
+    margin: 0 auto;
+}
+
+html {
+    overflow-x: hidden;
+}
+
+#main {
+    padding: 0.5em 0.5em 1em 0.5em;
+    height: 100vh;
+}

--- a/ts/fields/index.ts
+++ b/ts/fields/index.ts
@@ -1,0 +1,23 @@
+// Copyright: Ankitects Pty Ltd and contributors
+// License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
+
+import "./fields-base.css";
+
+import { ModuleName, setupI18n } from "../lib/i18n";
+import { checkNightMode } from "../lib/nightmode";
+import FieldsPage from "./FieldsPage.svelte";
+
+const i18n = setupI18n({
+    modules: [ModuleName.ACTIONS, ModuleName.CHANGE_NOTETYPE, ModuleName.KEYBOARD],
+});
+
+export async function setupFieldsPage(): Promise<FieldsPage> {
+    checkNightMode();
+
+    await i18n;
+    return new FieldsPage({
+        target: document.body,
+    });
+}
+
+setupFieldsPage();

--- a/ts/fields/tsconfig.json
+++ b/ts/fields/tsconfig.json
@@ -1,0 +1,10 @@
+{
+    "extends": "../tsconfig.json",
+    "include": ["*"],
+    "references": [
+        { "path": "../lib" },
+        { "path": "../sveltelib" },
+        { "path": "../components" }
+    ],
+    "compilerOptions": {}
+}


### PR DESCRIPTION
I'd like to defer https://github.com/ankitects/anki/pull/1691 and other impactful changes in order for 2.1.50 to finally arrive.

Instead I'd like to work on the fields web view. I'd like to implement it as sidebar, which knows about all fields, and a field editor, which only knows about a single field object. As such it would have similar setup as the parent container and NoteEditor, and I could try out how things would work best without possibly delaying 2.1.50.