### PR TITLE
Add regex tag search

### DIFF
--- a/rslib/src/search/builder.rs
+++ b/rslib/src/search/builder.rs
@@ -134,7 +134,10 @@ impl SearchNode {
 
     /// Construct [SearchNode] from an unescaped tag name.
     pub fn from_tag_name(name: &str) -> Self {
-        Self::Tag(escape_anki_wildcards_for_search_node(name))
+        Self::Tag {
+            tag: escape_anki_wildcards_for_search_node(name),
+            is_re: false,
+        }
     }
 
     /// Construct [SearchNode] from an unescaped notetype name.

--- a/rslib/src/search/writer.rs
+++ b/rslib/src/search/writer.rs
@@ -70,7 +70,7 @@ fn write_search_node(node: &SearchNode) -> String {
         NotetypeId(NotetypeIdType(i)) => format!("mid:{}", i),
         Notetype(s) => maybe_quote(&format!("note:{}", s)),
         Rated { days, ease } => write_rated(days, ease),
-        Tag(s) => maybe_quote(&format!("tag:{}", s)),
+        Tag { tag, is_re } => write_single_field("tag", tag, *is_re),
         Duplicates { notetype_id, text } => write_dupe(notetype_id, text),
         State(k) => write_state(k),
         Flag(u) => format!("flag:{}", u),
@@ -102,6 +102,7 @@ fn needs_quotation(txt: &str) -> bool {
     RE.is_match(txt)
 }
 
+/// Also used by tag search, which has the same syntax.
 fn write_single_field(field: &str, text: &str, is_re: bool) -> String {
     let re = if is_re { "re:" } else { "" };
     let text = if !is_re && text.starts_with("re:") {


### PR DESCRIPTION
Like in field searches, this is case-insensitive and doesn't require a full match.

In https://forums.ankiweb.net/t/how-to-search-for-head-tags-without-sub-tags/17788 I was talking about the non-regex case, but I see why it wouldn't work. Were you also talking about that and propose to use `regexp_tags` for it as well?