### PR TITLE
Fix html_media_regexps

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -97,6 +97,7 @@ Sam Bradshaw <samjr.bradshaw@gmail.com>
 gnnoh <gerongfenh@gmail.com>
 Sachin Govind <sachin.govind.too@gmail.com>
 Patric Cunha <patricc@agap2.pt>
+Brayan Oliveira <github.com/BrayanDSO>
 
 ********************
 

--- a/pylib/anki/media.py
+++ b/pylib/anki/media.py
@@ -34,13 +34,13 @@ class MediaManager(DeprecatedNamesMixin):
     sound_regexps = [r"(?i)(\[sound:(?P<fname>[^]]+)\])"]
     html_media_regexps = [
         # src element quoted case
-        r"(?i)(<[img|audio][^>]* src=(?P<str>[\"'])(?P<fname>[^>]+?)(?P=str)[^>]*>)",
+        r"(?i)(<(?:img|audio)\b[^>]* src=(?P<str>[\"'])(?P<fname>[^>]+?)(?P=str)[^>]*>)",
         # unquoted case
-        r"(?i)(<[img|audio][^>]* src=(?!['\"])(?P<fname>[^ >]+)[^>]*?>)",
+        r"(?i)(<(?:img|audio)\b[^>]* src=(?!['\"])(?P<fname>[^ >]+)[^>]*?>)",
         # src element quoted case
-        r"(?i)(<object[^>]* data=(?P<str>[\"'])(?P<fname>[^>]+?)(?P=str)[^>]*>)",
+        r"(?i)(<object\b[^>]* data=(?P<str>[\"'])(?P<fname>[^>]+?)(?P=str)[^>]*>)",
         # unquoted case
-        r"(?i)(<object[^>]* data=(?!['\"])(?P<fname>[^ >]+)[^>]*?>)",
+        r"(?i)(<object\b[^>]* data=(?!['\"])(?P<fname>[^ >]+)[^>]*?>)",
     ]
     regexps = sound_regexps + html_media_regexps
 


### PR DESCRIPTION
Some regexes on `html_media_regexps` were flawed, matching other tags, as you can see on:

src element quoted case: https://regex101.com/r/JXSruk/1

unquored case: https://regex101.com/r/F263nV/1

---

If anyone wants to test the fixed ones:

quoted: https://regex101.com/r/8KiURM/1

unquoted: https://regex101.com/r/ps45IC/1