### PR TITLE
Update prettier-plugin-svelte

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
         "minimist": "^1.2.5",
         "patch-package": "^6.4.7",
         "prettier": "2.4.1",
-        "prettier-plugin-svelte": "2.4.0",
+        "prettier-plugin-svelte": "2.6.0",
         "sass": "1.42.1",
         "semver": "^7.3.4",
         "svelte": "^3.25.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4173,10 +4173,10 @@ prelude-ls@~1.1.2:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
   integrity sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=
 
-prettier-plugin-svelte@2.4.0:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/prettier-plugin-svelte/-/prettier-plugin-svelte-2.4.0.tgz#482bb6003bf1d5bd7ff002261a42a32b87d42d00"
-  integrity sha512-JwJ9bOz4XHLQtiLnX4mTSSDUdhu12WH8sTwy/XTDCSyPlah6IcV7NWeYBZscPEcceu2YnW8Y9sJCP40Z2UH9GA==
+prettier-plugin-svelte@2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/prettier-plugin-svelte/-/prettier-plugin-svelte-2.6.0.tgz#0e845b560b55cd1d951d6c50431b4949f8591746"
+  integrity sha512-NPSRf6Y5rufRlBleok/pqg4+1FyGsL0zYhkYP6hnueeL1J/uCm3OfOZPsLX4zqD9VAdcXfyEL2PYqGv8ZoOSfA==
 
 prettier@2.4.1:
   version "2.4.1"


### PR DESCRIPTION
It brings support for newer Svelte syntax like `{@const}` and `style:` directives.