### PR TITLE
Do not prevent drop event in AnkiWebView

### DIFF
--- a/qt/aqt/webview.py
+++ b/qt/aqt/webview.py
@@ -321,9 +321,6 @@ class AnkiWebView(QWebEngineView):
         gui_hooks.webview_will_show_context_menu(self, m)
         m.popup(QCursor.pos())
 
-    def dropEvent(self, evt: QDropEvent) -> None:
-        pass
-
     def setHtml(self, html: str) -> None:  #  type: ignore
         # discard any previous pending actions
         self._pendingActions = []


### PR DESCRIPTION
Is there a reason we straight-out prevent it? It does not seem to interfere with DnD in the deck overview or the editor.