### PR TITLE
Fix `NotFoundError` when opening browser after switching profiles

### DIFF
--- a/qt/aqt/main.py
+++ b/qt/aqt/main.py
@@ -279,7 +279,7 @@ class AnkiQt(QMainWindow):
 
     def showProfileManager(self) -> None:
         self.pm.profile = None
-        self.state = "profileManager"
+        self.moveToState("profileManager")
         d = self.profileDiag = self.ProfileManager()
         f = self.profileForm = aqt.forms.profiles.Ui_MainWindow()
         f.setupUi(d)
@@ -669,7 +669,7 @@ class AnkiQt(QMainWindow):
         self.clearStateShortcuts()
         self.state = state
         gui_hooks.state_will_change(state, oldState)
-        getattr(self, f"_{state}State")(oldState, *args)
+        getattr(self, f"_{state}State", lambda *_: None)(oldState, *args)
         if state != "resetRequired":
             self.bottomWeb.show()
         gui_hooks.state_did_change(state, oldState)


### PR DESCRIPTION
Steps to reproduce:
1. Go to the review screen
2. <kbd>File</kbd> -> <kbd>Switch Profiles</kbd>, then open another profile
4. Open the browser before going to the review screen
5. `anki.errors.NotFoundError` will be thrown if the browser is in `Notes` mode