### PR TITLE
Speed up editor by lazily loading CodeMirror

### DIFF
--- a/ts/editor/CodeMirror.svelte
+++ b/ts/editor/CodeMirror.svelte
@@ -30,6 +30,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
     export let configuration: CodeMirrorLib.EditorConfiguration;
     export let code: Writable<string>;
+    export let hidden = false;
 
     const defaultConfiguration = {
         rtlMoveVisually: true,
@@ -79,6 +80,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         use:openCodeMirror={{
             configuration: { ...configuration, ...defaultConfiguration },
             resolve,
+            hidden,
         }}
     />
 </div>

--- a/ts/editor/plain-text-input/PlainTextInput.svelte
+++ b/ts/editor/plain-text-input/PlainTextInput.svelte
@@ -136,7 +136,13 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     class:hidden
     on:focusin={() => ($focusedInput = api)}
 >
-    <CodeMirror {configuration} {code} bind:api={codeMirror} on:change={onChange} />
+    <CodeMirror
+        {configuration}
+        {code}
+        {hidden}
+        bind:api={codeMirror}
+        on:change={onChange}
+    />
 </div>
 
 <style lang="scss">


### PR DESCRIPTION
When populating the fields with content, CodeMirror is preloaded even if the PlainTextInput isn't open. This populating takes up a good chunk of the entire loading time, and it is noticeable in the Browser, when there are a lot of fields. On a particular notetype with 20 fields, this shortened the time to interactive from ~750ms to ~250ms.