### PR TITLE
Add minimumContentsLength property to templatesBox

### DIFF
--- a/qt/aqt/forms/clayout_top.ui
+++ b/qt/aqt/forms/clayout_top.ui
@@ -49,6 +49,9 @@
          <verstretch>0</verstretch>
         </sizepolicy>
        </property>
+       <property name="minimumContentsLength">
+        <number>50</number>
+       </property>
        <property name="maxVisibleItems">
         <number>30</number>
        </property>


### PR DESCRIPTION
Fixes #1777 by adding the `minimumContentsLength` property to the comboBox, which causes the size policy to not require expanding beyond that amount while still expanding if the user stretches the window manually.

Note that users who were previously experiencing large window widths due to the previous behaviour might see the same size again due the geometry being restored.