### PR TITLE
Allow passing args to anki-console.bat

### DIFF
--- a/qt/bundle/win/anki-console.bat
+++ b/qt/bundle/win/anki-console.bat
@@ -1,5 +1,5 @@
 @echo off
-anki
+anki %*
 pause
 
      


### PR DESCRIPTION
Just noticed while testing an add-on with 2.1.50 on a dev profile using `-b` that it's no longer possible to pass arguments to `anki-console.bat`. Apparently, `anki` can now show console output on Windows, so `anki-console` is pretty much useless now, but still, let's keep it working properly for people who developed muscle memory for it like me.

<details>
<summary>A really minor, unrelated issue:</summary>
After running Anki and closing it in the console, the prompt is "clobbered" and not shown until typing something. Maybe an issue with the packager.

https://user-images.githubusercontent.com/41397710/162556128-50d88603-cc64-42b6-bdea-7e4fdd567509.mp4

</details>



 