### PR TITLE
Fix non-character keys resetting text style

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -99,6 +99,7 @@ Sachin Govind <sachin.govind.too@gmail.com>
 Bruce Harris <github.com/bruceharris>
 Patric Cunha <patricc@agap2.pt>
 Brayan Oliveira <github.com/BrayanDSO>
+Vincent van Aalten <vincent.aalten@hotmail.com>
 
 ********************
 

--- a/ts/lib/keys.ts
+++ b/ts/lib/keys.ts
@@ -23,10 +23,6 @@ export function checkIfInputKey(event: KeyboardEvent): boolean {
     return event.location === GENERAL_KEY || event.location === NUMPAD_KEY;
 }
 
-export function keyboardEventIsPrintableKey(event: KeyboardEvent): boolean {
-    return event.key.length === 1;
-}
-
 export const checkModifiers =
     (required: Modifier[], optional: Modifier[] = []) =>
     (event: KeyboardEvent): boolean => {

--- a/ts/sveltelib/input-handler.ts
+++ b/ts/sveltelib/input-handler.ts
@@ -63,8 +63,7 @@ function useInputHandler(): [InputHandlerAPI, SetupInputHandlerAction] {
 
     function onKeydown(event: KeyboardEvent): void {
         /* using arrow keys should cancel */
-	
-    if (["ArrowUp", "ArrowLeft", "ArrowDown", "ArrowRight"].includes(event.key)){
+        if (["ArrowUp", "ArrowLeft", "ArrowDown", "ArrowRight"].includes(event.key)) {
             clearInsertText();
         }
     }

--- a/ts/sveltelib/input-handler.ts
+++ b/ts/sveltelib/input-handler.ts
@@ -63,7 +63,8 @@ function useInputHandler(): [InputHandlerAPI, SetupInputHandlerAction] {
 
     function onKeydown(event: KeyboardEvent): void {
         /* using arrow keys should cancel */
-    if (event.key in ["ArrowUp", "ArrowLeft", "ArrowDown", "ArrowRight"]){
+	
+    if (["ArrowUp", "ArrowLeft", "ArrowDown", "ArrowRight"].includes(event.key)){
             clearInsertText();
         }
     }

--- a/ts/sveltelib/input-handler.ts
+++ b/ts/sveltelib/input-handler.ts
@@ -3,7 +3,6 @@
 
 import { getRange, getSelection } from "../lib/cross-browser";
 import { on } from "../lib/events";
-import { keyboardEventIsPrintableKey } from "../lib/keys";
 import { HandlerList } from "./handler-list";
 
 const nbsp = "\xa0";
@@ -64,7 +63,7 @@ function useInputHandler(): [InputHandlerAPI, SetupInputHandlerAction] {
 
     function onKeydown(event: KeyboardEvent): void {
         /* using arrow keys should cancel */
-        if (!keyboardEventIsPrintableKey(event)) {
+    if (event.key in ["ArrowUp", "ArrowLeft", "ArrowDown", "ArrowRight"]){
             clearInsertText();
         }
     }


### PR DESCRIPTION
Issue #1795 seems to have been caused in 0d83581ab08e1a92c5c55c99965e9f054b3f43e6 
The `clearInsertText()` call from line 68 of `ts/sveltelib/input-handler.ts` seems to remove any bold/italics/underlined etc. modifiers.
I am not sure what the intended behavior was, since the original commit seems to have to do with Mathjax which I know little about. However, the comment on line 66 seems to indicate that `!keyboardEventIsPrintableKey(event)` was intended to return true if any arrow key was pressed, when it in fact returns true when any key is pressed that does not have a 1 character name.

I have simply replaced the function call with a check if the key is an arrow key, which should hopefully retain the originally intended behavior as per the comment, while fixing the unintended behavior while editing regularly. The `keyboardEventIsPrintableKey` function is no longer used, so I also removed that.

Closes #1795.