### PR TITLE
Fix issue #1114 by scrolling the user to the top of the page

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -99,6 +99,7 @@ Sachin Govind <sachin.govind.too@gmail.com>
 Bruce Harris <github.com/bruceharris>
 Patric Cunha <patricc@agap2.pt>
 Brayan Oliveira <github.com/BrayanDSO>
+Luka Warren <github.com/lukawarren>
 
 ********************
 

--- a/qt/aqt/about.py
+++ b/qt/aqt/about.py
@@ -225,6 +225,7 @@ def show(mw: aqt.AnkiQt) -> QDialog:
             "Sergio Quintero",
             "Nicholas Flint",
             "Daniel Vieira Memoria10X",
+            "Luka Warren",
         )
     )
 

--- a/qt/aqt/stats.py
+++ b/qt/aqt/stats.py
@@ -174,6 +174,11 @@ class DeckStats(QDialog):
         path = self._imagePath()
         if not path:
             return
+        # when scrolled down in dark mode, the top of the back has
+        # a white background, which obviously makes it hard to read
+        # the white text, and so a simple fix for now is to simply
+        # scroll to the top instead
+        self.form.web.page().runJavaScript("window.scrollTo(0, 0);")
         self.form.web.page().printToPdf(path)
         tooltip(tr.statistics_saved())
 

--- a/qt/aqt/stats.py
+++ b/qt/aqt/stats.py
@@ -83,8 +83,15 @@ class NewDeckStats(QDialog):
         path = self._imagePath()
         if not path:
             return
-        self.form.web.page().printToPdf(path)
-        tooltip(tr.statistics_saved())
+        # When scrolled down in dark mode, the top of the page in the
+        # final PDF will have a white background, making the text and graphs
+        # unreadable. A simple fix for now is to scroll to the top of the
+        # page first.
+        def after_scroll(arg: Any) -> None:
+            self.form.web.page().printToPdf(path)
+            tooltip(tr.statistics_saved())
+
+        self.form.web.evalWithCallback("window.scrollTo(0, 0);", after_scroll)
 
     # legacy add-ons
     def changePeriod(self, n: Any) -> None:
@@ -174,11 +181,6 @@ class DeckStats(QDialog):
         path = self._imagePath()
         if not path:
             return
-        # when scrolled down in dark mode, the top of the page in the
-        # final PDF will have a white background, which obviously makes
-        # it hard to read the white text beneath, and so a simple fix
-        # for now is to simply scroll to the top first instead
-        self.form.web.page().runJavaScript("window.scrollTo(0, 0);")
         self.form.web.page().printToPdf(path)
         tooltip(tr.statistics_saved())
 

--- a/qt/aqt/stats.py
+++ b/qt/aqt/stats.py
@@ -174,10 +174,10 @@ class DeckStats(QDialog):
         path = self._imagePath()
         if not path:
             return
-        # when scrolled down in dark mode, the top of the back has
-        # a white background, which obviously makes it hard to read
-        # the white text, and so a simple fix for now is to simply
-        # scroll to the top instead
+        # when scrolled down in dark mode, the top of the page in the
+        # final PDF will have a white background, which obviously makes
+        # it hard to read the white text beneath, and so a simple fix
+        # for now is to simply scroll to the top first instead
         self.form.web.page().runJavaScript("window.scrollTo(0, 0);")
         self.form.web.page().printToPdf(path)
         tooltip(tr.statistics_saved())


### PR DESCRIPTION
I toyed with changing the CSS of the page instead, but I wasn't sure if that would have any adverse consequences on anything else. For now I believe it's better than nothing.

From the first commit's description:
`It's obviously a bit of a "hacky" solution, since it's slightly jarring for users to scroll down, click export, then find themselves all the way at the top again, but it's somewhat less confusing than wondering why your PDF is broken :-)`