### PR TITLE
Fix progress of chained operations

### DIFF
--- a/qt/aqt/importing.py
+++ b/qt/aqt/importing.py
@@ -14,7 +14,7 @@ import aqt.modelchooser
 from anki.errors import Interrupted
 from anki.importing.anki2 import V2ImportIntoV1
 from anki.importing.apkg import AnkiPackageImporter
-from aqt import AnkiQt, gui_hooks
+from aqt.main import AnkiQt, gui_hooks
 from aqt.operations import QueryOp
 from aqt.qt import *
 from aqt.utils import (
@@ -460,12 +460,13 @@ def full_apkg_import(mw: AnkiQt, file: str) -> None:
 
 
 def replace_with_apkg(
-    mw: aqt.AnkiQt, filename: str, callback: Callable[[bool], None]
+    mw: AnkiQt, filename: str, callback: Callable[[bool], None]
 ) -> None:
     """Tries to replace the provided collection with the provided backup,
     then calls the callback. True if success.
     """
-    dialog = mw.progress.start(immediate=True)
+    if not (dialog := mw.progress.start(immediate=True)):
+        print("No progress dialog during import; aborting will not work")
     timer = QTimer()
     timer.setSingleShot(False)
     timer.setInterval(100)

--- a/qt/aqt/operations/__init__.py
+++ b/qt/aqt/operations/__init__.py
@@ -217,6 +217,10 @@ class QueryOp(Generic[T]):
 
         def wrapped_done(future: Future) -> None:
             assert mw
+
+            if self._progress:
+                mw.progress.finish()
+
             mw._decrease_background_ops()
             # did something go wrong?
             if exception := future.exception():
@@ -230,11 +234,6 @@ class QueryOp(Generic[T]):
                     # BaseException like SystemExit; rethrow it
                     future.result()
 
-            result = future.result()
-            try:
-                self._success(result)
-            finally:
-                if self._progress:
-                    mw.progress.finish()
+            self._success(future.result())
 
         mw.taskman.run_in_background(wrapped_op, wrapped_done)


### PR DESCRIPTION
The new behaviour is more in line with `CollectionOp` which uses `mw.taskman.with_progress()`, which also calls `.finish()` _before_ the callback.

Motivation
---
4515c41d2cd2196e8624d5dd2f331f15228 broke aborting colpkg imports.
QueryOp starts a new progress, which is only finished after its success callback is run. But in `replace_with_apkg` we want to start a new progress inside that callback. However, `mw.progress.start()` returns `None` because of the already running progress.
It took me a while to figure this out due to the `except AttributeError: pass`. I had copied this from somewhere. Is it supposed to handle this very `dialog == None` case?

Somewhat related
---
Should I subclass `CollectionOp` with an `InteractiveCollectionOp` that wraps the progress handling from `replace_with_apkg()`? I need that same logic for apkg importing in #1743.