### PR TITLE
Remove onInput call in input handler

### DIFF
--- a/ts/sveltelib/input-handler.ts
+++ b/ts/sveltelib/input-handler.ts
@@ -61,21 +61,8 @@ function useInputHandler(): [InputHandlerAPI, SetupInputHandlerAction] {
         insertText.clear();
     }
 
-    function onInput(this: HTMLElement, event: InputEvent): void {
-        // prevent unwanted <div> from being left behind when clearing field contents
-        if (
-            !event.data &&
-            this.children.length === 1 &&
-            this.children.item(0) instanceof HTMLDivElement &&
-            /^\n?$/.test(this.innerText)
-        ) {
-            this.innerHTML = "";
-        }
-    }
-
     function setupHandler(element: HTMLElement): { destroy(): void } {
         const beforeInputOff = on(element, "beforeinput", onBeforeInput);
-        const inputOff = on(element, "input" as "beforeinput", onInput);
 
         const blurOff = on(element, "blur", clearInsertText);
         const pointerDownOff = on(element, "pointerdown", clearInsertText);
@@ -84,7 +71,6 @@ function useInputHandler(): [InputHandlerAPI, SetupInputHandlerAction] {
         return {
             destroy() {
                 beforeInputOff();
-                inputOff();
                 blurOff();
                 pointerDownOff();
                 selectionChangeOff();


### PR DESCRIPTION
Fixes #1805 

This was implemented by me to prevent seemingly empty fields,
which however still contain some HTML (e.g. `<div></div>`) and
thus will trigger in the templates.
However it only worked in very limited cases, maybe we could
solve this better by indicating whether a field has content somehow.