### PR TITLE
Extends the SearchNode interface to support field and unqualified searches

### DIFF
--- a/proto/anki/search.proto
+++ b/proto/anki/search.proto
@@ -68,6 +68,11 @@ message SearchNode {
     repeated SearchNode nodes = 1;
     Joiner joiner = 2;
   }
+  message Field {
+    string field_name = 1;
+    string text = 2;
+    bool is_re = 3;
+  }
   oneof filter {
     Group group = 1;
     SearchNode negated = 2;
@@ -88,6 +93,7 @@ message SearchNode {
     string tag = 17;
     string note = 18;
     uint32 introduced_in_days = 19;
+    Field field = 20;
   }
 }
 

--- a/proto/anki/search.proto
+++ b/proto/anki/search.proto
@@ -94,6 +94,7 @@ message SearchNode {
     string note = 18;
     uint32 introduced_in_days = 19;
     Field field = 20;
+    string text = 21;
   }
 }
 

--- a/proto/anki/search.proto
+++ b/proto/anki/search.proto
@@ -73,6 +73,7 @@ message SearchNode {
     string text = 2;
     bool is_re = 3;
   }
+
   oneof filter {
     Group group = 1;
     SearchNode negated = 2;
@@ -94,7 +95,7 @@ message SearchNode {
     string note = 18;
     uint32 introduced_in_days = 19;
     Field field = 20;
-    string text = 21;
+    string literal_text = 21;
   }
 }
 

--- a/rslib/src/backend/search/search_node.rs
+++ b/rslib/src/backend/search/search_node.rs
@@ -9,7 +9,7 @@ use crate::{
     search::{
         parse_search, Negated, Node, PropertyKind, RatingKind, SearchNode, StateKind, TemplateKind,
     },
-    text::escape_anki_wildcards_for_search_node,
+    text::{escape_anki_wildcards, escape_anki_wildcards_for_search_node},
 };
 
 impl TryFrom<pb::SearchNode> for Node {
@@ -98,6 +98,11 @@ impl TryFrom<pb::SearchNode> for Node {
                         Node::Group(nodes)
                     }
                 }
+                Filter::Field(field) => Node::Search(SearchNode::SingleField {
+                    field: escape_anki_wildcards_for_search_node(&field.field_name),
+                    text: escape_anki_wildcards(&field.text),
+                    is_re: field.is_re,
+                }),
             }
         } else {
             Node::Search(SearchNode::WholeCollection)

--- a/rslib/src/backend/search/search_node.rs
+++ b/rslib/src/backend/search/search_node.rs
@@ -103,7 +103,7 @@ impl TryFrom<pb::SearchNode> for Node {
                     text: escape_anki_wildcards(&field.text),
                     is_re: field.is_re,
                 }),
-                Filter::Text(text) => {
+                Filter::LiteralText(text) => {
                     let text = escape_anki_wildcards(&text);
                     Node::Search(SearchNode::UnqualifiedText(text))
                 }

--- a/rslib/src/backend/search/search_node.rs
+++ b/rslib/src/backend/search/search_node.rs
@@ -99,7 +99,7 @@ impl TryFrom<pb::SearchNode> for Node {
                     }
                 }
                 Filter::Field(field) => Node::Search(SearchNode::SingleField {
-                    field: escape_anki_wildcards_for_search_node(&field.field_name),
+                    field: escape_anki_wildcards(&field.field_name),
                     text: escape_anki_wildcards(&field.text),
                     is_re: field.is_re,
                 }),

--- a/rslib/src/backend/search/search_node.rs
+++ b/rslib/src/backend/search/search_node.rs
@@ -103,6 +103,10 @@ impl TryFrom<pb::SearchNode> for Node {
                     text: escape_anki_wildcards(&field.text),
                     is_re: field.is_re,
                 }),
+                Filter::Text(text) => {
+                    let text = escape_anki_wildcards(&text);
+                    Node::Search(SearchNode::UnqualifiedText(text))
+                }
             }
         } else {
             Node::Search(SearchNode::WholeCollection)


### PR DESCRIPTION
Context: https://forums.ankiweb.net/t/is-it-possible-to-construct-field-foo-searches-using-searchnode/19365

This adds two new options to SearchNode to support field searches and unqualified searches with automatic escaping.

Maybe the `text` option can use a more descriptive name (maybe `literal_text`?). I'm open to suggestions.

Can we somehow attach a docstring to SearchNode (in case there is any need for that)?