### PR TITLE
Fix previewer runtime error "deleted"

### DIFF
--- a/qt/aqt/browser/previewer.py
+++ b/qt/aqt/browser/previewer.py
@@ -106,7 +106,7 @@ class Previewer(QDialog):
 
     def _on_finished(self, ok: int) -> None:
         saveGeom(self, "preview")
-        self.mw.progress.single_shot(100, self._on_close)
+        self._on_close()
 
     def _on_replay_audio(self) -> None:
         if self._state == "question":


### PR DESCRIPTION
Easily reproducible by quickly selecting multiple rows while the previewer shows (dragging the mouse, or using a shortcut like <kbd>Shift+End/Home</kbd>).
I don't know what the purpose of the async close was, and therefore if it's safe to remove it. But I didn't notice any issues when testing manually.

```
Caught exception:
Traceback (most recent call last):
  File "\\?\C:\bazel\anki\c5pd2hpw\execroot\ankidesktop\bazel-out\x64_windows-fastbuild\bin\qt\runanki.exe.runfiles\ankidesktop\qt\aqt\webview.py", line 563, in handler
    cb(val)
  File "\\?\C:\bazel\anki\c5pd2hpw\execroot\ankidesktop\bazel-out\x64_windows-fastbuild\bin\qt\runanki.exe.runfiles\ankidesktop\qt\aqt\editor.py", line 558, in <lambda>
    self.web.evalWithCallback("saveNow(%d)" % keepFocus, lambda res: callback())
  File "\\?\C:\bazel\anki\c5pd2hpw\execroot\ankidesktop\bazel-out\x64_windows-fastbuild\bin\qt\runanki.exe.runfiles\ankidesktop\qt\aqt\utils.py", line 1018, in <lambda>
    self.editor.call_after_note_saved(lambda: func(self, *args, **kwargs))
  File "\\?\C:\bazel\anki\c5pd2hpw\execroot\ankidesktop\bazel-out\x64_windows-fastbuild\bin\qt\runanki.exe.runfiles\ankidesktop\qt\aqt\browser\browser.py", line 473, in on_all_or_selected_rows_changed
    self._renderPreview()
  File "\\?\C:\bazel\anki\c5pd2hpw\execroot\ankidesktop\bazel-out\x64_windows-fastbuild\bin\qt\runanki.exe.runfiles\ankidesktop\qt\aqt\browser\browser.py", line 656, in _renderPreview
    self.onTogglePreview()
  File "\\?\C:\bazel\anki\c5pd2hpw\execroot\ankidesktop\bazel-out\x64_windows-fastbuild\bin\qt\runanki.exe.runfiles\ankidesktop\qt\aqt\browser\browser.py", line 645, in onTogglePreview
    self._previewer.close()
RuntimeError: wrapped C/C++ object of type BrowserPreviewer has been deleted
```