### PR TITLE
Fix some apkg import issues

### DIFF
--- a/rslib/src/import_export/gather.rs
+++ b/rslib/src/import_export/gather.rs
@@ -187,12 +187,10 @@ impl Collection {
     ) -> Result<()> {
         if let Some(parent_name) = immediate_parent_name(name) {
             if parent_names.insert(parent_name.to_owned()) {
-                parents.push(
-                    self.storage
-                        .get_deck_by_name(parent_name)?
-                        .ok_or(AnkiError::DatabaseCheckRequired)?,
-                );
-                self.add_parent_decks(parent_name, parent_names, parents)?;
+                if let Some(parent) = self.storage.get_deck_by_name(parent_name)? {
+                    parents.push(parent);
+                    self.add_parent_decks(parent_name, parent_names, parents)?;
+                }
             }
         }
         Ok(())


### PR DESCRIPTION
Closes #1835. That was an unintended side effect of using the gather code for both im- and export.
One more issue I realised: Unexported siblings don't get generated on import. I'll deal with that after plaintext imports, because it won't be easy to add this, but it needs to be taken care of when importing text at the very least.