### PR TITLE
Fix caret jumping to start when moving through autocomplete suggestion

### DIFF
--- a/ts/editor/tag-editor/TagEditor.svelte
+++ b/ts/editor/tag-editor/TagEditor.svelte
@@ -90,7 +90,8 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         const activeTag = tagTypes[active!];
 
         activeName = selected ?? activeTag.name;
-        activeInput.setSelectionRange(Infinity, Infinity);
+        const inputEnd = activeInput.value.length;
+        activeInput.setSelectionRange(inputEnd, inputEnd);
     }
 
     async function updateTagName(tag: TagType): Promise<void> {


### PR DESCRIPTION
The caret sometimes jumps to the start of the currently editing tag when selecting previous/next tag with tab or arrow keys. This PR fixes the bug.


Fixes https://github.com/ankitects/anki/issues/1823(https://forums.ankiweb.net/t/on-anki-2-1-50-in-note-editor-you-cant-add-a-tag-after-typing-its-full-name-and-selecting-it-using-tab/19436)