### PR TITLE
Fix when tooltip changes before tooltipObject is created

### DIFF
--- a/ts/components/WithTooltip.svelte
+++ b/ts/components/WithTooltip.svelte
@@ -43,9 +43,11 @@
     let previousTooltip: string = tooltip;
     $: if (tooltip !== previousTooltip) {
         previousTooltip = tooltip;
-        const element: HTMLElement = tooltipObject["_element"];
-        tooltipObject.dispose();
-        createTooltip(element);
+        if (tooltipObject !== undefined) {
+            const element: HTMLElement = tooltipObject["_element"];
+            tooltipObject.dispose();
+            createTooltip(element);
+        }
     }
 </script>
 


### PR DESCRIPTION
This PR fixes an error that occurs in `TagWithTooltip.svelte` when a shortened tag is normalized beause of leading/trailing delimiter.

# Bug Details

When you create a lot of tags to fill the first two rows, the hierarchical tags are shortened and tooltip is shown when hovered. 

https://github.com/ankitects/anki/blob/faa21266db9baf485055dde4b64626ff72184771/ts/editor/tag-editor/TagWithTooltip.svelte#L73-L85


`createTooltip` is called when `Tag` is mounted. So if `tooltip` changes before `Tag` mounts, it results in an error because `tooltipObject` is not defined.

Create a tag `a::b::` in 3+ row, and press enter. `splitText` is called which calls `appendTagAndFocusAt` and attaches an id to tag and creates a new `TagWithTooltip` instance. `normalizeTagname` changes `tag.name`, which in `WithTooltip` triggers the modified reactive statement. Because createTooltip has not been called yet, it results in an error. 