### PR TITLE
select all tags with Ctrl+A

### DIFF
--- a/ts/editor/tag-editor/TagEditor.svelte
+++ b/ts/editor/tag-editor/TagEditor.svelte
@@ -111,6 +111,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
     function appendEmptyTag(): void {
         // used by tag badge and tag spacer
+        deselect();
         const lastTag = tagTypes[tagTypes.length - 1];
 
         if (!lastTag || lastTag.name.length > 0) {
@@ -447,6 +448,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
                                 splitTag(index, detail.start, detail.end)}
                             on:tagadd={() => insertTagKeepFocus(index)}
                             on:tagdelete={() => deleteTagAt(index)}
+                            on:tagselectall={selectAllTags}
                             on:tagjoinprevious={() => joinWithPreviousTag(index)}
                             on:tagjoinnext={() => joinWithNextTag(index)}
                             on:tagmoveprevious={() => moveToPreviousTag(index)}

--- a/ts/editor/tag-editor/TagInput.svelte
+++ b/ts/editor/tag-editor/TagInput.svelte
@@ -5,6 +5,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 <script lang="ts">
     import { createEventDispatcher, onMount, tick } from "svelte";
 
+    import { registerShortcut } from "../../lib/shortcuts";
     import {
         delimChar,
         normalizeTagname,
@@ -230,7 +231,20 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         name = last;
     }
 
-    onMount(() => input.focus());
+    async function onSelectAll(event: KeyboardEvent) {
+        if (name.length === 0) {
+            input.blur();
+            await tick(); // ensure blur events are processed before tagselectall
+            dispatch("tagselectall");
+            event.preventDefault();
+            event.stopPropagation();
+        }
+    }
+
+    onMount(() => {
+        registerShortcut(onSelectAll, "Control+A", { target: input });
+        input.focus();
+    });
 </script>
 
 <input


### PR DESCRIPTION
Pressing Ctrl + A while in tag input selects all tags if input is empty.

Fixes #1824