### PR TITLE
Fix activeName updating wrongly when selecting previous tag from invalid tag

### DIFF
--- a/ts/editor/tag-editor/TagEditor.svelte
+++ b/ts/editor/tag-editor/TagEditor.svelte
@@ -219,6 +219,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
         activeAfterBlur = index - 1;
         active = null;
+        activeInput.blur();
     }
 
     async function moveToNextTag(index: number): Promise<void> {
@@ -232,6 +233,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
         activeAfterBlur = index + 1;
         active = null;
+        activeInput.blur();
 
         await tick();
         activeInput.setSelectionRange(0, 0);


### PR DESCRIPTION
Closes #1849