### PR TITLE
Change sequence of Mathjax escaping

### DIFF
--- a/ts/editable/mathjax.ts
+++ b/ts/editable/mathjax.ts
@@ -70,7 +70,7 @@ export function convertMathjax(
  * Escape characters which are technically legal in Mathjax, but confuse HTML.
  */
 export function escapeSomeEntities(value: string): string {
-    return value.replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/&/g, "&amp;");
+    return value.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
 }
 
 export function unescapeSomeEntities(value: string): string {


### PR DESCRIPTION
Follow-up to #1818.

I noticed that there was still an issue when using `<`, `>` directly.
Could swear this did not happen when writing the original PR, but the issue is clear: escaping transformed `<` into `&amp;lt;` instead of just `&lt;`, which could not be undone by `unescapeSomeEntities`.