### PR TITLE
remove image.style.height on resize

### DIFF
--- a/ts/editor/image-overlay/ImageHandle.svelte
+++ b/ts/editor/image-overlay/ImageHandle.svelte
@@ -152,12 +152,13 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         }
 
         /**
-         * Image resizing add-ons previously used image.style.width to set the
-         * preferred width of an image. In these cases, if we'd only set
-         * image.width, there would be no visible effect on the image.
-         * To avoid confusion with users we'll clear image.style.width (for now).
+         * Image resizing add-ons previously used image.style.width/height to set the
+         * preferred dimension of an image. In these cases, if we'd only set
+         * image.[dimension], there would be no visible effect on the image.
+         * To avoid confusion with users we'll clear image.style.[dimension] (for now).
          */
         activeImage!.style.removeProperty("width");
+        activeImage!.style.removeProperty("height");
         if (activeImage!.getAttribute("style")?.length === 0) {
             activeImage!.removeAttribute("style");
         }


### PR DESCRIPTION
Image style editor add-on may also set `image.style.height`.

Related: #1579 https://forums.ankiweb.net/t/macos-anki-2-1-51-qt5-incorrect-image-resizing/19469