### PR TITLE
Change behaviour or image handles

### DIFF
--- a/ts/editor/HandleControl.svelte
+++ b/ts/editor/HandleControl.svelte
@@ -107,10 +107,6 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         &.nw {
             top: calc(0px - var(--offsetY));
             left: calc(0px - var(--offsetX));
-
-            &.active {
-                cursor: nw-resize;
-            }
         }
 
         &.ne {


### PR DESCRIPTION
This PR is quite opinionated. 

Personally, I feel that the image resizing handles are very unintuitive when shrinking images. As can be seen in the below video, for nw (northwest), ne, and sw handles you have to drag _outside_ the image to shrink it, when dragging outside should make the image larger. It's difficult to change width with the ne handle, or height with sw handle.

This PR changes the ne handle into a width handle, sw into height, and disables nw handle. 

Original:
![image_handle_behaviour](https://user-images.githubusercontent.com/50060875/167543500-012411f3-9368-47af-8ddf-576a94ad10d0.gif)

This PR:
![Screen Recording 2022-05-10 at 1 42 06 PM](https://user-images.githubusercontent.com/50060875/167544202-f8613793-2406-418f-82eb-01f68b989d82.gif)

