### PR TITLE
Render cloze deletions in MathJax preview

### DIFF
--- a/proto/anki/card_rendering.proto
+++ b/proto/anki/card_rendering.proto
@@ -24,6 +24,7 @@ service CardRenderingService {
   rpc EncodeIriPaths(generic.String) returns (generic.String);
   rpc DecodeIriPaths(generic.String) returns (generic.String);
   rpc StripHtml(StripHtmlRequest) returns (generic.String);
+  rpc RenderClozeForMathjax(generic.String) returns (generic.String);
 }
 
 message ExtractAVTagsRequest {

--- a/qt/aqt/mediasrv.py
+++ b/qt/aqt/mediasrv.py
@@ -463,6 +463,8 @@ exposed_backend_list = [
     "set_graph_preferences",
     # TagsService
     "complete_tag",
+    # CardRenderingService
+    "render_cloze_for_mathjax",
 ]
 
 

--- a/rslib/src/backend/cardrendering.rs
+++ b/rslib/src/backend/cardrendering.rs
@@ -6,6 +6,7 @@ pub(super) use crate::backend_proto::cardrendering_service::Service as CardRende
 use crate::{
     backend_proto as pb,
     card_rendering::{extract_av_tags, strip_av_tags},
+    cloze::render_cloze_for_mathjax,
     latex::{extract_latex, extract_latex_expanding_clozes, ExtractedLatex},
     markdown::render_markdown,
     notetype::{CardTemplateSchema11, RenderCardOutput},
@@ -146,6 +147,10 @@ impl CardRenderingService for Backend {
         }
         .to_string()
         .into())
+    }
+
+    fn render_cloze_for_mathjax(&self, input: pb::String) -> Result<pb::String> {
+        Ok(render_cloze_for_mathjax(&input.val).into())
     }
 }
 

--- a/rslib/src/cloze.rs
+++ b/rslib/src/cloze.rs
@@ -122,6 +122,12 @@ pub fn reveal_cloze_text_only(text: &str, cloze_ord: u16, question: bool) -> Cow
         .into()
 }
 
+fn reveal_all_clozes(text: &str) -> Cow<str> {
+    CLOZE.replace_all(text, |caps: &Captures| {
+        return caps.get(cloze_caps::TEXT).unwrap().as_str().to_owned();
+    })
+}
+
 /// If text contains any LaTeX tags, render the front and back
 /// of each cloze deletion so that LaTeX can be generated. If
 /// no LaTeX is found, returns an empty string.
@@ -168,6 +174,11 @@ fn strip_html_inside_mathjax(text: &str) -> Cow<str> {
             caps.get(mathjax_caps::CLOSING_TAG).unwrap().as_str()
         )
     })
+}
+
+/// Used for rendering MathJax previews.
+pub(crate) fn render_cloze_for_mathjax(text: &str) -> String {
+    strip_html_inside_mathjax(reveal_all_clozes(text).as_ref()).into_owned()
 }
 
 pub(crate) fn cloze_filter<'a>(text: &'a str, context: &RenderContext) -> Cow<'a, str> {

--- a/ts/editable/Mathjax.svelte
+++ b/ts/editable/Mathjax.svelte
@@ -3,7 +3,13 @@ Copyright: Ankitects Pty Ltd and contributors
 License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 -->
 <script context="module" lang="ts">
+    import { onDestroy } from "svelte";
     import type { Writable } from "svelte/store";
+    import { writable } from "svelte/store";
+
+    import { randomUUID } from "../lib/uuid";
+    import { pageTheme } from "../sveltelib/theme";
+    import { convertMathjax, unescapeSomeEntities } from "./mathjax";
 
     const imageToHeightMap = new Map<string, Writable<number>>();
     const observer = new ResizeObserver((entries: ResizeObserverEntry[]) => {
@@ -18,22 +24,22 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 </script>
 
 <script lang="ts">
-    import { onDestroy } from "svelte";
-    import { writable } from "svelte/store";
-
-    import { randomUUID } from "../lib/uuid";
-    import { pageTheme } from "../sveltelib/theme";
-    import { convertMathjax, unescapeSomeEntities } from "./mathjax";
-
     export let mathjax: string;
     export let block: boolean;
     export let fontSize: number;
 
-    $: [converted, title] = convertMathjax(
-        unescapeSomeEntities(mathjax),
-        $pageTheme.isDark,
-        fontSize,
-    );
+    let converted: string;
+    let title: string;
+    function convert(
+        unescapedMathjax: string,
+        isDark: boolean,
+        fontSize: number,
+    ): void {
+        convertMathjax(unescapedMathjax, isDark, fontSize).then((out) => {
+            [converted, title] = out;
+        });
+    }
+    $: convert(unescapeSomeEntities(mathjax), $pageTheme.isDark, fontSize);
     $: empty = title === "MathJax";
     $: encoded = encodeURIComponent(converted);
 

--- a/ts/editable/mathjax.ts
+++ b/ts/editable/mathjax.ts
@@ -5,6 +5,7 @@
 @typescript-eslint/no-explicit-any: "off",
  */
 
+import { cardRendering, Generic } from "../lib/proto";
 import { mathIcon } from "./icons";
 
 const parser = new DOMParser();
@@ -29,11 +30,11 @@ function getEmptyIcon(style: HTMLStyleElement): [string, string] {
     return [svg.outerHTML, "MathJax"];
 }
 
-export function convertMathjax(
+export async function convertMathjax(
     input: string,
     nightMode: boolean,
     fontSize: number,
-): [string, string] {
+): Promise<[string, string]> {
     const style = getStyle(getCSS(nightMode, fontSize));
 
     if (input.trim().length === 0) {
@@ -42,7 +43,10 @@ export function convertMathjax(
 
     let output: Element;
     try {
-        output = globalThis.MathJax.tex2svg(input);
+        const strippedInput = await cardRendering.renderClozeForMathjax(
+            Generic.String.create({ val: input }),
+        );
+        output = globalThis.MathJax.tex2svg(strippedInput.val);
     } catch (e) {
         return ["Mathjax Error", String(e)];
     }

--- a/ts/editor/ClozeButtons.svelte
+++ b/ts/editor/ClozeButtons.svelte
@@ -3,19 +3,18 @@ Copyright: Ankitects Pty Ltd and contributors
 License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 -->
 <script lang="ts">
+    import { createEventDispatcher } from "svelte";
     import { get } from "svelte/store";
 
-    import ButtonGroup from "../../components/ButtonGroup.svelte";
-    import IconButton from "../../components/IconButton.svelte";
-    import Shortcut from "../../components/Shortcut.svelte";
-    import * as tr from "../../lib/ftl";
-    import { isApplePlatform } from "../../lib/platform";
-    import { getPlatformString } from "../../lib/shortcuts";
-    import { wrapInternal } from "../../lib/wrap";
-    import { context as noteEditorContext } from "../NoteEditor.svelte";
-    import type { RichTextInputAPI } from "../rich-text-input";
-    import { editingInputIsRichText } from "../rich-text-input";
+    import ButtonGroup from "../components/ButtonGroup.svelte";
+    import IconButton from "../components/IconButton.svelte";
+    import Shortcut from "../components/Shortcut.svelte";
+    import * as tr from "../lib/ftl";
+    import { isApplePlatform } from "../lib/platform";
+    import { getPlatformString } from "../lib/shortcuts";
     import { clozeIcon, incrementClozeIcon } from "./icons";
+    import { context as noteEditorContext } from "./NoteEditor.svelte";
+    import { editingInputIsRichText } from "./rich-text-input";
 
     const { focusedInput, fields } = noteEditorContext.get();
 
@@ -48,20 +47,24 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         return Math.max(1, highest);
     }
 
-    $: richTextAPI = $focusedInput as RichTextInputAPI;
+    const dispatch = createEventDispatcher();
 
     async function onIncrementCloze(): Promise<void> {
-        const richText = await richTextAPI.element;
-
         const highestCloze = getCurrentHighestCloze(true);
-        wrapInternal(richText, `{{c${highestCloze}::`, "}}", false);
+
+        dispatch("surround", {
+            prefix: `{{c${highestCloze}::`,
+            suffix: "}}",
+        });
     }
 
     async function onSameCloze(): Promise<void> {
-        const richText = await richTextAPI.element;
-
         const highestCloze = getCurrentHighestCloze(false);
-        wrapInternal(richText, `{{c${highestCloze}::`, "}}", false);
+
+        dispatch("surround", {
+            prefix: `{{c${highestCloze}::`,
+            suffix: "}}",
+        });
     }
 
     $: disabled = !editingInputIsRichText($focusedInput);

--- a/ts/editor/editor-toolbar/EditorToolbar.svelte
+++ b/ts/editor/editor-toolbar/EditorToolbar.svelte
@@ -56,9 +56,9 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     import Item from "../../components/Item.svelte";
     import StickyContainer from "../../components/StickyContainer.svelte";
     import BlockButtons from "./BlockButtons.svelte";
-    import ClozeButtons from "./ClozeButtons.svelte";
     import InlineButtons from "./InlineButtons.svelte";
     import NotetypeButtons from "./NotetypeButtons.svelte";
+    import RichTextClozeButtons from "./RichTextClozeButtons.svelte";
     import TemplateButtons from "./TemplateButtons.svelte";
 
     export let size: number;
@@ -108,7 +108,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
             </Item>
 
             <Item id="cloze">
-                <ClozeButtons />
+                <RichTextClozeButtons />
             </Item>
         </DynamicallySlottable>
     </ButtonToolbar>

--- a/ts/editor/editor-toolbar/RichTextClozeButtons.svelte
+++ b/ts/editor/editor-toolbar/RichTextClozeButtons.svelte
@@ -1,0 +1,23 @@
+<!--
+Copyright: Ankitects Pty Ltd and contributors
+License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
+-->
+<script lang="ts">
+    import { wrapInternal } from "../../lib/wrap";
+    import ClozeButtons from "../ClozeButtons.svelte";
+    import { context as noteEditorContext } from "../NoteEditor.svelte";
+    import type { RichTextInputAPI } from "../rich-text-input";
+
+    const { focusedInput } = noteEditorContext.get();
+
+    $: richTextAPI = $focusedInput as RichTextInputAPI;
+
+    async function onSurround({ detail }): Promise<void> {
+        const richText = await richTextAPI.element;
+        const { prefix, suffix } = detail;
+
+        wrapInternal(richText, prefix, suffix, false);
+    }
+</script>
+
+<ClozeButtons on:surround={onSurround} />

--- a/ts/editor/editor-toolbar/icons.ts
+++ b/ts/editor/editor-toolbar/icons.ts
@@ -24,8 +24,6 @@ export { default as underlineIcon } from "bootstrap-icons/icons/type-underline.s
 export const arrowIcon =
     '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"><path fill="transparent" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2 5l6 6 6-6"/></svg>';
 
-export { default as incrementClozeIcon } from "../../icons/contain-plus.svg";
-export { default as clozeIcon } from "@mdi/svg/svg/contain.svg";
 export { default as functionIcon } from "@mdi/svg/svg/function-variant.svg";
 export { default as paperclipIcon } from "@mdi/svg/svg/paperclip.svg";
 export { default as micIcon } from "bootstrap-icons/icons/mic.svg";

--- a/ts/editor/editor-toolbar/index.ts
+++ b/ts/editor/editor-toolbar/index.ts
@@ -3,3 +3,4 @@
 
 export type { EditorToolbarAPI } from "./EditorToolbar.svelte";
 export { default as EditorToolbar, editorToolbar } from "./EditorToolbar.svelte";
+export { default as ClozeButtons } from "./EditorToolbar.svelte";

--- a/ts/editor/icons.ts
+++ b/ts/editor/icons.ts
@@ -3,8 +3,10 @@
 
 /// <reference types="../lib/image-import" />
 
+export { default as incrementClozeIcon } from "../icons/contain-plus.svg";
 export { default as alertIcon } from "@mdi/svg/svg/alert.svg";
 export { default as htmlOn } from "@mdi/svg/svg/code-tags.svg";
+export { default as clozeIcon } from "@mdi/svg/svg/contain.svg";
 export { default as richTextOff } from "@mdi/svg/svg/eye-off-outline.svg";
 export { default as richTextOn } from "@mdi/svg/svg/eye-outline.svg";
 export { default as stickyOff } from "@mdi/svg/svg/pin-off-outline.svg";

--- a/ts/editor/mathjax-overlay/MathjaxButtons.svelte
+++ b/ts/editor/mathjax-overlay/MathjaxButtons.svelte
@@ -10,6 +10,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     import IconButton from "../../components/IconButton.svelte";
     import { hasBlockAttribute } from "../../lib/dom";
     import * as tr from "../../lib/ftl";
+    import ClozeButtons from "../ClozeButtons.svelte";
     import { blockIcon, deleteIcon, inlineIcon } from "./icons";
 
     export let element: Element;
@@ -47,6 +48,8 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
             --border-right-radius="5px">{@html blockIcon}</IconButton
         >
     </ButtonGroup>
+
+    <ClozeButtons on:surround />
 
     <ButtonGroup>
         <IconButton

--- a/ts/editor/mathjax-overlay/MathjaxEditor.svelte
+++ b/ts/editor/mathjax-overlay/MathjaxEditor.svelte
@@ -99,6 +99,8 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     />
 </div>
 
+<slot editor={codeMirror} />
+
 <style lang="scss">
     .mathjax-editor {
         :global(.CodeMirror) {

--- a/ts/editor/mathjax-overlay/MathjaxMenu.svelte
+++ b/ts/editor/mathjax-overlay/MathjaxMenu.svelte
@@ -47,21 +47,28 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
             on:blur={() => dispatch("reset")}
             on:moveoutstart
             on:moveoutend
-        />
+            let:editor={mathjaxEditor}
+        >
+            <Shortcut
+                keyCombination={acceptShortcut}
+                on:action={() => dispatch("moveoutend")}
+            />
 
-        <Shortcut
-            keyCombination={acceptShortcut}
-            on:action={() => dispatch("moveoutend")}
-        />
+            <MathjaxButtons
+                {element}
+                on:delete={() => {
+                    placeCaretAfter(element);
+                    element.remove();
+                    dispatch("reset");
+                }}
+                on:surround={async ({ detail }) => {
+                    const editor = await mathjaxEditor.editor;
+                    const { prefix, suffix } = detail;
 
-        <MathjaxButtons
-            {element}
-            on:delete={() => {
-                placeCaretAfter(element);
-                element.remove();
-                dispatch("reset");
-            }}
-        />
+                    editor.replaceSelection(prefix + editor.getSelection() + suffix);
+                }}
+            />
+        </MathjaxEditor>
     </DropdownMenu>
 </div>
 

--- a/ts/lib/proto.ts
+++ b/ts/lib/proto.ts
@@ -10,6 +10,7 @@ import type { Message, rpc, RPCImpl, RPCImplCallback } from "protobufjs";
 import { anki } from "./backend_proto";
 
 import Cards = anki.cards;
+import CardRendering = anki.card_rendering;
 import Collection = anki.collection;
 import DeckConfig = anki.deckconfig;
 import Decks = anki.decks;
@@ -22,6 +23,13 @@ import Stats = anki.stats;
 import Tags = anki.tags;
 
 export { Cards, Collection, Decks, Generic, Notes };
+export { DeckConfig };
+export { I18n };
+export { CardRendering };
+export { Notetypes };
+export { Scheduler };
+export { Stats };
+export { Tags };
 
 export const empty = Generic.Empty.create();
 
@@ -54,22 +62,20 @@ async function serviceCallback(
     }
 }
 
-export { DeckConfig };
 export const deckConfig = DeckConfig.DeckConfigService.create(
     serviceCallback as RPCImpl,
 );
 
-export { I18n };
 export const i18n = I18n.I18nService.create(serviceCallback as RPCImpl);
 
-export { Notetypes };
+export const cardRendering = CardRendering.CardRenderingService.create(
+    serviceCallback as RPCImpl,
+);
+
 export const notetypes = Notetypes.NotetypesService.create(serviceCallback as RPCImpl);
 
-export { Scheduler };
 export const scheduler = Scheduler.SchedulerService.create(serviceCallback as RPCImpl);
 
-export { Stats };
 export const stats = Stats.StatsService.create(serviceCallback as RPCImpl);
 
-export { Tags };
 export const tags = Tags.TagsService.create(serviceCallback as RPCImpl);


### PR DESCRIPTION
This builds on #1860 

This seems to be a bit buggy at the moment:

- when switching between fields, you can briefly see a broken image icon
- when you press esc in the Add screen and get the 'are you sure?' message, the broken icon appears until you cancel - probably just because the dialog has paused the webview from updating

It was my first time using the gRPC service code you implemented - it was lovely and ergonomic :-)

The moved imports were done automatically by the VSCode extension, and not something I did deliberately. I can filter them out if you'd like, though we'll need to keep doing that when editing the file in the future.