### PR TITLE
Add some helper functions to AVPlayer

### DIFF
--- a/qt/aqt/sound.py
+++ b/qt/aqt/sound.py
@@ -149,6 +149,14 @@ class AVPlayer:
         self._enqueued = tags[:]
         self._play_next_if_idle()
 
+    def append_tags(self, tags: list[AVTag]) -> None:
+        """Append provided tags to the queue, then start playing them if the current player is idle."""
+        self._enqueued.extend(tags)
+        self._play_next_if_idle()
+
+    def queue_is_empty(self) -> bool:
+        return bool(self._enqueued)
+
     def stop_and_clear_queue(self) -> None:
         self._enqueued = []
         self._stop_if_playing()


### PR DESCRIPTION
This adds some small helper functions to AVPlayer for add-ons. I know that code not used by Anki itself tends not to be added just for the sake of add-ons, but I thought this would be an improvement over accessing protected members. My use case for append_tags is adding tags that are not available when the `av_player_will_play_tags` hook is called. Specifically, I want to use this to play sounds fetched only when the user clicks on a button, either from the user's collection or the network, but I also don't want to clear the queue. More generally, I have a [helper function](https://github.com/abdnh/anki-control-audio-playback/blob/01c8b4428b73229abf56b739ef7ec1731b932947/src/playback_controller.py#L178) in one add-on that parses sound tags, transforms them to play buttons, and appends the tags to the queue. I plan to generalize this to make it support more fancy things like custom buttons that otherwise behave like standard buttons and play nicely with standard shortcuts to control audio.
