### PR TITLE
Allow style tags in HTML editor

### DIFF
--- a/ts/editor/plain-text-input/remove-prohibited.ts
+++ b/ts/editor/plain-text-input/remove-prohibited.ts
@@ -11,7 +11,7 @@ function removeTag(element: HTMLElement, tagName: string): void {
     }
 }
 
-const prohibitedTags = ["script", "link", "style"];
+const prohibitedTags = ["script", "link"];
 
 /**
  * The use cases for using those tags in the field html are slim to none.


### PR DESCRIPTION
Motivated by [this post](https://forums.ankiweb.net/t/revert-style-stripping-in-html-editor/19966/4)

The reason I stripped the style tags was because I don't think they would be compatible with card-preloading. But that was probably a bad decision and a case of premature optimization...