### PR TITLE
Add the reviewer_will_replay_recording hook

### DIFF
--- a/qt/aqt/reviewer.py
+++ b/qt/aqt/reviewer.py
@@ -1095,6 +1095,9 @@ time = %(time)d;
         record_audio(self.mw, self.mw, False, after_record)
 
     def onReplayRecorded(self) -> None:
+        self._recordedAudio = gui_hooks.reviewer_will_replay_recording(
+            self._recordedAudio
+        )
         if not self._recordedAudio:
             tooltip(tr.studying_you_havent_recorded_your_voice_yet())
             return

--- a/qt/tools/genhooks_gui.py
+++ b/qt/tools/genhooks_gui.py
@@ -164,6 +164,12 @@ hooks = [
         option is unchecked; This is so as to allow playing custom
         sounds regardless of that option.""",
     ),
+    Hook(
+        name="reviewer_will_replay_recording",
+        args=["path: str"],
+        return_type="str",
+        doc="""Used to inspect and modify a recording recorded by "Record Own Voice" before replaying.""",
+    ),
     # Debug
     ###################
     Hook(


### PR DESCRIPTION
This adds the reviewer_will_replay_recording hook to inspect and modify recordings recorded by "Record Own Voice".

I want to use this in [Record Own Voice History](https://ankiweb.net/shared/info/1508039970) in the following way to reduce monkey-patching a bit:

```python
def on_replay_recording(path: str) -> str:
    if not path:
        path = get_most_recent_recording(mw.reviewer.card.id)
    return path


gui_hooks.reviewer_will_replay_recording.append(on_replay_recording)
```