### PR TITLE
Add getNoteId to exports

### DIFF
--- a/ts/editor/NoteEditor.svelte
+++ b/ts/editor/NoteEditor.svelte
@@ -245,6 +245,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
             setClozeHint,
             saveNow: saveFieldNow,
             focusIfField,
+            getNoteId,
             setNoteId,
             wrap,
             ...oldEditorAdapter,


### PR DESCRIPTION
I'm currently updating my Closet add-on to work with current versions, which is where I noticed this oversight. It would be nice if this could make it into 2.1.53.