### PR TITLE
workaround on the ibus first character issue

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -100,6 +100,7 @@ Bruce Harris <github.com/bruceharris>
 Patric Cunha <patricc@agap2.pt>
 Brayan Oliveira <github.com/BrayanDSO>
 Luka Warren <github.com/lukawarren>
+wisherhxl <wisherhxl@gmail.com>
 
 ********************
 

--- a/ts/editor/rich-text-input/RichTextInput.svelte
+++ b/ts/editor/rich-text-input/RichTextInput.svelte
@@ -72,7 +72,9 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
     async function moveCaretToEnd(): Promise<void> {
         const richText = await richTextPromise;
-        placeCaretAfterContent(richText);
+        if (richText.innerHTML === "") {
+            placeCaretAfterContent(richText);
+        }
     }
 
     async function focus(): Promise<void> {


### PR DESCRIPTION
I'm using ibus with candidate characters, when adding cards, the first keystroke goes double. For example, if I type "a" it becomes "aa".

`placeCaretAfterContent(richText);` When `richText` is empty will cause this problem when adding cards.

Since when it is empty, there is no need to place the caret. I think add a check can solve this problem.