### PR TITLE
workaround on ibus first character twice issue

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -100,6 +100,7 @@ Bruce Harris <github.com/bruceharris>
 Patric Cunha <patricc@agap2.pt>
 Brayan Oliveira <github.com/BrayanDSO>
 Luka Warren <github.com/lukawarren>
+wisherhxl <wisherhxl@gmail.com>
 
 ********************
 

--- a/ts/editor/rich-text-input/RichTextInput.svelte
+++ b/ts/editor/rich-text-input/RichTextInput.svelte
@@ -72,6 +72,14 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
     async function moveCaretToEnd(): Promise<void> {
         const richText = await richTextPromise;
+        if (richText.textContent?.length === 0) {
+            // Calling this method when richText is empty will cause the first keystroke of
+            // ibus-based input methods with candidates to go double. For example, if you
+            // type "a" it becomes "aa". This problem exists in many linux distributions.
+            // When richText is empty, there is no need to place the caret, just return.
+            return;
+        }
+
         placeCaretAfterContent(richText);
     }
 


### PR DESCRIPTION
I'm using ibus-rime which has candidate characters, when adding cards, the first keystroke goes double. For example, if I type "a" it becomes "aa".

This problem exists in many Linux operating systems, I've checked in Ubuntu 22.0, Arch Linux, with multiple Anki versions.

call `placeCaretAfterContent(richText);` When `richText` is empty will cause this problem, I found it when adding cards.

Since when `richText` it is empty, there is no need to place the caret, I add the check as a workaround.