### PR TITLE
Add TTS flag `skip_parenthesis`

### DIFF
--- a/rslib/src/card_rendering/mod.rs
+++ b/rslib/src/card_rendering/mod.rs
@@ -72,6 +72,7 @@ struct TtsDirective<'a> {
     voices: Vec<&'a str>,
     speed: f32,
     blank: Option<&'a str>,
+    skip_parenthesis: bool,
     options: HashMap<&'a str, &'a str>,
 }
 
@@ -113,7 +114,11 @@ mod test {
     fn av_extracting() {
         let tr = I18n::template_only();
         let (txt, tags) = extract_av_tags(
-            "foo [sound:bar.mp3] baz [anki:tts lang=en_US][...][/anki:tts]",
+            concat!(
+                "foo [sound:bar.mp3] baz ",
+                "[anki:tts lang=en_US skip_parenthesis=true cloze_blank=bar]",
+                "(foo)[...][/anki:tts]"
+            ),
             true,
             &tr,
         );
@@ -127,7 +132,7 @@ mod test {
                     },
                     pb::AvTag {
                         value: Some(pb::av_tag::Value::Tts(pb::TtsTag {
-                            field_text: tr.card_templates_blank().to_string(),
+                            field_text: String::from("bar"),
                             lang: "en_US".to_string(),
                             voices: vec![],
                             speed: 1.0,

--- a/rslib/src/card_rendering/parser.rs
+++ b/rslib/src/card_rendering/parser.rs
@@ -36,6 +36,7 @@ impl<'a> Directive<'a> {
                 let mut voices = vec![];
                 let mut speed = 1.0;
                 let mut blank = None;
+                let mut skip_parenthesis = false;
                 let mut other_options = HashMap::new();
 
                 for option in options {
@@ -44,6 +45,9 @@ impl<'a> Directive<'a> {
                         "voices" => voices = option.1.split(',').collect(),
                         "speed" => speed = option.1.parse().unwrap_or(1.0),
                         "cloze_blank" => blank = Some(option.1),
+                        "skip_parenthesis" => {
+                            skip_parenthesis = option.1.parse().unwrap_or_default()
+                        }
                         _ => {
                             other_options.insert(option.0, option.1);
                         }
@@ -56,6 +60,7 @@ impl<'a> Directive<'a> {
                     voices,
                     speed,
                     blank,
+                    skip_parenthesis,
                     options: other_options,
                 })
             }
@@ -235,13 +240,16 @@ mod test {
 
         // tts tags
         assert_parsed_nodes!(
-            "[anki:tts lang=jp_JP voices=Alice,Bob speed=0.5 cloze_blank= bar=baz][/anki:tts]",
+            concat!(
+            "[anki:tts lang=jp_JP voices=Alice,Bob speed=0.5 cloze_blank= skip_parenthesis=true ",
+            "bar=baz][/anki:tts]"),
             Directive(super::Directive::Tts(TtsDirective {
                 content: "",
                 lang: "jp_JP",
                 voices: vec!["Alice", "Bob"],
                 speed: 0.5,
                 blank: Some(""),
+                skip_parenthesis: true,
                 options: [("bar", "baz")].into_iter().collect(),
             }))
         );
@@ -253,6 +261,7 @@ mod test {
                 voices: vec![],
                 speed: 1.0,
                 blank: None,
+                skip_parenthesis: false,
                 options: HashMap::new(),
             }))
         );


### PR DESCRIPTION
https://forums.ankiweb.net/t/modify-string-before-tts-reads-the-field-advanced/20075/

Arbitrary replacements (with regex I presume) would require some work, because the parser would need to be taught escaping. But even if it was implemented, this use case seems common enough to support a simpler solution.