### PR TITLE
Add the media_check_did_finish hook

### DIFF
--- a/qt/aqt/mediacheck.py
+++ b/qt/aqt/mediacheck.py
@@ -13,6 +13,7 @@ import aqt.progress
 from anki.collection import Collection, SearchNode
 from anki.errors import Interrupted
 from anki.media import CheckMediaResponse
+from aqt import gui_hooks
 from aqt.operations import QueryOp
 from aqt.qt import *
 from aqt.utils import (
@@ -96,6 +97,7 @@ class MediaChecker:
             return
 
         output: CheckMediaResponse = future.result()
+        gui_hooks.media_check_did_finish(output)
         report = output.report
 
         # show report and offer to delete

--- a/qt/tools/genhooks_gui.py
+++ b/qt/tools/genhooks_gui.py
@@ -762,6 +762,13 @@ gui_hooks.webview_did_inject_style_into_page.append(mytest)
         Note that the media sync did not necessarily finish at this point.""",
     ),
     Hook(name="media_check_will_start", args=[]),
+    Hook(
+        name="media_check_did_finish",
+        args=["output: anki.media.CheckMediaResponse"],
+        doc="""Called after Media Check finishes.
+
+        `output` provides access to the unused/missing file lists and the text output that will be shown in the Check Media screen.""",
+    ),
     # Dialog Manager
     ###################
     Hook(


### PR DESCRIPTION
This adds the media_check_did_finish hook.
I was updating the [Add a tag to notes with missing media](https://ankiweb.net/shared/info/2027876532) add-on to work on Anki 2.1.49+ and felt the need for such a hook. Currently, I'm [patching `MediaChecker.check`](https://github.com/abdnh/anki-tag-missing-medias/blob/1180998bd14945b55a6b8652d22a6f1de3b5f249/__init__.py#L35).
Note that this is called before the Check Media screen is shown to allow add-ons to change the output (I don't need this in the aforementioned add-on, though).