### PR TITLE
rust impl stdError trait

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -101,6 +101,7 @@ Patric Cunha <patricc@agap2.pt>
 Brayan Oliveira <github.com/BrayanDSO>
 Luka Warren <github.com/lukawarren>
 wisherhxl <wisherhxl@gmail.com>
+dobefore <1432338032@qq.com>
 
 ********************
 

--- a/rslib/src/error/mod.rs
+++ b/rslib/src/error/mod.rs
@@ -50,6 +50,8 @@ pub enum AnkiError {
     CustomStudyError(CustomStudyError),
     ImportError(ImportError),
 }
+//fix: doesn't satisfy `AnkiError: StdError` when using crate thiserror
+impl std::error::Error for AnkiError {}
 
 impl Display for AnkiError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/rslib/src/error/mod.rs
+++ b/rslib/src/error/mod.rs
@@ -50,7 +50,7 @@ pub enum AnkiError {
     CustomStudyError(CustomStudyError),
     ImportError(ImportError),
 }
-//fix: doesn't satisfy `AnkiError: StdError` when using crate thiserror
+
 impl std::error::Error for AnkiError {}
 
 impl Display for AnkiError {


### PR DESCRIPTION
get AbkiError as from error using crate `thiserror`,error appears
```
#[derive(Error, Debug)]
pub enum ApplicationError {
  #[error("Anki lib error: {0}")]
    AnkiError(#[from] anki::error::AnkiError ),
}
```
```
doesn't satisfy `AnkiError: StdError`
```

this is a rather simple fix.

orginal forum post https://forums.ankiweb.net/t/rust-error-handle-get-ankierror-as-a-from-error/16703