### PR TITLE
add addons_dialog_will_toggle_enable_addons hook

### DIFF
--- a/qt/aqt/addons.py
+++ b/qt/aqt/addons.py
@@ -874,8 +874,12 @@ class AddonsDialog(QDialog):
         return self.addons[idxs[0]]
 
     def onToggleEnabled(self) -> None:
-        for module in self.selectedAddons():
+        selected = self.selectedAddons()
+        gui_hooks.addons_dialog_will_toggle_enable_addons(self, selected)
+        for module in selected:
             self.mgr.toggleEnabled(module)
+        if not selected:
+            return
         self._require_restart = True
         self.redrawAddons()
 

--- a/qt/tools/genhooks_gui.py
+++ b/qt/tools/genhooks_gui.py
@@ -1004,6 +1004,11 @@ gui_hooks.webview_did_inject_style_into_page.append(mytest)
         args=["dialog: aqt.addons.AddonsDialog", "ids: list[str]"],
         doc="""Allows doing an action before an add-on is deleted.""",
     ),
+    Hook(
+        name="addons_dialog_will_toggle_enable_addons",
+        args=["dialog: aqt.addons.AddonsDialog", "ids: list[str]"],
+        doc="""Allows doing an action before an add-on is enabled/disabled""",
+    ),
     # Model
     ###################
     Hook(


### PR DESCRIPTION
This adds `addons_dialog_will_toggle_enable_addons` hook.

I'm developing an add-on that adds functionality to note types, and I'd like to use this hook to remove the script from note types when the add-on is disabled.