### PR TITLE
Update get_linux_dark_mode to use freedesktop.org standard

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -102,7 +102,7 @@ Brayan Oliveira <github.com/BrayanDSO>
 Luka Warren <github.com/lukawarren>
 wisherhxl <wisherhxl@gmail.com>
 dobefore <1432338032@qq.com>
-Bart Louwers <bart.git@emeel.net>
+Bart Louwers <bart.git@emeel.net> 
 
 ********************
 

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -102,6 +102,7 @@ Brayan Oliveira <github.com/BrayanDSO>
 Luka Warren <github.com/lukawarren>
 wisherhxl <wisherhxl@gmail.com>
 dobefore <1432338032@qq.com>
+Bart Louwers <bart.git@emeel.net>
 
 ********************
 

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -102,7 +102,7 @@ Brayan Oliveira <github.com/BrayanDSO>
 Luka Warren <github.com/lukawarren>
 wisherhxl <wisherhxl@gmail.com>
 dobefore <1432338032@qq.com>
-Bart Louwers <bart.git@emeel.net> 
+Bart Louwers <bart.git@emeel.net>
 
 ********************
 

--- a/qt/aqt/theme.py
+++ b/qt/aqt/theme.py
@@ -360,10 +360,10 @@ def get_linux_dark_mode() -> bool:
         return False
     try:
         process = subprocess.run(
-                "dbus-send --session --print-reply=literal --reply-timeout=1000 " \
-                "--dest=org.freedesktop.portal.Desktop /org/freedesktop/portal/desktop " \
-                "org.freedesktop.portal.Settings.Read string:'org.freedesktop.appearance' " \
-                "string:'color-scheme'",
+            "dbus-send --session --print-reply=literal --reply-timeout=1000 "
+            "--dest=org.freedesktop.portal.Desktop /org/freedesktop/portal/desktop "
+            "org.freedesktop.portal.Settings.Read string:'org.freedesktop.appearance' "
+            "string:'color-scheme'",
             shell=True,
             check=True,
             capture_output=True,
@@ -384,7 +384,7 @@ def get_linux_dark_mode() -> bool:
         return False
 
     # https://github.com/flatpak/xdg-desktop-portal/blob/main/data/org.freedesktop.impl.portal.Settings.xml#L40
-    PREFER_DARK = '1'
+    PREFER_DARK = "1"
 
     return response[-1] == PREFER_DARK
 

--- a/qt/aqt/theme.py
+++ b/qt/aqt/theme.py
@@ -356,7 +356,8 @@ def get_macos_dark_mode() -> bool:
 def get_linux_dark_mode() -> bool:
     """True if Linux system is in dark mode.
     Only works if D-Bus is installed and system uses org.freedesktop.appearance
-    color-scheme to indicate dark mode preference."""
+    color-scheme to indicate dark mode preference OR if GNOME theme has
+    '-dark' in the name."""
     if not is_lin:
         return False
 

--- a/qt/aqt/theme.py
+++ b/qt/aqt/theme.py
@@ -360,7 +360,7 @@ def get_linux_dark_mode() -> bool:
     if not is_lin:
         return False
 
-    def parse_stdout_dbus_send(stdout: string) -> bool:
+    def parse_stdout_dbus_send(stdout: str) -> bool:
         dbus_response = stdout.split()
         if len(dbus_response) != 4:
             return False


### PR DESCRIPTION
Fixes #1903

Instead of relying on unreliable GNOME-specific dark mode detection (that does not work anymore in the most recent version of GNOME), use freedesktop.org standard (see link in comments in code).