### PR TITLE
Fix JS drop event not firing in the reviewer

### DIFF
--- a/qt/aqt/browser/previewer.py
+++ b/qt/aqt/browser/previewer.py
@@ -132,6 +132,7 @@ class Previewer(QDialog):
             ],
             context=self,
         )
+        self._web.allow_drops = True
         self._web.set_bridge_command(self._on_bridge_cmd, self)
 
     def _on_bridge_cmd(self, cmd: str) -> Any:

--- a/qt/aqt/browser/previewer.py
+++ b/qt/aqt/browser/previewer.py
@@ -133,6 +133,7 @@ class Previewer(QDialog):
             context=self,
         )
         self._web.allow_drops = True
+        self._web.eval("_blockDefaultDragDropBehavior();")
         self._web.set_bridge_command(self._on_bridge_cmd, self)
 
     def _on_bridge_cmd(self, cmd: str) -> Any:

--- a/qt/aqt/clayout.py
+++ b/qt/aqt/clayout.py
@@ -356,6 +356,7 @@ class CardLayout(QDialog):
             context=self,
         )
         self.preview_web.allow_drops = True
+        self.preview_web.eval("_blockDefaultDragDropBehavior();")
         self.preview_web.set_bridge_command(self._on_bridge_cmd, self)
 
         if self._isCloze():

--- a/qt/aqt/clayout.py
+++ b/qt/aqt/clayout.py
@@ -355,6 +355,7 @@ class CardLayout(QDialog):
             ],
             context=self,
         )
+        self.preview_web.allow_drops = True
         self.preview_web.set_bridge_command(self._on_bridge_cmd, self)
 
         if self._isCloze():

--- a/qt/aqt/reviewer.py
+++ b/qt/aqt/reviewer.py
@@ -313,6 +313,7 @@ class Reviewer:
             ],
             context=self,
         )
+        self.web.allow_drops = True
         # show answer / ease buttons
         self.bottom.web.show()
         self.bottom.web.stdHtml(

--- a/qt/aqt/reviewer.py
+++ b/qt/aqt/reviewer.py
@@ -313,7 +313,9 @@ class Reviewer:
             ],
             context=self,
         )
+        # block default drag & drop behavior while allowing drop events to be received by JS handlers
         self.web.allow_drops = True
+        self.web.eval("_blockDefaultDragDropBehavior();")
         # show answer / ease buttons
         self.bottom.web.show()
         self.bottom.web.stdHtml(

--- a/qt/aqt/toolbar.py
+++ b/qt/aqt/toolbar.py
@@ -47,7 +47,7 @@ class Toolbar:
         self.web.stdHtml(
             self._body % self._centerLinks(),
             css=["css/toolbar.css"],
-            js=["js/webview.js", "js/vendor/jquery.min.js", "js/toolbar.js"],
+            js=["js/vendor/jquery.min.js", "js/toolbar.js"],
             context=web_context,
         )
         self.web.adjustHeightToFit()

--- a/qt/aqt/webview.py
+++ b/qt/aqt/webview.py
@@ -222,6 +222,8 @@ class WebContent:
 
 
 class AnkiWebView(QWebEngineView):
+    allow_drops = False
+
     def __init__(
         self,
         parent: Optional[QWidget] = None,
@@ -245,7 +247,6 @@ class AnkiWebView(QWebEngineView):
         self._disable_zoom = False
 
         self.resetHandlers()
-        self.allow_drops = False
         self._filterSet = False
         QShortcut(  # type: ignore
             QKeySequence("Esc"),

--- a/qt/aqt/webview.py
+++ b/qt/aqt/webview.py
@@ -245,6 +245,7 @@ class AnkiWebView(QWebEngineView):
         self._disable_zoom = False
 
         self.resetHandlers()
+        self.allow_drops = False
         self._filterSet = False
         QShortcut(  # type: ignore
             QKeySequence("Esc"),
@@ -322,7 +323,8 @@ class AnkiWebView(QWebEngineView):
         m.popup(QCursor.pos())
 
     def dropEvent(self, evt: QDropEvent) -> None:
-        pass
+        if self.allow_drops:
+            super().dropEvent(evt)
 
     def setHtml(self, html: str) -> None:  #  type: ignore
         # discard any previous pending actions
@@ -331,6 +333,7 @@ class AnkiWebView(QWebEngineView):
         self._queueAction("setHtml", html)
         self.set_open_links_externally(True)
         self.setZoomFactor(1)
+        self.allow_drops = False
         self.show()
 
     def _setHtml(self, html: str) -> None:
@@ -357,6 +360,7 @@ class AnkiWebView(QWebEngineView):
     def load_url(self, url: QUrl) -> None:
         # allow queuing actions when loading url directly
         self._domDone = False
+        self.allow_drops = False
         super().load(url)
 
     def app_zoom_factor(self) -> float:

--- a/ts/reviewer/index.ts
+++ b/ts/reviewer/index.ts
@@ -227,3 +227,13 @@ export function _typeAnsPress(): void {
 export function _emulateMobile(enabled: boolean): void {
     document.documentElement.classList.toggle("mobile", enabled);
 }
+
+// Block Qt's default drag & drop behavior by default
+export function _blockDefaultDragDropBehavior(): void {
+    function handler(evt: DragEvent) {
+        evt.preventDefault();
+    }
+    document.ondragenter = handler;
+    document.ondragover = handler;
+    document.ondrop = handler;
+}


### PR DESCRIPTION
I noted in #1562 that the `drop` event is not firing in JS. I recently revisited the issue because I needed drag & drop to work on a template I'm designing. It turned out the issue is caused by `AnkiWebView.dropEvent`. I vaguely remember testing if removing it fixes the issue previously, but maybe I didn't...

You can confirm this works by trying the code you posted in the previous PR. I'm not sure if this will have unintended effects on other screens, but I didn't notice any issues after some brief testing. These two lines are too ancient that I had to work on my git-blame skills to find when they were originally introduced: they were [added in 2008](https://github.com/ankitects/anki/commit/7391cef4f2).
