### PR TITLE
Fix field description not toggled properly

### DIFF
--- a/ts/editable/ContentEditable.svelte
+++ b/ts/editable/ContentEditable.svelte
@@ -39,14 +39,12 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     const description = getContext<Readable<string>>(descriptionKey);
     $: descriptionCSSValue = `"${$description}"`;
 
-    let innerHTML = "";
-    $: empty = ["", "<br>"].includes(innerHTML);
+    export let content: Writable<string>;
 </script>
 
 <anki-editable
-    class:empty
+    class:empty={!$content}
     contenteditable="true"
-    bind:innerHTML
     use:resolve
     use:setupFocusHandling
     use:preventBuiltinShortcuts

--- a/ts/editor/rich-text-input/RichTextInput.svelte
+++ b/ts/editor/rich-text-input/RichTextInput.svelte
@@ -148,6 +148,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
                     mirrors: [mirror],
                     inputHandlers: [setupInputHandler, setupGlobalInputHandler],
                     api: api.editable,
+                    content,
                 },
                 context: allContexts,
             });


### PR DESCRIPTION
Follow-up to #1912 

### Issue
The field description is not properly toggled in the following cases:
1. when opening a *Browser* or *Edlit Current*, as mentioned in #1912
2. when editing HTML in the HTML editor.

### Proposed solution
This PR fixes the issue by toggling the `empty` class according to changes in the value of the  `content` store.