### PR TITLE
Fix field description

### DIFF
--- a/ts/editable/ContentEditable.svelte
+++ b/ts/editable/ContentEditable.svelte
@@ -7,11 +7,9 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 </script>
 
 <script lang="ts">
-    import { getContext } from "svelte";
-    import type { Readable, Writable } from "svelte/store";
+    import type { Writable } from "svelte/store";
 
     import { updateAllState } from "../components/WithState.svelte";
-    import { descriptionKey } from "../lib/context-keys";
     import actionList from "../sveltelib/action-list";
     import type { MirrorAction } from "../sveltelib/dom-mirror";
     import type { SetupInputHandlerAction } from "../sveltelib/input-handler";
@@ -35,15 +33,9 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     const [focusHandler, setupFocusHandling] = useFocusHandler();
 
     Object.assign(api, { focusHandler });
-
-    const description = getContext<Readable<string>>(descriptionKey);
-    $: descriptionCSSValue = `"${$description}"`;
-
-    export let content: string;
 </script>
 
 <anki-editable
-    class:empty={!content}
     contenteditable="true"
     use:resolve
     use:setupFocusHandling
@@ -54,7 +46,6 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     on:blur
     on:click={updateAllState}
     on:keyup={updateAllState}
-    style="--description: {descriptionCSSValue}"
 />
 
 <style lang="scss">
@@ -69,17 +60,6 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
         &:focus {
             outline: none;
-        }
-        &.empty::before {
-            content: var(--description);
-            opacity: 0.4;
-            cursor: text;
-            /* stay on single line */
-            position: absolute;
-            max-width: 95%;
-            overflow-x: hidden;
-            white-space: nowrap;
-            text-overflow: ellipsis;
         }
     }
 

--- a/ts/editable/ContentEditable.svelte
+++ b/ts/editable/ContentEditable.svelte
@@ -52,7 +52,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     anki-editable {
         display: block;
         position: relative;
-        padding: 6px;
+
         overflow: auto;
         overflow-wrap: anywhere;
         /* fallback for iOS */

--- a/ts/editor/rich-text-input/RichTextInput.svelte
+++ b/ts/editor/rich-text-input/RichTextInput.svelte
@@ -248,7 +248,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
     .rich-text-placeholder {
         position: absolute;
-        color: var(--slightly-grey-text);
+        color: var(--disabled);
 
         /* Adopts same size as the content editable element */
         width: 100%;

--- a/ts/editor/rich-text-input/RichTextInput.svelte
+++ b/ts/editor/rich-text-input/RichTextInput.svelte
@@ -160,7 +160,6 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
                     mirrors: [mirror],
                     inputHandlers: [setupInputHandler, setupGlobalInputHandler],
                     api: api.editable,
-                    content: $content,
                 },
                 context: allContexts,
             });

--- a/ts/editor/rich-text-input/RichTextInput.svelte
+++ b/ts/editor/rich-text-input/RichTextInput.svelte
@@ -215,7 +215,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
             style:font-size={$fontSize + "px"}
             style:direction={$direction}
         >
-            {@html $description}
+            {$description}
         </div>
     {/if}
 

--- a/ts/editor/rich-text-input/RichTextInput.svelte
+++ b/ts/editor/rich-text-input/RichTextInput.svelte
@@ -52,17 +52,17 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
     import { placeCaretAfterContent } from "../../domlib/place-caret";
     import ContentEditable from "../../editable/ContentEditable.svelte";
-    import { promiseWithResolver } from "../../lib/promise";
-    import { singleCallback } from "../../lib/typing";
-    import useDOMMirror from "../../sveltelib/dom-mirror";
-    import useInputHandler from "../../sveltelib/input-handler";
-    import { pageTheme } from "../../sveltelib/theme";
     import {
         descriptionKey,
         directionKey,
         fontFamilyKey,
         fontSizeKey,
     } from "../../lib/context-keys";
+    import { promiseWithResolver } from "../../lib/promise";
+    import { singleCallback } from "../../lib/typing";
+    import useDOMMirror from "../../sveltelib/dom-mirror";
+    import useInputHandler from "../../sveltelib/input-handler";
+    import { pageTheme } from "../../sveltelib/theme";
     import { context as editingAreaContext } from "../EditingArea.svelte";
     import { context as noteEditorContext } from "../NoteEditor.svelte";
     import getNormalizingNodeStore from "./normalizing-node-store";

--- a/ts/editor/rich-text-input/RichTextInput.svelte
+++ b/ts/editor/rich-text-input/RichTextInput.svelte
@@ -201,7 +201,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     setupLifecycleHooks(api);
 </script>
 
-<div class="rich-text-input" on:focusin={setFocus}>
+<div class="rich-text-input" on:focusin={setFocus} {hidden}>
     {#if $content.length === 0}
         <div
             class="rich-text-placeholder"
@@ -225,7 +225,6 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         <div
             bind:this={richTextDiv}
             class={className}
-            class:hidden
             class:night-mode={$pageTheme.isDark}
             use:attachShadow
             use:attachStyles
@@ -252,12 +251,8 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         position: absolute;
         color: var(--slightly-grey-text);
 
-        /* Adopts same size as the editable element */
+        /* Adopts same size as the content editable element */
         width: 100%;
         height: 100%;
-    }
-
-    .hidden {
-        display: none;
     }
 </style>

--- a/ts/editor/rich-text-input/RichTextInput.svelte
+++ b/ts/editor/rich-text-input/RichTextInput.svelte
@@ -172,19 +172,13 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         $editingInputs = $editingInputs;
     }
 
-    let hasFocus = false;
-
     function setFocus(): void {
         $focusedInput = api;
-        hasFocus = true;
-    }
 
-    function removeFocus(): void {
         // We do not unset focusedInput here.
         // If we did, UI components for the input would react the store
         // being unset, even though most likely it will be set to some other
         // field right away.
-        hasFocus = false;
     }
 
     $: pushUpdate(!hidden);
@@ -207,8 +201,8 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     setupLifecycleHooks(api);
 </script>
 
-<div class="rich-text-input" on:focusin={setFocus} on:focusout={removeFocus}>
-    {#if $content.length === 0 && !hasFocus}
+<div class="rich-text-input" on:focusin={setFocus}>
+    {#if $content.length === 0}
         <div
             class="rich-text-placeholder"
             style:font-family={$fontFamily}

--- a/ts/editor/rich-text-input/RichTextStyles.svelte
+++ b/ts/editor/rich-text-input/RichTextStyles.svelte
@@ -3,10 +3,6 @@ Copyright: Ankitects Pty Ltd and contributors
 License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 -->
 <script lang="ts">
-    import { getContext } from "svelte";
-    import type { Readable } from "svelte/store";
-
-    import { directionKey, fontFamilyKey, fontSizeKey } from "../../lib/context-keys";
     import { promiseWithResolver } from "../../lib/promise";
     import type { StyleLinkType, StyleObject } from "./CustomStyles.svelte";
     import CustomStyles from "./CustomStyles.svelte";
@@ -25,9 +21,9 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     });
 
     export let color: string;
-    const fontFamily = getContext<Readable<string>>(fontFamilyKey);
-    const fontSize = getContext<Readable<number>>(fontSizeKey);
-    const direction = getContext<Readable<"ltr" | "rtl">>(directionKey);
+    export let fontFamily: string;
+    export let fontSize: number;
+    export let direction: "ltr" | "rtl";
 
     async function setStyling(property: string, value: unknown): Promise<void> {
         const rule = await userBaseRule;
@@ -35,9 +31,9 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     }
 
     $: setStyling("color", color);
-    $: setStyling("fontFamily", $fontFamily);
-    $: setStyling("fontSize", $fontSize + "px");
-    $: setStyling("direction", $direction);
+    $: setStyling("fontFamily", fontFamily);
+    $: setStyling("fontSize", fontSize + "px");
+    $: setStyling("direction", direction);
 
     const styles = [
         {


### PR DESCRIPTION
This is my solution :)

However there's one minor thing to keep in mind: Once we allow for e.g. all inputs to be collapsed by default, or have the HTML editor uncollapsed instead of the visual editor, the description will not be visible.

Fixes regressions introduced by #1912 and #1919