### PR TITLE
Check ids when gathering data

### DIFF
--- a/ftl/core/errors.ftl
+++ b/ftl/core/errors.ftl
@@ -11,6 +11,7 @@ errors-multiple-notetypes-selected = Please select notes from only one notetype.
 errors-please-check-database = Please use the Check Database action, then try again.
 errors-please-check-media = Please use the Check Media action, then try again.
 errors-collection-too-new = This collection requires a newer version of Anki to open.
+errors-invalid-ids = This deck contains timestamps in the future. Please contact the deck author and ask them to fix the issue.
 
 ## Card Rendering
 

--- a/rslib/src/backend/error.rs
+++ b/rslib/src/backend/error.rs
@@ -39,6 +39,7 @@ impl AnkiError {
             AnkiError::ImportError(_) => Kind::ImportError,
             AnkiError::FileIoError(_) => Kind::IoError,
             AnkiError::MediaCheckRequired => Kind::InvalidInput,
+            AnkiError::InvalidId => Kind::InvalidInput,
         };
 
         pb::BackendError {

--- a/rslib/src/error/mod.rs
+++ b/rslib/src/error/mod.rs
@@ -49,6 +49,7 @@ pub enum AnkiError {
     MediaCheckRequired,
     CustomStudyError(CustomStudyError),
     ImportError(ImportError),
+    InvalidId,
 }
 
 impl std::error::Error for AnkiError {}
@@ -105,6 +106,7 @@ impl AnkiError {
             AnkiError::CustomStudyError(err) => err.localized_description(tr),
             AnkiError::ImportError(err) => err.localized_description(tr),
             AnkiError::Deleted => tr.browsing_row_deleted().into(),
+            AnkiError::InvalidId => tr.errors_invalid_ids().into(),
             AnkiError::IoError(_)
             | AnkiError::JsonError(_)
             | AnkiError::ProtoError(_)


### PR DESCRIPTION
I reasoned we can just as well throw an error on export, too, as an unimportable apkg is useless.
You suggested mentioning some add-on, but I think there's only one for fixing card ids. If you think the current message isn't helpful enough, maybe we can add a help page instead?