### PR TITLE
Fix Study Deck in Sway spawning tiled window instead of floating window

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -75,6 +75,7 @@ Meredith Derecho <meredithderecho@gmail.com>
 Daniel Wallgren <github.com/wallgrenen>
 Kerrick Staley <kerrick@kerrickstaley.com>
 Maksim Abramchuk <maximabramchuck@gmail.com>
+Mateus Etto <mateus.etto@gmail.com>
 Benjamin Kulnik <benjamin.kulnik@student.tuwien.ac.at>
 Shaun Ren <shaun.ren@linux.com>
 Ryan Greenblatt <greenblattryan@gmail.com>

--- a/qt/aqt/main.py
+++ b/qt/aqt/main.py
@@ -1532,7 +1532,11 @@ title="{}" {}>{}</button>""".format(
             ).run_in_background()
 
         StudyDeck(
-            self, parent=self, dyn=True, current=self.col.decks.current()["name"], callback=callback
+            self,
+            parent=self,
+            dyn=True,
+            current=self.col.decks.current()["name"],
+            callback=callback,
         )
 
     def onEmptyCards(self) -> None:

--- a/qt/aqt/main.py
+++ b/qt/aqt/main.py
@@ -1532,7 +1532,7 @@ title="{}" {}>{}</button>""".format(
             ).run_in_background()
 
         StudyDeck(
-            self, dyn=True, current=self.col.decks.current()["name"], callback=callback
+            self, parent=self, dyn=True, current=self.col.decks.current()["name"], callback=callback
         )
 
     def onEmptyCards(self) -> None:


### PR DESCRIPTION
In Sway (a tiling wayland compositor), if creating a `QDialog` without a parent widget, a new tiled window is created instead of a floating window. Probably because Sway is picky about the window properties or whatever.

I had the [same problem in my add-on](https://github.com/Yutsuten/anki-lifedrain/pull/127), and fixed it by passing the `mw` variable to `QDialog`. And to fix this Study Deck window issue I did the same thing.

By the way the Study Deck window is that window that pops up when you press the `/` shortcut anywhere.

Hope this can be merged upstream, this bug was annoying me for a while. Thanks!