### PR TITLE
fixed hook description (browser_will_search)

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -104,6 +104,7 @@ Luka Warren <github.com/lukawarren>
 wisherhxl <wisherhxl@gmail.com>
 dobefore <1432338032@qq.com>
 Bart Louwers <bart.git@emeel.net>
+Sam Penny <github.com/sam1penny>
 
 ********************
 

--- a/qt/tools/genhooks_gui.py
+++ b/qt/tools/genhooks_gui.py
@@ -430,11 +430,14 @@ hooks = [
          You can modify context.search to change the text that is sent to the
          searching backend.
          
-         If you set context.card_ids to a list of ids, the regular search will
+         If you set context.ids to a list of ids, the regular search will
          not be performed, and the provided ids will be used instead.
          
-         Your add-on should check if context.card_ids is not None, and return
+         Your add-on should check if context.ids is not None, and return
          without making changes if it has been set.
+
+         In versions of Anki lower than 2.1.45 the field to check is
+         context.card_ids rather than context.ids
          """,
     ),
     Hook(


### PR DESCRIPTION
In the update to Anki 2.1.45, a field of aqt.browser.table.SearchContext was changed from card_ids -> ids, the hook description was not changed. This PR updates the description and adds a note of the change for add-on developers.

