### PR TITLE
Use portable filter to match all files in getFile

### DIFF
--- a/qt/aqt/utils.py
+++ b/qt/aqt/utils.py
@@ -430,7 +430,7 @@ def getFile(
     title: str,
     # single file returned unless multi=True
     cb: Callable[[str | Sequence[str]], None] | None,
-    filter: str = "*.*",
+    filter: str = "*",
     dir: str | None = None,
     key: str | None = None,
     multi: bool = False,  # controls whether a single or multiple files is returned


### PR DESCRIPTION
`*.*` matches files with no extensions on Windows, while it doesn't do so on
macOS. I had this issue with AnkiApp Importer.

Reference: https://doc.qt.io/qt-6/qfiledialog.html#setNameFilters