### PR TITLE
Add hook: overview_will_render_bottom

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -75,7 +75,6 @@ Meredith Derecho <meredithderecho@gmail.com>
 Daniel Wallgren <github.com/wallgrenen>
 Kerrick Staley <kerrick@kerrickstaley.com>
 Maksim Abramchuk <maximabramchuck@gmail.com>
-Mateus Etto <mateus.etto@gmail.com>
 Benjamin Kulnik <benjamin.kulnik@student.tuwien.ac.at>
 Shaun Ren <shaun.ren@linux.com>
 Ryan Greenblatt <greenblattryan@gmail.com>
@@ -105,6 +104,7 @@ wisherhxl <wisherhxl@gmail.com>
 dobefore <1432338032@qq.com>
 Bart Louwers <bart.git@emeel.net>
 Sam Penny <github.com/sam1penny>
+Mateus Etto <mateus.etto@gmail.com>
 
 ********************
 

--- a/qt/aqt/overview.py
+++ b/qt/aqt/overview.py
@@ -287,8 +287,8 @@ class Overview:
             links.append(["U", "unbury", tr.studying_unbury()])
         links.append(["", "description", tr.scheduling_description()])
         link_handler = gui_hooks.overview_will_render_bottom(
-            links,
             self._linkHandler,
+            links,
         )
         if not callable(link_handler):
             link_handler = self._linkHandler

--- a/qt/aqt/overview.py
+++ b/qt/aqt/overview.py
@@ -286,6 +286,12 @@ class Overview:
         if self.mw.col.sched.have_buried():
             links.append(["U", "unbury", tr.studying_unbury()])
         links.append(["", "description", tr.scheduling_description()])
+        link_handler = gui_hooks.overview_will_render_bottom(
+            links,
+            self._linkHandler,
+        )
+        if not callable(link_handler):
+            link_handler = self._linkHandler
         buf = ""
         for b in links:
             if b[0]:
@@ -295,7 +301,9 @@ class Overview:
                 b
             )
         self.bottom.draw(
-            buf=buf, link_handler=self._linkHandler, web_context=OverviewBottomBar(self)
+            buf=buf,
+            link_handler=link_handler,
+            web_context=OverviewBottomBar(self),
         )
 
     # Studying more

--- a/qt/tools/genhooks_gui.py
+++ b/qt/tools/genhooks_gui.py
@@ -69,7 +69,7 @@ hooks = [
         name="overview_will_render_bottom",
         args=[
             "links: Union[Callable[[str], bool], List[Any]]",
-            "link_handler: Callable[[str], bool]"
+            "link_handler: Callable[[str], bool]",
         ],
         return_type="Callable[[str], bool] | list",
         doc="""Allows adding buttons to the Overview bottom bar.

--- a/qt/tools/genhooks_gui.py
+++ b/qt/tools/genhooks_gui.py
@@ -67,8 +67,8 @@ hooks = [
     ),
     Hook(
         name="overview_will_render_bottom",
-        args=["links: list[list[str]]", "link_handler: Callable[[url], bool]"],
-        return_type="Callable[[url], bool] | List[List[str]]",
+        args=["links: list[list[str]]", "link_handler: Callable[[str], bool]"],
+        return_type="Callable[[str], bool] | List[List[str]]",
         doc="""Allows adding buttons to the Overview bottom bar.
 
         Append a list of strings to 'links' argument to add new buttons.

--- a/qt/tools/genhooks_gui.py
+++ b/qt/tools/genhooks_gui.py
@@ -67,10 +67,7 @@ hooks = [
     ),
     Hook(
         name="overview_will_render_bottom",
-        args=[
-            "links: list[list[str, str, str], ...]",
-            "link_handler: Callable[str]"
-        ],
+        args=["links: list[list[str, str, str], ...]", "link_handler: Callable[str]"],
         return_type="Callable[str]",
         doc="""Allows adding buttons to the Overview bottom bar.
 
@@ -91,7 +88,7 @@ hooks = [
                 print('Hello World!')
             return link_handler(url=url)
         return custom_link_handler
-        """
+        """,
     ),
     Hook(
         name="reviewer_did_show_question",

--- a/qt/tools/genhooks_gui.py
+++ b/qt/tools/genhooks_gui.py
@@ -67,8 +67,8 @@ hooks = [
     ),
     Hook(
         name="overview_will_render_bottom",
-        args=["links: list[list[str]]", "link_handler: Callable[str]"],
-        return_type="Callable[[str], bool]",
+        args=["links: list[list[str]]", "link_handler: Callable[[url], bool]"],
+        return_type="Callable[[url], bool] | List[List[str]]",
         doc="""Allows adding buttons to the Overview bottom bar.
 
         Append a list of strings to 'links' argument to add new buttons.

--- a/qt/tools/genhooks_gui.py
+++ b/qt/tools/genhooks_gui.py
@@ -66,6 +66,34 @@ hooks = [
         """,
     ),
     Hook(
+        name="overview_will_render_bottom",
+        args=[
+            "links: list[list[str, str, str], ...]",
+            "link_handler: Callable[str]"
+        ],
+        return_type="Callable[str]",
+        doc="""Allows adding buttons to the Overview bottom bar.
+
+        Append a list of strings to 'links' argument to add new buttons.
+        - The first value is the shortcut to appear in the tooltip.
+        - The second value is the url to be triggered.
+        - The third value is the text of the new button.
+
+        Extend the callable 'link_handler' to deal with new urls. This callable
+        accepts one argument: the triggered url.
+        Make a check of the triggered url, call any functions related to
+        that trigger, and return the new link_handler.
+
+        Example:
+        links.append(['H', 'hello', 'Click me!'])
+        def custom_link_handler(url):
+            if url == 'hello':
+                print('Hello World!')
+            return link_handler(url=url)
+        return custom_link_handler
+        """
+    ),
+    Hook(
         name="reviewer_did_show_question",
         args=["card: Card"],
         legacy_hook="showQuestion",

--- a/qt/tools/genhooks_gui.py
+++ b/qt/tools/genhooks_gui.py
@@ -68,7 +68,7 @@ hooks = [
     Hook(
         name="overview_will_render_bottom",
         args=["links: list[list[str]]", "link_handler: Callable[[str], bool]"],
-        return_type="Callable[[str], bool] | List[List[str]]",
+        return_type="Callable[[str], bool] | list",
         doc="""Allows adding buttons to the Overview bottom bar.
 
         Append a list of strings to 'links' argument to add new buttons.

--- a/qt/tools/genhooks_gui.py
+++ b/qt/tools/genhooks_gui.py
@@ -67,8 +67,8 @@ hooks = [
     ),
     Hook(
         name="overview_will_render_bottom",
-        args=["links: list[list[str, str, str]]", "link_handler: Callable[str]"],
-        return_type="Callable[str]",
+        args=["links: list[list[str]]", "link_handler: Callable[str]"],
+        return_type="Callable[[str], bool]",
         doc="""Allows adding buttons to the Overview bottom bar.
 
         Append a list of strings to 'links' argument to add new buttons.

--- a/qt/tools/genhooks_gui.py
+++ b/qt/tools/genhooks_gui.py
@@ -68,10 +68,10 @@ hooks = [
     Hook(
         name="overview_will_render_bottom",
         args=[
-            "links: list | Callable[[str], bool]",
             "link_handler: Callable[[str], bool]",
+            "links: list[list[str]]",
         ],
-        return_type="Callable[[str], bool] | list",
+        return_type="Callable[[str], bool]",
         doc="""Allows adding buttons to the Overview bottom bar.
 
         Append a list of strings to 'links' argument to add new buttons.

--- a/qt/tools/genhooks_gui.py
+++ b/qt/tools/genhooks_gui.py
@@ -67,7 +67,10 @@ hooks = [
     ),
     Hook(
         name="overview_will_render_bottom",
-        args=["links: Union[Callable[[str], bool], List[Any]]", "link_handler: Callable[[str], bool]"],
+        args=[
+            "links: Union[Callable[[str], bool], List[Any]]",
+            "link_handler: Callable[[str], bool]"
+        ],
         return_type="Callable[[str], bool] | list",
         doc="""Allows adding buttons to the Overview bottom bar.
 

--- a/qt/tools/genhooks_gui.py
+++ b/qt/tools/genhooks_gui.py
@@ -68,7 +68,7 @@ hooks = [
     Hook(
         name="overview_will_render_bottom",
         args=[
-            "links: Union[Callable[[str], bool], List[Any]]",
+            "links: list | Callable[[str], bool]",
             "link_handler: Callable[[str], bool]",
         ],
         return_type="Callable[[str], bool] | list",

--- a/qt/tools/genhooks_gui.py
+++ b/qt/tools/genhooks_gui.py
@@ -67,7 +67,7 @@ hooks = [
     ),
     Hook(
         name="overview_will_render_bottom",
-        args=["links: list[list[str]]", "link_handler: Callable[[str], bool]"],
+        args=["links: Union[Callable[[str], bool], List[Any]]", "link_handler: Callable[[str], bool]"],
         return_type="Callable[[str], bool] | list",
         doc="""Allows adding buttons to the Overview bottom bar.
 

--- a/qt/tools/genhooks_gui.py
+++ b/qt/tools/genhooks_gui.py
@@ -67,7 +67,7 @@ hooks = [
     ),
     Hook(
         name="overview_will_render_bottom",
-        args=["links: list[list[str, str, str], ...]", "link_handler: Callable[str]"],
+        args=["links: list[list[str, str, str]]", "link_handler: Callable[str]"],
         return_type="Callable[str]",
         doc="""Allows adding buttons to the Overview bottom bar.
 


### PR DESCRIPTION
This is my first time adding a hook, pardon me if I did anything wrong here.

# Use case

In my add-on [Life Drain](https://ankiweb.net/shared/info/715575551) I add two buttons to the Overview screen. (screenshots [here](https://github.com/Yutsuten/anki-lifedrain/wiki/Deck-Settings))

- `Life Drain`: This is a configuration at a deck level. Not every deck have the same difficulty so I allowed customization per deck.
- `Recover`: Fully restore life.

For a long time I monkey patched `aqt.toolbar.BottomBar.draw` like [this](https://github.com/Yutsuten/anki-lifedrain/blob/53ff173c7de9118004f89ba6fd7112b03a7e32e2/src/main.py#L82-L107), but I think it would be better to have a hook for this.

Another thing that motivated me to open this Pull Request is that another add-on creator inadequately monkey patched `Overview._renderBottom` and caused add-on incompatibility.
- https://github.com/Yutsuten/anki-lifedrain/issues/129
- https://github.com/telotortium/anki-reset-limits/issues/5

# About the change

I call `gui_hooks.overview_will_render_bottom` inside `_renderBottom` with 2 arguments: `links` and `self._linkHandler`.

Manipulating `links` from an add-on is not a problem.

But `self._linkHandler` is a function. Inside it we only have a chain of `if-elif` and I see no easy way to handle new `url`s it if not monkey paching it.

So a simple usage would be like:

```python
def add_hello_button(links, link_handler):
    links.append(['H', 'hello', 'Click me!'])
    def custom_link_handler(url):
        if url == 'hello':
            print('Hello World!')
        return link_handler(url=url)
    return custom_link_handler

gui_hooks.overview_will_render_bottom.append(add_hello_button)
```

Not so beautiful but works. The best would be to refactor the link handling in my opinion, but that's not the objective of this Pull Request.

Any feedback is greatly appreciated.