### PR TITLE
Template err improvements

### DIFF
--- a/ftl/core/card-template-rendering.ftl
+++ b/ftl/core/card-template-rendering.ftl
@@ -6,6 +6,8 @@
 card-template-rendering-more-info = More information
 card-template-rendering-front-side-problem = Front template has a problem:
 card-template-rendering-back-side-problem = Back template has a problem:
+card-template-rendering-browser-front-side-problem = Browser appearance front template has a problem:
+card-template-rendering-browser-back-side-problem = Browser appearance back template has a problem:
 # when the user forgot to close a field reference,
 # eg, Missing '}}' in '{{Field'
 card-template-rendering-no-closing-brackets = Missing '{ $missing }' in '{ $tag }'

--- a/ftl/core/card-template-rendering.ftl
+++ b/ftl/core/card-template-rendering.ftl
@@ -6,8 +6,8 @@
 card-template-rendering-more-info = More information
 card-template-rendering-front-side-problem = Front template has a problem:
 card-template-rendering-back-side-problem = Back template has a problem:
-card-template-rendering-browser-front-side-problem = Browser appearance front template has a problem:
-card-template-rendering-browser-back-side-problem = Browser appearance back template has a problem:
+card-template-rendering-browser-front-side-problem = Browser-specific front template has a problem:
+card-template-rendering-browser-back-side-problem = Browser-specific back template has a problem:
 # when the user forgot to close a field reference,
 # eg, Missing '}}' in '{{Field'
 card-template-rendering-no-closing-brackets = Missing '{ $missing }' in '{ $tag }'

--- a/rslib/src/browser_table.rs
+++ b/rslib/src/browser_table.rs
@@ -64,14 +64,18 @@ struct RowContext {
     original_deck: Option<Arc<Deck>>,
     tr: I18n,
     timing: SchedTimingToday,
-    render_context: Option<RenderContext>,
+    render_context: RenderContext,
 }
 
-/// The answer string needs the question string but not the other way around, so only build the
-/// answer string when needed.
-struct RenderContext {
-    question: String,
-    answer_nodes: Vec<RenderedNode>,
+enum RenderContext {
+    // The answer string needs the question string, but not the other way around,
+    // so only build the answer string when needed.
+    Ok {
+        question: String,
+        answer_nodes: Vec<RenderedNode>,
+    },
+    Err(String),
+    Unset,
 }
 
 fn card_render_required(columns: &[Column]) -> bool {
@@ -251,33 +255,49 @@ impl Collection {
 }
 
 impl RenderContext {
-    fn new(col: &mut Collection, card: &Card, note: &Note, notetype: &Notetype) -> Result<Self> {
-        let render = col.render_card(
-            note,
-            card,
-            notetype,
-            notetype.get_template(card.template_idx)?,
-            true,
-        )?;
-        let qnodes_text = render
-            .qnodes
-            .iter()
-            .map(|node| match node {
-                RenderedNode::Text { text } => text,
-                RenderedNode::Replacement {
-                    field_name: _,
-                    current_text,
-                    filters: _,
-                } => current_text,
-            })
-            .join("");
-        let question = prettify_av_tags(qnodes_text);
-
-        Ok(RenderContext {
-            question,
-            answer_nodes: render.anodes,
-        })
+    fn new(col: &mut Collection, card: &Card, note: &Note, notetype: &Notetype) -> Self {
+        match notetype
+            .get_template(card.template_idx)
+            .and_then(|template| col.render_card(note, card, notetype, template, true))
+        {
+            Ok(render) => RenderContext::Ok {
+                question: rendered_nodes_to_str(&render.qnodes),
+                answer_nodes: render.anodes,
+            },
+            Err(err) => RenderContext::Err(err.localized_description(&col.tr)),
+        }
     }
+
+    fn side_str(&self, is_answer: bool) -> String {
+        let back;
+        let html = match self {
+            Self::Ok {
+                question,
+                answer_nodes,
+            } => {
+                if is_answer {
+                    back = rendered_nodes_to_str(answer_nodes);
+                    back.strip_prefix(question).unwrap_or(&back)
+                } else {
+                    question
+                }
+            }
+            Self::Err(err) => err,
+            Self::Unset => "Invalid input: RenderContext unset",
+        };
+        html_to_text_line(html, true).into()
+    }
+}
+
+fn rendered_nodes_to_str(nodes: &[RenderedNode]) -> String {
+    let txt = nodes
+        .iter()
+        .map(|node| match node {
+            RenderedNode::Text { text } => text,
+            RenderedNode::Replacement { current_text, .. } => current_text,
+        })
+        .join("");
+    prettify_av_tags(txt)
 }
 
 impl RowContext {
@@ -324,9 +344,9 @@ impl RowContext {
         };
         let timing = col.timing_today()?;
         let render_context = if with_card_render {
-            Some(RenderContext::new(col, &cards[0], &note, &notetype)?)
+            RenderContext::new(col, &cards[0], &note, &notetype)
         } else {
-            None
+            RenderContext::Unset
         };
 
         Ok(RowContext {
@@ -363,8 +383,8 @@ impl RowContext {
 
     fn get_cell_text(&self, column: Column) -> Result<String> {
         Ok(match column {
-            Column::Question => self.question_str(),
-            Column::Answer => self.answer_str(),
+            Column::Question => self.render_context.side_str(false),
+            Column::Answer => self.render_context.side_str(true),
             Column::Deck => self.deck_str(),
             Column::Due => self.due_str(),
             Column::Ease => self.ease_str(),
@@ -403,32 +423,6 @@ impl RowContext {
 
     fn template(&self) -> Result<&CardTemplate> {
         self.notetype.get_template(self.cards[0].template_idx)
-    }
-
-    fn answer_str(&self) -> String {
-        let render_context = self.render_context.as_ref().unwrap();
-        let answer = render_context
-            .answer_nodes
-            .iter()
-            .map(|node| match node {
-                RenderedNode::Text { text } => text,
-                RenderedNode::Replacement {
-                    field_name: _,
-                    current_text,
-                    filters: _,
-                } => current_text,
-            })
-            .join("");
-        let answer = prettify_av_tags(answer);
-        html_to_text_line(
-            if let Some(stripped) = answer.strip_prefix(&render_context.question) {
-                stripped
-            } else {
-                &answer
-            },
-            true,
-        )
-        .to_string()
     }
 
     fn due_str(&self) -> String {
@@ -514,7 +508,7 @@ impl RowContext {
             .iter()
             .map(|c| c.mtime)
             .max()
-            .unwrap()
+            .expect("cards missing from RowContext")
             .date_string()
     }
 
@@ -543,10 +537,6 @@ impl RowContext {
                 NotetypeKind::Cloze => format!("{} {}", name, self.cards[0].template_idx + 1),
             }
         })
-    }
-
-    fn question_str(&self) -> String {
-        html_to_text_line(&self.render_context.as_ref().unwrap().question, true).to_string()
     }
 
     fn get_row_font_name(&self) -> Result<String> {

--- a/rslib/src/notetype/mod.rs
+++ b/rslib/src/notetype/mod.rs
@@ -391,10 +391,12 @@ impl Notetype {
         if let Some((invalid_index, details)) =
             templates.iter().enumerate().find_map(|(index, sides)| {
                 if let (Some(q), Some(a)) = sides {
-                    let q_fields = q.fields();
+                    let q_fields = q.all_referenced_field_names();
                     if q_fields.is_empty() {
                         Some((index, CardTypeErrorDetails::NoFrontField))
-                    } else if self.unknown_field_name(q_fields.union(&a.fields())) {
+                    } else if self
+                        .unknown_field_name(q_fields.union(&a.all_referenced_field_names()))
+                    {
                         Some((index, CardTypeErrorDetails::NoSuchField))
                     } else {
                         None
@@ -601,7 +603,7 @@ impl Notetype {
             HashSet::new()
         } else if let Some((Some(front), _)) = self.parsed_templates().get(0) {
             front
-                .cloze_fields()
+                .all_referenced_cloze_field_names()
                 .iter()
                 .filter_map(|name| self.get_field_ord(name))
                 .collect()
@@ -624,7 +626,7 @@ fn missing_cloze_filter(
 fn has_cloze(template: &Option<ParsedTemplate>) -> bool {
     template
         .as_ref()
-        .map_or(false, |t| !t.cloze_fields().is_empty())
+        .map_or(false, |t| !t.all_referenced_cloze_field_names().is_empty())
 }
 
 impl From<Notetype> for NotetypeProto {

--- a/rslib/src/notetype/render.rs
+++ b/rslib/src/notetype/render.rs
@@ -118,6 +118,7 @@ impl Collection {
             &field_map,
             card.template_idx,
             nt.is_cloze(),
+            browser,
             &self.tr,
         )?;
         Ok(RenderCardOutput {

--- a/rslib/src/notetype/render.rs
+++ b/rslib/src/notetype/render.rs
@@ -172,7 +172,7 @@ fn flag_name(n: u8) -> &'static str {
 
 fn fill_empty_fields(note: &mut Note, qfmt: &str, nt: &Notetype, tr: &I18n) {
     if let Ok(tmpl) = ParsedTemplate::from_text(qfmt) {
-        let cloze_fields = tmpl.cloze_fields();
+        let cloze_fields = tmpl.all_referenced_cloze_field_names();
 
         for (val, field) in note.fields_mut().iter_mut().zip(nt.fields.iter()) {
             if field_is_empty(val) {


### PR DESCRIPTION
https://forums.ankiweb.net/t/template-overrides-are-not-mentioned-in-the-error-message-when-they-reference-a-non-existent-field/21245

I would also like to check the browser templates on save and export, but I'm not sure how this could work. The error prompt currently says 'See preview ...' and those templates don't have one. We could display the error messages in the regular preview window or embed it in the error prompt, but even then I'm afraid there would be users who get stuck, because they can't track down the *Browser Appearance* dialog.

I think in a future redesign of the cards dialog, the browser templates should be located more closely to the regular ones.