### PR TITLE
Add reviewer suspend and bury hooks

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -104,7 +104,7 @@ wisherhxl <wisherhxl@gmail.com>
 dobefore <1432338032@qq.com>
 Bart Louwers <bart.git@emeel.net>
 Sam Penny <github.com/sam1penny>
-Mateus Etto <mateus.etto@gmail.com>
+Yutsuten <mateus.etto@gmail.com>
 
 ********************
 

--- a/qt/aqt/reviewer.py
+++ b/qt/aqt/reviewer.py
@@ -1051,23 +1051,27 @@ time = %(time)d;
             op.run_in_background()
 
     def suspend_current_note(self) -> None:
+        gui_hooks.reviewer_will_suspend_note(self.card.nid)
         suspend_note(
             parent=self.mw,
             note_ids=[self.card.nid],
         ).success(lambda _: tooltip(tr.studying_note_suspended())).run_in_background()
 
     def suspend_current_card(self) -> None:
+        gui_hooks.reviewer_will_suspend_card(self.card.id)
         suspend_cards(
             parent=self.mw,
             card_ids=[self.card.id],
         ).success(lambda _: tooltip(tr.studying_card_suspended())).run_in_background()
 
     def bury_current_note(self) -> None:
+        gui_hooks.reviewer_will_bury_note(self.card.nid)
         bury_notes(parent=self.mw, note_ids=[self.card.nid],).success(
             lambda res: tooltip(tr.studying_cards_buried(count=res.count))
         ).run_in_background()
 
     def bury_current_card(self) -> None:
+        gui_hooks.reviewer_will_bury_card(self.card.id)
         bury_cards(parent=self.mw, card_ids=[self.card.id],).success(
             lambda res: tooltip(tr.studying_cards_buried(count=res.count))
         ).run_in_background()

--- a/qt/tools/genhooks_gui.py
+++ b/qt/tools/genhooks_gui.py
@@ -198,6 +198,22 @@ hooks = [
         return_type="str",
         doc="""Used to inspect and modify a recording recorded by "Record Own Voice" before replaying.""",
     ),
+    Hook(
+        name="reviewer_will_suspend_note",
+        args=["nid: int"],
+    ),
+    Hook(
+        name="reviewer_will_suspend_card",
+        args=["id: int"],
+    ),
+    Hook(
+        name="reviewer_will_bury_note",
+        args=["nid: int"],
+    ),
+    Hook(
+        name="reviewer_will_bury_card",
+        args=["id: int"],
+    ),
     # Debug
     ###################
     Hook(


### PR DESCRIPTION
In my add-on Lifedrain I have some custom handling when a card is suspended or buried, as it is not the same as when answering a card.
So far [I have monkey patched](https://github.com/Yutsuten/anki-lifedrain/blob/53ff173c7de9118004f89ba6fd7112b03a7e32e2/src/main.py#L133-L138) the `Scheduler` class, but I'm having issues with the v3 scheduler not triggering my function.

Having these hooks will ease handling suspended and buried cards in my add-on, hope this can be merged.

By the way I didn't add documentation to the new hooks as I think the names are pretty self-descriptive.

Thanks!