### PR TITLE
Expose cloze text as HTML attribute on question side

### DIFF
--- a/pylib/tests/test_models.py
+++ b/pylib/tests/test_models.py
@@ -178,7 +178,7 @@ def test_cloze():
     note["Text"] = "hello {{c1::world}}"
     assert col.addNote(note) == 1
     assert (
-        'hello <span class="cloze" data-text="world">[...]</span>'
+        f'hello <span class="cloze" data-text="{html.escape("world")}">[...]</span>'
         in note.cards()[0].question()
     )
     assert 'hello <span class="cloze">world</span>' in note.cards()[0].answer()
@@ -187,7 +187,7 @@ def test_cloze():
     note["Text"] = "hello {{c1::world::typical}}"
     assert col.addNote(note) == 1
     assert (
-        '<span class="cloze" data-text="world">[typical]</span>'
+        f'<span class="cloze" data-text="{html.escape("world")}">[typical]</span>'
         in note.cards()[0].question()
     )
     assert '<span class="cloze">world</span>' in note.cards()[0].answer()
@@ -196,9 +196,15 @@ def test_cloze():
     note["Text"] = "hello {{c1::world}} {{c2::bar}}"
     assert col.addNote(note) == 2
     (c1, c2) = note.cards()
-    assert '<span class="cloze" data-text="world">[...]</span> bar' in c1.question()
+    assert (
+        f'<span class="cloze" data-text="{html.escape("world")}">[...]</span> bar'
+        in c1.question()
+    )
     assert '<span class="cloze">world</span> bar' in c1.answer()
-    assert 'world <span class="cloze" data-text="bar">[...]</span>' in c2.question()
+    assert (
+        f'world <span class="cloze" data-text="{html.escape("bar")}">[...]</span>'
+        in c2.question()
+    )
     assert 'world <span class="cloze">bar</span>' in c2.answer()
     # if there are multiple answers for a single cloze, they are given in a
     # list
@@ -223,18 +229,29 @@ def test_cloze_mathjax():
     col = getEmptyCol()
     m = col.models.by_name("Cloze")
     note = col.new_note(m)
+    q1 = "ok"
+    q2 = "not ok"
+    q3 = "2"
+    q4 = "blah"
+    q5 = "text with \(x^2\) jax"
     note[
         "Text"
-    ] = r"{{c1::ok}} \(2^2\) {{c2::not ok}} \(2^{{c3::2}}\) \(x^3\) {{c4::blah}} {{c5::text with \(x^2\) jax}}"
+    ] = "{{{{c1::{}}}}} \(2^2\) {{{{c2::{}}}}} \(2^{{{{c3::{}}}}}\) \(x^3\) {{{{c4::{}}}}} {{{{c5::{}}}}}".format(
+        q1,
+        q2,
+        q3,
+        q4,
+        q5,
+    )
     assert col.addNote(note)
     assert len(note.cards()) == 5
-    assert 'class="cloze" data-text="ok"' in note.cards()[0].question()
-    assert 'class="cloze" data-text="not ok"' in note.cards()[1].question()
-    assert 'class="cloze" data-text="2"' not in note.cards()[2].question()
-    assert 'class="cloze" data-text="blah"' in note.cards()[3].question()
+    assert f'class="cloze" data-text="{html.escape(q1)}"' in note.cards()[0].question()
+    assert f'class="cloze" data-text="{html.escape(q2)}"' in note.cards()[1].question()
     assert (
-        'class="cloze" data-text="text with \(x^2\) jax"' in note.cards()[4].question()
+        f'class="cloze" data-text="{html.escape(q3)}"' not in note.cards()[2].question()
     )
+    assert f'class="cloze" data-text="{html.escape(q4)}"' in note.cards()[3].question()
+    assert f'class="cloze" data-text="{html.escape(q5)}"' in note.cards()[4].question()
 
     note = col.new_note(m)
     note["Text"] = r"\(a\) {{c1::b}} \[ {{c1::c}} \]"
@@ -243,9 +260,7 @@ def test_cloze_mathjax():
     assert (
         note.cards()[0]
         .question()
-        .endswith(
-            r"\(a\) <span class=\"cloze\" data-text=\"b\">[...]</span> \[ [...] \]"
-        )
+        .endswith(r'\(a\) <span class="cloze" data-text="b">[...]</span> \[ [...] \]')
     )
 
 
@@ -289,12 +304,12 @@ def test_chained_mods():
     )
     assert col.addNote(note) == 1
     assert (
-        f'This <span class="cloze" data-text="{html.escape(q1)}">[sentence]</span>'
-        f'demonstrates <span class="cloze" data-text="{html.escape(q2)}">[chained]</span> clozes.'
+        f'This <span class="cloze" data-text="{html.escape("phrase")}">[sentence]</span>'
+        f' demonstrates <span class="cloze" data-text="{html.escape("en chaine")}">[chained]</span> clozes.'
         in note.cards()[0].question()
     )
     assert (
-        'This <span class="cloze">phrase</span> demonstrates <span class="cloze">en chaine</span> clozes.'
+        f'This <span class="cloze">phrase</span> demonstrates <span class="cloze">en chaine</span> clozes.'
         in note.cards()[0].answer()
     )
 

--- a/pylib/tests/test_models.py
+++ b/pylib/tests/test_models.py
@@ -3,12 +3,19 @@
 
 # coding: utf-8
 import html
+import re
 import time
 
 from anki.consts import MODEL_CLOZE
 from anki.errors import NotFoundError
 from anki.utils import is_win, strip_html
 from tests.shared import getEmptyCol
+
+
+def encode_attribute(s):
+    return "".join(
+        c if c.isalnum() else "&#x{:X};".format(ord(c)) for c in html.escape(s)
+    )
 
 
 def test_modelDelete():
@@ -178,7 +185,7 @@ def test_cloze():
     note["Text"] = "hello {{c1::world}}"
     assert col.addNote(note) == 1
     assert (
-        f'hello <span class="cloze" data-cloze="{html.escape("world")}">[...]</span>'
+        f'hello <span class="cloze" data-cloze="{encode_attribute("world")}">[...]</span>'
         in note.cards()[0].question()
     )
     assert 'hello <span class="cloze">world</span>' in note.cards()[0].answer()
@@ -187,7 +194,7 @@ def test_cloze():
     note["Text"] = "hello {{c1::world::typical}}"
     assert col.addNote(note) == 1
     assert (
-        f'<span class="cloze" data-cloze="{html.escape("world")}">[typical]</span>'
+        f'<span class="cloze" data-cloze="{encode_attribute("world")}">[typical]</span>'
         in note.cards()[0].question()
     )
     assert '<span class="cloze">world</span>' in note.cards()[0].answer()
@@ -197,12 +204,12 @@ def test_cloze():
     assert col.addNote(note) == 2
     (c1, c2) = note.cards()
     assert (
-        f'<span class="cloze" data-cloze="{html.escape("world")}">[...]</span> bar'
+        f'<span class="cloze" data-cloze="{encode_attribute("world")}">[...]</span> bar'
         in c1.question()
     )
     assert '<span class="cloze">world</span> bar' in c1.answer()
     assert (
-        f'world <span class="cloze" data-cloze="{html.escape("bar")}">[...]</span>'
+        f'world <span class="cloze" data-cloze="{encode_attribute("bar")}">[...]</span>'
         in c2.question()
     )
     assert 'world <span class="cloze">bar</span>' in c2.answer()
@@ -245,14 +252,26 @@ def test_cloze_mathjax():
     )
     assert col.addNote(note)
     assert len(note.cards()) == 5
-    assert f'class="cloze" data-cloze="{html.escape(q1)}"' in note.cards()[0].question()
-    assert f'class="cloze" data-cloze="{html.escape(q2)}"' in note.cards()[1].question()
     assert (
-        f'class="cloze" data-cloze="{html.escape(q3)}"'
+        f'class="cloze" data-cloze="{encode_attribute(q1)}"'
+        in note.cards()[0].question()
+    )
+    assert (
+        f'class="cloze" data-cloze="{encode_attribute(q2)}"'
+        in note.cards()[1].question()
+    )
+    assert (
+        f'class="cloze" data-cloze="{encode_attribute(q3)}"'
         not in note.cards()[2].question()
     )
-    assert f'class="cloze" data-cloze="{html.escape(q4)}"' in note.cards()[3].question()
-    assert f'class="cloze" data-cloze="{html.escape(q5)}"' in note.cards()[4].question()
+    assert (
+        f'class="cloze" data-cloze="{encode_attribute(q4)}"'
+        in note.cards()[3].question()
+    )
+    assert (
+        f'class="cloze" data-cloze="{encode_attribute(q5)}"'
+        in note.cards()[4].question()
+    )
 
     note = col.new_note(m)
     note["Text"] = r"\(a\) {{c1::b}} \[ {{c1::c}} \]"
@@ -305,8 +324,8 @@ def test_chained_mods():
     )
     assert col.addNote(note) == 1
     assert (
-        f'This <span class="cloze" data-cloze="{html.escape("phrase")}">[sentence]</span>'
-        f' demonstrates <span class="cloze" data-cloze="{html.escape("en chaine")}">[chained]</span> clozes.'
+        f'This <span class="cloze" data-cloze="{encode_attribute("phrase")}">[sentence]</span>'
+        f' demonstrates <span class="cloze" data-cloze="{encode_attribute("en chaine")}">[chained]</span> clozes.'
         in note.cards()[0].question()
     )
     assert (

--- a/pylib/tests/test_models.py
+++ b/pylib/tests/test_models.py
@@ -2,6 +2,7 @@
 # License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
 # coding: utf-8
+import html
 import time
 
 from anki.consts import MODEL_CLOZE
@@ -231,7 +232,9 @@ def test_cloze_mathjax():
     assert 'class="cloze" data-text="not ok"' in note.cards()[1].question()
     assert 'class="cloze" data-text="2"' not in note.cards()[2].question()
     assert 'class="cloze" data-text="blah"' in note.cards()[3].question()
-    assert 'class="cloze" data-text="text with \(x^2\) jax"' in note.cards()[4].question()
+    assert (
+        'class="cloze" data-text="text with \(x^2\) jax"' in note.cards()[4].question()
+    )
 
     note = col.new_note(m)
     note["Text"] = r"\(a\) {{c1::b}} \[ {{c1::c}} \]"
@@ -240,7 +243,9 @@ def test_cloze_mathjax():
     assert (
         note.cards()[0]
         .question()
-        .endswith(r"\(a\) <span class=\"cloze\" data-text=\"b\">[...]</span> \[ [...] \]")
+        .endswith(
+            r"\(a\) <span class=\"cloze\" data-text=\"b\">[...]</span> \[ [...] \]"
+        )
     )
 
 
@@ -284,7 +289,8 @@ def test_chained_mods():
     )
     assert col.addNote(note) == 1
     assert (
-        'This <span class="cloze">[sentence]</span> demonstrates <span class="cloze">[chained]</span> clozes.'
+        f'This <span class="cloze" data-text="{html.escape(q1)}">[sentence]</span>'
+        f'demonstrates <span class="cloze" data-text="{html.escape(q2)}">[chained]</span> clozes.'
         in note.cards()[0].question()
     )
     assert (

--- a/pylib/tests/test_models.py
+++ b/pylib/tests/test_models.py
@@ -176,29 +176,35 @@ def test_cloze():
     note = col.new_note(m)
     note["Text"] = "hello {{c1::world}}"
     assert col.addNote(note) == 1
-    assert "hello <span class=cloze>[...]</span>" in note.cards()[0].question()
-    assert "hello <span class=cloze>world</span>" in note.cards()[0].answer()
+    assert (
+        'hello <span class="cloze" data-text="world">[...]</span>'
+        in note.cards()[0].question()
+    )
+    assert 'hello <span class="cloze">world</span>' in note.cards()[0].answer()
     # and with a comment
     note = col.new_note(m)
     note["Text"] = "hello {{c1::world::typical}}"
     assert col.addNote(note) == 1
-    assert "<span class=cloze>[typical]</span>" in note.cards()[0].question()
-    assert "<span class=cloze>world</span>" in note.cards()[0].answer()
+    assert (
+        '<span class="cloze" data-text="world">[typical]</span>'
+        in note.cards()[0].question()
+    )
+    assert '<span class="cloze">world</span>' in note.cards()[0].answer()
     # and with 2 clozes
     note = col.new_note(m)
     note["Text"] = "hello {{c1::world}} {{c2::bar}}"
     assert col.addNote(note) == 2
     (c1, c2) = note.cards()
-    assert "<span class=cloze>[...]</span> bar" in c1.question()
-    assert "<span class=cloze>world</span> bar" in c1.answer()
-    assert "world <span class=cloze>[...]</span>" in c2.question()
-    assert "world <span class=cloze>bar</span>" in c2.answer()
+    assert '<span class="cloze" data-text="world">[...]</span> bar' in c1.question()
+    assert '<span class="cloze">world</span> bar' in c1.answer()
+    assert 'world <span class="cloze" data-text="bar">[...]</span>' in c2.question()
+    assert 'world <span class="cloze">bar</span>' in c2.answer()
     # if there are multiple answers for a single cloze, they are given in a
     # list
     note = col.new_note(m)
     note["Text"] = "a {{c1::b}} {{c1::c}}"
     assert col.addNote(note) == 1
-    assert "<span class=cloze>b</span> <span class=cloze>c</span>" in (
+    assert '<span class="cloze">b</span> <span class="cloze">c</span>' in (
         note.cards()[0].answer()
     )
     # if we add another cloze, a card should be generated
@@ -221,11 +227,11 @@ def test_cloze_mathjax():
     ] = r"{{c1::ok}} \(2^2\) {{c2::not ok}} \(2^{{c3::2}}\) \(x^3\) {{c4::blah}} {{c5::text with \(x^2\) jax}}"
     assert col.addNote(note)
     assert len(note.cards()) == 5
-    assert "class=cloze" in note.cards()[0].question()
-    assert "class=cloze" in note.cards()[1].question()
-    assert "class=cloze" not in note.cards()[2].question()
-    assert "class=cloze" in note.cards()[3].question()
-    assert "class=cloze" in note.cards()[4].question()
+    assert 'class="cloze" data-text="ok"' in note.cards()[0].question()
+    assert 'class="cloze" data-text="not ok"' in note.cards()[1].question()
+    assert 'class="cloze" data-text="2"' not in note.cards()[2].question()
+    assert 'class="cloze" data-text="blah"' in note.cards()[3].question()
+    assert 'class="cloze" data-text="text with \(x^2\) jax"' in note.cards()[4].question()
 
     note = col.new_note(m)
     note["Text"] = r"\(a\) {{c1::b}} \[ {{c1::c}} \]"
@@ -234,7 +240,7 @@ def test_cloze_mathjax():
     assert (
         note.cards()[0]
         .question()
-        .endswith(r"\(a\) <span class=cloze>[...]</span> \[ [...] \]")
+        .endswith(r"\(a\) <span class=\"cloze\" data-text=\"b\">[...]</span> \[ [...] \]")
     )
 
 
@@ -278,11 +284,11 @@ def test_chained_mods():
     )
     assert col.addNote(note) == 1
     assert (
-        "This <span class=cloze>[sentence]</span> demonstrates <span class=cloze>[chained]</span> clozes."
+        'This <span class="cloze">[sentence]</span> demonstrates <span class="cloze">[chained]</span> clozes.'
         in note.cards()[0].question()
     )
     assert (
-        "This <span class=cloze>phrase</span> demonstrates <span class=cloze>en chaine</span> clozes."
+        'This <span class="cloze">phrase</span> demonstrates <span class="cloze">en chaine</span> clozes.'
         in note.cards()[0].answer()
     )
 

--- a/pylib/tests/test_models.py
+++ b/pylib/tests/test_models.py
@@ -178,7 +178,7 @@ def test_cloze():
     note["Text"] = "hello {{c1::world}}"
     assert col.addNote(note) == 1
     assert (
-        f'hello <span class="cloze" data-text="{html.escape("world")}">[...]</span>'
+        f'hello <span class="cloze" data-cloze="{html.escape("world")}">[...]</span>'
         in note.cards()[0].question()
     )
     assert 'hello <span class="cloze">world</span>' in note.cards()[0].answer()
@@ -187,7 +187,7 @@ def test_cloze():
     note["Text"] = "hello {{c1::world::typical}}"
     assert col.addNote(note) == 1
     assert (
-        f'<span class="cloze" data-text="{html.escape("world")}">[typical]</span>'
+        f'<span class="cloze" data-cloze="{html.escape("world")}">[typical]</span>'
         in note.cards()[0].question()
     )
     assert '<span class="cloze">world</span>' in note.cards()[0].answer()
@@ -197,12 +197,12 @@ def test_cloze():
     assert col.addNote(note) == 2
     (c1, c2) = note.cards()
     assert (
-        f'<span class="cloze" data-text="{html.escape("world")}">[...]</span> bar'
+        f'<span class="cloze" data-cloze="{html.escape("world")}">[...]</span> bar'
         in c1.question()
     )
     assert '<span class="cloze">world</span> bar' in c1.answer()
     assert (
-        f'world <span class="cloze" data-text="{html.escape("bar")}">[...]</span>'
+        f'world <span class="cloze" data-cloze="{html.escape("bar")}">[...]</span>'
         in c2.question()
     )
     assert 'world <span class="cloze">bar</span>' in c2.answer()
@@ -245,13 +245,13 @@ def test_cloze_mathjax():
     )
     assert col.addNote(note)
     assert len(note.cards()) == 5
-    assert f'class="cloze" data-text="{html.escape(q1)}"' in note.cards()[0].question()
-    assert f'class="cloze" data-text="{html.escape(q2)}"' in note.cards()[1].question()
+    assert f'class="cloze" data-cloze="{html.escape(q1)}"' in note.cards()[0].question()
+    assert f'class="cloze" data-cloze="{html.escape(q2)}"' in note.cards()[1].question()
     assert (
-        f'class="cloze" data-text="{html.escape(q3)}"' not in note.cards()[2].question()
+        f'class="cloze" data-cloze="{html.escape(q3)}"' not in note.cards()[2].question()
     )
-    assert f'class="cloze" data-text="{html.escape(q4)}"' in note.cards()[3].question()
-    assert f'class="cloze" data-text="{html.escape(q5)}"' in note.cards()[4].question()
+    assert f'class="cloze" data-cloze="{html.escape(q4)}"' in note.cards()[3].question()
+    assert f'class="cloze" data-cloze="{html.escape(q5)}"' in note.cards()[4].question()
 
     note = col.new_note(m)
     note["Text"] = r"\(a\) {{c1::b}} \[ {{c1::c}} \]"
@@ -260,7 +260,7 @@ def test_cloze_mathjax():
     assert (
         note.cards()[0]
         .question()
-        .endswith(r'\(a\) <span class="cloze" data-text="b">[...]</span> \[ [...] \]')
+        .endswith(r'\(a\) <span class="cloze" data-cloze="b">[...]</span> \[ [...] \]')
     )
 
 
@@ -304,8 +304,8 @@ def test_chained_mods():
     )
     assert col.addNote(note) == 1
     assert (
-        f'This <span class="cloze" data-text="{html.escape("phrase")}">[sentence]</span>'
-        f' demonstrates <span class="cloze" data-text="{html.escape("en chaine")}">[chained]</span> clozes.'
+        f'This <span class="cloze" data-cloze="{html.escape("phrase")}">[sentence]</span>'
+        f' demonstrates <span class="cloze" data-cloze="{html.escape("en chaine")}">[chained]</span> clozes.'
         in note.cards()[0].question()
     )
     assert (

--- a/pylib/tests/test_models.py
+++ b/pylib/tests/test_models.py
@@ -248,7 +248,8 @@ def test_cloze_mathjax():
     assert f'class="cloze" data-cloze="{html.escape(q1)}"' in note.cards()[0].question()
     assert f'class="cloze" data-cloze="{html.escape(q2)}"' in note.cards()[1].question()
     assert (
-        f'class="cloze" data-cloze="{html.escape(q3)}"' not in note.cards()[2].question()
+        f'class="cloze" data-cloze="{html.escape(q3)}"'
+        not in note.cards()[2].question()
     )
     assert f'class="cloze" data-cloze="{html.escape(q4)}"' in note.cards()[3].question()
     assert f'class="cloze" data-cloze="{html.escape(q5)}"' in note.cards()[4].question()

--- a/rslib/src/cloze.rs
+++ b/rslib/src/cloze.rs
@@ -68,7 +68,7 @@ pub fn reveal_cloze_text(text: &str, cloze_ord: u16, question: bool) -> Cow<str>
         let text_attr;
         let replacement;
         if question {
-            text_attr = format!(r#" data-cloze="{}""#, htmlescape::encode_minimal(&text));
+            text_attr = format!(r#" data-cloze="{}""#, htmlescape::encode_attribute(&text));
             // hint provided?
             if let Some(hint) = caps.get(cloze_caps::HINT) {
                 replacement = format!("[{}]", hint.as_str());

--- a/rslib/src/cloze.rs
+++ b/rslib/src/cloze.rs
@@ -57,26 +57,30 @@ pub fn reveal_cloze_text(text: &str, cloze_ord: u16, question: bool) -> Cow<str>
             .parse()
             .unwrap_or(0);
 
+        let text = caps.get(cloze_caps::TEXT).unwrap().as_str().to_owned();
         if captured_ord != cloze_ord {
             // other cloze deletions are unchanged
-            return caps.get(cloze_caps::TEXT).unwrap().as_str().to_owned();
+            return text;
         } else {
             cloze_ord_was_in_text = true;
         }
 
+        let text_attr;
         let replacement;
         if question {
+            text_attr = format!(r#" data-text="{}""#, text);
             // hint provided?
             if let Some(hint) = caps.get(cloze_caps::HINT) {
                 replacement = format!("[{}]", hint.as_str());
             } else {
-                replacement = "[...]".to_string()
+                replacement = "[...]".to_string();
             }
         } else {
-            replacement = caps.get(cloze_caps::TEXT).unwrap().as_str().to_owned();
+            text_attr = "".to_string();
+            replacement = text;
         }
 
-        format!("<span class=cloze>{}</span>", replacement)
+        format!(r#"<span class="cloze"{}>{}</span>"#, text_attr, replacement)
     });
 
     if !cloze_ord_was_in_text {

--- a/rslib/src/cloze.rs
+++ b/rslib/src/cloze.rs
@@ -68,7 +68,7 @@ pub fn reveal_cloze_text(text: &str, cloze_ord: u16, question: bool) -> Cow<str>
         let text_attr;
         let replacement;
         if question {
-            text_attr = format!(r#" data-text="{}""#, text);
+            text_attr = format!(r#" data-text="{}""#, htmlescape::encode_attribute(&text));
             // hint provided?
             if let Some(hint) = caps.get(cloze_caps::HINT) {
                 replacement = format!("[{}]", hint.as_str());

--- a/rslib/src/cloze.rs
+++ b/rslib/src/cloze.rs
@@ -68,7 +68,7 @@ pub fn reveal_cloze_text(text: &str, cloze_ord: u16, question: bool) -> Cow<str>
         let text_attr;
         let replacement;
         if question {
-            text_attr = format!(r#" data-text="{}""#, htmlescape::encode_attribute(&text));
+            text_attr = format!(r#" data-text="{}""#, htmlescape::encode_minimal(&text));
             // hint provided?
             if let Some(hint) = caps.get(cloze_caps::HINT) {
                 replacement = format!("[{}]", hint.as_str());

--- a/rslib/src/cloze.rs
+++ b/rslib/src/cloze.rs
@@ -68,7 +68,7 @@ pub fn reveal_cloze_text(text: &str, cloze_ord: u16, question: bool) -> Cow<str>
         let text_attr;
         let replacement;
         if question {
-            text_attr = format!(r#" data-text="{}""#, htmlescape::encode_minimal(&text));
+            text_attr = format!(r#" data-cloze="{}""#, htmlescape::encode_minimal(&text));
             // hint provided?
             if let Some(hint) = caps.get(cloze_caps::HINT) {
                 replacement = format!("[{}]", hint.as_str());

--- a/rslib/src/template_filters.rs
+++ b/rslib/src/template_filters.rs
@@ -256,7 +256,7 @@ field</a>
         assert_eq!(strip_html(&cloze_filter(text, &ctx)).as_ref(), "[...] two");
         assert_eq!(
             cloze_filter(text, &ctx),
-            r#"<span class="cloze" data-text="one">[...]</span> two"#
+            r#"<span class="cloze" data-cloze="one">[...]</span> two"#
         );
 
         ctx.card_ord = 1;

--- a/rslib/src/template_filters.rs
+++ b/rslib/src/template_filters.rs
@@ -256,7 +256,7 @@ field</a>
         assert_eq!(strip_html(&cloze_filter(text, &ctx)).as_ref(), "[...] two");
         assert_eq!(
             cloze_filter(text, &ctx),
-            "<span class=cloze>[...]</span> two"
+            r#"<span class="cloze" data-text="one">[...]</span> two"#
         );
 
         ctx.card_ord = 1;


### PR DESCRIPTION
Exposes clozed text as a data-attribute on the front side.
Use case: https://forums.ankiweb.net/t/an-improved-implementation-of-cloze-to-enable-sequential-uncovering/21489/6

# Example
Input:
```
{{c1::hidden text}}
```

Output with current implementation:
```html
<span class=cloze>[...]</span>
```

After this PR:
```html
<span class="cloze" data-cloze="hidden text">[...]</span>
```