### PR TITLE
Expose side of card in body className

### DIFF
--- a/ts/reviewer/index.ts
+++ b/ts/reviewer/index.ts
@@ -167,7 +167,7 @@ export function _showQuestion(q: string, a: string, bodyclass: string): void {
                 // return to top of window
                 window.scrollTo(0, 0);
 
-                document.body.className = bodyclass;
+                document.body.className = `${bodyclass} front`;
             },
             function () {
                 // focus typing area if visible
@@ -194,7 +194,7 @@ export function _showAnswer(a: string, bodyclass: string): void {
             function () {
                 if (bodyclass) {
                     //  when previewing
-                    document.body.className = bodyclass;
+                    document.body.className = `${bodyclass} back`;
                 }
 
                 // avoid scrolling to the answer until images load


### PR DESCRIPTION
Makes wrapping the front template in `<div class="front">` or similar hacks to allow side-specific CSS redundant.

I find "front/back" more fitting than "question/answer", because it is more generic.