### PR TITLE
Fix legacy import switch

### DIFF
--- a/qt/aqt/profiles.py
+++ b/qt/aqt/profiles.py
@@ -543,7 +543,7 @@ create table if not exists profiles
         return self.meta.get("legacy_import", False)
 
     def set_legacy_import_export(self, enabled: bool) -> None:
-        self.meta["legacy_import"] = not enabled
+        self.meta["legacy_import"] = enabled
 
     def last_loaded_profile_name(self) -> str | None:
         return self.meta.get("last_loaded_profile_name")


### PR DESCRIPTION
Just a super minor typo/remnant from the old logic that prevents the switch from working atm