### PR TITLE
Add deck/collection export hooks

### DIFF
--- a/qt/aqt/exporting.py
+++ b/qt/aqt/exporting.py
@@ -196,7 +196,7 @@ class ExportDialog(QDialog):
                 else:
                     self.on_export_finished()
 
-            gui_hooks.legacy_exporter_will_export(self.exporter.ext)
+            gui_hooks.legacy_exporter_will_export(self.exporter)
             if self.isVerbatim:
                 gui_hooks.collection_will_temporarily_close(self.mw.col)
             self.mw.progress.start()
@@ -214,7 +214,7 @@ class ExportDialog(QDialog):
                 msg = tr.exporting_note_exported(count=self.exporter.count)
             else:
                 msg = tr.exporting_card_exported(count=self.exporter.count)
-        gui_hooks.legacy_exporter_did_export(self.exporter.ext)
+        gui_hooks.legacy_exporter_did_export(self.exporter)
         tooltip(msg, period=3000)
         QDialog.reject(self)
 

--- a/qt/aqt/exporting.py
+++ b/qt/aqt/exporting.py
@@ -196,6 +196,7 @@ class ExportDialog(QDialog):
                 else:
                     self.on_export_finished()
 
+            gui_hooks.legacy_exporter_will_export(self.exporter.ext)
             if self.isVerbatim:
                 gui_hooks.collection_will_temporarily_close(self.mw.col)
             self.mw.progress.start()
@@ -213,6 +214,7 @@ class ExportDialog(QDialog):
                 msg = tr.exporting_note_exported(count=self.exporter.count)
             else:
                 msg = tr.exporting_card_exported(count=self.exporter.count)
+        gui_hooks.legacy_exporter_did_export(self.exporter.ext)
         tooltip(msg, period=3000)
         QDialog.reject(self)
 

--- a/qt/aqt/import_export/exporting.py
+++ b/qt/aqt/import_export/exporting.py
@@ -49,14 +49,14 @@ class ExportDialog(QDialog):
         self.open()
 
     def setup(self, did: DeckId | None) -> None:
-        self.exporter_classes: list[Type[Exporter]] = [
+        self.exporters: list[Type[Exporter]] = [
             ApkgExporter,
             ColpkgExporter,
             NoteCsvExporter,
             CardCsvExporter,
         ]
         self.frm.format.insertItems(
-            0, [f"{e.name()} (.{e.extension})" for e in self.exporter_classes]
+            0, [f"{e.name()} (.{e.extension})" for e in self.exporters]
         )
         qconnect(self.frm.format.activated, self.exporter_changed)
         if self.nids is None and not did:
@@ -86,7 +86,7 @@ class ExportDialog(QDialog):
             self.frm.includeSched.setChecked(False)
 
     def exporter_changed(self, idx: int) -> None:
-        self.exporter = self.exporter_classes[idx]()
+        self.exporter = self.exporters[idx]()
         self.frm.includeSched.setVisible(self.exporter.show_include_scheduling)
         self.frm.includeMedia.setVisible(self.exporter.show_include_media)
         self.frm.includeTags.setVisible(self.exporter.show_include_tags)

--- a/qt/aqt/import_export/exporting.py
+++ b/qt/aqt/import_export/exporting.py
@@ -126,14 +126,14 @@ class ExportDialog(QDialog):
             break
         return path
 
-    def options(self, out_path: str) -> Options:
+    def options(self, out_path: str) -> ExportOptions:
         limit: ExportLimit = None
         if self.nids:
             limit = NoteIdsLimit(self.nids)
         elif current_deck_id := self.current_deck_id():
             limit = DeckIdLimit(current_deck_id)
 
-        return Options(
+        return ExportOptions(
             out_path=out_path,
             include_scheduling=self.frm.includeSched.isChecked(),
             include_media=self.frm.includeMedia.isChecked(),
@@ -166,7 +166,7 @@ class ExportDialog(QDialog):
 
 
 @dataclass
-class Options:
+class ExportOptions:
     out_path: str
     include_scheduling: bool
     include_media: bool
@@ -200,7 +200,7 @@ class Exporter(ABC):
 
     @classmethod
     @abstractmethod
-    def export(cls, mw: aqt.main.AnkiQt, options: Options) -> None:
+    def export(cls, mw: aqt.main.AnkiQt, options: ExportOptions) -> None:
         pass
 
     @staticmethod
@@ -219,7 +219,7 @@ class ColpkgExporter(Exporter):
         return tr.exporting_anki_collection_package()
 
     @classmethod
-    def export(cls, mw: aqt.main.AnkiQt, options: Options) -> None:
+    def export(cls, mw: aqt.main.AnkiQt, options: ExportOptions) -> None:
         options = gui_hooks.exporter_will_export(options, cls.format)
 
         def on_success(_: None) -> None:
@@ -257,7 +257,7 @@ class ApkgExporter(Exporter):
         return tr.exporting_anki_deck_package()
 
     @classmethod
-    def export(cls, mw: aqt.main.AnkiQt, options: Options) -> None:
+    def export(cls, mw: aqt.main.AnkiQt, options: ExportOptions) -> None:
         options = gui_hooks.exporter_will_export(options, cls.format)
 
         def on_success(count: int) -> None:
@@ -291,7 +291,7 @@ class NoteCsvExporter(Exporter):
         return tr.exporting_notes_in_plain_text()
 
     @classmethod
-    def export(cls, mw: aqt.main.AnkiQt, options: Options) -> None:
+    def export(cls, mw: aqt.main.AnkiQt, options: ExportOptions) -> None:
         options = gui_hooks.exporter_will_export(options, cls.format)
 
         def on_success(count: int) -> None:
@@ -323,7 +323,7 @@ class CardCsvExporter(Exporter):
         return tr.exporting_cards_in_plain_text()
 
     @classmethod
-    def export(cls, mw: aqt.main.AnkiQt, options: Options) -> None:
+    def export(cls, mw: aqt.main.AnkiQt, options: ExportOptions) -> None:
         options = gui_hooks.exporter_will_export(options, cls.format)
 
         def on_success(count: int) -> None:

--- a/qt/aqt/import_export/exporting.py
+++ b/qt/aqt/import_export/exporting.py
@@ -42,21 +42,21 @@ class ExportDialog(QDialog):
         self.col = mw.col.weakref()
         self.frm = aqt.forms.exporting.Ui_ExportDialog()
         self.frm.setupUi(self)
-        self.exporter: Type[Exporter] = None
+        self.exporter: Exporter
         self.nids = nids
         disable_help_button(self)
         self.setup(did)
         self.open()
 
     def setup(self, did: DeckId | None) -> None:
-        self.exporters: list[Type[Exporter]] = [
+        self.exporter_classes: list[Type[Exporter]] = [
             ApkgExporter,
             ColpkgExporter,
             NoteCsvExporter,
             CardCsvExporter,
         ]
         self.frm.format.insertItems(
-            0, [f"{e.name()} (.{e.extension})" for e in self.exporters]
+            0, [f"{e.name()} (.{e.extension})" for e in self.exporter_classes]
         )
         qconnect(self.frm.format.activated, self.exporter_changed)
         if self.nids is None and not did:
@@ -86,7 +86,7 @@ class ExportDialog(QDialog):
             self.frm.includeSched.setChecked(False)
 
     def exporter_changed(self, idx: int) -> None:
-        self.exporter = self.exporters[idx]
+        self.exporter = self.exporter_classes[idx]()
         self.frm.includeSched.setVisible(self.exporter.show_include_scheduling)
         self.frm.includeMedia.setVisible(self.exporter.show_include_media)
         self.frm.includeTags.setVisible(self.exporter.show_include_tags)
@@ -190,9 +190,8 @@ class Exporter(ABC):
     show_include_notetype = False
     show_include_guid = False
 
-    @classmethod
     @abstractmethod
-    def export(cls, mw: aqt.main.AnkiQt, options: ExportOptions) -> None:
+    def export(self, mw: aqt.main.AnkiQt, options: ExportOptions) -> None:
         pass
 
     @staticmethod
@@ -210,13 +209,12 @@ class ColpkgExporter(Exporter):
     def name() -> str:
         return tr.exporting_anki_collection_package()
 
-    @classmethod
-    def export(cls, mw: aqt.main.AnkiQt, options: ExportOptions) -> None:
-        options = gui_hooks.exporter_will_export(options, cls)
+    def export(self, mw: aqt.main.AnkiQt, options: ExportOptions) -> None:
+        options = gui_hooks.exporter_will_export(options, self)
 
         def on_success(_: None) -> None:
             mw.reopen()
-            gui_hooks.exporter_did_export(options, cls)
+            gui_hooks.exporter_did_export(options, self)
             tooltip(tr.exporting_collection_exported(), parent=mw)
 
         def on_failure(exception: Exception) -> None:
@@ -248,12 +246,11 @@ class ApkgExporter(Exporter):
     def name() -> str:
         return tr.exporting_anki_deck_package()
 
-    @classmethod
-    def export(cls, mw: aqt.main.AnkiQt, options: ExportOptions) -> None:
-        options = gui_hooks.exporter_will_export(options, cls)
+    def export(self, mw: aqt.main.AnkiQt, options: ExportOptions) -> None:
+        options = gui_hooks.exporter_will_export(options, self)
 
         def on_success(count: int) -> None:
-            gui_hooks.exporter_did_export(options, cls)
+            gui_hooks.exporter_did_export(options, self)
             tooltip(tr.exporting_note_exported(count=count), parent=mw)
 
         QueryOp(
@@ -282,12 +279,11 @@ class NoteCsvExporter(Exporter):
     def name() -> str:
         return tr.exporting_notes_in_plain_text()
 
-    @classmethod
-    def export(cls, mw: aqt.main.AnkiQt, options: ExportOptions) -> None:
-        options = gui_hooks.exporter_will_export(options, cls)
+    def export(self, mw: aqt.main.AnkiQt, options: ExportOptions) -> None:
+        options = gui_hooks.exporter_will_export(options, self)
 
         def on_success(count: int) -> None:
-            gui_hooks.exporter_did_export(options, cls)
+            gui_hooks.exporter_did_export(options, self)
             tooltip(tr.exporting_note_exported(count=count), parent=mw)
 
         QueryOp(
@@ -314,12 +310,11 @@ class CardCsvExporter(Exporter):
     def name() -> str:
         return tr.exporting_cards_in_plain_text()
 
-    @classmethod
-    def export(cls, mw: aqt.main.AnkiQt, options: ExportOptions) -> None:
-        options = gui_hooks.exporter_will_export(options, cls)
+    def export(self, mw: aqt.main.AnkiQt, options: ExportOptions) -> None:
+        options = gui_hooks.exporter_will_export(options, self)
 
         def on_success(count: int) -> None:
-            gui_hooks.exporter_did_export(options, cls)
+            gui_hooks.exporter_did_export(options, self)
             tooltip(tr.exporting_card_exported(count=count), parent=mw)
 
         QueryOp(

--- a/qt/aqt/import_export/exporting.py
+++ b/qt/aqt/import_export/exporting.py
@@ -220,8 +220,11 @@ class ColpkgExporter(Exporter):
 
     @staticmethod
     def export(mw: aqt.main.AnkiQt, options: Options) -> None:
+        gui_hooks.exporter_will_export(ExportFormat.COLPKG, options)
+
         def on_success(_: None) -> None:
             mw.reopen()
+            gui_hooks.exporter_did_export(ExportFormat.COLPKG, options)
             tooltip(tr.exporting_collection_exported(), parent=mw)
 
         def on_failure(exception: Exception) -> None:
@@ -255,6 +258,12 @@ class ApkgExporter(Exporter):
 
     @staticmethod
     def export(mw: aqt.main.AnkiQt, options: Options) -> None:
+        gui_hooks.exporter_will_export(ExportFormat.APKG, options)
+
+        def on_success(count: int) -> None:
+            gui_hooks.exporter_did_export(ExportFormat.APKG, options)
+            tooltip(tr.exporting_note_exported(count=count), parent=mw)
+
         QueryOp(
             parent=mw,
             op=lambda col: col.export_anki_package(
@@ -264,9 +273,7 @@ class ApkgExporter(Exporter):
                 with_media=options.include_media,
                 legacy_support=options.legacy_support,
             ),
-            success=lambda count: tooltip(
-                tr.exporting_note_exported(count=count), parent=mw
-            ),
+            success=on_success,
         ).with_backend_progress(export_progress_update).run_in_background()
 
 
@@ -285,6 +292,12 @@ class NoteCsvExporter(Exporter):
 
     @staticmethod
     def export(mw: aqt.main.AnkiQt, options: Options) -> None:
+        gui_hooks.exporter_will_export(ExportFormat.CSV_NOTES, options)
+
+        def on_success(count: int) -> None:
+            gui_hooks.exporter_did_export(ExportFormat.CSV_NOTES, options)
+            tooltip(tr.exporting_note_exported(count=count), parent=mw)
+
         QueryOp(
             parent=mw,
             op=lambda col: col.export_note_csv(
@@ -296,9 +309,7 @@ class NoteCsvExporter(Exporter):
                 with_notetype=options.include_notetype,
                 with_guid=options.include_guid,
             ),
-            success=lambda count: tooltip(
-                tr.exporting_note_exported(count=count), parent=mw
-            ),
+            success=on_success,
         ).with_backend_progress(export_progress_update).run_in_background()
 
 
@@ -313,6 +324,12 @@ class CardCsvExporter(Exporter):
 
     @staticmethod
     def export(mw: aqt.main.AnkiQt, options: Options) -> None:
+        gui_hooks.exporter_will_export(ExportFormat.CSV_CARDS, options)
+
+        def on_success(count: int) -> None:
+            gui_hooks.exporter_did_export(ExportFormat.CSV_CARDS, options)
+            tooltip(tr.exporting_card_exported(count=count), parent=mw)
+
         QueryOp(
             parent=mw,
             op=lambda col: col.export_card_csv(
@@ -320,9 +337,7 @@ class CardCsvExporter(Exporter):
                 limit=options.limit,
                 with_html=options.include_html,
             ),
-            success=lambda count: tooltip(
-                tr.exporting_card_exported(count=count), parent=mw
-            ),
+            success=on_success,
         ).with_backend_progress(export_progress_update).run_in_background()
 
 

--- a/qt/aqt/import_export/exporting.py
+++ b/qt/aqt/import_export/exporting.py
@@ -8,6 +8,7 @@ import re
 import time
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
+from enum import Enum
 from typing import Sequence, Type
 
 import aqt.forms
@@ -178,6 +179,13 @@ class Options:
     limit: ExportLimit
 
 
+class ExportFormat(Enum):
+    COLPKG = "colpkg"
+    APKG = "apkg"
+    CSV_NOTES = "txt"
+    CSV_CARDS = "txt"
+
+
 class Exporter(ABC):
     extension: str
     show_deck_list = False
@@ -202,7 +210,7 @@ class Exporter(ABC):
 
 
 class ColpkgExporter(Exporter):
-    extension = "colpkg"
+    extension = ExportFormat.COLPKG.value
     show_include_media = True
     show_legacy_support = True
 
@@ -235,7 +243,7 @@ class ColpkgExporter(Exporter):
 
 
 class ApkgExporter(Exporter):
-    extension = "apkg"
+    extension = ExportFormat.APKG.value
     show_deck_list = True
     show_include_scheduling = True
     show_include_media = True
@@ -263,7 +271,7 @@ class ApkgExporter(Exporter):
 
 
 class NoteCsvExporter(Exporter):
-    extension = "txt"
+    extension = ExportFormat.CSV_NOTES.value
     show_deck_list = True
     show_include_html = True
     show_include_tags = True
@@ -295,7 +303,7 @@ class NoteCsvExporter(Exporter):
 
 
 class CardCsvExporter(Exporter):
-    extension = "txt"
+    extension = ExportFormat.CSV_CARDS.value
     show_deck_list = True
     show_include_html = True
 

--- a/qt/aqt/import_export/exporting.py
+++ b/qt/aqt/import_export/exporting.py
@@ -57,7 +57,7 @@ class ExportDialog(QDialog):
             CardCsvExporter,
         ]
         self.frm.format.insertItems(
-            0, [f"{e.name()} (.{e.extension})" for e in self.exporters]
+            0, [f"{e.name()} (.{e.format.value})" for e in self.exporters]
         )
         qconnect(self.frm.format.activated, self.exporter_changed)
         if self.nids is None and not did:
@@ -112,7 +112,7 @@ class ExportDialog(QDialog):
                 title=tr.actions_export(),
                 dir_description="export",
                 key=self.exporter.name(),
-                ext="." + self.exporter.extension,
+                ext="." + self.exporter.format.value,
                 fname=filename,
             )
             if not path:
@@ -162,7 +162,7 @@ class ExportDialog(QDialog):
         else:
             time_str = time.strftime("%Y-%m-%d@%H-%M-%S", time.localtime(time.time()))
             stem = f"{tr.exporting_collection()}-{time_str}"
-        return f"{stem}.{self.exporter.extension}"
+        return f"{stem}.{self.exporter.format.value}"
 
 
 @dataclass
@@ -187,7 +187,7 @@ class ExportFormat(Enum):
 
 
 class Exporter(ABC):
-    extension: str
+    format: ExportFormat
     show_deck_list = False
     show_include_scheduling = False
     show_include_media = False
@@ -198,9 +198,9 @@ class Exporter(ABC):
     show_include_notetype = False
     show_include_guid = False
 
-    @staticmethod
+    @classmethod
     @abstractmethod
-    def export(mw: aqt.main.AnkiQt, options: Options) -> None:
+    def export(cls, mw: aqt.main.AnkiQt, options: Options) -> None:
         pass
 
     @staticmethod
@@ -210,7 +210,7 @@ class Exporter(ABC):
 
 
 class ColpkgExporter(Exporter):
-    extension = ExportFormat.COLPKG.value
+    format = ExportFormat.COLPKG
     show_include_media = True
     show_legacy_support = True
 
@@ -218,13 +218,13 @@ class ColpkgExporter(Exporter):
     def name() -> str:
         return tr.exporting_anki_collection_package()
 
-    @staticmethod
-    def export(mw: aqt.main.AnkiQt, options: Options) -> None:
-        options = gui_hooks.exporter_will_export(options, ExportFormat.COLPKG)
+    @classmethod
+    def export(cls, mw: aqt.main.AnkiQt, options: Options) -> None:
+        options = gui_hooks.exporter_will_export(options, cls.format)
 
         def on_success(_: None) -> None:
             mw.reopen()
-            gui_hooks.exporter_did_export(options, ExportFormat.COLPKG)
+            gui_hooks.exporter_did_export(options, cls.format)
             tooltip(tr.exporting_collection_exported(), parent=mw)
 
         def on_failure(exception: Exception) -> None:
@@ -246,7 +246,7 @@ class ColpkgExporter(Exporter):
 
 
 class ApkgExporter(Exporter):
-    extension = ExportFormat.APKG.value
+    format = ExportFormat.APKG
     show_deck_list = True
     show_include_scheduling = True
     show_include_media = True
@@ -256,12 +256,12 @@ class ApkgExporter(Exporter):
     def name() -> str:
         return tr.exporting_anki_deck_package()
 
-    @staticmethod
-    def export(mw: aqt.main.AnkiQt, options: Options) -> None:
-        options = gui_hooks.exporter_will_export(options, ExportFormat.APKG)
+    @classmethod
+    def export(cls, mw: aqt.main.AnkiQt, options: Options) -> None:
+        options = gui_hooks.exporter_will_export(options, cls.format)
 
         def on_success(count: int) -> None:
-            gui_hooks.exporter_did_export(options, ExportFormat.APKG)
+            gui_hooks.exporter_did_export(options, cls.format)
             tooltip(tr.exporting_note_exported(count=count), parent=mw)
 
         QueryOp(
@@ -278,7 +278,7 @@ class ApkgExporter(Exporter):
 
 
 class NoteCsvExporter(Exporter):
-    extension = ExportFormat.CSV_NOTES.value
+    format = ExportFormat.CSV_NOTES
     show_deck_list = True
     show_include_html = True
     show_include_tags = True
@@ -290,12 +290,12 @@ class NoteCsvExporter(Exporter):
     def name() -> str:
         return tr.exporting_notes_in_plain_text()
 
-    @staticmethod
-    def export(mw: aqt.main.AnkiQt, options: Options) -> None:
-        options = gui_hooks.exporter_will_export(options, ExportFormat.CSV_NOTES)
+    @classmethod
+    def export(cls, mw: aqt.main.AnkiQt, options: Options) -> None:
+        options = gui_hooks.exporter_will_export(options, cls.format)
 
         def on_success(count: int) -> None:
-            gui_hooks.exporter_did_export(options, ExportFormat.CSV_NOTES)
+            gui_hooks.exporter_did_export(options, cls.format)
             tooltip(tr.exporting_note_exported(count=count), parent=mw)
 
         QueryOp(
@@ -314,7 +314,7 @@ class NoteCsvExporter(Exporter):
 
 
 class CardCsvExporter(Exporter):
-    extension = ExportFormat.CSV_CARDS.value
+    format = ExportFormat.CSV_CARDS
     show_deck_list = True
     show_include_html = True
 
@@ -322,12 +322,12 @@ class CardCsvExporter(Exporter):
     def name() -> str:
         return tr.exporting_cards_in_plain_text()
 
-    @staticmethod
-    def export(mw: aqt.main.AnkiQt, options: Options) -> None:
-        options = gui_hooks.exporter_will_export(options, ExportFormat.CSV_CARDS)
+    @classmethod
+    def export(cls, mw: aqt.main.AnkiQt, options: Options) -> None:
+        options = gui_hooks.exporter_will_export(options, cls.format)
 
         def on_success(count: int) -> None:
-            gui_hooks.exporter_did_export(options, ExportFormat.CSV_CARDS)
+            gui_hooks.exporter_did_export(options, cls.format)
             tooltip(tr.exporting_card_exported(count=count), parent=mw)
 
         QueryOp(

--- a/qt/aqt/import_export/exporting.py
+++ b/qt/aqt/import_export/exporting.py
@@ -220,11 +220,11 @@ class ColpkgExporter(Exporter):
 
     @staticmethod
     def export(mw: aqt.main.AnkiQt, options: Options) -> None:
-        gui_hooks.exporter_will_export(ExportFormat.COLPKG, options)
+        options = gui_hooks.exporter_will_export(options, ExportFormat.COLPKG)
 
         def on_success(_: None) -> None:
             mw.reopen()
-            gui_hooks.exporter_did_export(ExportFormat.COLPKG, options)
+            gui_hooks.exporter_did_export(options, ExportFormat.COLPKG)
             tooltip(tr.exporting_collection_exported(), parent=mw)
 
         def on_failure(exception: Exception) -> None:
@@ -258,10 +258,10 @@ class ApkgExporter(Exporter):
 
     @staticmethod
     def export(mw: aqt.main.AnkiQt, options: Options) -> None:
-        gui_hooks.exporter_will_export(ExportFormat.APKG, options)
+        options = gui_hooks.exporter_will_export(options, ExportFormat.APKG)
 
         def on_success(count: int) -> None:
-            gui_hooks.exporter_did_export(ExportFormat.APKG, options)
+            gui_hooks.exporter_did_export(options, ExportFormat.APKG)
             tooltip(tr.exporting_note_exported(count=count), parent=mw)
 
         QueryOp(
@@ -292,10 +292,10 @@ class NoteCsvExporter(Exporter):
 
     @staticmethod
     def export(mw: aqt.main.AnkiQt, options: Options) -> None:
-        gui_hooks.exporter_will_export(ExportFormat.CSV_NOTES, options)
+        options = gui_hooks.exporter_will_export(options, ExportFormat.CSV_NOTES)
 
         def on_success(count: int) -> None:
-            gui_hooks.exporter_did_export(ExportFormat.CSV_NOTES, options)
+            gui_hooks.exporter_did_export(options, ExportFormat.CSV_NOTES)
             tooltip(tr.exporting_note_exported(count=count), parent=mw)
 
         QueryOp(
@@ -324,10 +324,10 @@ class CardCsvExporter(Exporter):
 
     @staticmethod
     def export(mw: aqt.main.AnkiQt, options: Options) -> None:
-        gui_hooks.exporter_will_export(ExportFormat.CSV_CARDS, options)
+        options = gui_hooks.exporter_will_export(options, ExportFormat.CSV_CARDS)
 
         def on_success(count: int) -> None:
-            gui_hooks.exporter_did_export(ExportFormat.CSV_CARDS, options)
+            gui_hooks.exporter_did_export(options, ExportFormat.CSV_CARDS)
             tooltip(tr.exporting_card_exported(count=count), parent=mw)
 
         QueryOp(

--- a/qt/aqt/import_export/exporting.py
+++ b/qt/aqt/import_export/exporting.py
@@ -49,14 +49,14 @@ class ExportDialog(QDialog):
         self.open()
 
     def setup(self, did: DeckId | None) -> None:
-        self.exporters: list[Type[Exporter]] = [
+        self.exporter_classes: list[Type[Exporter]] = [
             ApkgExporter,
             ColpkgExporter,
             NoteCsvExporter,
             CardCsvExporter,
         ]
         self.frm.format.insertItems(
-            0, [f"{e.name()} (.{e.extension})" for e in self.exporters]
+            0, [f"{e.name()} (.{e.extension})" for e in self.exporter_classes]
         )
         qconnect(self.frm.format.activated, self.exporter_changed)
         if self.nids is None and not did:
@@ -86,7 +86,7 @@ class ExportDialog(QDialog):
             self.frm.includeSched.setChecked(False)
 
     def exporter_changed(self, idx: int) -> None:
-        self.exporter = self.exporters[idx]()
+        self.exporter = self.exporter_classes[idx]()
         self.frm.includeSched.setVisible(self.exporter.show_include_scheduling)
         self.frm.includeMedia.setVisible(self.exporter.show_include_media)
         self.frm.includeTags.setVisible(self.exporter.show_include_tags)

--- a/qt/tools/genhooks_gui.py
+++ b/qt/tools/genhooks_gui.py
@@ -19,7 +19,7 @@ prefix = """\
 
 from __future__ import annotations
 
-from typing import Any, Callable, Sequence, Literal, Type
+from typing import Any, Callable, Sequence, Literal
 
 import anki
 import aqt
@@ -822,7 +822,7 @@ gui_hooks.webview_did_inject_style_into_page.append(mytest)
         name="exporter_will_export",
         args=[
             "export_options: aqt.import_export.exporting.ExportOptions",
-            "exporter: Type[aqt.import_export.exporting.Exporter]",
+            "exporter: aqt.import_export.exporting.Exporter",
         ],
         return_type="aqt.import_export.exporting.ExportOptions",
         doc="""Called before collection and deck exports.
@@ -831,8 +831,8 @@ gui_hooks.webview_did_inject_style_into_page.append(mytest)
         modify the export options. To perform the export unaltered, please return
         `export_options` as is, e.g.:
         
-            def on_exporter_will_export(export_options: ExportOptions, exporter: Type[Exporter]):
-                if not exporter == ApkgExporter:
+            def on_exporter_will_export(export_options: ExportOptions, exporter: Exporter):
+                if not isinstance(exporter, ApkgExporter):
                     return export_options
                 export_options.limit = ...
                 return export_options
@@ -842,7 +842,7 @@ gui_hooks.webview_did_inject_style_into_page.append(mytest)
         name="exporter_did_export",
         args=[
             "export_options: aqt.import_export.exporting.ExportOptions",
-            "exporter: Type[aqt.import_export.exporting.Exporter]",
+            "exporter: aqt.import_export.exporting.Exporter",
         ],
         doc="""Called after collection and deck exports.""",
     ),

--- a/qt/tools/genhooks_gui.py
+++ b/qt/tools/genhooks_gui.py
@@ -819,27 +819,27 @@ gui_hooks.webview_did_inject_style_into_page.append(mytest)
     Hook(
         name="exporter_will_export",
         args=[
-            "options: aqt.import_export.exporting.Options",
+            "export_options: aqt.import_export.exporting.ExportOptions",
             "export_format: aqt.import_export.exporting.ExportFormat",
         ],
-        return_type="aqt.import_export.exporting.Options",
+        return_type="aqt.import_export.exporting.ExportOptions",
         doc="""Called before collection and deck exports.
         
         Allows add-ons to be notified of impending deck exports and potentially
         modify the export options. To perform the export unaltered, please return
-        `options` as is, e.g.:
+        `export_options` as is, e.g.:
         
-            def on_exporter_will_export(options: Options, export_format: ExportFormat):
+            def on_exporter_will_export(export_options: ExportOptions, export_format: ExportFormat):
                 if export_format != ExportFormat.APKG:
-                    return options
-                options.limit = ...
-                return options
+                    return export_options
+                export_options.limit = ...
+                return export_options
         """,
     ),
     Hook(
         name="exporter_did_export",
         args=[
-            "options: aqt.import_export.exporting.Options",
+            "export_options: aqt.import_export.exporting.ExportOptions",
             "export_format: aqt.import_export.exporting.ExportFormat",
         ],
         doc="""Called after collection and deck exports.""",

--- a/qt/tools/genhooks_gui.py
+++ b/qt/tools/genhooks_gui.py
@@ -19,7 +19,7 @@ prefix = """\
 
 from __future__ import annotations
 
-from typing import Any, Callable, Sequence, Literal
+from typing import Any, Callable, Sequence, Literal, Type
 
 import anki
 import aqt
@@ -822,7 +822,7 @@ gui_hooks.webview_did_inject_style_into_page.append(mytest)
         name="exporter_will_export",
         args=[
             "export_options: aqt.import_export.exporting.ExportOptions",
-            "export_format: aqt.import_export.exporting.ExportFormat",
+            "exporter: Type[aqt.import_export.exporting.Exporter]",
         ],
         return_type="aqt.import_export.exporting.ExportOptions",
         doc="""Called before collection and deck exports.
@@ -831,8 +831,8 @@ gui_hooks.webview_did_inject_style_into_page.append(mytest)
         modify the export options. To perform the export unaltered, please return
         `export_options` as is, e.g.:
         
-            def on_exporter_will_export(export_options: ExportOptions, export_format: ExportFormat):
-                if export_format != ExportFormat.APKG:
+            def on_exporter_will_export(export_options: ExportOptions, exporter: Type[Exporter]):
+                if not exporter == ApkgExporter:
                     return export_options
                 export_options.limit = ...
                 return export_options
@@ -842,18 +842,18 @@ gui_hooks.webview_did_inject_style_into_page.append(mytest)
         name="exporter_did_export",
         args=[
             "export_options: aqt.import_export.exporting.ExportOptions",
-            "export_format: aqt.import_export.exporting.ExportFormat",
+            "exporter: Type[aqt.import_export.exporting.Exporter]",
         ],
         doc="""Called after collection and deck exports.""",
     ),
     Hook(
         name="legacy_exporter_will_export",
-        args=["file_extension: str"],
+        args=["legacy_exporter: anki.exporting.Exporter"],
         doc="""Called before collection and deck exports performed by legacy exporters.""",
     ),
     Hook(
         name="legacy_exporter_did_export",
-        args=["file_extension: str"],
+        args=["legacy_exporter: anki.exporting.Exporter"],
         doc="""Called after collection and deck exports performed by legacy exporters.""",
     ),
     # Dialog Manager

--- a/qt/tools/genhooks_gui.py
+++ b/qt/tools/genhooks_gui.py
@@ -816,6 +816,8 @@ gui_hooks.webview_did_inject_style_into_page.append(mytest)
 
         `output` provides access to the unused/missing file lists and the text output that will be shown in the Check Media screen.""",
     ),
+    # Importing/exporting data
+    ###################
     Hook(
         name="exporter_will_export",
         args=[
@@ -843,6 +845,16 @@ gui_hooks.webview_did_inject_style_into_page.append(mytest)
             "export_format: aqt.import_export.exporting.ExportFormat",
         ],
         doc="""Called after collection and deck exports.""",
+    ),
+    Hook(
+        name="legacy_exporter_will_export",
+        args=["file_extension: str"],
+        doc="""Called before collection and deck exports performed by legacy exporters.""",
+    ),
+    Hook(
+        name="legacy_exporter_did_export",
+        args=["file_extension: str"],
+        doc="""Called after collection and deck exports performed by legacy exporters.""",
     ),
     # Dialog Manager
     ###################

--- a/qt/tools/genhooks_gui.py
+++ b/qt/tools/genhooks_gui.py
@@ -819,16 +819,28 @@ gui_hooks.webview_did_inject_style_into_page.append(mytest)
     Hook(
         name="exporter_will_export",
         args=[
-            "export_format: aqt.import_export.exporting.ExportFormat",
             "options: aqt.import_export.exporting.Options",
+            "export_format: aqt.import_export.exporting.ExportFormat",
         ],
-        doc="""Called before collection and deck exports.""",
+        return_type="aqt.import_export.exporting.Options",
+        doc="""Called before collection and deck exports.
+        
+        Allows add-ons to be notified of impending deck exports and potentially
+        modify the export options. To perform the export unaltered, please return
+        `options` as is, e.g.:
+        
+            def on_exporter_will_export(options: Options, export_format: ExportFormat):
+                if export_format != ExportFormat.APKG:
+                    return options
+                options.limit = ...
+                return options
+        """,
     ),
     Hook(
         name="exporter_did_export",
         args=[
-            "export_format: aqt.import_export.exporting.ExportFormat",
             "options: aqt.import_export.exporting.Options",
+            "export_format: aqt.import_export.exporting.ExportFormat",
         ],
         doc="""Called after collection and deck exports.""",
     ),

--- a/qt/tools/genhooks_gui.py
+++ b/qt/tools/genhooks_gui.py
@@ -816,6 +816,22 @@ gui_hooks.webview_did_inject_style_into_page.append(mytest)
 
         `output` provides access to the unused/missing file lists and the text output that will be shown in the Check Media screen.""",
     ),
+    Hook(
+        name="exporter_will_export",
+        args=[
+            "export_format: aqt.import_export.exporting.ExportFormat",
+            "options: aqt.import_export.exporting.Options",
+        ],
+        doc="""Called before collection and deck exports.""",
+    ),
+    Hook(
+        name="exporter_did_export",
+        args=[
+            "export_format: aqt.import_export.exporting.ExportFormat",
+            "options: aqt.import_export.exporting.Options",
+        ],
+        doc="""Called after collection and deck exports.""",
+    ),
     # Dialog Manager
     ###################
     Hook(


### PR DESCRIPTION
Adds a number of hooks that allow add-ons to perform actions before/after decks are exported and – in the case of the new export handling – modify the options of the export.

Previously, add-ons could achieve something similar by wrapping `Exporter.exportInto`. However, with exports now being handled by the Rust backend in the background and `on_success` out of easy reach, my hope is that these hooks will allow add-on authors to retain the ability to act upon deck exports without major monkey-patches.

**Use case**

Although I think this could be useful in many scenarios, the concrete use case I'm targeting is mobile / AnkiWeb support for the AMBOSS add-on: To make the medical definition pop-ups work on these platforms, in its current beta release the add-on appends a small one-liner to card templates – in an idempotent operation that's fully reversible. However, keeping the one-liner around when exporting decks is not ideal as the user importing the deck might not have the add-on installed, nor want the explanations to show up in their cards.

So to address this scenario, with legacy export handling, the add-on currently monkey-patches legacy exporters to remove the snippet ahead of exports, and then re-introduce it afterwards. With the new export code this is much more difficult to do because of the asynchronous background operation, so I thought it would be best to handle this by extending the hook API.

**Some notes**:

- I tried to keep the footprint as minimal as possible, but did end up introducing some minor refactoring changes to improve typing and clarity of the API when used in add-ons (e.g. use of `ExportFormat`, `Options` → `ExportOptions`). Hope that's ok still in this early phase of the new exporter code
- `exporter_will_export` being a filter for `ExportOptions` isn't necessary for the AMBOSS use case, but I figured it could be helpful to other add-ons, so I opted to add it now rather than the hook API having to change in the future. Would be happy to grade this down to a regular hook, however, if you think it's pre-mature and add-ons wanting to modify the export settings at this stage is not as likely.
- To make it easier to give the hooks a try, I've added a debug console snippet in the comment below

----

*Copyright disclosure: This patch was written as part of my work for AMBOSS. Its rights of use lie with AMBOSS MD Inc and it is being submitted in agreement with Anki's contributor license agreement, as signed by AMBOSS MD Inc. (see the `CONTRIBUTORS` file).*
