### PR TITLE
modify type hint in aqt/qt/profiles

### DIFF
--- a/qt/aqt/profiles.py
+++ b/qt/aqt/profiles.py
@@ -149,8 +149,8 @@ class ProfileManager:
     # Profile load/save
     ######################################################################
 
-    def profiles(self) -> list:
-        def names() -> list:
+    def profiles(self) -> list[str]:
+        def names() -> list[str]:
             return self.db.list("select name from profiles where name != '_global'")
 
         n = names()


### PR DESCRIPTION
A very minor change [discussed on my last pr](https://github.com/ankitects/anki/pull/1960/files#r922944488). Gives a more specific type hint to `profiles()` in `qt/aqt/profiles.py` than the one created automatically.
