### PR TITLE
Improve temporary table handling

### DIFF
--- a/rslib/src/card/mod.rs
+++ b/rslib/src/card/mod.rs
@@ -274,12 +274,11 @@ impl Collection {
         ))?;
         let config = self.get_deck_config(config_id, true)?.unwrap();
         let mut steps_adjuster = RemainingStepsAdjuster::new(&config);
-        self.storage.set_search_table_to_card_ids(cards, false)?;
         let sched = self.scheduler_version();
         let usn = self.usn()?;
         self.transact(Op::SetCardDeck, |col| {
             let mut count = 0;
-            for mut card in col.storage.all_searched_cards()? {
+            for mut card in col.all_cards_for_ids(cards, false)? {
                 if card.deck_id == deck_id {
                     continue;
                 }
@@ -299,11 +298,10 @@ impl Collection {
         }
         let flag = flag as u8;
 
-        self.storage.set_search_table_to_card_ids(cards, false)?;
         let usn = self.usn()?;
         self.transact(Op::SetFlag, |col| {
             let mut count = 0;
-            for mut card in col.storage.all_searched_cards()? {
+            for mut card in col.all_cards_for_ids(cards, false)? {
                 let original = card.clone();
                 if card.set_flag(flag) {
                     // To avoid having to rebuild the study queues, we mark the card as requiring

--- a/rslib/src/import_export/text/csv/export.rs
+++ b/rslib/src/import_export/text/csv/export.rs
@@ -53,16 +53,15 @@ impl Collection {
         progress.call(ExportProgress::File)?;
         let mut incrementor = progress.incrementor(ExportProgress::Notes);
 
-        self.search_notes_into_table(request.search_node())?;
-        let ctx = NoteContext::new(&request, self)?;
+        let guard = self.search_notes_into_table(request.search_node())?;
+        let ctx = NoteContext::new(&request, guard.col)?;
         let mut writer = note_file_writer_with_header(&request.out_path, &ctx)?;
-        self.storage.for_each_note_in_search(|note| {
+        guard.col.storage.for_each_note_in_search(|note| {
             incrementor.increment()?;
             writer.write_record(ctx.record(&note))?;
             Ok(())
         })?;
         writer.flush()?;
-        self.storage.clear_searched_notes_table()?;
 
         Ok(incrementor.count())
     }

--- a/rslib/src/notetype/notetypechange.rs
+++ b/rslib/src/notetype/notetypechange.rs
@@ -8,7 +8,7 @@ use std::collections::{HashMap, HashSet};
 use super::{CardGenContext, Notetype, NotetypeKind};
 use crate::{
     prelude::*,
-    search::{JoinSearches, Node, SearchNode, SortMode, TemplateKind},
+    search::{JoinSearches, Node, SearchNode, TemplateKind},
     storage::comma_separated_ids,
 };
 
@@ -294,11 +294,9 @@ impl Collection {
         if !map.removed.is_empty() {
             let ords =
                 SearchBuilder::any(map.removed.iter().map(|o| TemplateKind::Ordinal(*o as u16)));
-            self.search_cards_into_table(nids.and(ords), SortMode::NoOrder)?;
-            for card in self.storage.all_searched_cards()? {
+            for card in self.all_cards_for_search(nids.and(ords))? {
                 self.remove_card_and_add_grave_undoable(card, usn)?;
             }
-            self.storage.clear_searched_cards_table()?;
         }
 
         Ok(())
@@ -316,14 +314,12 @@ impl Collection {
                     .keys()
                     .map(|o| TemplateKind::Ordinal(*o as u16)),
             );
-            self.search_cards_into_table(nids.and(ords), SortMode::NoOrder)?;
-            for mut card in self.storage.all_searched_cards()? {
+            for mut card in self.all_cards_for_search(nids.and(ords))? {
                 let original = card.clone();
                 card.template_idx =
                     *map.remapped.get(&(card.template_idx as usize)).unwrap() as u16;
                 self.update_card_inner(&mut card, original, usn)?;
             }
-            self.storage.clear_searched_cards_table()?;
         }
 
         Ok(())

--- a/rslib/src/notetype/notetypechange.rs
+++ b/rslib/src/notetype/notetypechange.rs
@@ -345,7 +345,6 @@ impl Collection {
             {
                 self.remove_card_and_add_grave_undoable(card, usn)?;
             }
-            self.storage.clear_searched_notes_table()?;
         }
 
         Ok(())

--- a/rslib/src/scheduler/bury_and_suspend.rs
+++ b/rslib/src/scheduler/bury_and_suspend.rs
@@ -42,12 +42,10 @@ impl Collection {
     /// Unbury cards from the previous day.
     /// Done automatically, and does not mark the cards as modified.
     pub(crate) fn unbury_on_day_rollover(&mut self, today: u32) -> Result<()> {
-        self.search_cards_into_table("is:buried", SortMode::NoOrder)?;
-        self.storage.for_each_card_in_search(|mut card| {
+        self.for_each_card_in_search(StateKind::Buried, |col, mut card| {
             card.restore_queue_after_bury_or_suspend();
-            self.storage.update_card(&card)
+            col.storage.update_card(&card)
         })?;
-        self.storage.clear_searched_cards_table()?;
         self.set_last_unburied_day(today)
     }
 

--- a/rslib/src/scheduler/bury_and_suspend.rs
+++ b/rslib/src/scheduler/bury_and_suspend.rs
@@ -51,8 +51,7 @@ impl Collection {
         self.set_last_unburied_day(today)
     }
 
-    /// Unsuspend/unbury cards in search table, and clear it.
-    /// Marks the cards as modified.
+    /// Unsuspend/unbury cards in search table. Marks the cards as modified.
     fn unsuspend_or_unbury_searched_cards(&mut self) -> Result<()> {
         let usn = self.usn()?;
         for original in self.storage.all_searched_cards()? {
@@ -61,7 +60,7 @@ impl Collection {
                 self.update_card_inner(&mut card, original, usn)?;
             }
         }
-        self.storage.clear_searched_cards_table()
+        Ok(())
     }
 
     pub fn unbury_or_unsuspend_cards(&mut self, cids: &[CardId]) -> Result<OpOutput<()>> {
@@ -78,11 +77,11 @@ impl Collection {
             UnburyDeckMode::SchedOnly => StateKind::SchedBuried,
         };
         self.transact(Op::UnburyUnsuspend, |col| {
-            col.search_cards_into_table(
+            let guard = col.search_cards_into_table(
                 SearchNode::DeckIdWithChildren(deck_id).and(state),
                 SortMode::NoOrder,
             )?;
-            col.unsuspend_or_unbury_searched_cards()
+            guard.col.unsuspend_or_unbury_searched_cards()
         })
     }
 

--- a/rslib/src/scheduler/bury_and_suspend.rs
+++ b/rslib/src/scheduler/bury_and_suspend.rs
@@ -83,7 +83,11 @@ impl Collection {
 
     /// Bury/suspend cards in search table, and clear it.
     /// Marks the cards as modified.
-    fn bury_or_suspend_searched_cards(&mut self, mode: BuryOrSuspendMode) -> Result<usize> {
+    fn bury_or_suspend_cards_inner(
+        &mut self,
+        cards: Vec<Card>,
+        mode: BuryOrSuspendMode,
+    ) -> Result<usize> {
         let mut count = 0;
         let usn = self.usn()?;
         let sched = self.scheduler_version();
@@ -100,7 +104,7 @@ impl Collection {
             }
         };
 
-        for original in self.storage.all_searched_cards()? {
+        for original in cards {
             let mut card = original.clone();
             if card.queue != desired_queue {
                 // do not bury suspended cards as that would unsuspend them
@@ -116,8 +120,6 @@ impl Collection {
             }
         }
 
-        self.storage.clear_searched_cards_table()?;
-
         Ok(count)
     }
 
@@ -131,8 +133,8 @@ impl Collection {
             BuryOrSuspendMode::BurySched | BuryOrSuspendMode::BuryUser => Op::Bury,
         };
         self.transact(op, |col| {
-            col.storage.set_search_table_to_card_ids(cids, false)?;
-            col.bury_or_suspend_searched_cards(mode)
+            let cards = col.all_cards_for_ids(cids, false)?;
+            col.bury_or_suspend_cards_inner(cards, mode)
         })
     }
 
@@ -144,14 +146,14 @@ impl Collection {
         include_reviews: bool,
         include_day_learn: bool,
     ) -> Result<usize> {
-        self.storage.search_siblings_for_bury(
+        let cards = self.storage.all_siblings_for_bury(
             cid,
             nid,
             include_new,
             include_reviews,
             include_day_learn,
         )?;
-        self.bury_or_suspend_searched_cards(BuryOrSuspendMode::BurySched)
+        self.bury_or_suspend_cards_inner(cards, BuryOrSuspendMode::BurySched)
     }
 }
 

--- a/rslib/src/scheduler/filtered/mod.rs
+++ b/rslib/src/scheduler/filtered/mod.rs
@@ -135,8 +135,7 @@ impl Collection {
         );
         let order = order_and_limit_for_search(term, ctx.today);
 
-        self.search_cards_into_table(&search, SortMode::Custom(order))?;
-        for mut card in self.storage.all_searched_cards_in_search_order()? {
+        for mut card in self.all_cards_for_search_in_order(&search, SortMode::Custom(order))? {
             let original = card.clone();
             card.move_into_filtered_deck(ctx, position);
             self.update_card_inner(&mut card, original, ctx.usn)?;

--- a/rslib/src/scheduler/new.rs
+++ b/rslib/src/scheduler/new.rs
@@ -167,7 +167,6 @@ impl Collection {
                 col.update_card_inner(&mut card, original, usn)?;
             }
             col.set_next_card_position(position)?;
-            col.storage.clear_searched_cards_table()?;
 
             match context {
                 Some(ScheduleAsNewContext::Browser) => {
@@ -243,7 +242,6 @@ impl Collection {
                 self.update_card_inner(&mut card, original, usn)?;
             }
         }
-        self.storage.clear_searched_cards_table()?;
         Ok(count)
     }
 

--- a/rslib/src/scheduler/new.rs
+++ b/rslib/src/scheduler/new.rs
@@ -155,8 +155,7 @@ impl Collection {
         let usn = self.usn()?;
         let mut position = self.get_next_card_position();
         self.transact(Op::ScheduleAsNew, |col| {
-            col.storage.set_search_table_to_card_ids(cids, true)?;
-            let cards = col.storage.all_searched_cards_in_search_order()?;
+            let cards = col.all_cards_for_ids(cids, true)?;
             for mut card in cards {
                 let original = card.clone();
                 if card.schedule_as_new(position, reset_counts, restore_position) {
@@ -234,8 +233,7 @@ impl Collection {
         if shift {
             self.shift_existing_cards(starting_from, step * cids.len() as u32, usn, v2)?;
         }
-        self.storage.set_search_table_to_card_ids(cids, true)?;
-        let cards = self.storage.all_searched_cards_in_search_order()?;
+        let cards = self.all_cards_for_ids(cids, true)?;
         let sorter = NewCardSorter::new(&cards, starting_from, step, order);
         let mut count = 0;
         for mut card in cards {

--- a/rslib/src/scheduler/new.rs
+++ b/rslib/src/scheduler/new.rs
@@ -282,13 +282,11 @@ impl Collection {
     }
 
     fn shift_existing_cards(&mut self, start: u32, by: u32, usn: Usn, v2: bool) -> Result<()> {
-        self.storage.search_cards_at_or_above_position(start)?;
-        for mut card in self.storage.all_searched_cards()? {
+        for mut card in self.storage.all_cards_at_or_above_position(start)? {
             let original = card.clone();
             card.set_new_position(card.due as u32 + by, v2);
             self.update_card_inner(&mut card, original, usn)?;
         }
-        self.storage.clear_searched_cards_table()?;
         Ok(())
     }
 }

--- a/rslib/src/scheduler/reviews.rs
+++ b/rslib/src/scheduler/reviews.rs
@@ -112,8 +112,7 @@ impl Collection {
         let distribution = Uniform::from(spec.min..=spec.max);
         let mut decks_initial_ease: HashMap<DeckId, f32> = HashMap::new();
         self.transact(Op::SetDueDate, |col| {
-            col.storage.set_search_table_to_card_ids(cids, false)?;
-            for mut card in col.storage.all_searched_cards()? {
+            for mut card in col.all_cards_for_ids(cids, false)? {
                 let deck_id = card.original_deck_id.or(card.deck_id);
                 let ease_factor = match decks_initial_ease.get(&deck_id) {
                     Some(ease) => *ease,

--- a/rslib/src/scheduler/reviews.rs
+++ b/rslib/src/scheduler/reviews.rs
@@ -138,7 +138,6 @@ impl Collection {
                 col.log_manually_scheduled_review(&card, &original, usn)?;
                 col.update_card_inner(&mut card, original, usn)?;
             }
-            col.storage.clear_searched_cards_table()?;
             if let Some(key) = context {
                 col.set_config_string_inner(key, days)?;
             }

--- a/rslib/src/scheduler/upgrade.rs
+++ b/rslib/src/scheduler/upgrade.rs
@@ -130,21 +130,21 @@ impl Collection {
     }
 
     fn upgrade_cards_to_v2(&mut self) -> Result<()> {
-        let count = self.search_cards_into_table(
+        let guard = self.search_cards_into_table(
             // can't add 'is:learn' here, as it matches on card type, not card queue
             "deck:filtered OR is:review",
             SortMode::NoOrder,
         )?;
-        if count > 0 {
-            let decks = self.storage.get_decks_map()?;
-            let configs = self.storage.get_deck_config_map()?;
-            self.storage.for_each_card_in_search(|mut card| {
+        if guard.cards > 0 {
+            let decks = guard.col.storage.get_decks_map()?;
+            let configs = guard.col.storage.get_deck_config_map()?;
+            guard.col.storage.for_each_card_in_search(|mut card| {
                 let filtered_info = get_filter_info_for_card(&card, &decks, &configs);
                 card.upgrade_to_v2(filtered_info);
-                self.storage.update_card(&card)
+                guard.col.storage.update_card(&card)
             })?;
         }
-        self.storage.clear_searched_cards_table()
+        Ok(())
     }
 }
 #[cfg(test)]

--- a/rslib/src/search/mod.rs
+++ b/rslib/src/search/mod.rs
@@ -238,6 +238,13 @@ impl Collection {
         guard.col.storage.all_searched_cards()
     }
 
+    pub(crate) fn all_cards_for_search_in_order(
+        &mut self,
+        search: impl TryIntoSearch,
+        mode: SortMode,
+    ) -> Result<Vec<Card>> {
+        let guard = self.search_cards_into_table(search, mode)?;
+        guard.col.storage.all_searched_cards_in_search_order()
     }
 
     pub(crate) fn for_each_card_in_search(

--- a/rslib/src/search/mod.rs
+++ b/rslib/src/search/mod.rs
@@ -248,19 +248,18 @@ impl Collection {
     }
 
     pub(crate) fn all_cards_for_ids(
-        &mut self,
+        &self,
         cards: &[CardId],
         preserve_order: bool,
     ) -> Result<Vec<Card>> {
-        self.storage
-            .set_search_table_to_card_ids(cards, preserve_order)?;
-        let cards = if preserve_order {
-            self.storage.all_searched_cards_in_search_order()
-        } else {
-            self.storage.all_searched_cards()
-        };
-        self.storage.clear_searched_cards_table()?;
-        cards
+        self.storage.with_searched_cards_table(preserve_order, || {
+            self.storage.set_search_table_to_card_ids(cards)?;
+            if preserve_order {
+                self.storage.all_searched_cards_in_search_order()
+            } else {
+                self.storage.all_searched_cards()
+            }
+        })
     }
 
     pub(crate) fn for_each_card_in_search(

--- a/rslib/src/search/mod.rs
+++ b/rslib/src/search/mod.rs
@@ -316,6 +316,7 @@ impl Collection {
     /// Place the ids of cards with notes in 'search_nids' into 'search_cids'.
     /// Returns number of added cards.
     pub(crate) fn search_cards_of_notes_into_table(&mut self) -> Result<CardTableGuard> {
+        self.storage.setup_searched_cards_table()?;
         let cards = self.storage.search_cards_of_notes_into_table()?;
         Ok(CardTableGuard { cards, col: self })
     }

--- a/rslib/src/search/mod.rs
+++ b/rslib/src/search/mod.rs
@@ -247,6 +247,22 @@ impl Collection {
         guard.col.storage.all_searched_cards_in_search_order()
     }
 
+    pub(crate) fn all_cards_for_ids(
+        &mut self,
+        cards: &[CardId],
+        preserve_order: bool,
+    ) -> Result<Vec<Card>> {
+        self.storage
+            .set_search_table_to_card_ids(cards, preserve_order)?;
+        let cards = if preserve_order {
+            self.storage.all_searched_cards_in_search_order()
+        } else {
+            self.storage.all_searched_cards()
+        };
+        self.storage.clear_searched_cards_table()?;
+        cards
+    }
+
     pub(crate) fn for_each_card_in_search(
         &mut self,
         search: impl TryIntoSearch,

--- a/rslib/src/stats/graphs.rs
+++ b/rslib/src/stats/graphs.rs
@@ -15,9 +15,9 @@ impl Collection {
         search: &str,
         days: u32,
     ) -> Result<pb::GraphsResponse> {
-        self.search_cards_into_table(search, SortMode::NoOrder)?;
+        let guard = self.search_cards_into_table(search, SortMode::NoOrder)?;
         let all = search.trim().is_empty();
-        self.graph_data(all, days)
+        guard.col.graph_data(all, days)
     }
 
     fn graph_data(&mut self, all: bool, days: u32) -> Result<pb::GraphsResponse> {
@@ -40,8 +40,6 @@ impl Collection {
             self.storage
                 .get_pb_revlog_entries_for_searched_cards(revlog_start)?
         };
-
-        self.storage.clear_searched_cards_table()?;
 
         Ok(pb::GraphsResponse {
             cards: cards.into_iter().map(Into::into).collect(),

--- a/rslib/src/storage/card/mod.rs
+++ b/rslib/src/storage/card/mod.rs
@@ -516,7 +516,6 @@ impl super::SqliteStorage {
     /// Place the ids of cards with notes in 'search_nids' into 'search_cids'.
     /// Returns number of added cards.
     pub(crate) fn search_cards_of_notes_into_table(&self) -> Result<usize> {
-        self.setup_searched_cards_table()?;
         self.db
             .prepare(include_str!("search_cards_of_notes_into_table.sql"))?
             .execute([])
@@ -592,12 +591,13 @@ impl super::SqliteStorage {
             .unwrap()
     }
 
-    pub(crate) fn search_cards_at_or_above_position(&self, start: u32) -> Result<()> {
-        self.setup_searched_cards_table()?;
-        self.db
-            .prepare(include_str!("at_or_above_position.sql"))?
-            .execute([start, CardType::New as u32])?;
-        Ok(())
+    pub(crate) fn all_cards_at_or_above_position(&self, start: u32) -> Result<Vec<Card>> {
+        self.with_searched_cards_table(false, || {
+            self.db
+                .prepare(include_str!("at_or_above_position.sql"))?
+                .execute([start, CardType::New as u32])?;
+            self.all_searched_cards()
+        })
     }
 
     pub(crate) fn setup_searched_cards_table(&self) -> Result<()> {

--- a/rslib/src/storage/card/mod.rs
+++ b/rslib/src/storage/card/mod.rs
@@ -455,7 +455,6 @@ impl super::SqliteStorage {
         Ok(cids)
     }
 
-    /// Place matching card ids into the search table.
     pub(crate) fn all_siblings_for_bury(
         &self,
         cid: CardId,

--- a/rslib/src/storage/card/mod.rs
+++ b/rslib/src/storage/card/mod.rs
@@ -456,14 +456,14 @@ impl super::SqliteStorage {
     }
 
     /// Place matching card ids into the search table.
-    pub(crate) fn search_siblings_for_bury(
+    pub(crate) fn all_siblings_for_bury(
         &self,
         cid: CardId,
         nid: NoteId,
         include_new: bool,
         include_reviews: bool,
         include_day_learn: bool,
-    ) -> Result<()> {
+    ) -> Result<Vec<Card>> {
         self.setup_searched_cards_table()?;
         let params = named_params! {
             ":card_id": cid,
@@ -478,7 +478,9 @@ impl super::SqliteStorage {
         self.db
             .prepare_cached(include_str!("siblings_for_bury.sql"))?
             .execute(params)?;
-        Ok(())
+        let cards = self.all_searched_cards();
+        self.clear_searched_cards_table()?;
+        cards
     }
 
     pub(crate) fn note_ids_of_cards(&self, cids: &[CardId]) -> Result<HashSet<NoteId>> {

--- a/rslib/src/tags/notes.rs
+++ b/rslib/src/tags/notes.rs
@@ -10,16 +10,18 @@ use crate::{prelude::*, search::SearchNode};
 
 impl Collection {
     pub(crate) fn all_tags_in_deck(&mut self, deck_id: DeckId) -> Result<HashSet<UniCase<String>>> {
-        self.search_notes_into_table(SearchNode::DeckIdWithChildren(deck_id))?;
+        let guard = self.search_notes_into_table(SearchNode::DeckIdWithChildren(deck_id))?;
         let mut all_tags: HashSet<UniCase<String>> = HashSet::new();
-        self.storage.for_each_note_tag_in_searched_notes(|tags| {
-            for tag in split_tags(tags) {
-                // A benchmark on a large deck indicates that nothing is gained by using a Cow and skipping
-                // an allocation in the duplicate case, and this approach is simpler.
-                all_tags.insert(UniCase::new(tag.to_string()));
-            }
-        })?;
-        self.storage.clear_searched_notes_table()?;
+        guard
+            .col
+            .storage
+            .for_each_note_tag_in_searched_notes(|tags| {
+                for tag in split_tags(tags) {
+                    // A benchmark on a large deck indicates that nothing is gained by using a Cow and skipping
+                    // an allocation in the duplicate case, and this approach is simpler.
+                    all_tags.insert(UniCase::new(tag.to_string()));
+                }
+            })?;
         Ok(all_tags)
     }
 }


### PR DESCRIPTION
I've investigated RAII guards for temporary tables and here's a start on the refactoring. My conclusions so far:

- Guards make a lot of sense in `gather.rs`, where there are several operations relying on the tables. Responsibility for the table is explicitly passed around and for any call in `gather_data()` it's clear if the table is still alive.
- Functions like `gather_revlog()`, that rely on the cards table already exisisting, can and probably should be implemented on `CardTableGuard`, so it's clear inside the callee as well.
- However, every other table user is either immediately collecting or iterating over the searched cards/notes. Here, it seems sensible to move the setup→collect→clear logic into a helper, but inside such a small function a RAII guard gains us little.
- Even without a guard, adhering more to RAII might help reduce missing cleanups. That is to say, `setup_searched_cards_table()` should be called in the same scope as `clear_searched_cards_table()` as demonstrated in 9d85400a567804ea4d2676cccfbafb8ca414cd83.

WDYT? Are guards overkill if they're only really useful at one place? Should I continue to implement the other refactorings?