### PR TITLE
Introduce exporters_list_created hook to new export code

### DIFF
--- a/qt/aqt/import_export/exporting.py
+++ b/qt/aqt/import_export/exporting.py
@@ -55,7 +55,7 @@ class ExportDialog(QDialog):
             NoteCsvExporter,
             CardCsvExporter,
         ]
-        gui_hooks.exporters_list_created(self.exporters)
+        gui_hooks.exporters_list_did_initialize(self.exporter_classes)
         self.frm.format.insertItems(
             0, [f"{e.name()} (.{e.extension})" for e in self.exporter_classes]
         )

--- a/qt/aqt/import_export/exporting.py
+++ b/qt/aqt/import_export/exporting.py
@@ -55,6 +55,7 @@ class ExportDialog(QDialog):
             NoteCsvExporter,
             CardCsvExporter,
         ]
+        gui_hooks.exporters_list_created(self.exporters)
         self.frm.format.insertItems(
             0, [f"{e.name()} (.{e.extension})" for e in self.exporters]
         )

--- a/qt/tools/genhooks_gui.py
+++ b/qt/tools/genhooks_gui.py
@@ -19,7 +19,7 @@ prefix = """\
 
 from __future__ import annotations
 
-from typing import Any, Callable, Sequence, Literal
+from typing import Any, Callable, Sequence, Literal, Type
 
 import anki
 import aqt
@@ -815,6 +815,17 @@ gui_hooks.webview_did_inject_style_into_page.append(mytest)
         doc="""Called after Media Check finishes.
 
         `output` provides access to the unused/missing file lists and the text output that will be shown in the Check Media screen.""",
+    ),
+    # Importing/exporting data
+    ###################
+    Hook(
+        name="exporters_list_created",
+        args=["exporters: list[Type[aqt.import_export.exporting.Exporter]]"],
+        doc="""Called after the list of exporter classes is created.
+
+        Allows you to register custom exporters and/or replace existing ones by
+        modifying the exporter list.
+        """,
     ),
     # Dialog Manager
     ###################


### PR DESCRIPTION
Basically just bringing the old `hooks.exporters_list_created` hook to the new export code. Thought it would be a good follow-up to #1971 in order to further flesh out the exporter add-on API.

*(filing as myself again, so no disclosure)*

Sample add-on (presupposing #1971):

```python
from typing import List, Type

from aqt.gui_hooks import exporters_list_created
from aqt.import_export.exporting import Exporter, ExportOptions
from aqt.main import AnkiQt


class MyExporter(Exporter):
    extension = "foo"
    show_deck_list = True
    show_include_html = True

    @staticmethod
    def name():
        return "My Export File Format"

    def export(self, mw: AnkiQt, options: ExportOptions) -> None:
        print(f"Exporting data with options {options}")


def extend_exporters_list(exporters_list: List[Type[Exporter]]):
    exporters_list.append(MyExporter)


exporters_list_created.append(extend_exporters_list)

```