### PR TITLE
Fix sidebar not being restored properly

### DIFF
--- a/qt/aqt/browser/browser.py
+++ b/qt/aqt/browser/browser.py
@@ -124,13 +124,14 @@ class Browser(QMainWindow):
         self.form = aqt.forms.browser.Ui_Dialog()
         self.form.setupUi(self)
         restoreGeom(self, "editor", 0)
-        restoreState(self, "editor")
         restoreSplitter(self.form.splitter, "editor3")
         self.form.splitter.setChildrenCollapsible(False)
         # set if exactly 1 row is selected; used by the previewer
         self.card: Card | None = None
         self.current_card: Card | None = None
         self.setupSidebar()
+        # make sure to call restoreState() after QDockWidget is attached to QMainWindow
+        restoreState(self, "editor")
         self.setup_table()
         self.setupMenus()
         self.setupHooks()


### PR DESCRIPTION
Fixes #1902

I was able to reproduce the issue with Qt6 builds on Windows 10 and Linux (Lubuntu 22.04).

#### Steps to reproduce the issue
1. Open the browser and make the window size as small as possible
1. Click on the maximize button
1. Close the browser and re-open it

It appears that calling `restoreState()` before setting up the sidebar(`QDockWidget`) is causing the issue. I am not sure why the issue did not happen before even though the code has not been changed, but I suspect that [this patch](https://codereview.qt-project.org/c/qt/qtbase/+/375521) has probably brought the issue to the surface.
