### PR TITLE
Default input setting in fields dialog

### DIFF
--- a/ftl/core/fields.ftl
+++ b/ftl/core/fields.ftl
@@ -10,6 +10,7 @@ fields-font = Font:
 fields-new-position-1 = New position (1...{ $val }):
 fields-notes-require-at-least-one-field = Notes require at least one field.
 fields-reverse-text-direction-rtl = Reverse text direction (RTL)
+fields-html-by-default = Use HTML editor by default
 fields-size = Size:
 fields-sort-by-this-field-in-the = Sort by this field in the browser
 fields-that-field-name-is-already-used = That field name is already used.

--- a/proto/anki/notetypes.proto
+++ b/proto/anki/notetypes.proto
@@ -72,6 +72,7 @@ message Notetype {
       string font_name = 3;
       uint32 font_size = 4;
       string description = 5;
+      string input = 6;
 
       bytes other = 255;
     }

--- a/proto/anki/notetypes.proto
+++ b/proto/anki/notetypes.proto
@@ -72,7 +72,7 @@ message Notetype {
       string font_name = 3;
       uint32 font_size = 4;
       string description = 5;
-      string input = 6;
+      bool plain_text = 6;
 
       bytes other = 255;
     }

--- a/qt/aqt/editor.py
+++ b/qt/aqt/editor.py
@@ -499,7 +499,7 @@ require("anki/ui").loaded.then(() => require("anki/NoteEditor").instances[0].too
         ]
 
         flds = self.note.note_type()["flds"]
-        plain_texts = [fld.get("plain_text", False) for fld in flds]
+        plain_texts = [fld.get("plainText", False) for fld in flds]
         descriptions = [fld.get("description", "") for fld in flds]
 
         self.widget.show()

--- a/qt/aqt/editor.py
+++ b/qt/aqt/editor.py
@@ -499,7 +499,7 @@ require("anki/ui").loaded.then(() => require("anki/NoteEditor").instances[0].too
         ]
 
         flds = self.note.note_type()["flds"]
-        inputs = [fld.get("input", "") for fld in flds]
+        plain_texts = [fld.get("plain_text", False) for fld in flds]
         descriptions = [fld.get("description", "") for fld in flds]
 
         self.widget.show()
@@ -522,7 +522,7 @@ require("anki/ui").loaded.then(() => require("anki/NoteEditor").instances[0].too
 
         js = """
             setFields({});
-            setInputs({});
+            setPlainTexts({});
             setDescriptions({});
             setFonts({});
             focusField({});
@@ -531,7 +531,7 @@ require("anki/ui").loaded.then(() => require("anki/NoteEditor").instances[0].too
             setTags({});
             """.format(
             json.dumps(data),
-            json.dumps(inputs),
+            json.dumps(plain_texts),
             json.dumps(descriptions),
             json.dumps(self.fonts()),
             json.dumps(focusTo),

--- a/qt/aqt/editor.py
+++ b/qt/aqt/editor.py
@@ -499,6 +499,7 @@ require("anki/ui").loaded.then(() => require("anki/NoteEditor").instances[0].too
         ]
 
         flds = self.note.note_type()["flds"]
+        inputs = [fld.get("input", "") for fld in flds]
         descriptions = [fld.get("description", "") for fld in flds]
 
         self.widget.show()
@@ -519,8 +520,18 @@ require("anki/ui").loaded.then(() => require("anki/NoteEditor").instances[0].too
         text_color = self.mw.pm.profile.get("lastTextColor", "#00f")
         highlight_color = self.mw.pm.profile.get("lastHighlightColor", "#00f")
 
-        js = "setFields({}); setDescriptions({}); setFonts({}); focusField({}); setNoteId({}); setColorButtons({}); setTags({}); ".format(
+        js = """
+            setFields({});
+            setInputs({});
+            setDescriptions({});
+            setFonts({});
+            focusField({});
+            setNoteId({});
+            setColorButtons({});
+            setTags({});
+            """.format(
             json.dumps(data),
+            json.dumps(inputs),
             json.dumps(descriptions),
             json.dumps(self.fonts()),
             json.dumps(focusTo),

--- a/qt/aqt/fields.py
+++ b/qt/aqt/fields.py
@@ -243,7 +243,7 @@ class FieldDialog(QDialog):
         f.fontSize.setValue(fld["size"])
         f.sortField.setChecked(self.model["sortf"] == fld["ord"])
         f.rtl.setChecked(fld["rtl"])
-        f.plainTextByDefault.setChecked(fld["plain_text"])
+        f.plainTextByDefault.setChecked(fld["plainText"])
         f.fieldDescription.setText(fld.get("description", ""))
 
     def saveField(self) -> None:
@@ -266,8 +266,8 @@ class FieldDialog(QDialog):
             fld["rtl"] = rtl
             self.change_tracker.mark_basic()
         plain_text = f.plainTextByDefault.isChecked()
-        if fld["plain_text"] != plain_text:
-            fld["plain_text"] = plain_text
+        if fld["plainText"] != plain_text:
+            fld["plainText"] = plain_text
             self.change_tracker.mark_basic()
         desc = f.fieldDescription.text()
         if fld.get("description", "") != desc:

--- a/qt/aqt/fields.py
+++ b/qt/aqt/fields.py
@@ -243,6 +243,7 @@ class FieldDialog(QDialog):
         f.fontSize.setValue(fld["size"])
         f.sortField.setChecked(self.model["sortf"] == fld["ord"])
         f.rtl.setChecked(fld["rtl"])
+        f.plainInputByDefault.setChecked(fld["input"] == "plain")
         f.fieldDescription.setText(fld.get("description", ""))
 
     def saveField(self) -> None:
@@ -263,6 +264,10 @@ class FieldDialog(QDialog):
         rtl = f.rtl.isChecked()
         if fld["rtl"] != rtl:
             fld["rtl"] = rtl
+            self.change_tracker.mark_basic()
+        input = "plain" if f.plainInputByDefault.isChecked() else "rich"
+        if fld["input"] != input:
+            fld["input"] = input
             self.change_tracker.mark_basic()
         desc = f.fieldDescription.text()
         if fld.get("description", "") != desc:

--- a/qt/aqt/fields.py
+++ b/qt/aqt/fields.py
@@ -243,7 +243,7 @@ class FieldDialog(QDialog):
         f.fontSize.setValue(fld["size"])
         f.sortField.setChecked(self.model["sortf"] == fld["ord"])
         f.rtl.setChecked(fld["rtl"])
-        f.plainInputByDefault.setChecked(fld["input"] == "plain")
+        f.plainTextByDefault.setChecked(fld["plain_text"])
         f.fieldDescription.setText(fld.get("description", ""))
 
     def saveField(self) -> None:
@@ -265,9 +265,9 @@ class FieldDialog(QDialog):
         if fld["rtl"] != rtl:
             fld["rtl"] = rtl
             self.change_tracker.mark_basic()
-        input = "plain" if f.plainInputByDefault.isChecked() else "rich"
-        if fld["input"] != input:
-            fld["input"] = input
+        plain_text = f.plainTextByDefault.isChecked()
+        if fld["plain_text"] != plain_text:
+            fld["plain_text"] = plain_text
             self.change_tracker.mark_basic()
         desc = f.fieldDescription.text()
         if fld.get("description", "") != desc:

--- a/qt/aqt/forms/fields.ui
+++ b/qt/aqt/forms/fields.ui
@@ -84,10 +84,41 @@
    </item>
    <item>
     <layout class="QGridLayout" name="_2">
+     <item row="3" column="1">
+      <widget class="QCheckBox" name="rtl">
+       <property name="text">
+        <string>fields_reverse_text_direction_rtl</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="QFontComboBox" name="fontFamily">
+       <property name="minimumSize">
+        <size>
+         <width>0</width>
+         <height>25</height>
+        </size>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="label_font">
+       <property name="text">
+        <string>fields_editing_font</string>
+       </property>
+      </widget>
+     </item>
      <item row="0" column="1" colspan="2">
       <widget class="QLineEdit" name="fieldDescription">
        <property name="placeholderText">
         <string>fields_description_placeholder</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="0">
+      <widget class="QLabel" name="label_sort">
+       <property name="text">
+        <string>actions_options</string>
        </property>
       </widget>
      </item>
@@ -104,27 +135,6 @@
        </property>
       </widget>
      </item>
-     <item row="2" column="0">
-      <widget class="QLabel" name="label_sort">
-       <property name="text">
-        <string>actions_options</string>
-       </property>
-      </widget>
-     </item>
-     <item row="3" column="1">
-      <widget class="QCheckBox" name="rtl">
-       <property name="text">
-        <string>fields_reverse_text_direction_rtl</string>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="0">
-      <widget class="QLabel" name="label_font">
-       <property name="text">
-        <string>fields_editing_font</string>
-       </property>
-      </widget>
-     </item>
      <item row="1" column="2">
       <widget class="QSpinBox" name="fontSize">
        <property name="minimum">
@@ -135,16 +145,6 @@
        </property>
       </widget>
      </item>
-     <item row="1" column="1">
-      <widget class="QFontComboBox" name="fontFamily">
-       <property name="minimumSize">
-        <size>
-         <width>0</width>
-         <height>25</height>
-        </size>
-       </property>
-      </widget>
-     </item>
      <item row="2" column="1">
       <widget class="QRadioButton" name="sortField">
        <property name="text">
@@ -152,7 +152,7 @@
        </property>
       </widget>
      </item>
-     <item row="2" column="2">
+     <item row="4" column="1">
       <widget class="QCheckBox" name="plainTextByDefault">
        <property name="enabled">
         <bool>true</bool>

--- a/qt/aqt/forms/fields.ui
+++ b/qt/aqt/forms/fields.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>586</width>
-    <height>376</height>
+    <width>598</width>
+    <height>378</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -84,41 +84,10 @@
    </item>
    <item>
     <layout class="QGridLayout" name="_2">
-     <item row="1" column="0">
-      <widget class="QLabel" name="label_font">
-       <property name="text">
-        <string>fields_editing_font</string>
-       </property>
-      </widget>
-     </item>
-     <item row="3" column="1">
-      <widget class="QCheckBox" name="rtl">
-       <property name="text">
-        <string>fields_reverse_text_direction_rtl</string>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="2">
-      <widget class="QSpinBox" name="fontSize">
-       <property name="minimum">
-        <number>5</number>
-       </property>
-       <property name="maximum">
-        <number>300</number>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="0">
-      <widget class="QLabel" name="label_sort">
-       <property name="text">
-        <string>actions_options</string>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="1">
-      <widget class="QRadioButton" name="sortField">
-       <property name="text">
-        <string>fields_sort_by_this_field_in_the</string>
+     <item row="0" column="1" colspan="2">
+      <widget class="QLineEdit" name="fieldDescription">
+       <property name="placeholderText">
+        <string>fields_description_placeholder</string>
        </property>
       </widget>
      </item>
@@ -135,6 +104,37 @@
        </property>
       </widget>
      </item>
+     <item row="2" column="0">
+      <widget class="QLabel" name="label_sort">
+       <property name="text">
+        <string>actions_options</string>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="1">
+      <widget class="QCheckBox" name="rtl">
+       <property name="text">
+        <string>fields_reverse_text_direction_rtl</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="label_font">
+       <property name="text">
+        <string>fields_editing_font</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="2">
+      <widget class="QSpinBox" name="fontSize">
+       <property name="minimum">
+        <number>5</number>
+       </property>
+       <property name="maximum">
+        <number>300</number>
+       </property>
+      </widget>
+     </item>
      <item row="1" column="1">
       <widget class="QFontComboBox" name="fontFamily">
        <property name="minimumSize">
@@ -145,10 +145,20 @@
        </property>
       </widget>
      </item>
-     <item row="0" column="1" colspan="2">
-      <widget class="QLineEdit" name="fieldDescription">
-       <property name="placeholderText">
-        <string>fields_description_placeholder</string>
+     <item row="2" column="1">
+      <widget class="QRadioButton" name="sortField">
+       <property name="text">
+        <string>fields_sort_by_this_field_in_the</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="2">
+      <widget class="QCheckBox" name="plainInputByDefault">
+       <property name="enabled">
+        <bool>true</bool>
+       </property>
+       <property name="text">
+        <string>fields_html_by_default</string>
        </property>
       </widget>
      </item>

--- a/qt/aqt/forms/fields.ui
+++ b/qt/aqt/forms/fields.ui
@@ -153,7 +153,7 @@
       </widget>
      </item>
      <item row="2" column="2">
-      <widget class="QCheckBox" name="plainInputByDefault">
+      <widget class="QCheckBox" name="plainTextByDefault">
        <property name="enabled">
         <bool>true</bool>
        </property>

--- a/rslib/src/notetype/fields.rs
+++ b/rslib/src/notetype/fields.rs
@@ -42,6 +42,7 @@ impl NoteField {
             config: NoteFieldConfig {
                 sticky: false,
                 rtl: false,
+                input: "rich".into(),
                 font_name: "Arial".into(),
                 font_size: 20,
                 description: "".into(),

--- a/rslib/src/notetype/fields.rs
+++ b/rslib/src/notetype/fields.rs
@@ -42,7 +42,7 @@ impl NoteField {
             config: NoteFieldConfig {
                 sticky: false,
                 rtl: false,
-                input: "rich".into(),
+                plain_text: false,
                 font_name: "Arial".into(),
                 font_size: 20,
                 description: "".into(),

--- a/rslib/src/notetype/schema11.rs
+++ b/rslib/src/notetype/schema11.rs
@@ -164,7 +164,7 @@ fn clear_other_field_duplicates(other: &mut HashMap<String, Value>) {
     for key in &["description"] {
         other.remove(*key);
     }
-    for key in &["input"] {
+    for key in &["plain_text"] {
         other.remove(*key);
     }
 }
@@ -215,7 +215,7 @@ pub struct NoteFieldSchema11 {
     pub(crate) description: String,
 
     #[serde(default, deserialize_with = "default_on_invalid")]
-    pub(crate) input: String,
+    pub(crate) plain_text: bool,
 
     #[serde(flatten)]
     pub(crate) other: HashMap<String, Value>,
@@ -228,7 +228,7 @@ impl Default for NoteFieldSchema11 {
             ord: None,
             sticky: false,
             rtl: false,
-            input: "rich".to_string(),
+            plain_text: false,
             font: "Arial".to_string(),
             size: 20,
             description: String::new(),
@@ -245,7 +245,7 @@ impl From<NoteFieldSchema11> for NoteField {
             config: NoteFieldConfig {
                 sticky: f.sticky,
                 rtl: f.rtl,
-                input: f.input,
+                plain_text: f.plain_text,
                 font_name: f.font,
                 font_size: f.size as u32,
                 description: f.description,
@@ -267,7 +267,7 @@ impl From<NoteField> for NoteFieldSchema11 {
             ord: p.ord.map(|o| o as u16),
             sticky: conf.sticky,
             rtl: conf.rtl,
-            input: conf.input,
+            plain_text: conf.plain_text,
             font: conf.font_name,
             size: conf.font_size as u16,
             description: conf.description,

--- a/rslib/src/notetype/schema11.rs
+++ b/rslib/src/notetype/schema11.rs
@@ -164,6 +164,9 @@ fn clear_other_field_duplicates(other: &mut HashMap<String, Value>) {
     for key in &["description"] {
         other.remove(*key);
     }
+    for key in &["input"] {
+        other.remove(*key);
+    }
 }
 
 impl From<CardRequirementSchema11> for CardRequirement {
@@ -211,6 +214,9 @@ pub struct NoteFieldSchema11 {
     #[serde(default, deserialize_with = "default_on_invalid")]
     pub(crate) description: String,
 
+    #[serde(default, deserialize_with = "default_on_invalid")]
+    pub(crate) input: String,
+
     #[serde(flatten)]
     pub(crate) other: HashMap<String, Value>,
 }
@@ -222,6 +228,7 @@ impl Default for NoteFieldSchema11 {
             ord: None,
             sticky: false,
             rtl: false,
+            input: "rich".to_string(),
             font: "Arial".to_string(),
             size: 20,
             description: String::new(),
@@ -238,6 +245,7 @@ impl From<NoteFieldSchema11> for NoteField {
             config: NoteFieldConfig {
                 sticky: f.sticky,
                 rtl: f.rtl,
+                input: f.input,
                 font_name: f.font,
                 font_size: f.size as u32,
                 description: f.description,
@@ -259,6 +267,7 @@ impl From<NoteField> for NoteFieldSchema11 {
             ord: p.ord.map(|o| o as u16),
             sticky: conf.sticky,
             rtl: conf.rtl,
+            input: conf.input,
             font: conf.font_name,
             size: conf.font_size as u16,
             description: conf.description,

--- a/rslib/src/notetype/schema11.rs
+++ b/rslib/src/notetype/schema11.rs
@@ -161,10 +161,7 @@ impl From<Notetype> for NotetypeSchema11 {
 
 /// See [crate::deckconfig::schema11::clear_other_duplicates()].
 fn clear_other_field_duplicates(other: &mut HashMap<String, Value>) {
-    for key in &["description"] {
-        other.remove(*key);
-    }
-    for key in &["plain_text"] {
+    for key in &["description", "plain_text"] {
         other.remove(*key);
     }
 }

--- a/rslib/src/notetype/schema11.rs
+++ b/rslib/src/notetype/schema11.rs
@@ -161,7 +161,7 @@ impl From<Notetype> for NotetypeSchema11 {
 
 /// See [crate::deckconfig::schema11::clear_other_duplicates()].
 fn clear_other_field_duplicates(other: &mut HashMap<String, Value>) {
-    for key in &["description", "plain_text"] {
+    for key in &["description", "plainText"] {
         other.remove(*key);
     }
 }
@@ -195,6 +195,7 @@ impl From<CardRequirement> for CardRequirementSchema11 {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
 pub struct NoteFieldSchema11 {
     pub(crate) name: String,
     pub(crate) ord: Option<u16>,

--- a/ts/components/WithTooltip.svelte
+++ b/ts/components/WithTooltip.svelte
@@ -38,17 +38,6 @@
     }
 
     onDestroy(() => tooltipObject?.dispose());
-
-    // hack to update field description tooltips
-    let previousTooltip: string = tooltip;
-    $: if (tooltip !== previousTooltip) {
-        previousTooltip = tooltip;
-        if (tooltipObject !== undefined) {
-            const element: HTMLElement = tooltipObject["_element"];
-            tooltipObject.dispose();
-            createTooltip(element);
-        }
-    }
 </script>
 
 <slot {createTooltip} {tooltipObject} />

--- a/ts/editor/EditorField.svelte
+++ b/ts/editor/EditorField.svelte
@@ -12,7 +12,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         fontFamily: string;
         fontSize: number;
         direction: "ltr" | "rtl";
-        input: "rich" | "plain";
+        plainText: boolean;
         description: string;
     }
 

--- a/ts/editor/EditorField.svelte
+++ b/ts/editor/EditorField.svelte
@@ -12,6 +12,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         fontFamily: string;
         fontSize: number;
         direction: "ltr" | "rtl";
+        input: "rich" | "plain";
         description: string;
     }
 

--- a/ts/editor/NoteEditor.svelte
+++ b/ts/editor/NoteEditor.svelte
@@ -108,21 +108,27 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         fieldNames = newFieldNames;
     }
 
+    let inputs: Array<"rich" | "plain"> = [];
+    let richTextsHidden: boolean[] = [];
+    let plainTextsHidden: boolean[] = [];
+
+    export function setInputs(fs: Array<"rich" | "plain">): void {
+        inputs = fs;
+
+        richTextsHidden = Array.from(inputs, (v) => v === "plain");
+        plainTextsHidden = Array.from(inputs, (v) => v === "rich");
+    }
+
     let fieldDescriptions: string[] = [];
     export function setDescriptions(fs: string[]): void {
         fieldDescriptions = fs;
     }
 
     let fonts: [string, number, boolean][] = [];
-    let richTextsHidden: boolean[] = [];
-    let plainTextsHidden: boolean[] = [];
     const fields = clearableArray<EditorFieldAPI>();
 
     export function setFonts(fs: [string, number, boolean][]): void {
         fonts = fs;
-
-        richTextsHidden = fonts.map((_, index) => richTextsHidden[index] ?? false);
-        plainTextsHidden = fonts.map((_, index) => plainTextsHidden[index] ?? true);
     }
 
     export function focusField(index: number | null): void {
@@ -170,6 +176,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
     $: fieldsData = fieldNames.map((name, index) => ({
         name,
+        input: inputs[index],
         description: fieldDescriptions[index],
         fontFamily: quoteFontFamily(fonts[index][0]),
         fontSize: fonts[index][1],
@@ -238,6 +245,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
         Object.assign(globalThis, {
             setFields,
+            setInputs,
             setDescriptions,
             setFonts,
             focusField,

--- a/ts/editor/NoteEditor.svelte
+++ b/ts/editor/NoteEditor.svelte
@@ -109,15 +109,13 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         fieldNames = newFieldNames;
     }
 
-    let inputs: Array<"rich" | "plain"> = [];
+    let plainTexts: boolean[] = [];
     let richTextsHidden: boolean[] = [];
     let plainTextsHidden: boolean[] = [];
 
-    export function setInputs(fs: Array<"rich" | "plain">): void {
-        inputs = fs;
-
-        richTextsHidden = Array.from(inputs, (v) => v === "plain");
-        plainTextsHidden = Array.from(inputs, (v) => v === "rich");
+    export function setPlainTexts(fs: boolean[]): void {
+        richTextsHidden = plainTexts = fs;
+        plainTextsHidden = Array.from(fs, (v) => !v);
     }
 
     let fieldDescriptions: string[] = [];
@@ -177,7 +175,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
     $: fieldsData = fieldNames.map((name, index) => ({
         name,
-        input: inputs[index],
+        plainText: plainTexts[index],
         description: fieldDescriptions[index],
         fontFamily: quoteFontFamily(fonts[index][0]),
         fontSize: fonts[index][1],
@@ -246,7 +244,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
         Object.assign(globalThis, {
             setFields,
-            setInputs,
+            setPlainTexts,
             setDescriptions,
             setFonts,
             focusField,


### PR DESCRIPTION
Adds a checkbox to the "Options" section of the fields dialog that allows users to show the HTML editor by default. This is a preparation for the Editor design changes I've been planning for some time. I decided to split the project into mulitple PRs.

I went for `"rich" | "plain"` instead of a boolean because it is easier to understand for devs/add-on authors.

## Why introduce this setting?
I'd like to get rid of the trio of buttons on the top left of `LabelContainer` and scatter them to more intuitive places.

![image](https://user-images.githubusercontent.com/62722460/181081973-0ccc6b0c-10f7-4899-b861-faa1a107b99d.png)
###### For brainstorming on the new editor look and feel, see [here](https://forums.ankiweb.net/t/brainstorming-for-modern-ui-anki-3-0/17510).

Expected behavior:

- chevron collapses the whole field (`richTextInput` AND `plainTextInput`)
- the text on the bottom corner shows up on highlight and toggles the non-default input

The latter is why I want to introduce a default input toggle: for toggled fields it could say "OUTPUT" instead of "HTML", for example. Side note: With the new fields design, a "[collapsed by default](https://forums.ankiweb.net/t/toggle-visual-editor-collapse-permanently-by-default-like-collapsible-fields/20845)" setting would fit nicely underneath this one in the fields dialog.

@dae I have read your "1000 settings later" comment and understand your hesitancy towards this. No hard feelings if you reject it - I only made this to cater to the people who would enjoy this feature.

## Forum requests:
https://forums.ankiweb.net/t/set-html-editor-as-a-default-editor-instead-of-visual-editor/20988
https://forums.ankiweb.net/t/html-editor-by-default-for-ankimobile-ios/20223

---
Related: https://forums.ankiweb.net/t/default-editor-settings-instead-of-persistent/12761