### PR TITLE
Rename vars.scss to colors.scss / Introduce props.scss / Unify scrollbar design

### DIFF
--- a/qt/BUILD.bazel
+++ b/qt/BUILD.bazel
@@ -24,6 +24,15 @@ py_binary(
     visibility = [":__subpackages__"],
 )
 
+py_binary(
+    name = "extract_sass_props",
+    srcs = [
+        "tools/extract_sass_props.py",
+    ],
+    imports = ["."],
+    visibility = [":__subpackages__"],
+)
+
 py_test(
     name = "pytest",
     srcs = glob(["tests/*.py"]) + ["bazelfixes.py"],

--- a/qt/aqt/BUILD.bazel
+++ b/qt/aqt/BUILD.bazel
@@ -13,12 +13,24 @@ genrule(
 genrule(
     name = "extract_sass_colors",
     srcs = [
-        "//sass:_vars.scss",
+        "//sass:_colors.scss",
     ],
     outs = ["colors.py"],
     cmd = "$(location //qt:extract_sass_colors) $< $@",
     tools = [
         "//qt:extract_sass_colors",
+    ],
+)
+
+genrule(
+    name = "extract_sass_props",
+    srcs = [
+        "//sass:_props.scss",
+    ],
+    outs = ["props.py"],
+    cmd = "$(location //qt:extract_sass_props) $< $@",
+    tools = [
+        "//qt:extract_sass_props",
     ],
 )
 
@@ -35,6 +47,7 @@ _py_srcs_and_forms = _py_srcs + [
 
 aqt_core_data = [
     "colors.py",
+    "props.py",
     "py.typed",
     ":hooks_gen",
 ]

--- a/qt/aqt/browser/sidebar/searchbar.py
+++ b/qt/aqt/browser/sidebar/searchbar.py
@@ -29,7 +29,7 @@ class SidebarSearchBar(QLineEdit):
         aqt.gui_hooks.theme_did_change.append(self.setup_style)
 
     def setup_style(self) -> None:
-        border = theme_manager.color(colors.MEDIUM_BORDER)
+        border = theme_manager.value(colors.MEDIUM_BORDER)
         styles = [
             "padding: 1px",
             "padding-left: 3px",

--- a/qt/aqt/browser/sidebar/tree.py
+++ b/qt/aqt/browser/sidebar/tree.py
@@ -105,7 +105,7 @@ class SidebarTreeView(QTreeView):
     def _setup_style(self) -> None:
         # match window background color and tweak style
         bgcolor = QPalette().window().color().name()
-        border = theme_manager.color(colors.MEDIUM_BORDER)
+        border = theme_manager.value(colors.MEDIUM_BORDER)
         styles = [
             "padding: 3px",
             "padding-right: 0px",

--- a/qt/aqt/data/web/css/webview.scss
+++ b/qt/aqt/data/web/css/webview.scss
@@ -12,6 +12,8 @@
 }
 
 body {
+    @include scrollbar.custom;
+
     color: var(--text-fg);
     background: var(--window-bg);
     margin: 1em;
@@ -31,8 +33,4 @@ body {
 
 h1 {
     margin-bottom: 0.2em;
-}
-
-.night-mode {
-    @include scrollbar.night-mode;
 }

--- a/qt/aqt/editor.py
+++ b/qt/aqt/editor.py
@@ -652,7 +652,7 @@ require("anki/ui").loaded.then(() => require("anki/NoteEditor").instances[0].too
         self.tags = aqt.tagedit.TagEdit(self.widget)
         qconnect(self.tags.lostFocus, self.on_tag_focus_lost)
         self.tags.setToolTip(shortcut(tr.editing_jump_to_tags_with_ctrlandshiftandt()))
-        border = theme_manager.color(colors.BORDER)
+        border = theme_manager.value(colors.BORDER)
         self.tags.setStyleSheet(f"border: 1px solid {border}")
         tb.addWidget(self.tags, 1, 1)
         g.setLayout(tb)

--- a/qt/aqt/filtered_deck.py
+++ b/qt/aqt/filtered_deck.py
@@ -84,8 +84,8 @@ class FilteredDeckConfigDialog(QDialog):
         qconnect(self.form.search_button.clicked, self.on_search_button)
         qconnect(self.form.search_button_2.clicked, self.on_search_button_2)
         qconnect(self.form.hint_button.clicked, self.on_hint_button)
-        blue = theme_manager.color(colors.LINK)
-        grey = theme_manager.color(colors.DISABLED)
+        blue = theme_manager.value(colors.LINK)
+        grey = theme_manager.value(colors.DISABLED)
         self.setStyleSheet(
             f"""QPushButton[label] {{ padding: 0; border: 0 }}
             QPushButton[label]:hover {{ text-decoration: underline }}

--- a/qt/aqt/theme.py
+++ b/qt/aqt/theme.py
@@ -145,13 +145,13 @@ class ThemeManager:
         "Returns body classes used when showing a card."
         return f"card card{card_ord+1} {self.body_class(night_mode)}"
 
-    def color(self, colors: tuple[str, str]) -> str:
-        """Given day/night colors, return the correct one for the current theme."""
+    def value(self, values: tuple[str, str]) -> str:
+        """Given day/night values, return the correct one for the current theme."""
         idx = 1 if self.night_mode else 0
-        return colors[idx]
+        return values[idx]
 
     def qcolor(self, colors: tuple[str, str]) -> QColor:
-        return QColor(self.color(colors))
+        return QColor(self.value(colors))
 
     def _determine_night_mode(self) -> bool:
         theme = aqt.mw.pm.theme()
@@ -193,55 +193,48 @@ class ThemeManager:
             # also set for border to apply
             buf += f"""
 QMenuBar {{
-  border-bottom: 1px solid {self.color(colors.BORDER)};
-  background: {self.color(colors.WINDOW_BG) if self.night_mode else "white"};
+  border-bottom: 1px solid {self.value(colors.BORDER)};
+  background: {self.value(colors.WINDOW_BG) if self.night_mode else "white"};
 }}
 """
-            # qt bug? setting the above changes the browser sidebar
-            # to white as well, so set it back
-            buf += f"""
-QTreeWidget {{
-  background: {self.color(colors.WINDOW_BG)};
-}}
-            """
 
-        if self.night_mode:
-            buf += """
+        buf += """
 QToolTip {
   border: 0;
 }
-            """
+        """
 
-            if not self.macos_dark_mode():
-                buf += """
-QScrollBar {{ background-color: {}; }}
-QScrollBar::handle {{ background-color: {}; border-radius: {}; }} 
-
-QScrollBar:horizontal {{ height: 12px; }}
-QScrollBar::handle:horizontal {{ min-width: 50px; }} 
-
-QScrollBar:vertical {{ width: 12px; }}
-QScrollBar::handle:vertical {{ min-height: 50px; }} 
-    
-QScrollBar::add-line {{
-      border: none;
-      background: none;
+        buf += f"""
+QScrollBar {{
+  background-color: {self.value(colors.FRAME_BG)};
 }}
-
+QScrollBar::handle {{
+  background-color: {self.value(colors.CONTROL_IDLE)};
+  border-radius: {self.value(props.BORDER_RADIUS_DEFAULT)};
+}} 
+QScrollBar::handle:hover {{
+  background-color: {self.value(colors.CONTROL_HOVER)};
+}} 
+QScrollBar:horizontal {{
+  height: {self.value(props.SCROLLBAR_HANDLE_WIDTH)};
+}}
+QScrollBar:vertical {{
+  width: {self.value(props.SCROLLBAR_HANDLE_WIDTH)};
+}}
+QScrollBar::handle:vertical {{
+  min-height: {self.value(props.SCROLLBAR_HANDLE_LENGTH)};
+}} 
+QScrollBar::groove,
+QScrollBar::add-line,
 QScrollBar::sub-line {{
-      border: none;
-      background: none;
+  border: none;
+  background: none;
 }}
 
-QTabWidget {{ background-color: {}; }}
-""".format(
-                    self.color(colors.WINDOW_BG),
-                    # fushion-button-hover-bg
-                    "#656565",
-                    self.color(colors.WINDOW_BG),
-                    props.BORDER_RADIUS_DEFAULT,
-                )
-
+QTabWidget {{
+  background-color: {self.value(colors.WINDOW_BG)};
+}}
+        """
         # allow addons to modify the styling
         buf = gui_hooks.style_did_init(buf)
 
@@ -306,11 +299,11 @@ QTabWidget {{ background-color: {}; }}
     def _update_stat_colors(self) -> None:
         import anki.stats as s
 
-        s.colLearn = self.color(colors.NEW_COUNT)
-        s.colRelearn = self.color(colors.LEARN_COUNT)
-        s.colCram = self.color(colors.SUSPENDED_BG)
-        s.colSusp = self.color(colors.SUSPENDED_BG)
-        s.colMature = self.color(colors.REVIEW_COUNT)
+        s.colLearn = self.value(colors.NEW_COUNT)
+        s.colRelearn = self.value(colors.LEARN_COUNT)
+        s.colCram = self.value(colors.SUSPENDED_BG)
+        s.colSusp = self.value(colors.SUSPENDED_BG)
+        s.colMature = self.value(colors.REVIEW_COUNT)
         s._legacy_nightmode = self._night_mode_preference
 
 

--- a/qt/aqt/theme.py
+++ b/qt/aqt/theme.py
@@ -11,7 +11,7 @@ from typing import Callable, List, Tuple
 
 import aqt
 from anki.utils import is_lin, is_mac, is_win
-from aqt import QApplication, colors, gui_hooks
+from aqt import QApplication, colors, gui_hooks, props
 from aqt.qt import (
     QColor,
     QGuiApplication,
@@ -215,7 +215,7 @@ QToolTip {
             if not self.macos_dark_mode():
                 buf += """
 QScrollBar {{ background-color: {}; }}
-QScrollBar::handle {{ background-color: {}; border-radius: 5px; }} 
+QScrollBar::handle {{ background-color: {}; border-radius: {}; }} 
 
 QScrollBar:horizontal {{ height: 12px; }}
 QScrollBar::handle:horizontal {{ min-width: 50px; }} 
@@ -239,6 +239,7 @@ QTabWidget {{ background-color: {}; }}
                     # fushion-button-hover-bg
                     "#656565",
                     self.color(colors.WINDOW_BG),
+                    props.BORDER_RADIUS_DEFAULT,
                 )
 
         # allow addons to modify the styling

--- a/qt/aqt/theme.py
+++ b/qt/aqt/theme.py
@@ -214,7 +214,10 @@ QScrollBar::handle {{
 }} 
 QScrollBar::handle:hover {{
   background-color: {self.value(colors.CONTROL_HOVER)};
-}} 
+}}
+QScrollBar::handle:pressed {{
+  background-color: {self.value(colors.CONTROL_ACTIVE)};
+}}
 QScrollBar:horizontal {{
   height: {self.value(props.SCROLLBAR_HANDLE_WIDTH)};
 }}

--- a/qt/aqt/webview.py
+++ b/qt/aqt/webview.py
@@ -11,7 +11,7 @@ import anki
 import anki.lang
 from anki.lang import is_rtl
 from anki.utils import is_lin, is_mac, is_win
-from aqt import colors, gui_hooks
+from aqt import colors, gui_hooks, props
 from aqt.qt import *
 from aqt.theme import theme_manager
 from aqt.utils import askUser, is_gesture_or_zoom_event, openLink, showInfo, tr
@@ -432,9 +432,12 @@ button:focus {{ outline: 5px auto {color_hl}; }}"""
                 color = "background: #fff; border: 1px solid #ccc;"
             button_style = (
                 """
-button { -webkit-appearance: none; %s
-border-radius:5px; font-family: Helvetica }"""
-                % color
+button {{ -webkit-appearance: none; {}
+border-radius: {}; font-family: Helvetica }}
+                """.format(
+                    color,
+                    props.BORDER_RADIUS_DEFAULT,
+                )
             )
         else:
             family = self.font().family()

--- a/qt/aqt/webview.py
+++ b/qt/aqt/webview.py
@@ -430,14 +430,12 @@ button:focus {{ outline: 5px auto {color_hl}; }}"""
             color = ""
             if not theme_manager.night_mode:
                 color = "background: #fff; border: 1px solid #ccc;"
-            button_style = (
-                """
+            button_style = """
 button {{ -webkit-appearance: none; {}
 border-radius: {}; font-family: Helvetica }}
                 """.format(
-                    color,
-                    props.BORDER_RADIUS_DEFAULT,
-                )
+                color,
+                props.BORDER_RADIUS_DEFAULT,
             )
         else:
             family = self.font().family()

--- a/qt/tools/extract_sass_props.py
+++ b/qt/tools/extract_sass_props.py
@@ -40,6 +40,10 @@ with open(output_py, "w") as buf:
 """
     )
     buf.write("# this file is auto-generated from _props.scss\n")
-    for prop, (day, night) in props.items():
+    for prop, val in props.items():
+        day = val[0]
+        night = val[1] if len(val) > 1 else day
+
         prop = prop.replace("-", "_").upper()
+
         buf.write(f'{prop} = ("{day}", "{night}")\n')

--- a/qt/tools/extract_sass_props.py
+++ b/qt/tools/extract_sass_props.py
@@ -9,7 +9,7 @@ import sys
 input_scss = sys.argv[1]
 output_py = sys.argv[2]
 
-colors = {}
+props = {}
 
 for line in open(input_scss):
     line = line.strip()
@@ -22,7 +22,7 @@ for line in open(input_scss):
             and not ":root" in line
             and "Copyright" not in line
             and "License" not in line
-            and "color-scheme" not in line
+            and "prop-scheme" not in line
         ):
             print("failed to match", line)
         continue
@@ -30,7 +30,7 @@ for line in open(input_scss):
     var = m.group(1)
     val = m.group(2)
 
-    colors.setdefault(var, []).append(val)
+    props.setdefault(var, []).append(val)
 
 with open(output_py, "w") as buf:
     buf.write(
@@ -39,7 +39,7 @@ with open(output_py, "w") as buf:
 # License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 """
     )
-    buf.write("# this file is auto-generated from _colors.scss\n")
-    for color, (day, night) in colors.items():
-        color = color.replace("-", "_").upper()
-        buf.write(f'{color} = ("{day}", "{night}")\n')
+    buf.write("# this file is auto-generated from _props.scss\n")
+    for prop, (day, night) in props.items():
+        prop = prop.replace("-", "_").upper()
+        buf.write(f'{prop} = ("{day}", "{night}")\n')

--- a/sass/BUILD.bazel
+++ b/sass/BUILD.bazel
@@ -4,7 +4,8 @@ sass_library(
     name = "base_lib",
     srcs = [
         "_fusion-vars.scss",
-        "_vars.scss",
+        "_colors.scss",
+        "_props.scss",
         "base.scss",
         "bootstrap-dark.scss",
     ],
@@ -36,7 +37,8 @@ sass_library(
 sass_library(
     name = "core_lib",
     srcs = [
-        "_vars.scss",
+        "_colors.scss",
+        "_props.scss",
         "core.scss",
     ],
     visibility = ["//visibility:public"],
@@ -84,6 +86,9 @@ sass_library(
 )
 
 exports_files(
-    ["_vars.scss"],
+    [
+        "_colors.scss",
+        "_props.scss",
+    ],
     visibility = ["//visibility:public"],
 )

--- a/sass/_colors.scss
+++ b/sass/_colors.scss
@@ -9,6 +9,8 @@
     --medium-border: #b6b6b6;
     --faint-border: #e7e7e7;
     --link: #00a;
+    --control-idle: #dbdbdb;
+    --control-hover: #cacaca;
     --review-count: #0a0;
     --new-count: #00a;
     --learn-count: #c35617;
@@ -41,13 +43,15 @@
 }
 
 :root[class*="night-mode"] {
-    --text-fg: #f8f8ff;
+    --text-fg: white;
     --window-bg: #2f2f31;
     --frame-bg: #3a3a3a;
     --border: #777;
     --medium-border: #444;
     --faint-border: #29292b;
     --link: #77ccff;
+    --control-idle: #5c5c5c;
+    --control-hover: #656565;
     --review-count: #5ccc00;
     --new-count: #77ccff;
     --learn-count: #ff935b;

--- a/sass/_colors.scss
+++ b/sass/_colors.scss
@@ -11,6 +11,7 @@
     --link: #00a;
     --control-idle: #dbdbdb;
     --control-hover: #cacaca;
+    --control-active: #b6b6b6;
     --review-count: #0a0;
     --new-count: #00a;
     --learn-count: #c35617;
@@ -52,6 +53,7 @@
     --link: #77ccff;
     --control-idle: #5c5c5c;
     --control-hover: #656565;
+    --control-active: #777;
     --review-count: #5ccc00;
     --new-count: #77ccff;
     --learn-count: #ff935b;

--- a/sass/_colors.scss
+++ b/sass/_colors.scss
@@ -41,7 +41,7 @@
 }
 
 :root[class*="night-mode"] {
-    --text-fg: white;
+    --text-fg: #f8f8ff;
     --window-bg: #2f2f31;
     --frame-bg: #3a3a3a;
     --border: #777;

--- a/sass/_props.scss
+++ b/sass/_props.scss
@@ -1,0 +1,10 @@
+/* Copyright: Ankitects Pty Ltd and contributors
+ * License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html */
+
+:root {
+    --border-radius-default: 5px;
+}
+
+:root[class*="night-mode"] {
+    --border-radius-default: 5px;
+}

--- a/sass/_props.scss
+++ b/sass/_props.scss
@@ -3,9 +3,14 @@
 
 :root {
     --border-radius-default: 5px;
+
     --scrollbar-handle-width: 12px;
     --scrollbar-handle-length: 50px;
     --scrollbar-radius: 6px;
+
+    --opacity-idle: 0.4;
+    --opacity-active: 0.8;
+    --opacity-hover: 1;
 }
 
 :root[class*="night-mode"] {

--- a/sass/_props.scss
+++ b/sass/_props.scss
@@ -3,6 +3,9 @@
 
 :root {
     --border-radius-default: 5px;
+    --scrollbar-handle-width: 12px;
+    --scrollbar-handle-length: 50px;
+    --scrollbar-radius: 6px;
 }
 
 :root[class*="night-mode"] {

--- a/sass/base.scss
+++ b/sass/base.scss
@@ -1,4 +1,5 @@
-@use "vars";
+@use "colors";
+@use "props";
 @use "scrollbar";
 
 $body-color: var(--text-fg);

--- a/sass/base.scss
+++ b/sass/base.scss
@@ -37,8 +37,8 @@ $utilities: (
     overscroll-behavior: none;
 }
 
-.night-mode {
-    @include scrollbar.night-mode;
+body {
+    @include scrollbar.custom;
 }
 
 button {

--- a/sass/bootstrap-dark.scss
+++ b/sass/bootstrap-dark.scss
@@ -1,7 +1,8 @@
 /* Copyright: Ankitects Pty Ltd and contributors
  * License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html */
 
-@use "vars";
+@use "colors";
+@use "props";
 @use "fusion-vars";
 
 @mixin night-mode {

--- a/sass/buttons.scss
+++ b/sass/buttons.scss
@@ -1,4 +1,5 @@
 @use "fusion-vars";
+@use "props";
 
 :root {
     --focus-color: #0078d7;
@@ -25,7 +26,7 @@
         font-size: 14px;
 
         -webkit-appearance: none;
-        border-radius: 5px;
+        border-radius: var(--border-radius-default);
         padding: 5px;
         border: 1px solid var(--border);
     }
@@ -45,7 +46,7 @@
         box-shadow: 0 0 3px fusion-vars.$button-outline;
         border: 1px solid fusion-vars.$button-border;
 
-        border-radius: 5px;
+        border-radius: var(--border-radius-default);
         padding: 3px 10px 3px;
 
         &:focus {

--- a/sass/core.scss
+++ b/sass/core.scss
@@ -1,7 +1,8 @@
 /* Copyright: Ankitects Pty Ltd and contributors
  * License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html */
 
-@use "vars";
+@use "colors";
+@use "props";
 
 * {
     box-sizing: border-box;

--- a/sass/scrollbar.scss
+++ b/sass/scrollbar.scss
@@ -33,6 +33,10 @@
         &:hover {
             background: var(--control-hover);
         }
+
+        &:active {
+            background: var(--control-active);
+        }
     }
 
     ::-webkit-scrollbar-corner {

--- a/sass/scrollbar.scss
+++ b/sass/scrollbar.scss
@@ -1,7 +1,8 @@
 /* Copyright: Ankitects Pty Ltd and contributors
  * License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html */
 
-@use "vars";
+@use "colors";
+@use "props";
 @use "fusion-vars";
 
 @mixin night-mode {

--- a/sass/scrollbar.scss
+++ b/sass/scrollbar.scss
@@ -5,33 +5,42 @@
 @use "props";
 @use "fusion-vars";
 
-@mixin night-mode {
+@mixin custom {
     ::-webkit-scrollbar {
         background-color: var(--window-bg);
 
         &:horizontal {
-            height: 12px;
+            height: var(--scrollbar-handle-width);
         }
 
         &:vertical {
-            width: 12px;
+            width: var(--scrollbar-handle-width);
         }
     }
 
     ::-webkit-scrollbar-thumb {
-        background: fusion-vars.$button-hover-bg;
-        border-radius: 8px;
+        background: var(--control-idle);
+        border-radius: var(--scrollbar-radius);
 
         &:horizontal {
-            min-width: 50px;
+            min-width: var(--scrollbar-handle-length);
         }
 
         &:vertical {
-            min-height: 50px;
+            min-height: var(--scrollbar-handle-length);
+        }
+
+        &:hover {
+            background: var(--control-hover);
         }
     }
 
     ::-webkit-scrollbar-corner {
         background-color: var(--window-bg);
+    }
+
+    ::-webkit-scrollbar-track {
+        border-radius: var(--scrollbar-radius);
+        background-color: transparent;
     }
 }

--- a/ts/change-notetype/change-notetype-base.scss
+++ b/ts/change-notetype/change-notetype-base.scss
@@ -1,4 +1,5 @@
-@use "sass/vars";
+@use "sass/colors";
+@use "sass/props";
 @use "sass/bootstrap-dark";
 
 @import "sass/base";

--- a/ts/components/DropdownMenu.svelte
+++ b/ts/components/DropdownMenu.svelte
@@ -31,7 +31,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
 <style lang="scss">
     .dropdown-menu {
-        border-radius: 5px;
+        border-radius: var(--border-radius-default);
         background-color: var(--frame-bg);
         border-color: var(--medium-border);
         min-width: 1rem;

--- a/ts/components/Popover.svelte
+++ b/ts/components/Popover.svelte
@@ -14,7 +14,7 @@ Alternative to DropdownMenu that avoids Bootstrap
 
 <style lang="scss">
     .popover {
-        border-radius: 5px;
+        border-radius: var(--border-radius-default);
         background-color: var(--frame-bg);
         min-width: 1rem;
         max-width: 95vw;

--- a/ts/components/WithFloating.svelte
+++ b/ts/components/WithFloating.svelte
@@ -87,7 +87,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
     .floating {
         position: absolute;
-        border-radius: 5px;
+        border-radius: var(--border-radius-default);
 
         z-index: 90;
         @include elevation.elevation(8);

--- a/ts/editable/editable-base.scss
+++ b/ts/editable/editable-base.scss
@@ -18,6 +18,6 @@ p {
     display: none;
 }
 
-:host(.night-mode) {
-    @include scrollbar.night-mode;
+:host(body) {
+    @include scrollbar.custom;
 }

--- a/ts/editor/EditorField.svelte
+++ b/ts/editor/EditorField.svelte
@@ -112,7 +112,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     .editor-field {
         --border-color: var(--border);
 
-        border-radius: 5px;
+        border-radius: var(--border-radius-default);
         border: 1px solid var(--border-color);
 
         &:focus-within {

--- a/ts/editor/HandleLabel.svelte
+++ b/ts/editor/HandleLabel.svelte
@@ -35,7 +35,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         color: white;
         background-color: rgba(0 0 0 / 0.3);
         border-color: black;
-        border-radius: 5px;
+        border-radius: var(--border-radius-default);
         padding: 0 5px;
 
         pointer-events: none;

--- a/ts/editor/LabelContainer.svelte
+++ b/ts/editor/LabelContainer.svelte
@@ -29,7 +29,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         border-width: 0 0 1px;
         border-style: dashed;
         border-color: var(--border-color);
-        border-radius: 5px 5px 0 0;
+        border-radius: var(--border-radius-default) 5px 0 0;
 
         padding: 0px 6px;
     }

--- a/ts/editor/Notification.svelte
+++ b/ts/editor/Notification.svelte
@@ -16,7 +16,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         user-select: none;
 
         border: 1px solid var(--medium-border);
-        border-radius: 5px;
+        border-radius: var(--border-radius-default);
         padding: 0.9rem 1.2rem;
     }
 </style>

--- a/ts/editor/PlainTextBadge.svelte
+++ b/ts/editor/PlainTextBadge.svelte
@@ -44,13 +44,13 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
 <style lang="scss">
     span {
-        opacity: 0.4;
+        opacity: var(--opacity-idle);
 
         &.highlighted {
-            opacity: 1;
+            opacity: var(--opacity-active);
         }
         &:hover {
-            opacity: 0.8;
+            opacity: var(--opacity-hover);
         }
     }
 </style>

--- a/ts/editor/RichTextBadge.svelte
+++ b/ts/editor/RichTextBadge.svelte
@@ -30,13 +30,13 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
 <style lang="scss">
     span {
-        opacity: 0.4;
+        opacity: var(--opacity-idle);
 
         &.highlighted {
-            opacity: 1;
+            opacity: var(--opacity-active);
         }
         &:hover {
-            opacity: 0.8;
+            opacity: var(--opacity-hover);
         }
     }
 </style>

--- a/ts/editor/StickyBadge.svelte
+++ b/ts/editor/StickyBadge.svelte
@@ -44,13 +44,13 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
 <style lang="scss">
     span {
-        opacity: 0.4;
+        opacity: var(--opacity-idle);
 
         &.highlighted {
-            opacity: 1;
+            opacity: var(--opacity-active);
         }
         &:hover {
-            opacity: 0.8;
+            opacity: var(--opacity-hover);
         }
     }
 </style>

--- a/ts/editor/editor-base.scss
+++ b/ts/editor/editor-base.scss
@@ -3,7 +3,6 @@
 
 @import "sass/base";
 
-$btn-disabled-opacity: 0.4;
 @import "sass/bootstrap/scss/buttons";
 @import "sass/bootstrap/scss/button-group";
 @import "sass/bootstrap/scss/dropdown";

--- a/ts/fields/fields-base.scss
+++ b/ts/fields/fields-base.scss
@@ -1,4 +1,5 @@
-@use "sass/vars";
+@use "sass/colors";
+@use "sass/props";
 @use "sass/bootstrap-dark";
 
 @import "sass/base";

--- a/ts/graphs/Tooltip.svelte
+++ b/ts/graphs/Tooltip.svelte
@@ -46,7 +46,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         position: absolute;
         white-space: nowrap;
         padding: 15px;
-        border-radius: 5px;
+        border-radius: var(--border-radius-default);
         font-size: 15px;
         opacity: 0;
         pointer-events: none;

--- a/ts/import-csv/import-csv-base.scss
+++ b/ts/import-csv/import-csv-base.scss
@@ -1,4 +1,5 @@
-@use "sass/vars";
+@use "sass/colors";
+@use "sass/props";
 @use "sass/bootstrap-dark";
 
 @import "sass/base";

--- a/ts/tag-editor/Tag.svelte
+++ b/ts/tag-editor/Tag.svelte
@@ -64,7 +64,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         --border-color: var(--medium-border);
 
         border: 1px solid var(--border-color) !important;
-        border-radius: 5px;
+        border-radius: var(--border-radius-default);
 
         &:focus,
         &:active {

--- a/ts/tag-editor/TagWithTooltip.svelte
+++ b/ts/tag-editor/TagWithTooltip.svelte
@@ -108,7 +108,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     }
 
     :global(.tag-icon-hover svg:hover) {
-        border-radius: 5px;
+        border-radius: var(--border-radius-default);
 
         $white-translucent: rgb(255 255 255 / 0.35);
         $dark-translucent: rgb(0 0 0 / 0.1);


### PR DESCRIPTION
This is a groundwork-PR for design work down the line.

## Changes
- rename `_vars.scss` to `_colors.scss`
- introduce `_props.scss` for CSS property values other than colors
  - This will be the place where default sizes, box-shadows, transitions etc. are defined.
  - I included a redundant night mode definition for demo purposes. If a value isn't set for night mode, `extract_sass_props` assumes the day value.

### Included sample use cases
- make scrollbar appearance consistent with a single custom style for all platforms and themes
- use CSS variables for UI elements that change opacity

---
Let me know if this is a valid way forward or if you had other plans in mind. I'd also love to take up the work on #1704 to have a solid system before making actual design changes.