### PR TITLE
Use wavy flag icons (flag-alternative)

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "dependencies": {
         "@floating-ui/dom": "^0.3.0",
         "@fluent/bundle": "^0.17.0",
-        "@mdi/svg": "^6.1.95",
+        "@mdi/svg": "^7.0.96",
         "@popperjs/core": "^2.9.2",
         "@types/lodash-es": "^4.17.4",
         "@types/marked": "^4.0.1",

--- a/qt/aqt/browser/sidebar/tree.py
+++ b/qt/aqt/browser/sidebar/tree.py
@@ -695,9 +695,9 @@ class SidebarTreeView(QTreeView):
     ###########################
 
     def _flags_tree(self, root: SidebarItem) -> None:
-        icon_off = "icons:flag-off-outline.svg"
-        icon = "icons:flag.svg"
-        icon_outline = "icons:flag-outline.svg"
+        icon_off = "icons:flag-variant-off-outline.svg"
+        icon = "icons:flag-variant.svg"
+        icon_outline = "icons:flag-variant-outline.svg"
 
         root = self._section_root(
             root=root,

--- a/qt/aqt/data/qt/icons/BUILD.bazel
+++ b/qt/aqt/data/qt/icons/BUILD.bazel
@@ -14,9 +14,9 @@ copy_mdi_icons(
         "circle-outline.svg",
 
         # flags
-        "flag.svg",
-        "flag-outline.svg",
-        "flag-off-outline.svg",
+        "flag-variant.svg",
+        "flag-variant-outline.svg",
+        "flag-variant-off-outline.svg",
 
         # decks
         "book-outline.svg",

--- a/qt/aqt/flags.py
+++ b/qt/aqt/flags.py
@@ -61,7 +61,7 @@ class FlagManager:
 
     def _load_flags(self) -> None:
         labels = cast(dict[str, str], self.mw.col.get_config("flagLabels", {}))
-        icon = ColoredIcon(path="icons:flag.svg", color=colors.DISABLED)
+        icon = ColoredIcon(path="icons:flag-variant.svg", color=colors.DISABLED)
 
         self._flags = [
             Flag(

--- a/ts/licenses.json
+++ b/ts/licenses.json
@@ -66,7 +66,7 @@
         "path": "node_modules/@humanwhocodes/object-schema",
         "licenseFile": "node_modules/@humanwhocodes/object-schema/LICENSE"
     },
-    "@mdi/svg@6.6.95": {
+    "@mdi/svg@7.0.96": {
         "licenses": "Apache-2.0",
         "repository": "https://github.com/Templarian/MaterialDesign-SVG",
         "publisher": "Austin Andrews",

--- a/yarn.lock
+++ b/yarn.lock
@@ -597,10 +597,10 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
-"@mdi/svg@^6.1.95":
-  version "6.6.95"
-  resolved "https://registry.yarnpkg.com/@mdi/svg/-/svg-6.6.95.tgz#334ef718a06889e6a02b6802020f4f35f0ad5adb"
-  integrity sha512-krWKPBPmDle424VI3cJzTEyZgL/DryScgYjmPoaMhv6cb50M7sjqPNBkE5H5fpru2fc+II2ICEWvlIM0sVW00w==
+"@mdi/svg@^7.0.96":
+  version "7.0.96"
+  resolved "https://registry.yarnpkg.com/@mdi/svg/-/svg-7.0.96.tgz#c7275a318da8594337243368c6b4dca6a90154f6"
+  integrity sha512-5DC+w7Kl2C82j4aTWCUf6wtHzgY60WBf1gT1qrpkLaMNcH6Vj9FpYPAXdSmtdkmSMvVMs8i1Rtv9cXWcHFQYpw==
 
 "@mdn/browser-compat-data@^3.3.14":
   version "3.3.14"


### PR DESCRIPTION
We used the blocky flag icon, instead of the wavy one, because it had more modifiers.
Well, now the wavy flag has just as much :)
