### PR TITLE
Fix Field Description

### DIFF
--- a/ts/editable/ContentEditable.svelte
+++ b/ts/editable/ContentEditable.svelte
@@ -7,11 +7,9 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 </script>
 
 <script lang="ts">
-    import { getContext } from "svelte";
-    import type { Readable, Writable } from "svelte/store";
+    import type { Writable } from "svelte/store";
 
     import { updateAllState } from "../components/WithState.svelte";
-    import { descriptionKey } from "../lib/context-keys";
     import actionList from "../sveltelib/action-list";
     import type { MirrorAction } from "../sveltelib/dom-mirror";
     import type { SetupInputHandlerAction } from "../sveltelib/input-handler";
@@ -36,9 +34,6 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
     Object.assign(api, { focusHandler });
 
-    const description = getContext<Readable<string>>(descriptionKey);
-    $: descriptionCSSValue = `"${$description}"`;
-
     export let content: string;
 </script>
 
@@ -54,7 +49,6 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     on:blur
     on:click={updateAllState}
     on:keyup={updateAllState}
-    style="--description: {descriptionCSSValue}"
 />
 
 <style lang="scss">
@@ -69,17 +63,6 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
         &:focus {
             outline: none;
-        }
-        &.empty::before {
-            content: var(--description);
-            opacity: 0.4;
-            cursor: text;
-            /* stay on single line */
-            position: absolute;
-            max-width: 95%;
-            overflow-x: hidden;
-            white-space: nowrap;
-            text-overflow: ellipsis;
         }
     }
 

--- a/ts/editor/EditorField.svelte
+++ b/ts/editor/EditorField.svelte
@@ -44,7 +44,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     import type { Writable } from "svelte/store";
     import { writable } from "svelte/store";
 
-    import { descriptionKey, directionKey } from "../lib/context-keys";
+    import { directionKey } from "../lib/context-keys";
     import { promiseWithResolver } from "../lib/promise";
     import type { Destroyable } from "./destroyable";
     import EditingArea from "./EditingArea.svelte";
@@ -59,11 +59,6 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     setContext(directionKey, directionStore);
 
     $: $directionStore = field.direction;
-
-    const descriptionStore = writable<string>();
-    setContext(descriptionKey, descriptionStore);
-
-    $: $descriptionStore = field.description;
 
     const editingArea: Partial<EditingAreaAPI> = {};
     const [element, elementResolve] = promiseWithResolver<HTMLElement>();

--- a/ts/editor/FieldDescription.svelte
+++ b/ts/editor/FieldDescription.svelte
@@ -7,19 +7,27 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     import type { Readable } from "svelte/store";
 
     import { directionKey, fontFamilyKey, fontSizeKey } from "../lib/context-keys";
+    import { context } from "./EditingArea.svelte";
+
+    const { content } = context.get();
 
     const fontFamily = getContext<Readable<string>>(fontFamilyKey);
     const fontSize = getContext<Readable<number>>(fontSizeKey);
     const direction = getContext<Readable<"ltr" | "rtl">>(directionKey);
+
+    $: empty = $content.length === 0;
 </script>
-<div
-    class="field-description"
-    style:font-family={$fontFamily}
-    style:font-size="{$fontSize}px"
-    style:direction={$direction}
->
-    <slot />
-</div>
+
+{#if empty}
+    <div
+        class="field-description"
+        style:font-family={$fontFamily}
+        style:font-size="{$fontSize}px"
+        style:direction={$direction}
+    >
+        <slot />
+    </div>
+{/if}
 
 <style>
     .field-description {

--- a/ts/editor/FieldDescription.svelte
+++ b/ts/editor/FieldDescription.svelte
@@ -8,12 +8,15 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
 <style>
     .field-description {
+        position: absolute;
+        top: 0;
+        left: 0;
+
         opacity: 0.4;
         cursor: text;
         /* same as in ContentEditable */
         padding: 6px;
         /* stay a on single line */
-        position: absolute;
         max-width: 95%;
         overflow-x: hidden;
         white-space: nowrap;

--- a/ts/editor/FieldDescription.svelte
+++ b/ts/editor/FieldDescription.svelte
@@ -1,0 +1,22 @@
+<!--
+Copyright: Ankitects Pty Ltd and contributors
+License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
+-->
+<div class="field-description">
+    <slot />
+</div>
+
+<style>
+    .field-description {
+        opacity: 0.4;
+        cursor: text;
+        /* same as in ContentEditable */
+        padding: 6px;
+        /* stay a on single line */
+        position: absolute;
+        max-width: 95%;
+        overflow-x: hidden;
+        white-space: nowrap;
+        text-overflow: ellipsis;
+    }
+</style>

--- a/ts/editor/FieldDescription.svelte
+++ b/ts/editor/FieldDescription.svelte
@@ -2,7 +2,22 @@
 Copyright: Ankitects Pty Ltd and contributors
 License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 -->
-<div class="field-description">
+<script lang="ts">
+    import { getContext } from "svelte";
+    import type { Readable } from "svelte/store";
+
+    import { directionKey, fontFamilyKey, fontSizeKey } from "../lib/context-keys";
+
+    const fontFamily = getContext<Readable<string>>(fontFamilyKey);
+    const fontSize = getContext<Readable<number>>(fontSizeKey);
+    const direction = getContext<Readable<"ltr" | "rtl">>(directionKey);
+</script>
+<div
+    class="field-description"
+    style:font-family={$fontFamily}
+    style:font-size="{$fontSize}px"
+    style:direction={$direction}
+>
     <slot />
 </div>
 

--- a/ts/editor/NoteEditor.svelte
+++ b/ts/editor/NoteEditor.svelte
@@ -303,9 +303,11 @@ the AddCards dialog) should be implemented in the user of this component.
         <Fields>
             <DecoratedElements>
                 {#each fieldsData as field, index}
+                    {@const content = fieldStores[index]}
+
                     <EditorField
                         {field}
-                        content={fieldStores[index]}
+                        {content}
                         api={fields[index]}
                         on:focusin={() => {
                             $focusedField = fields[index];
@@ -314,9 +316,7 @@ the AddCards dialog) should be implemented in the user of this component.
                         on:focusout={() => {
                             $focusedField = null;
                             bridgeCommand(
-                                `blur:${index}:${getNoteId()}:${get(
-                                    fieldStores[index],
-                                )}`,
+                                `blur:${index}:${getNoteId()}:${get(content)}`,
                             );
                         }}
                         --label-color={cols[index] === "dupe"
@@ -363,7 +363,7 @@ the AddCards dialog) should be implemented in the user of this component.
                                 <ImageHandle maxWidth={250} maxHeight={125} />
                                 <MathjaxHandle />
                                 <FieldDescription>
-                                    {fieldDescriptions[index]}
+                                    {field.description}
                                 </FieldDescription>
                             </RichTextInput>
 

--- a/ts/editor/NoteEditor.svelte
+++ b/ts/editor/NoteEditor.svelte
@@ -49,6 +49,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     import { EditorToolbar } from "./editor-toolbar";
     import type { FieldData } from "./EditorField.svelte";
     import EditorField from "./EditorField.svelte";
+    import FieldDescription from "./FieldDescription.svelte";
     import Fields from "./Fields.svelte";
     import FieldsEditor from "./FieldsEditor.svelte";
     import FrameElement from "./FrameElement.svelte";
@@ -361,6 +362,9 @@ the AddCards dialog) should be implemented in the user of this component.
                             >
                                 <ImageHandle maxWidth={250} maxHeight={125} />
                                 <MathjaxHandle />
+                                <FieldDescription>
+                                    {fieldDescriptions[index]}
+                                </FieldDescription>
                             </RichTextInput>
 
                             <PlainTextInput

--- a/ts/editor/rich-text-input/RichTextInput.svelte
+++ b/ts/editor/rich-text-input/RichTextInput.svelte
@@ -208,6 +208,10 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 </div>
 
 <style lang="scss">
+    .rich-text-input {
+        position: relative;
+    }
+
     .hidden {
         display: none;
     }

--- a/ts/editor/rich-text-input/RichTextStyles.svelte
+++ b/ts/editor/rich-text-input/RichTextStyles.svelte
@@ -47,15 +47,16 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         } as StyleLinkType,
     ];
 
-    async function attachToShadow(element: Element): Promise<void> {
+    function attachToShadow(element: Element) {
         const customStyles = new CustomStyles({
             target: element.shadowRoot as any,
             props: { styles },
         });
 
-        const styleTag = await customStyles.addStyleTag("userBase");
-        userBaseResolve(styleTag);
-        callback(customStyles);
+        customStyles.addStyleTag("userBase").then((styleTag) => {
+            userBaseResolve(styleTag);
+            callback(customStyles);
+        });
     }
 </script>
 

--- a/ts/editor/rich-text-input/RichTextStyles.svelte
+++ b/ts/editor/rich-text-input/RichTextStyles.svelte
@@ -47,16 +47,15 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         } as StyleLinkType,
     ];
 
-    function attachToShadow(element: Element) {
+    async function attachToShadow(element: Element): Promise<void> {
         const customStyles = new CustomStyles({
             target: element.shadowRoot as any,
             props: { styles },
         });
 
-        customStyles.addStyleTag("userBase").then((styleTag) => {
-            userBaseResolve(styleTag);
-            callback(customStyles);
-        });
+        const styleTag = await customStyles.addStyleTag("userBase");
+        userBaseResolve(styleTag);
+        callback(customStyles);
     }
 </script>
 

--- a/ts/lib/context-keys.ts
+++ b/ts/lib/context-keys.ts
@@ -4,4 +4,3 @@
 export const fontFamilyKey = Symbol("fontFamily");
 export const fontSizeKey = Symbol("fontSize");
 export const directionKey = Symbol("direction");
-export const descriptionKey = Symbol("description");


### PR DESCRIPTION
- Add field description directly in NoteEditor
- Strip description logic from ContentEditable
- Make RichTextInput position: relative
- Make attachToShadow an async function
- Apply field styling to field description
- Show FieldDescription only if content empty
- Remove descriptionStore and descriptionKey
- Revert "Make attachToShadow an async function"
