### PR TITLE
fix progress.update(value=0) to not increment progress

### DIFF
--- a/qt/aqt/progress.py
+++ b/qt/aqt/progress.py
@@ -219,7 +219,7 @@ class ProgressManager:
         self._max = max or 0
         self._win.form.progressBar.setMaximum(self._max)
         if self._max:
-            self._counter = value or (self._counter + 1)
+            self._counter = value if value is not None else (self._counter + 1)
             self._win.form.progressBar.setValue(self._counter)
 
     def finish(self) -> None:


### PR DESCRIPTION
This fixes a bug where calling `progress.update(value=0)` multiple times increments `self._counter`.