### PR TITLE
Use platform.platform() in supportText()

### DIFF
--- a/qt/aqt/utils.py
+++ b/qt/aqt/utils.py
@@ -905,12 +905,7 @@ def supportText() -> str:
 
     from aqt import mw
 
-    if is_win:
-        platname = f"Windows {platform.win32_ver()[0]}"
-    elif is_mac:
-        platname = f"Mac {platform.mac_ver()[0]}"
-    else:
-        platname = "Linux"
+    platname = platform.platform()
 
     def schedVer() -> str:
         try:


### PR DESCRIPTION
From [the documentation](https://docs.python.org/3.9/library/platform.html#platform.platform):
> Returns a single string identifying the underlying platform with as much useful information as possible.
The output is intended to be human readable rather than machine parseable. It may look different on different platforms and this is intended.
Changed in version 3.8: On macOS, the function now uses mac_ver(), if it returns a non-empty release string, to get the macOS version rather than the darwin version.

While slightly less readable, support text will now provide the architecture of the platform, which is increasingly relevant as ARM systems are becoming more common. It may also provide other useful information such as the Linux distro.

Some examples from my testing:
- macOS-12.4-arm64-arm-64bit
- Linux-5.15.0-40-generic-x86_64-with-glibc2.35 
- Linux-5.0.0-1029-gcp-x86_64-with-Ubuntu-16.04-xenial