### PR TITLE
Updated permalink to architecture visualization

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -8,6 +8,7 @@ At the highest level, Anki is logically separated into two parts.
 
 A neat visualization of the file layout is available here:
 <https://mango-dune-07a8b7110.1.azurestaticapps.net/?repo=ankitects%2Fanki>
+(or go to <https://githubnext.com/projects/repo-visualization#explore-for-yourself> and enter `ankitects/anki`).
 
 ### Library (rslib & pylib)
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -6,9 +6,8 @@ Very brief notes for now.
 
 At the highest level, Anki is logically separated into two parts.
 
-A neat visualization
-of the file layout is available here:
-<https://octo-repo-visualization.vercel.app/?repo=ankitects%2Fanki>
+A neat visualization of the file layout is available here:
+<https://mango-dune-07a8b7110.1.azurestaticapps.net/?repo=ankitects%2Fanki>
 
 ### Library (rslib & pylib)
 


### PR DESCRIPTION
The existing link in the docs 404's, so I've just updated to what seems to be the new url.
[The docs](https://githubnext.com/projects/repo-visualization#integrate-into-your-own-projects) for that project suggest using GitHub actions to generate an svg file, but it might be possible to do this with BuildKite?