### PR TITLE
Narrow typehints within pylib

### DIFF
--- a/pylib/anki/exporting.py
+++ b/pylib/anki/exporting.py
@@ -313,7 +313,7 @@ class AnkiExporter(Exporter):
         # such as update the deck description
         pass
 
-    def removeSystemTags(self, tags: str) -> Any:
+    def removeSystemTags(self, tags: str) -> str:
         return self.src.tags.rem_from_str("marked leech", tags)
 
     def _modelHasMedia(self, model, fname) -> bool:
@@ -464,7 +464,7 @@ class AnkiCollectionPackage21bExporter(AnkiCollectionPackageExporter):
 
 
 def exporters(col: Collection) -> list[tuple[str, Any]]:
-    def id(obj):
+    def id(obj) -> tuple[str, Exporter]:
         if callable(obj.key):
             key_str = obj.key(col)
         else:

--- a/pylib/anki/latex.py
+++ b/pylib/anki/latex.py
@@ -7,7 +7,6 @@ import html
 import os
 import re
 from dataclasses import dataclass
-from typing import Any
 
 import anki
 import anki.collection
@@ -168,7 +167,7 @@ def _save_latex_image(
         log.close()
 
 
-def _err_msg(col: anki.collection.Collection, type: str, texpath: str) -> Any:
+def _err_msg(col: anki.collection.Collection, type: str, texpath: str) -> str:
     msg = f"{col.tr.media_error_executing(val=type)}<br>"
     msg += f"{col.tr.media_generated_file(val=texpath)}<br>"
     try:

--- a/pylib/anki/media.py
+++ b/pylib/anki/media.py
@@ -8,7 +8,7 @@ import pprint
 import re
 import sys
 import time
-from typing import Any, Callable
+from typing import Callable
 
 from anki import media_pb2
 from anki._legacy import DeprecatedNamesMixin, deprecated_keywords
@@ -142,7 +142,7 @@ class MediaManager(DeprecatedNamesMixin):
                     files.append(fname)
         return files
 
-    def transform_names(self, txt: str, func: Callable) -> Any:
+    def transform_names(self, txt: str, func: Callable) -> str:
         for reg in self.regexps:
             txt = re.sub(reg, func, txt)
         return txt

--- a/pylib/anki/notes.py
+++ b/pylib/anki/notes.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 import copy
-from typing import Any, NewType, Sequence
+from typing import NewType, Sequence
 
 import anki  # pylint: disable=unused-import
 import anki.cards
@@ -182,7 +182,7 @@ class Note(DeprecatedNamesMixin):
         "Add tag. Duplicates will be stripped on save."
         self.tags.append(tag)
 
-    def string_tags(self) -> Any:
+    def string_tags(self) -> str:
         return self.col.tags.join(self.tags)
 
     def set_tags_from_str(self, tags: str) -> None:


### PR DESCRIPTION
This is a small set of type hint narrowings that I've applied in order to reduce the usage of `Any`.
These are very small in scope and so shouldn't impact any other components, but might provide a bit of clarity.