### PR TITLE
Add MessageBox class and associated funcs to aqt.utils and update the first few callers

### DIFF
--- a/qt/aqt/addons.py
+++ b/qt/aqt/addons.py
@@ -43,6 +43,7 @@ from aqt.utils import (
     saveGeom,
     saveSplitter,
     send_to_trash,
+    show_info,
     showInfo,
     showWarning,
     tooltip,
@@ -862,14 +863,14 @@ class AddonsDialog(QDialog):
     def onlyOneSelected(self) -> str | None:
         dirs = self.selectedAddons()
         if len(dirs) != 1:
-            showInfo(tr.addons_please_select_a_single_addon_first())
+            show_info(tr.addons_please_select_a_single_addon_first())
             return None
         return dirs[0]
 
     def selected_addon_meta(self) -> AddonMeta | None:
         idxs = [x.row() for x in self.form.addonList.selectedIndexes()]
         if len(idxs) != 1:
-            showInfo(tr.addons_please_select_a_single_addon_first())
+            show_info(tr.addons_please_select_a_single_addon_first())
             return None
         return self.addons[idxs[0]]
 

--- a/qt/aqt/sync.py
+++ b/qt/aqt/sync.py
@@ -145,7 +145,7 @@ def full_sync(
         ask_user_dialog(
             tr.sync_conflict_explanation(),
             callback=callback,
-            buttons=button_labels,  # type: ignore
+            buttons=button_labels,
             default_button=2,
         )
 

--- a/qt/aqt/sync.py
+++ b/qt/aqt/sync.py
@@ -134,10 +134,10 @@ def full_sync(
             tr.sync_cancel_button(),
         ]
 
-        def callback(choice: str) -> None:
-            if choice == button_labels[0]:
+        def callback(choice: int) -> None:
+            if choice == 0:
                 full_upload(mw, on_done)
-            elif choice == button_labels[1]:
+            elif choice == 1:
                 full_download(mw, on_done)
             else:
                 on_done()
@@ -146,7 +146,7 @@ def full_sync(
             tr.sync_conflict_explanation(),
             callback=callback,
             buttons=button_labels,  # type: ignore
-            default_button=button_labels[2],
+            default_button=2,
         )
 
 

--- a/qt/aqt/sync.py
+++ b/qt/aqt/sync.py
@@ -26,9 +26,14 @@ from aqt.qt import (
     QVBoxLayout,
     qconnect,
 )
-from aqt.utils import askUser, disable_help_button, showText, showWarning, tr
-
-from .utils import ask_user_dialog
+from aqt.utils import (
+    ask_user_dialog,
+    askUser,
+    disable_help_button,
+    showText,
+    showWarning,
+    tr,
+)
 
 
 def get_sync_status(

--- a/qt/aqt/sync.py
+++ b/qt/aqt/sync.py
@@ -3,7 +3,6 @@
 
 from __future__ import annotations
 
-import enum
 import os
 from concurrent.futures import Future
 from typing import Callable
@@ -129,7 +128,7 @@ def full_sync(
     elif out.required == out.FULL_UPLOAD:
         full_upload(mw, on_done)
     else:
-        button_labels = [
+        button_labels: list[str] = [
             tr.sync_upload_to_ankiweb(),
             tr.sync_download_from_ankiweb(),
             tr.sync_cancel_button(),
@@ -146,7 +145,7 @@ def full_sync(
         ask_user_dialog(
             tr.sync_conflict_explanation(),
             callback=callback,
-            buttons=button_labels,
+            buttons=button_labels,  # type: ignore
             default_button=button_labels[2],
         )
 

--- a/qt/aqt/sync.py
+++ b/qt/aqt/sync.py
@@ -135,7 +135,7 @@ def full_sync(
             tr.sync_cancel_button(),
         ]
 
-        def callback(choice):
+        def callback(choice: str) -> None:
             if choice == button_labels[0]:
                 full_upload(mw, on_done)
             elif choice == button_labels[1]:

--- a/qt/aqt/utils.py
+++ b/qt/aqt/utils.py
@@ -129,10 +129,7 @@ class MessageBox(QMessageBox):
         icon: QMessageBox.Icon = QMessageBox.Icon.NoIcon,
         help: HelpPageArgument | None = None,
         title: str = "Anki",
-        buttons: list[str]
-        | list[QMessageBox.StandardButton]
-        | list[str | QMessageBox.StandardButton]
-        | None = None,
+        buttons: Sequence[str | QMessageBox.StandardButton] | None = None,
         default_button: int = 0,
         textFormat: Qt.TextFormat = Qt.TextFormat.PlainText,
     ) -> None:
@@ -182,7 +179,7 @@ def ask_user(
 def ask_user_dialog(
     text: str,
     callback: Callable[[int], None],
-    buttons: list[str | QMessageBox.StandardButton] | None = None,
+    buttons: Sequence[str | QMessageBox.StandardButton] | None = None,
     default_button: int = 1,
     **kwargs: Any,
 ) -> MessageBox:

--- a/qt/aqt/utils.py
+++ b/qt/aqt/utils.py
@@ -124,13 +124,13 @@ class MessageBox(QMessageBox):
     def __init__(
         self,
         text: str,
-        callback: Callable[[str], None] = None,
-        parent: QWidget = None,
+        callback: Callable[[str], None] | None = None,
+        parent: QWidget | None = None,
         icon: QMessageBox.Icon = QMessageBox.Icon.NoIcon,
-        help: HelpPageArgument = None,
+        help: HelpPageArgument | None = None,
         title: str = "Anki",
-        buttons: list[str | QMessageBox.StandardButton] = None,
-        default_button: str | QMessageBox.StandardButton = None,
+        buttons: list[str | QMessageBox.StandardButton] | None = None,
+        default_button: str | QMessageBox.StandardButton | None = None,
         textFormat: Qt.TextFormat = Qt.TextFormat.PlainText,
     ) -> None:
         parent = parent or aqt.mw.app.activeWindow() or aqt.mw
@@ -183,7 +183,7 @@ def ask_user(
 def ask_user_dialog(
     text: str,
     callback: Callable[[str], None],
-    buttons: list[str | QMessageBox.StandardButton] = None,
+    buttons: list[str | QMessageBox.StandardButton] | None = None,
     default_button: str | QMessageBox.StandardButton = QMessageBox.StandardButton.Yes,
     **kwargs: Any,
 ) -> MessageBox:
@@ -200,7 +200,7 @@ def ask_user_dialog(
     )
 
 
-def show_info(text: str, callback: Callable = None, **kwargs: Any) -> MessageBox:
+def show_info(text: str, callback: Callable | None = None, **kwargs: Any) -> MessageBox:
     "Show a small info window with an OK button."
     if "icon" not in kwargs:
         kwargs["icon"] = QMessageBox.Icon.Information
@@ -211,12 +211,16 @@ def show_info(text: str, callback: Callable = None, **kwargs: Any) -> MessageBox
     )
 
 
-def show_warning(text: str, callback: Callable = None, **kwargs: Any) -> MessageBox:
+def show_warning(
+    text: str, callback: Callable | None = None, **kwargs: Any
+) -> MessageBox:
     "Show a small warning window with an OK button."
     return show_info(text, icon=QMessageBox.Icon.Warning, callback=callback, **kwargs)
 
 
-def show_critical(text: str, callback: Callable = None, **kwargs: Any) -> MessageBox:
+def show_critical(
+    text: str, callback: Callable | None = None, **kwargs: Any
+) -> MessageBox:
     "Show a small critical error window with an OK button."
     return show_info(text, icon=QMessageBox.Icon.Critical, callback=callback, **kwargs)
 

--- a/qt/aqt/utils.py
+++ b/qt/aqt/utils.py
@@ -140,9 +140,9 @@ class MessageBox(QMessageBox):
         self.setWindowModality(Qt.WindowModality.WindowModal)
         self.setIcon(icon)
         self.setTextFormat(textFormat)
-        default_button = default_button or buttons[0]
         if buttons is None:
             buttons = [QMessageBox.StandardButton.Ok]
+        default_button = default_button or buttons[0]
         for button in buttons:
             if isinstance(button, str):
                 b = self.addButton(button, QMessageBox.ButtonRole.ActionRole)
@@ -152,7 +152,8 @@ class MessageBox(QMessageBox):
                 continue
             if callback is not None:
                 qconnect(
-                    b.clicked, partial(callback, str(b).removeprefix("StandardButton."))
+                    b.clicked,
+                    partial(callback, str(button).removeprefix("StandardButton.")),
                 )
             if button == default_button:
                 self.setDefaultButton(b)
@@ -183,7 +184,7 @@ def ask_user_dialog(
     text: str,
     callback: Callable[[str], None],
     buttons: list[str | QMessageBox.StandardButton] = None,
-    default_button: str = "Yes",
+    default_button: str | QMessageBox.StandardButton = QMessageBox.StandardButton.Yes,
     **kwargs: Any,
 ) -> MessageBox:
     "Shows a question to the user, passes the answer to the callback function as a str."

--- a/qt/aqt/utils.py
+++ b/qt/aqt/utils.py
@@ -129,7 +129,10 @@ class MessageBox(QMessageBox):
         icon: QMessageBox.Icon = QMessageBox.Icon.NoIcon,
         help: HelpPageArgument | None = None,
         title: str = "Anki",
-        buttons: list[str | QMessageBox.StandardButton] | None = None,
+        buttons: list[str]
+        | list[QMessageBox.StandardButton]
+        | list[str | QMessageBox.StandardButton]
+        | None = None,
         default_button: int = 0,
         textFormat: Qt.TextFormat = Qt.TextFormat.PlainText,
     ) -> None:

--- a/qt/aqt/utils.py
+++ b/qt/aqt/utils.py
@@ -139,6 +139,10 @@ class MessageBox(QMessageBox):
         self.setWindowTitle(title)
         self.setWindowModality(Qt.WindowModality.WindowModal)
         self.setIcon(icon)
+        if icon == QMessageBox.Icon.Question and theme_manager.night_mode:
+            img = self.iconPixmap().toImage()
+            img.invertPixels()
+            self.setIconPixmap(QPixmap(img))
         self.setTextFormat(textFormat)
         if buttons is None:
             buttons = [QMessageBox.StandardButton.Ok]

--- a/qt/aqt/utils.py
+++ b/qt/aqt/utils.py
@@ -162,7 +162,7 @@ class MessageBox(QMessageBox):
 def ask_user(
     text: str,
     callback: Callable[[bool], None],
-    default_button: bool = True,
+    defaults_yes: bool = True,
     **kwargs: Any,
 ) -> MessageBox:
     "Shows a yes/no question, passes the answer to the callback function as a bool."
@@ -171,7 +171,7 @@ def ask_user(
         callback=lambda response: callback(not response),
         icon=QMessageBox.Icon.Question,
         buttons=[QMessageBox.StandardButton.Yes, QMessageBox.StandardButton.No],
-        default_button=not default_button,
+        default_button=not defaults_yes,
         **kwargs,
     )
 

--- a/qt/aqt/utils.py
+++ b/qt/aqt/utils.py
@@ -157,7 +157,7 @@ def ask_user(
     text: str,
     callback: Callable[[bool], None],
     default_button: Literal["Yes", "No"] = "Yes",
-    **kwargs,
+    **kwargs: Any,
 ) -> MessageBox:
     "Shows a yes/no question, passes the answer to the callback function as a bool."
     return MessageBox(
@@ -175,7 +175,7 @@ def ask_user_dialog(
     callback: Callable[[str], None],
     buttons: list[str] = ["Yes", "No"],
     default_button: str = "Yes",
-    **kwargs,
+    **kwargs: Any,
 ) -> MessageBox:
     "Shows a question to the user, passes the answer to the callback function as a str."
     return MessageBox(
@@ -188,7 +188,7 @@ def ask_user_dialog(
     )
 
 
-def show_info(text: str, callback: Callable = None, **kwargs) -> MessageBox:
+def show_info(text: str, callback: Callable = None, **kwargs: Any) -> MessageBox:
     "Show a small info window with an OK button."
     if "icon" not in kwargs:
         kwargs["icon"] = QMessageBox.Icon.Information
@@ -199,12 +199,12 @@ def show_info(text: str, callback: Callable = None, **kwargs) -> MessageBox:
     )
 
 
-def show_warning(text: str, callback: Callable = None, **kwargs) -> MessageBox:
+def show_warning(text: str, callback: Callable = None, **kwargs: Any) -> MessageBox:
     "Show a small warning window with an OK button."
     return show_info(text, icon=QMessageBox.Icon.Warning, callback=callback, **kwargs)
 
 
-def show_critical(text: str, callback: Callable = None, **kwargs) -> MessageBox:
+def show_critical(text: str, callback: Callable = None, **kwargs: Any) -> MessageBox:
     "Show a small critical error window with an OK button."
     return show_info(text, icon=QMessageBox.Icon.Critical, callback=callback, **kwargs)
 

--- a/qt/aqt/utils.py
+++ b/qt/aqt/utils.py
@@ -7,9 +7,9 @@ import re
 import shutil
 import subprocess
 import sys
-from functools import wraps
+from functools import partial, wraps
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Literal, Sequence, no_type_check
+from typing import TYPE_CHECKING, Any, Callable, Literal, Sequence, Union, no_type_check
 
 from send2trash import send2trash
 
@@ -25,6 +25,56 @@ from anki.utils import (
     version_with_build,
 )
 from aqt.qt import *
+from aqt.qt import (
+    PYQT_VERSION_STR,
+    QT_VERSION_STR,
+    QAction,
+    QApplication,
+    QCheckBox,
+    QColor,
+    QComboBox,
+    QDesktopServices,
+    QDialog,
+    QDialogButtonBox,
+    QEvent,
+    QFileDialog,
+    QFrame,
+    QHeaderView,
+    QIcon,
+    QKeySequence,
+    QLabel,
+    QLineEdit,
+    QListWidget,
+    QMainWindow,
+    QMenu,
+    QMessageBox,
+    QMouseEvent,
+    QNativeGestureEvent,
+    QOffscreenSurface,
+    QOpenGLContext,
+    QPalette,
+    QPixmap,
+    QPlainTextEdit,
+    QPoint,
+    QPushButton,
+    QShortcut,
+    QSize,
+    QSplitter,
+    QStandardPaths,
+    Qt,
+    QTextBrowser,
+    QTextOption,
+    QTimer,
+    QUrl,
+    QVBoxLayout,
+    QWheelEvent,
+    QWidget,
+    pyqtSlot,
+    qconnect,
+    qtmajor,
+    qtminor,
+    traceback,
+)
 from aqt.theme import theme_manager
 
 if TYPE_CHECKING:
@@ -68,6 +118,95 @@ def openLink(link: str | QUrl) -> None:
     tooltip(tr.qt_misc_loading(), period=1000)
     with no_bundled_libs():
         QDesktopServices.openUrl(QUrl(link))
+
+
+class MessageBox(QMessageBox):
+    def __init__(
+        self,
+        text: str,
+        callback: Callable[[str], None] = None,
+        parent: QWidget = None,
+        icon: QMessageBox.Icon = QMessageBox.Icon.NoIcon,
+        help: HelpPageArgument = None,
+        title: str = "Anki",
+        buttons: list[str] = ["Ok"],
+        default_button: str = None,
+        textFormat: Qt.TextFormat = Qt.TextFormat.PlainText,
+    ) -> None:
+        parent = parent or aqt.mw.app.activeWindow() or aqt.mw
+        super().__init__(parent)
+        self.setText(text)
+        self.setWindowTitle(title)
+        self.setWindowModality(Qt.WindowModality.WindowModal)
+        self.setIcon(icon)
+        self.setTextFormat(textFormat)
+        default_button = default_button or buttons[0]
+        for button in buttons:
+            b = self.addButton(button, QMessageBox.ButtonRole.ActionRole)
+            if callback is not None:
+                qconnect(b.clicked, partial(callback, button))
+            if button == default_button:
+                self.setDefaultButton(b)
+        if help is not None:
+            b = self.addButton(QMessageBox.StandardButton.Help)
+            qconnect(b.clicked, lambda: openHelp(help))
+        self.open()
+
+
+def ask_user(
+    text: str,
+    callback: Callable[[bool], None],
+    default: Literal["Yes", "No"] = "Yes",
+    **kwargs,
+) -> None:
+    "Shows a yes/no question, passes the answer to the callback function as a bool."
+    MessageBox(
+        text,
+        callback=lambda response: callback(response == "Yes"),
+        icon=QMessageBox.Icon.Question,
+        buttons=["Yes", "No"],
+        defualt=default,
+        **kwargs,
+    )
+
+
+def ask_user_dialog(
+    text: str,
+    callback: Callable[[str], None],
+    buttons: list[str] = ["Yes", "No"],
+    default_button: str = "Yes",
+    **kwargs,
+) -> None:
+    "Shows a question to the user, passes the answer to the callback function as a str."
+    MessageBox(
+        text,
+        callback=callback,
+        icon=QMessageBox.Icon.Question,
+        buttons=buttons,
+        default_button=default_button,
+        **kwargs,
+    )
+
+
+def show_info(text: str, callback: Callable = None, **kwargs) -> MessageBox:
+    "Show a small info window with an OK button."
+    if "icon" not in kwargs:
+        kwargs["icon"] = QMessageBox.Icon.Information
+    return MessageBox(
+        text,
+        callback=(lambda _: callback()) if callback is not None else None,
+        **kwargs,
+    )
+
+
+def show_warning(text: str, callback: Callable = None, **kwargs) -> MessageBox:
+    "Show a small warning window with an OK button."
+    return show_info(text, icon=QMessageBox.Icon.Warning, callback=callback, **kwargs)
+
+
+def show_critical(text: str, callback: Callable = None, **kwargs) -> MessageBox:
+    "Show a small critical error window with an OK button."
+    return show_info(text, icon=QMessageBox.Icon.Critical, callback=callback, **kwargs)
 
 
 def showWarning(

--- a/qt/aqt/utils.py
+++ b/qt/aqt/utils.py
@@ -158,9 +158,9 @@ def ask_user(
     callback: Callable[[bool], None],
     default: Literal["Yes", "No"] = "Yes",
     **kwargs,
-) -> None:
+) -> MessageBox:
     "Shows a yes/no question, passes the answer to the callback function as a bool."
-    MessageBox(
+    return MessageBox(
         text,
         callback=lambda response: callback(response == "Yes"),
         icon=QMessageBox.Icon.Question,
@@ -176,9 +176,9 @@ def ask_user_dialog(
     buttons: list[str] = ["Yes", "No"],
     default_button: str = "Yes",
     **kwargs,
-) -> None:
+) -> MessageBox:
     "Shows a question to the user, passes the answer to the callback function as a str."
-    MessageBox(
+    return MessageBox(
         text,
         callback=callback,
         icon=QMessageBox.Icon.Question,

--- a/qt/aqt/utils.py
+++ b/qt/aqt/utils.py
@@ -156,7 +156,7 @@ class MessageBox(QMessageBox):
 def ask_user(
     text: str,
     callback: Callable[[bool], None],
-    default: Literal["Yes", "No"] = "Yes",
+    default_button: Literal["Yes", "No"] = "Yes",
     **kwargs,
 ) -> MessageBox:
     "Shows a yes/no question, passes the answer to the callback function as a bool."
@@ -165,7 +165,7 @@ def ask_user(
         callback=lambda response: callback(response == "Yes"),
         icon=QMessageBox.Icon.Question,
         buttons=["Yes", "No"],
-        defualt=default,
+        default_button=default_button,
         **kwargs,
     )
 


### PR DESCRIPTION
First step in #1774. 

Implements a new `MessageBox` class, and the functions `ask_user`, `ask_user_dialog`, `show_info`, `show_warning`, `show_critical`, which all return an instance of MessageBox. This class is used to display a message to the user with some buttons that optionally trigger a callback which receives the name of the button pressed. This avoids the use of `exec()` in favour of `open()` for the reasons discussed in #987 and #1774 along with cleaning up this section of the code a bit.

Some design considerations to note:
- It turned out to be easiest to have a single class to handle both messages to the user and asking questions of the user. These were previously handled by separate but overlapping functions/classes. 
- Most of convenience functions wrap the callback function in a lambda to achieve more natural types for the callback's argument. By default MessageBox expects the callback to take a single str argument (the button pressed), but this becomes a bool for `ask_user` and is removed for all the info functions (since the only purpose of the callback in those functions is to delay an action until the user clicks 'Ok'). This is a little clunky, but should result in a smoother experience when using these functions.
- I've kept the arguments for the convenience functions to a minimum. If the other arguments need to be accessed it's possible to pass additional keyword arguments through to MessageBox or simply call MessageBox directly.
- Arguments for the icon and text format now expect Qt enums rather than strings. This gives more flexibility to the caller and removes the need for an unnecessary conversion. An alternative for the text format would to use `Qt.TextFormat.AutoText` instead of `PlainText` as the default.
- I haven't tried to have this class handle the role of `showText`, but this could probably be done without too much bloat

Happy to reconsider any of the above points as well the names of the class or functions.

I believe these functions should be able to handle all the existing callers, so if this is accepted I'll start converting the callers a few at a time - there's always the potential for bugs since these functions previously blocked the main loop while the dialog was open, which callers sometimes rely upon in unexpected ways. In this PR three calling functions (two in `addons.py`, one in `sync.py`) have been converted as a demonstration.

One known issue - the buttons are now left aligned, whereas before they were right aligned. I need to dig a bit more into what's causing that. I also haven't done much testing with the Qt5 version since I'm not sure how long that's going to stick around - can any guidance be provided on that? I'm marking this as draft while these two points are addressed.