### PR TITLE
Allow passing debug=True to jest_test for debugger support

### DIFF
--- a/ts/jest.bzl
+++ b/ts/jest.bzl
@@ -1,7 +1,7 @@
 load("@npm//@bazel/esbuild:index.bzl", "esbuild")
 load("@npm//jest-cli:index.bzl", _jest_test = "jest_test")
 
-def jest_test(deps, name = "jest", protobuf = False, env = "node"):
+def jest_test(deps, name = "jest", protobuf = False, env = "node", debug = False):
     ts_sources = native.glob(["**/*.test.ts"])
 
     # bundle each test file up with its dependencies for jest
@@ -30,7 +30,7 @@ def jest_test(deps, name = "jest", protobuf = False, env = "node"):
             srcs = esbuild_extra_srcs,
             deps = deps,
             # the code shaking saves close to a second off the deckoptions/lib.test.ts test
-            minify = True,
+            minify = not debug,
             target_compatible_with = select({
                 "@platforms//os:osx": [],
                 "@platforms//os:linux": [],
@@ -43,6 +43,13 @@ def jest_test(deps, name = "jest", protobuf = False, env = "node"):
         "@npm//jest-environment-jsdom",
     ] if env == "jsdom" else []
 
+    # After starting Jest, open the url "chrome://inspect" in
+    # a Chrome browser and inspect as remote target.
+    debug_args = [
+        "--run-in-band",
+        "--node_options=--inspect-brk",
+    ] if debug else []
+
     _jest_test(
         name = name,
         args = [
@@ -53,7 +60,7 @@ def jest_test(deps, name = "jest", protobuf = False, env = "node"):
             "--config",
             "$(location //ts:jest.config.js)",
             "--env=" + env,
-        ],
+        ] + debug_args,
         data = deps + bundled_srcs + [
             "//ts:jest.config.js",
         ] + optional_jsdom_deps,


### PR DESCRIPTION
Now, if you set `debug = True` in `jest.bzl`, you can use `debugger` in test files, and stop execution.

It is deactivated by default: I don't know what would be the best practice of passing flags to bazel commands, and I doubt that's a good idea anyway.

Having it in the repo at least can serve as documentation.