### PR TITLE
Last polishes for Surrounder class

### DIFF
--- a/ts/editor/editor-toolbar/RemoveFormatButton.svelte
+++ b/ts/editor/editor-toolbar/RemoveFormatButton.svelte
@@ -38,7 +38,9 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     $: inactiveKeys = filterForKeys($removeFormats, false);
 
     let showFormats: RemoveFormat[];
-    $: showFormats = $removeFormats.filter((format: RemoveFormat): boolean => format.show);
+    $: showFormats = $removeFormats.filter(
+        (format: RemoveFormat): boolean => format.show,
+    );
 
     function remove(): void {
         surrounder.remove(activeKeys, inactiveKeys);
@@ -64,7 +66,10 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     onMount(() => {
         const surroundElement = document.createElement("span");
 
-        function matcher(element: HTMLElement | SVGElement, match: MatchType<never>): void {
+        function matcher(
+            element: HTMLElement | SVGElement,
+            match: MatchType<never>,
+        ): void {
             if (
                 element.tagName === "SPAN" &&
                 element.className.length === 0 &&
@@ -81,12 +86,15 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
         const key = "simple spans";
 
-        removeFormats.update((formats: RemoveFormat[]): RemoveFormat[] => ([...formats, {
-            key,
-            name: key,
-            show: false,
-            active: true,
-        }]));
+        removeFormats.update((formats: RemoveFormat[]): RemoveFormat[] => [
+            ...formats,
+            {
+                key,
+                name: key,
+                show: false,
+                active: true,
+            },
+        ]);
 
         return singleCallback(
             surrounder.active.subscribe((value) => (disabled = !value)),

--- a/ts/editor/rich-text-input/RichTextInput.svelte
+++ b/ts/editor/rich-text-input/RichTextInput.svelte
@@ -3,6 +3,8 @@ Copyright: Ankitects Pty Ltd and contributors
 License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 -->
 <script context="module" lang="ts">
+    import { writable } from "svelte/store";
+
     import type { ContentEditableAPI } from "../../editable/ContentEditable.svelte";
     import type { InputHandlerAPI } from "../../sveltelib/input-handler";
     import type { EditingInputAPI, FocusableInputAPI } from "../EditingArea.svelte";
@@ -38,7 +40,8 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     const [globalInputHandler, setupGlobalInputHandler] = useInputHandler();
     const [lifecycle, instances, setupLifecycleHooks] =
         lifecycleHooks<RichTextInputAPI>();
-    const surrounder = Surrounder.make();
+    const apiStore = writable<SurroundedAPI | null>(null);
+    const surrounder = Surrounder.make(apiStore);
 
     registerPackage("anki/RichTextInput", {
         context,
@@ -176,16 +179,16 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
     function setFocus(): void {
         $focusedInput = api;
-        surrounder.enable(api);
+        $apiStore = api;
+    }
 
+    function removeFocus(): void {
         // We do not unset focusedInput here.
         // If we did, UI components for the input would react the store
         // being unset, even though most likely it will be set to some other
         // field right away.
-    }
 
-    function removeFocus(): void {
-        surrounder.disable();
+        $apiStore = null;
     }
 
     $: pushUpdate(!hidden);

--- a/ts/editor/surround.ts
+++ b/ts/editor/surround.ts
@@ -231,7 +231,10 @@ export class Surrounder<T = unknown> {
     /**
      * Update a surround format under a specific key.
      */
-    updateFormat(key: string, update: (format: SurroundFormat<T>) => SurroundFormat<T>): void {
+    updateFormat(
+        key: string,
+        update: (format: SurroundFormat<T>) => SurroundFormat<T>,
+    ): void {
         this.#formats.set(key, update(this.#formats.get(key)!));
     }
 

--- a/ts/editor/surround.ts
+++ b/ts/editor/surround.ts
@@ -158,7 +158,7 @@ export class Surrounder<T = unknown> {
         });
     }
 
-    async #toggleTriggerRemove<T>(
+    #toggleTriggerRemove<T>(
         base: HTMLElement,
         selection: Selection,
         formats: {
@@ -166,7 +166,7 @@ export class Surrounder<T = unknown> {
             trigger: TriggerItem<{ event: InputEvent; text: Text }>;
         }[],
         reformat: SurroundFormat<T>[] = [],
-    ): Promise<void> {
+    ): void {
         const remainingFormats = formats
             .filter(({ trigger }) => {
                 if (get(trigger.active)) {

--- a/ts/editor/surround.ts
+++ b/ts/editor/surround.ts
@@ -211,7 +211,7 @@ export class Surrounder<T = unknown> {
     }
 
     /**
-     * Register a surround format under a certain name.
+     * Register a surround format under a certain key.
      * This name is then used with the surround functions to actually apply or
      * remove the given format.
      */
@@ -229,10 +229,10 @@ export class Surrounder<T = unknown> {
     }
 
     /**
-     * Modify a surround format under a certain name.
+     * Update a surround format under a specific key.
      */
-    modifyFormat(key: string, modify: (format: SurroundFormat<T>) => void): void {
-        modify(this.#formats.get(key)!);
+    updateFormat(key: string, update: (format: SurroundFormat<T>) => SurroundFormat<T>): void {
+        this.#formats.set(key, update(this.#formats.get(key)!));
     }
 
     /**

--- a/ts/lib/functional.ts
+++ b/ts/lib/functional.ts
@@ -5,6 +5,10 @@ export function noop(): void {
     /* noop */
 }
 
+export async function asyncNoop(): Promise<void> {
+    /* noop */
+}
+
 export function id<T>(t: T): T {
     return t;
 }


### PR DESCRIPTION
Follow-up for #1931.

This does not change the public API, just extends it, and makes the implicitly private properties explicitly non-accessible.

There is one fix, for the behavior of putting the caret in unformatted text, and then using the eraser (Cmd+R). Before it would erroneously activate all the inline formats.

With `surrounder.updateFormat`, modifying the behavior of the built-in formatting buttons is trivial. For example, this will make the bold button use `<strong>` again:

```js
require("anki/RichTextInput").surrounder.updateFormat(
    "bold",
    (format) => ({
        ...format,
        surroundElement: document.createElement("strong"),
    }),
);
```

You can also hold Alt+Shift now while pressing a format in the eraser dropdown to activate all but the clicked one.