### PR TITLE
Use extern error crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 3
 
 [[package]]
+name = "addr2line"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9ecd88a8c8378ca913a680cd98f0f13ac67383d35993f86c90a70e3f137816b"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
 name = "adler"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -200,6 +209,21 @@ name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
+name = "backtrace"
+version = "0.3.66"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab84319d616cfb654d03394f38ab7e6f0919e181b1b57e1fd15e7fb4077d9a7"
+dependencies = [
+ "addr2line",
+ "cc",
+ "cfg-if",
+ "libc",
+ "miniz_oxide 0.5.3",
+ "object",
+ "rustc-demangle",
+]
 
 [[package]]
 name = "base64"
@@ -685,7 +709,7 @@ dependencies = [
  "cfg-if",
  "crc32fast",
  "libc",
- "miniz_oxide",
+ "miniz_oxide 0.4.4",
 ]
 
 [[package]]
@@ -911,6 +935,12 @@ dependencies = [
  "libc",
  "wasi 0.10.0+wasi-snapshot-preview1",
 ]
+
+[[package]]
+name = "gimli"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22030e2c5a68ec659fde1e949a745124b48e6fa8b045b7ed5bd1fe4ccc5c4e5d"
 
 [[package]]
 name = "h2"
@@ -1430,6 +1460,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "miniz_oxide"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f5c75688da582b8ffc1f1799e9db273f32133c49e048f614d22ec3256773ccc"
+dependencies = [
+ "adler",
+]
+
+[[package]]
 name = "mio"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1574,6 +1613,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c539a50b93a303167eded6e8dff5220cd39447409fb659f4cd24b1f72fe4f133"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "object"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21158b2c33aa6d4561f1c0a6ea283ca92bc54802a93b263e910746d679a7eb53"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -2279,6 +2327,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-demangle"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
+
+[[package]]
 name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2642,6 +2696,7 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5177903bf45656592d9eb5c0e22f408fc023aae51dbe2088889b71633ba451f2"
 dependencies = [
+ "backtrace",
  "doc-comment",
  "snafu-derive",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,6 +95,7 @@ dependencies = [
  "slog-async",
  "slog-envlogger",
  "slog-term",
+ "snafu",
  "strum",
  "tempfile",
  "tokio",
@@ -594,6 +595,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c97b9233581d84b8e1e689cdd3a47b6f69770084fc246e86a7f78b0d9c1d4a5"
 
 [[package]]
+name = "doc-comment"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
+
+[[package]]
 name = "dtoa"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -956,6 +963,12 @@ checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
 dependencies = [
  "unicode-segmentation",
 ]
+
+[[package]]
+name = "heck"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
 
 [[package]]
 name = "hermit-abi"
@@ -1923,7 +1936,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62941722fb675d463659e49c4f3fe1fe792ff24fe5bbaa9c08cd3b98a1c354f5"
 dependencies = [
  "bytes",
- "heck",
+ "heck 0.3.3",
  "itertools",
  "lazy_static",
  "log",
@@ -2624,6 +2637,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83"
 
 [[package]]
+name = "snafu"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5177903bf45656592d9eb5c0e22f408fc023aae51dbe2088889b71633ba451f2"
+dependencies = [
+ "doc-comment",
+ "snafu-derive",
+]
+
+[[package]]
+name = "snafu-derive"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "410b26ed97440d90ced3e2488c868d56a86e2064f5d7d6f417909b286afe25e5"
+dependencies = [
+ "heck 0.4.0",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "snowflake"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2692,7 +2727,7 @@ version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5bb0dc7ee9c15cea6199cde9a127fa16a4c5819af85395457ad72d68edc85a38"
 dependencies = [
- "heck",
+ "heck 0.3.3",
  "proc-macro2",
  "quote",
  "rustversion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,9 @@ compile_data_attr = "glob([\"**/*.rsv\"])"
 [package.metadata.raze.crates.bstr.'*']
 compile_data_attr = "glob([\"**/*.dfa\"])"
 
+[package.metadata.raze.crates.snafu.'*']
+compile_data_attr = "glob([\"**/*.md\"])"
+
 [package.metadata.raze.crates.pyo3-build-config.'*']
 buildrs_additional_environment_variables = { "PYO3_NO_PYTHON" = "1" }
 

--- a/cargo/BUILD.bazel
+++ b/cargo/BUILD.bazel
@@ -490,6 +490,15 @@ alias(
 )
 
 alias(
+    name = "snafu",
+    actual = "@raze__snafu__0_7_1//:snafu",
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+)
+
+alias(
     name = "strum",
     actual = "@raze__strum__0_23_0//:strum",
     tags = [

--- a/cargo/crates.bzl
+++ b/cargo/crates.bzl
@@ -443,6 +443,16 @@ def raze_fetch_remote_crates():
 
     maybe(
         http_archive,
+        name = "raze__doc_comment__0_3_3",
+        url = "https://crates.io/api/v1/crates/doc-comment/0.3.3/download",
+        type = "tar.gz",
+        sha256 = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10",
+        strip_prefix = "doc-comment-0.3.3",
+        build_file = Label("//cargo/remote:BUILD.doc-comment-0.3.3.bazel"),
+    )
+
+    maybe(
+        http_archive,
         name = "raze__dtoa__0_4_8",
         url = "https://crates.io/api/v1/crates/dtoa/0.4.8/download",
         type = "tar.gz",
@@ -819,6 +829,16 @@ def raze_fetch_remote_crates():
         sha256 = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c",
         strip_prefix = "heck-0.3.3",
         build_file = Label("//cargo/remote:BUILD.heck-0.3.3.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__heck__0_4_0",
+        url = "https://crates.io/api/v1/crates/heck/0.4.0/download",
+        type = "tar.gz",
+        sha256 = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9",
+        strip_prefix = "heck-0.4.0",
+        build_file = Label("//cargo/remote:BUILD.heck-0.4.0.bazel"),
     )
 
     maybe(
@@ -2389,6 +2409,26 @@ def raze_fetch_remote_crates():
         sha256 = "f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83",
         strip_prefix = "smallvec-1.8.0",
         build_file = Label("//cargo/remote:BUILD.smallvec-1.8.0.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__snafu__0_7_1",
+        url = "https://crates.io/api/v1/crates/snafu/0.7.1/download",
+        type = "tar.gz",
+        sha256 = "5177903bf45656592d9eb5c0e22f408fc023aae51dbe2088889b71633ba451f2",
+        strip_prefix = "snafu-0.7.1",
+        build_file = Label("//cargo/remote:BUILD.snafu-0.7.1.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__snafu_derive__0_7_1",
+        url = "https://crates.io/api/v1/crates/snafu-derive/0.7.1/download",
+        type = "tar.gz",
+        sha256 = "410b26ed97440d90ced3e2488c868d56a86e2064f5d7d6f417909b286afe25e5",
+        strip_prefix = "snafu-derive-0.7.1",
+        build_file = Label("//cargo/remote:BUILD.snafu-derive-0.7.1.bazel"),
     )
 
     maybe(

--- a/cargo/crates.bzl
+++ b/cargo/crates.bzl
@@ -13,6 +13,16 @@ def raze_fetch_remote_crates():
     """This function defines a collection of repos and should be called in a WORKSPACE file"""
     maybe(
         http_archive,
+        name = "raze__addr2line__0_17_0",
+        url = "https://crates.io/api/v1/crates/addr2line/0.17.0/download",
+        type = "tar.gz",
+        sha256 = "b9ecd88a8c8378ca913a680cd98f0f13ac67383d35993f86c90a70e3f137816b",
+        strip_prefix = "addr2line-0.17.0",
+        build_file = Label("//cargo/remote:BUILD.addr2line-0.17.0.bazel"),
+    )
+
+    maybe(
+        http_archive,
         name = "raze__adler__1_0_2",
         url = "https://crates.io/api/v1/crates/adler/1.0.2/download",
         type = "tar.gz",
@@ -129,6 +139,16 @@ def raze_fetch_remote_crates():
         sha256 = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa",
         strip_prefix = "autocfg-1.1.0",
         build_file = Label("//cargo/remote:BUILD.autocfg-1.1.0.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__backtrace__0_3_66",
+        url = "https://crates.io/api/v1/crates/backtrace/0.3.66/download",
+        type = "tar.gz",
+        sha256 = "cab84319d616cfb654d03394f38ab7e6f0919e181b1b57e1fd15e7fb4077d9a7",
+        strip_prefix = "backtrace-0.3.66",
+        build_file = Label("//cargo/remote:BUILD.backtrace-0.3.66.bazel"),
     )
 
     maybe(
@@ -793,6 +813,16 @@ def raze_fetch_remote_crates():
 
     maybe(
         http_archive,
+        name = "raze__gimli__0_26_2",
+        url = "https://crates.io/api/v1/crates/gimli/0.26.2/download",
+        type = "tar.gz",
+        sha256 = "22030e2c5a68ec659fde1e949a745124b48e6fa8b045b7ed5bd1fe4ccc5c4e5d",
+        strip_prefix = "gimli-0.26.2",
+        build_file = Label("//cargo/remote:BUILD.gimli-0.26.2.bazel"),
+    )
+
+    maybe(
+        http_archive,
         name = "raze__h2__0_3_12",
         url = "https://crates.io/api/v1/crates/h2/0.3.12/download",
         type = "tar.gz",
@@ -1303,6 +1333,16 @@ def raze_fetch_remote_crates():
 
     maybe(
         http_archive,
+        name = "raze__miniz_oxide__0_5_3",
+        url = "https://crates.io/api/v1/crates/miniz_oxide/0.5.3/download",
+        type = "tar.gz",
+        sha256 = "6f5c75688da582b8ffc1f1799e9db273f32133c49e048f614d22ec3256773ccc",
+        strip_prefix = "miniz_oxide-0.5.3",
+        build_file = Label("//cargo/remote:BUILD.miniz_oxide-0.5.3.bazel"),
+    )
+
+    maybe(
+        http_archive,
         name = "raze__mio__0_8_1",
         url = "https://crates.io/api/v1/crates/mio/0.8.1/download",
         type = "tar.gz",
@@ -1449,6 +1489,16 @@ def raze_fetch_remote_crates():
         sha256 = "c539a50b93a303167eded6e8dff5220cd39447409fb659f4cd24b1f72fe4f133",
         strip_prefix = "num_threads-0.1.4",
         build_file = Label("//cargo/remote:BUILD.num_threads-0.1.4.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__object__0_29_0",
+        url = "https://crates.io/api/v1/crates/object/0.29.0/download",
+        type = "tar.gz",
+        sha256 = "21158b2c33aa6d4561f1c0a6ea283ca92bc54802a93b263e910746d679a7eb53",
+        strip_prefix = "object-0.29.0",
+        build_file = Label("//cargo/remote:BUILD.object-0.29.0.bazel"),
     )
 
     maybe(
@@ -2049,6 +2099,16 @@ def raze_fetch_remote_crates():
         sha256 = "4ba4d3462c8b2e4d7f4fcfcf2b296dc6b65404fbbc7b63daa37fd485c149daf7",
         strip_prefix = "rusqlite-0.26.3",
         build_file = Label("//cargo/remote:BUILD.rusqlite-0.26.3.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__rustc_demangle__0_1_21",
+        url = "https://crates.io/api/v1/crates/rustc-demangle/0.1.21/download",
+        type = "tar.gz",
+        sha256 = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342",
+        strip_prefix = "rustc-demangle-0.1.21",
+        build_file = Label("//cargo/remote:BUILD.rustc-demangle-0.1.21.bazel"),
     )
 
     maybe(

--- a/cargo/licenses.json
+++ b/cargo/licenses.json
@@ -351,6 +351,15 @@
     "description": "Diff library with semantic cleanup, based on Google's diff-match-patch"
   },
   {
+    "name": "doc-comment",
+    "version": "0.3.3",
+    "authors": "Guillaume Gomez <guillaume1.gomez@gmail.com>",
+    "repository": "https://github.com/GuillaumeGomez/doc-comment",
+    "license": "MIT",
+    "license_file": null,
+    "description": "Macro to generate doc comments"
+  },
+  {
     "name": "either",
     "version": "1.6.1",
     "authors": "bluss",
@@ -650,6 +659,15 @@
   {
     "name": "heck",
     "version": "0.3.3",
+    "authors": "Without Boats <woboats@gmail.com>",
+    "repository": "https://github.com/withoutboats/heck",
+    "license": "Apache-2.0 OR MIT",
+    "license_file": null,
+    "description": "heck is a case conversion library."
+  },
+  {
+    "name": "heck",
+    "version": "0.4.0",
     "authors": "Without Boats <woboats@gmail.com>",
     "repository": "https://github.com/withoutboats/heck",
     "license": "Apache-2.0 OR MIT",
@@ -1924,6 +1942,24 @@
     "license": "Apache-2.0 OR MIT",
     "license_file": null,
     "description": "'Small vector' optimization: store up to a small number of items on the stack"
+  },
+  {
+    "name": "snafu",
+    "version": "0.7.1",
+    "authors": "Jake Goulding <jake.goulding@gmail.com>",
+    "repository": "https://github.com/shepmaster/snafu",
+    "license": "Apache-2.0 OR MIT",
+    "license_file": null,
+    "description": "An ergonomic error handling library"
+  },
+  {
+    "name": "snafu-derive",
+    "version": "0.7.1",
+    "authors": "Jake Goulding <jake.goulding@gmail.com>",
+    "repository": "https://github.com/shepmaster/snafu",
+    "license": "Apache-2.0 OR MIT",
+    "license_file": null,
+    "description": "An ergonomic error handling library"
   },
   {
     "name": "snowflake",

--- a/cargo/licenses.json
+++ b/cargo/licenses.json
@@ -1,5 +1,14 @@
 [
   {
+    "name": "addr2line",
+    "version": "0.17.0",
+    "authors": null,
+    "repository": "https://github.com/gimli-rs/addr2line",
+    "license": "Apache-2.0 OR MIT",
+    "license_file": null,
+    "description": "A cross-platform symbolication library written in Rust, using `gimli`"
+  },
+  {
     "name": "adler",
     "version": "1.0.2",
     "authors": "Jonas Schievink <jonasschievink@gmail.com>",
@@ -124,6 +133,15 @@
     "license": "Apache-2.0 OR MIT",
     "license_file": null,
     "description": "Automatic cfg for Rust compiler features"
+  },
+  {
+    "name": "backtrace",
+    "version": "0.3.66",
+    "authors": "The Rust Project Developers",
+    "repository": "https://github.com/rust-lang/backtrace-rs",
+    "license": "Apache-2.0 OR MIT",
+    "license_file": null,
+    "description": "A library to acquire a stack trace (backtrace) at runtime in a Rust program."
   },
   {
     "name": "base64",
@@ -630,6 +648,15 @@
     "description": "A small cross-platform library for retrieving random data from system source"
   },
   {
+    "name": "gimli",
+    "version": "0.26.2",
+    "authors": null,
+    "repository": "https://github.com/gimli-rs/gimli",
+    "license": "Apache-2.0 OR MIT",
+    "license_file": null,
+    "description": "A library for reading and writing the DWARF debugging format."
+  },
+  {
     "name": "h2",
     "version": "0.3.12",
     "authors": "Carl Lerche <me@carllerche.com>|Sean McArthur <sean@seanmonstar.com>",
@@ -1044,6 +1071,15 @@
     "description": "DEFLATE compression and decompression library rewritten in Rust based on miniz"
   },
   {
+    "name": "miniz_oxide",
+    "version": "0.5.3",
+    "authors": "Frommi <daniil.liferenko@gmail.com>|oyvindln <oyvindln@users.noreply.github.com>",
+    "repository": "https://github.com/Frommi/miniz_oxide/tree/master/miniz_oxide",
+    "license": "Apache-2.0 OR MIT OR Zlib",
+    "license_file": null,
+    "description": "DEFLATE compression and decompression library rewritten in Rust based on miniz"
+  },
+  {
     "name": "mio",
     "version": "0.8.1",
     "authors": "Carl Lerche <me@carllerche.com>|Thomas de Zeeuw <thomasdezeeuw@gmail.com>|Tokio Contributors <team@tokio.rs>",
@@ -1177,6 +1213,15 @@
     "license": "Apache-2.0 OR MIT",
     "license_file": null,
     "description": "A minimal library that determines the number of running threads for the current process."
+  },
+  {
+    "name": "object",
+    "version": "0.29.0",
+    "authors": null,
+    "repository": "https://github.com/gimli-rs/object",
+    "license": "Apache-2.0 OR MIT",
+    "license_file": null,
+    "description": "A unified interface for reading and writing object file formats."
   },
   {
     "name": "once_cell",
@@ -1663,6 +1708,15 @@
     "license": "MIT",
     "license_file": null,
     "description": "Ergonomic wrapper for SQLite"
+  },
+  {
+    "name": "rustc-demangle",
+    "version": "0.1.21",
+    "authors": "Alex Crichton <alex@alexcrichton.com>",
+    "repository": "https://github.com/alexcrichton/rustc-demangle",
+    "license": "Apache-2.0 OR MIT",
+    "license_file": null,
+    "description": "Rust compiler symbol demangling."
   },
   {
     "name": "rustc-hash",

--- a/cargo/remote/BUILD.addr2line-0.17.0.bazel
+++ b/cargo/remote/BUILD.addr2line-0.17.0.bazel
@@ -1,0 +1,63 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:defs.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_proc_macro",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # Apache-2.0 from expression "Apache-2.0 OR MIT"
+])
+
+# Generated Targets
+
+# Unsupported target "addr2line" with type "example" omitted
+
+rust_library(
+    name = "addr2line",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+    ],
+    crate_root = "src/lib.rs",
+    data = [],
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "crate-name=addr2line",
+        "manual",
+    ],
+    version = "0.17.0",
+    # buildifier: leave-alone
+    deps = [
+        "@raze__gimli__0_26_2//:gimli",
+    ],
+)
+
+# Unsupported target "correctness" with type "test" omitted
+
+# Unsupported target "output_equivalence" with type "test" omitted
+
+# Unsupported target "parse" with type "test" omitted

--- a/cargo/remote/BUILD.backtrace-0.3.66.bazel
+++ b/cargo/remote/BUILD.backtrace-0.3.66.bazel
@@ -1,0 +1,111 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:defs.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_proc_macro",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+# buildifier: disable=out-of-order-load
+# buildifier: disable=load-on-top
+load(
+    "@rules_rust//cargo:cargo_build_script.bzl",
+    "cargo_build_script",
+)
+
+cargo_build_script(
+    name = "backtrace_build_script",
+    srcs = glob(["**/*.rs"]),
+    build_script_env = {
+    },
+    crate_features = [
+        "default",
+        "std",
+    ],
+    crate_root = "build.rs",
+    data = glob(["**"]),
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.3.66",
+    visibility = ["//visibility:private"],
+    deps = [
+        "@raze__cc__1_0_73//:cc",
+    ],
+)
+
+# Unsupported target "benchmarks" with type "bench" omitted
+
+# Unsupported target "backtrace" with type "example" omitted
+
+# Unsupported target "raw" with type "example" omitted
+
+rust_library(
+    name = "backtrace",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+        "default",
+        "std",
+    ],
+    crate_root = "src/lib.rs",
+    data = [],
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "crate-name=backtrace",
+        "manual",
+    ],
+    version = "0.3.66",
+    # buildifier: leave-alone
+    deps = [
+        ":backtrace_build_script",
+        "@raze__addr2line__0_17_0//:addr2line",
+        "@raze__cfg_if__1_0_0//:cfg_if",
+        "@raze__libc__0_2_120//:libc",
+        "@raze__miniz_oxide__0_5_3//:miniz_oxide",
+        "@raze__object__0_29_0//:object",
+        "@raze__rustc_demangle__0_1_21//:rustc_demangle",
+    ],
+)
+
+# Unsupported target "accuracy" with type "test" omitted
+
+# Unsupported target "concurrent-panics" with type "test" omitted
+
+# Unsupported target "long_fn_name" with type "test" omitted
+
+# Unsupported target "skip_inner_frames" with type "test" omitted
+
+# Unsupported target "smoke" with type "test" omitted

--- a/cargo/remote/BUILD.doc-comment-0.3.3.bazel
+++ b/cargo/remote/BUILD.doc-comment-0.3.3.bazel
@@ -1,0 +1,84 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:defs.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_proc_macro",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT"
+])
+
+# Generated Targets
+# buildifier: disable=out-of-order-load
+# buildifier: disable=load-on-top
+load(
+    "@rules_rust//cargo:cargo_build_script.bzl",
+    "cargo_build_script",
+)
+
+cargo_build_script(
+    name = "doc_comment_build_script",
+    srcs = glob(["**/*.rs"]),
+    build_script_env = {
+    },
+    crate_features = [
+    ],
+    crate_root = "build.rs",
+    data = glob(["**"]),
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.3.3",
+    visibility = ["//visibility:private"],
+    deps = [
+    ],
+)
+
+rust_library(
+    name = "doc_comment",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+    ],
+    crate_root = "src/lib.rs",
+    data = [],
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "crate-name=doc_comment",
+        "manual",
+    ],
+    version = "0.3.3",
+    # buildifier: leave-alone
+    deps = [
+        ":doc_comment_build_script",
+    ],
+)

--- a/cargo/remote/BUILD.gimli-0.26.2.bazel
+++ b/cargo/remote/BUILD.gimli-0.26.2.bazel
@@ -1,0 +1,70 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:defs.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_proc_macro",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+
+# Unsupported target "bench" with type "bench" omitted
+
+# Unsupported target "dwarf-validate" with type "example" omitted
+
+# Unsupported target "dwarfdump" with type "example" omitted
+
+# Unsupported target "simple" with type "example" omitted
+
+# Unsupported target "simple_line" with type "example" omitted
+
+rust_library(
+    name = "gimli",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+        "read",
+        "read-core",
+    ],
+    crate_root = "src/lib.rs",
+    data = [],
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "crate-name=gimli",
+        "manual",
+    ],
+    version = "0.26.2",
+    # buildifier: leave-alone
+    deps = [
+    ],
+)
+
+# Unsupported target "convert_self" with type "test" omitted
+
+# Unsupported target "parse_self" with type "test" omitted

--- a/cargo/remote/BUILD.heck-0.4.0.bazel
+++ b/cargo/remote/BUILD.heck-0.4.0.bazel
@@ -1,0 +1,55 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:defs.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_proc_macro",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+
+rust_library(
+    name = "heck",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+        "default",
+    ],
+    crate_root = "src/lib.rs",
+    data = [],
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "crate-name=heck",
+        "manual",
+    ],
+    version = "0.4.0",
+    # buildifier: leave-alone
+    deps = [
+    ],
+)

--- a/cargo/remote/BUILD.miniz_oxide-0.5.3.bazel
+++ b/cargo/remote/BUILD.miniz_oxide-0.5.3.bazel
@@ -1,0 +1,55 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:defs.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_proc_macro",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR (Zlib OR Apache-2.0)"
+])
+
+# Generated Targets
+
+rust_library(
+    name = "miniz_oxide",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+    ],
+    crate_root = "src/lib.rs",
+    data = [],
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "crate-name=miniz_oxide",
+        "manual",
+    ],
+    version = "0.5.3",
+    # buildifier: leave-alone
+    deps = [
+        "@raze__adler__1_0_2//:adler",
+    ],
+)

--- a/cargo/remote/BUILD.object-0.29.0.bazel
+++ b/cargo/remote/BUILD.object-0.29.0.bazel
@@ -1,0 +1,66 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:defs.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_proc_macro",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # Apache-2.0 from expression "Apache-2.0 OR MIT"
+])
+
+# Generated Targets
+
+rust_library(
+    name = "object",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+        "archive",
+        "coff",
+        "elf",
+        "macho",
+        "pe",
+        "read_core",
+        "unaligned",
+    ],
+    crate_root = "src/lib.rs",
+    data = [],
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "crate-name=object",
+        "manual",
+    ],
+    version = "0.29.0",
+    # buildifier: leave-alone
+    deps = [
+        "@raze__memchr__2_4_1//:memchr",
+    ],
+)
+
+# Unsupported target "integration" with type "test" omitted
+
+# Unsupported target "parse_self" with type "test" omitted

--- a/cargo/remote/BUILD.rustc-demangle-0.1.21.bazel
+++ b/cargo/remote/BUILD.rustc-demangle-0.1.21.bazel
@@ -1,0 +1,54 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:defs.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_proc_macro",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+
+rust_library(
+    name = "rustc_demangle",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+    ],
+    crate_root = "src/lib.rs",
+    data = [],
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "crate-name=rustc-demangle",
+        "manual",
+    ],
+    version = "0.1.21",
+    # buildifier: leave-alone
+    deps = [
+    ],
+)

--- a/cargo/remote/BUILD.snafu-0.7.1.bazel
+++ b/cargo/remote/BUILD.snafu-0.7.1.bazel
@@ -1,0 +1,127 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:defs.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_proc_macro",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+
+rust_library(
+    name = "snafu",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+        "default",
+        "rust_1_46",
+        "std",
+    ],
+    crate_root = "src/lib.rs",
+    data = [],
+    edition = "2018",
+    proc_macro_deps = [
+        "@raze__snafu_derive__0_7_1//:snafu_derive",
+    ],
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "crate-name=snafu",
+        "manual",
+    ],
+    version = "0.7.1",
+    # buildifier: leave-alone
+    deps = [
+        "@raze__doc_comment__0_3_3//:doc_comment",
+    ],
+)
+
+# Unsupported target "backtrace" with type "test" omitted
+
+# Unsupported target "backtrace-optional" with type "test" omitted
+
+# Unsupported target "backtrace-optional-enabled" with type "test" omitted
+
+# Unsupported target "backtrace_attributes" with type "test" omitted
+
+# Unsupported target "basic" with type "test" omitted
+
+# Unsupported target "boxed_error_trait_object" with type "test" omitted
+
+# Unsupported target "build-leaf-error" with type "test" omitted
+
+# Unsupported target "context_selector_name" with type "test" omitted
+
+# Unsupported target "default_error_display" with type "test" omitted
+
+# Unsupported target "display-shorthand" with type "test" omitted
+
+# Unsupported target "doc_comment" with type "test" omitted
+
+# Unsupported target "ensure" with type "test" omitted
+
+# Unsupported target "error_chain" with type "test" omitted
+
+# Unsupported target "generics" with type "test" omitted
+
+# Unsupported target "generics_with_default" with type "test" omitted
+
+# Unsupported target "implicit" with type "test" omitted
+
+# Unsupported target "location" with type "test" omitted
+
+# Unsupported target "mapping_result_without_try_operator" with type "test" omitted
+
+# Unsupported target "module" with type "test" omitted
+
+# Unsupported target "multiple_attributes" with type "test" omitted
+
+# Unsupported target "name-conflicts" with type "test" omitted
+
+# Unsupported target "no_context" with type "test" omitted
+
+# Unsupported target "opaque" with type "test" omitted
+
+# Unsupported target "options" with type "test" omitted
+
+# Unsupported target "premade_error" with type "test" omitted
+
+# Unsupported target "raw_idents" with type "test" omitted
+
+# Unsupported target "recursive_error" with type "test" omitted
+
+# Unsupported target "send_between_threads" with type "test" omitted
+
+# Unsupported target "single_use_lifetimes_lint" with type "test" omitted
+
+# Unsupported target "source_attributes" with type "test" omitted
+
+# Unsupported target "stringly_typed" with type "test" omitted
+
+# Unsupported target "structs" with type "test" omitted
+
+# Unsupported target "visibility" with type "test" omitted

--- a/cargo/remote/BUILD.snafu-0.7.1.bazel
+++ b/cargo/remote/BUILD.snafu-0.7.1.bazel
@@ -35,6 +35,8 @@ rust_library(
     name = "snafu",
     srcs = glob(["**/*.rs"]),
     crate_features = [
+        "backtrace",
+        "backtraces",
         "default",
         "rust_1_46",
         "std",
@@ -56,6 +58,7 @@ rust_library(
     version = "0.7.1",
     # buildifier: leave-alone
     deps = [
+        "@raze__backtrace__0_3_66//:backtrace",
         "@raze__doc_comment__0_3_3//:doc_comment",
     ],
 )

--- a/cargo/remote/BUILD.snafu-0.7.1.bazel
+++ b/cargo/remote/BUILD.snafu-0.7.1.bazel
@@ -43,6 +43,7 @@ rust_library(
     ],
     crate_root = "src/lib.rs",
     data = [],
+    compile_data = glob(["**/*.md"]),
     edition = "2018",
     proc_macro_deps = [
         "@raze__snafu_derive__0_7_1//:snafu_derive",

--- a/cargo/remote/BUILD.snafu-derive-0.7.1.bazel
+++ b/cargo/remote/BUILD.snafu-derive-0.7.1.bazel
@@ -1,0 +1,59 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:defs.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_proc_macro",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+
+rust_proc_macro(
+    name = "snafu_derive",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+        "rust_1_46",
+    ],
+    crate_root = "src/lib.rs",
+    data = [],
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "crate-name=snafu-derive",
+        "manual",
+    ],
+    version = "0.7.1",
+    # buildifier: leave-alone
+    deps = [
+        "@raze__heck__0_4_0//:heck",
+        "@raze__proc_macro2__1_0_36//:proc_macro2",
+        "@raze__quote__1_0_15//:quote",
+        "@raze__syn__1_0_88//:syn",
+    ],
+)

--- a/proto/anki/backend.proto
+++ b/proto/anki/backend.proto
@@ -72,4 +72,5 @@ message BackendError {
   Kind kind = 2;
   // optional page in the manual
   optional links.HelpPageLinkRequest.HelpPage help_page = 3;
+  string backtrace = 4;
 }

--- a/pylib/anki/_backend/__init__.py
+++ b/pylib/anki/_backend/__init__.py
@@ -197,13 +197,13 @@ def backend_exception_to_pylib(err: backend_pb2.BackendError) -> Exception:
         return TemplateError(err.localized)
 
     elif val == kind.INVALID_INPUT:
-        return InvalidInput(err.localized)
+        return InvalidInput(err.localized, backtrace=err.backtrace)
 
     elif val == kind.JSON_ERROR:
         return LocalizedError(err.localized)
 
     elif val == kind.NOT_FOUND_ERROR:
-        return NotFoundError()
+        return NotFoundError(err.localized, backtrace=err.backtrace)
 
     elif val == kind.EXISTS:
         return ExistsError()

--- a/pylib/anki/errors.py
+++ b/pylib/anki/errors.py
@@ -44,6 +44,14 @@ class DocumentedError(LocalizedError):
         super().__init__(localized)
 
 
+class BacktracedError(AnkiException):
+    """An error with a backtrace."""
+
+    def __init__(self, *args, backtrace: str, **kwargs) -> None:
+        self.backtrace = backtrace
+        super().__init__(*args, **kwargs)
+
+
 class Interrupted(AnkiException):
     pass
 
@@ -83,7 +91,7 @@ class TemplateError(LocalizedError):
     pass
 
 
-class NotFoundError(AnkiException):
+class NotFoundError(BacktracedError):
     pass
 
 
@@ -103,7 +111,7 @@ class FilteredDeckError(LocalizedError):
     pass
 
 
-class InvalidInput(LocalizedError):
+class InvalidInput(BacktracedError, LocalizedError):
     pass
 
 

--- a/pylib/anki/errors.py
+++ b/pylib/anki/errors.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 from enum import Enum
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     import anki.collection
@@ -47,7 +47,7 @@ class DocumentedError(LocalizedError):
 class BacktracedError(AnkiException):
     """An error with a backtrace."""
 
-    def __init__(self, *args, backtrace: str, **kwargs) -> None:
+    def __init__(self, *args: Any, backtrace: str = "", **kwargs: Any) -> None:
         self.backtrace = backtrace
         super().__init__(*args, **kwargs)
 

--- a/pylib/rsbridge/cargo/BUILD.bazel
+++ b/pylib/rsbridge/cargo/BUILD.bazel
@@ -490,6 +490,15 @@ alias(
 )
 
 alias(
+    name = "snafu",
+    actual = "@raze__snafu__0_7_1//:snafu",
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+)
+
+alias(
     name = "strum",
     actual = "@raze__strum__0_23_0//:strum",
     tags = [

--- a/rslib/BUILD.bazel
+++ b/rslib/BUILD.bazel
@@ -109,6 +109,7 @@ rust_library(
         "//rslib/cargo:slog_async",
         "//rslib/cargo:slog_envlogger",
         "//rslib/cargo:slog_term",
+        "//rslib/cargo:snafu",
         "//rslib/cargo:strum",
         "//rslib/cargo:tempfile",
         "//rslib/cargo:tokio",

--- a/rslib/Cargo.toml
+++ b/rslib/Cargo.toml
@@ -102,4 +102,4 @@ zstd = { version="0.10.0", features=["zstdmt"] }
 num_cpus = "1.13.1"
 csv = { git="https://github.com/ankitects/rust-csv.git", rev="1c9d3aab6f79a7d815c69f925a46a4590c115f90" }
 dissimilar = "1.0.4"
-snafu = "0.7.1"
+snafu = { version = "0.7.1", features = ["backtraces"] }

--- a/rslib/Cargo.toml
+++ b/rslib/Cargo.toml
@@ -102,3 +102,4 @@ zstd = { version="0.10.0", features=["zstdmt"] }
 num_cpus = "1.13.1"
 csv = { git="https://github.com/ankitects/rust-csv.git", rev="1c9d3aab6f79a7d815c69f925a46a4590c115f90" }
 dissimilar = "1.0.4"
+snafu = "0.7.1"

--- a/rslib/cargo/BUILD.bazel
+++ b/rslib/cargo/BUILD.bazel
@@ -490,6 +490,15 @@ alias(
 )
 
 alias(
+    name = "snafu",
+    actual = "@raze__snafu__0_7_1//:snafu",
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+)
+
+alias(
     name = "strum",
     actual = "@raze__strum__0_23_0//:strum",
     tags = [

--- a/rslib/i18n/cargo/BUILD.bazel
+++ b/rslib/i18n/cargo/BUILD.bazel
@@ -490,6 +490,15 @@ alias(
 )
 
 alias(
+    name = "snafu",
+    actual = "@raze__snafu__0_7_1//:snafu",
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+)
+
+alias(
     name = "strum",
     actual = "@raze__strum__0_23_0//:strum",
     tags = [

--- a/rslib/i18n_helpers/cargo/BUILD.bazel
+++ b/rslib/i18n_helpers/cargo/BUILD.bazel
@@ -490,6 +490,15 @@ alias(
 )
 
 alias(
+    name = "snafu",
+    actual = "@raze__snafu__0_7_1//:snafu",
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+)
+
+alias(
     name = "strum",
     actual = "@raze__strum__0_23_0//:strum",
     tags = [

--- a/rslib/linkchecker/cargo/BUILD.bazel
+++ b/rslib/linkchecker/cargo/BUILD.bazel
@@ -490,6 +490,15 @@ alias(
 )
 
 alias(
+    name = "snafu",
+    actual = "@raze__snafu__0_7_1//:snafu",
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+)
+
+alias(
     name = "strum",
     actual = "@raze__strum__0_23_0//:strum",
     tags = [

--- a/rslib/src/backend/error.rs
+++ b/rslib/src/backend/error.rs
@@ -13,18 +13,18 @@ impl AnkiError {
         let localized = self.localized_description(tr);
         let help_page = self.help_page().map(|page| page as i32);
         let kind = match self {
-            AnkiError::InvalidInput(_) => Kind::InvalidInput,
+            AnkiError::InvalidInput(_) | AnkiError::InvalidInputError(_) => Kind::InvalidInput,
             AnkiError::TemplateError(_) => Kind::TemplateParse,
             AnkiError::IoError(_) => Kind::IoError,
             AnkiError::DbError(_) => Kind::DbError,
             AnkiError::NetworkError(_) => Kind::NetworkError,
-            AnkiError::SyncError(err) => err.kind.into(),
+            AnkiError::SyncError(ref err) => err.kind.into(),
             AnkiError::Interrupted => Kind::Interrupted,
             AnkiError::CollectionNotOpen => Kind::InvalidInput,
             AnkiError::CollectionAlreadyOpen => Kind::InvalidInput,
             AnkiError::JsonError(_) => Kind::JsonError,
             AnkiError::ProtoError(_) => Kind::ProtoError,
-            AnkiError::NotFound => Kind::NotFoundError,
+            AnkiError::NotFound | AnkiError::NotFoundError(_) => Kind::NotFoundError,
             AnkiError::Deleted => Kind::Deleted,
             AnkiError::Existing => Kind::Exists,
             AnkiError::FilteredDeckError(_) => Kind::FilteredDeckError,
@@ -46,6 +46,7 @@ impl AnkiError {
             kind: kind as i32,
             localized,
             help_page,
+            backtrace: self.backtrace(),
         }
     }
 }

--- a/rslib/src/browser_table.rs
+++ b/rslib/src/browser_table.rs
@@ -312,12 +312,9 @@ impl RowContext {
         if notes_mode {
             note = col
                 .get_note_maybe_with_fields(NoteId(id), with_card_render)
-                .map_err(|e| {
-                    if e == AnkiError::NotFound {
-                        AnkiError::Deleted
-                    } else {
-                        e
-                    }
+                .map_err(|err| match err {
+                    AnkiError::NotFound => AnkiError::Deleted,
+                    _ => err,
                 })?;
             cards = col.storage.all_cards_of_note(note.id)?;
             if cards.is_empty() {

--- a/rslib/src/error/mod.rs
+++ b/rslib/src/error/mod.rs
@@ -319,3 +319,9 @@ impl FileIoError {
         )
     }
 }
+
+impl From<FileIoError> for AnkiError {
+    fn from(err: FileIoError) -> Self {
+        Self::FileIoError(err)
+    }
+}

--- a/rslib/src/error/mod.rs
+++ b/rslib/src/error/mod.rs
@@ -19,7 +19,7 @@ use crate::{i18n::I18n, links::HelpPage};
 
 pub type Result<T, E = AnkiError> = std::result::Result<T, E>;
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug)]
 pub enum AnkiError {
     InvalidInput(String),
     InvalidInputError(InvalidInputError),

--- a/rslib/src/error/network.rs
+++ b/rslib/src/error/network.rs
@@ -26,7 +26,7 @@ pub struct SyncError {
     pub kind: SyncErrorKind,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone, Copy)]
 pub enum SyncErrorKind {
     Conflict,
     ServerError,

--- a/rslib/src/import_export/package/apkg/import/mod.rs
+++ b/rslib/src/import_export/package/apkg/import/mod.rs
@@ -122,8 +122,7 @@ fn collection_to_tempfile(meta: &Meta, archive: &mut ZipArchive<File>) -> Result
     .with_context(|_| FileIoSnafu {
         path: tempfile.path(),
         op: FileOp::copy(zip_file.name()),
-    })
-    .map_err(AnkiError::FileIoError)?;
+    })?;
 
     Ok(tempfile)
 }

--- a/rslib/src/import_export/package/colpkg/import.rs
+++ b/rslib/src/import_export/package/colpkg/import.rs
@@ -134,8 +134,7 @@ fn restore_media_file(meta: &Meta, mut zip_file: &mut ZipFile, path: &Path) -> R
     .with_context(|_| FileIoSnafu {
         path: tempfile.path(),
         op: FileOp::copy(zip_file.name()),
-    })
-    .map_err(AnkiError::FileIoError)?;
+    })?;
 
     atomic_rename(tempfile, path, false)
 }

--- a/rslib/src/import_export/package/colpkg/tests.rs
+++ b/rslib/src/import_export/package/colpkg/tests.rs
@@ -88,11 +88,10 @@ fn normalization_check_on_export() -> Result<()> {
     let colpkg_name = dir.join("normalize.colpkg");
     // manually write a file in the wrong encoding.
     std::fs::write(col.media_folder.join("ぱぱ.jpg"), "nfd encoding")?;
-    assert_eq!(
-        col.export_colpkg(&colpkg_name, true, false, |_, _| true,)
-            .unwrap_err(),
-        AnkiError::MediaCheckRequired
-    );
+    assert!(matches!(
+        col.export_colpkg(&colpkg_name, true, false, |_, _| true,),
+        Err(AnkiError::MediaCheckRequired)
+    ));
     // file should have been cleaned up
     assert!(!colpkg_name.exists());
 

--- a/rslib/src/io.rs
+++ b/rslib/src/io.rs
@@ -20,7 +20,7 @@ pub(crate) fn tempfile_in_parent_of(file: &Path) -> Result<NamedTempFile> {
             path: dir,
             op: FileOp::Create,
         })
-        .map_err(AnkiError::FileIoError)
+        .map_err(Into::into)
 }
 
 /// Atomically replace the target path with the provided temp file.
@@ -38,8 +38,7 @@ pub(crate) fn atomic_rename(file: NamedTempFile, target: &Path, fsync: bool) -> 
         .context(FileIoSnafu {
             path: target,
             op: FileOp::Write,
-        })
-        .map_err(AnkiError::FileIoError)?;
+        })?;
     #[cfg(not(windows))]
     if fsync {
         if let Some(parent) = target.parent() {

--- a/rslib/src/notetype/fields.rs
+++ b/rslib/src/notetype/fields.rs
@@ -82,7 +82,7 @@ mod test {
     #[test]
     fn name() {
         let mut field = NoteField::new("  # /^ t:e{s\"t} field name #/^  ");
-        assert_eq!(field.fix_name(), Ok(()));
+        assert!(field.fix_name().is_ok());
         assert_eq!(&field.name, "test field name #/^");
     }
 }

--- a/rslib/src/scheduler/filtered/custom_study.rs
+++ b/rslib/src/scheduler/filtered/custom_study.rs
@@ -346,7 +346,7 @@ mod test {
             tags_to_include: vec!["2::two".to_string()],
             tags_to_exclude: vec!["3".to_string()],
         };
-        assert_eq!(
+        assert!(matches!(
             col.custom_study(CustomStudyRequest {
                 deck_id: 1,
                 value: Some(Value::Cram(cram.clone())),
@@ -354,7 +354,7 @@ mod test {
             Err(AnkiError::CustomStudyError(
                 CustomStudyError::NoMatchingCards
             ))
-        );
+        ));
         assert_eq!(
             &get_defaults(&mut col)?,
             &[

--- a/rslib/src/scheduler/filtered/custom_study.rs
+++ b/rslib/src/scheduler/filtered/custom_study.rs
@@ -180,12 +180,11 @@ impl Collection {
 
         self.add_or_update_filtered_deck_inner(deck)
             .map(|_| ())
-            .map_err(|err| {
-                if err == AnkiError::FilteredDeckError(FilteredDeckError::SearchReturnedNoCards) {
+            .map_err(|err| match err {
+                AnkiError::FilteredDeckError(FilteredDeckError::SearchReturnedNoCards) => {
                     CustomStudyError::NoMatchingCards.into()
-                } else {
-                    err
                 }
+                _ => err,
             })
     }
 }

--- a/rslib/src/search/parser.rs
+++ b/rslib/src/search/parser.rs
@@ -788,18 +788,18 @@ mod test {
         );
 
         // escaping parentheses is optional (only) inside quotes
-        assert_eq!(parse(r#""\)\(""#), parse(r#"")(""#));
+        assert_eq!(parse(r#""\)\(""#)?, parse(r#"")(""#)?);
 
         // escaping : is optional if it is preceded by another :
-        assert_eq!(parse("field:val:ue"), parse(r"field:val\:ue"));
-        assert_eq!(parse(r#""field:val:ue""#), parse(r"field:val\:ue"));
-        assert_eq!(parse(r#"field:"val:ue""#), parse(r"field:val\:ue"));
+        assert_eq!(parse("field:val:ue")?, parse(r"field:val\:ue")?);
+        assert_eq!(parse(r#""field:val:ue""#)?, parse(r"field:val\:ue")?);
+        assert_eq!(parse(r#"field:"val:ue""#)?, parse(r"field:val\:ue")?);
 
         // escaping - is optional if it cannot be mistaken for a negator
-        assert_eq!(parse("-"), parse(r"\-"));
-        assert_eq!(parse("A-"), parse(r"A\-"));
-        assert_eq!(parse(r#""-A""#), parse(r"\-A"));
-        assert_ne!(parse("-A"), parse(r"\-A"));
+        assert_eq!(parse("-")?, parse(r"\-")?);
+        assert_eq!(parse("A-")?, parse(r"A\-")?);
+        assert_eq!(parse(r#""-A""#)?, parse(r"\-A")?);
+        assert_ne!(parse("-A")?, parse(r"\-A")?);
 
         // any character should be escapable on the right side of re:
         assert_eq!(
@@ -883,7 +883,7 @@ mod test {
         use crate::error::AnkiError;
 
         fn assert_err_kind(input: &str, kind: FailKind) {
-            assert_eq!(parse(input), Err(AnkiError::SearchError(kind)));
+            assert!(matches!(parse(input), Err(AnkiError::SearchError(k)) if k == kind));
         }
 
         fn failkind(input: &str) -> SearchErrorKind {


### PR DESCRIPTION
Here is a showcase of what an error crate like snafu could bring to the table. Curious to hear what you think. 

## Why snafu
1. anyhow / eyre, thiserror and error_stack seem mostly concerned with an error's string representation, which is not as useful for Anki. snafu seems the most convenient for assembling typed errors as well.
2. Backtraces on the stable toolchain.
3. Support for Options.

## Caveats
1. Tuple structs or enums with tuple variants, like `AnkiError`, cannot derive `Snafu`. To set up a quick demonstration, I had to use nested structs like `AnkiError::InvalidInputError(InvalidInputError)`. This should later be inlined to `AnkiError::InvalidInputError { message, backtrace }`.
2. `Backtrace` doesn't implement `PartialEq`, so I've implemented it manually for the error structs. But equality checks with `AnkiError`s are probably completely expendable.

## Conclusions
I think we can roughly differentiate between two kinds of errors.

#### 1. Unexpected Errors
`NotFound` is the prime example. As we don't expect this error to happen, we don't want to spend a lot of effort attaching context. With snafu we can simply replace `.ok_or(AnkiError::NotFound)` with `.context(NotFoundSnafu)` to at least have a backtrace.
`InvalidInput` is another one. We can make this the `whatever` variant to create string errors very concisely like in `ensure_whatever!(!self.name.is_empty(), "Empty note type name");`.
(Side note: `InvalidInput` should probably not inherit `LocalizedException` and be shown with `show_exception()`.)

#### 2. Localized Errors
This kind of errors needs some manual context handling. Since currently most fallible functions in the codebase return an `AnkiError` as the error variant, all context needs to be available in the lowest failing function. This often counteracts proper separation of concerns. I think more modules should define their own errors which then get contextualised as they pass through the call stack. Snafu makes this quite painless as in `ensure_valid_parsed_templates()`.
They still may happen under unexpected circumstances and we can add a backtrace to help with debugging here as well, but snafu admonishes not to generate backtraces in a tight loop.