### PR TITLE
add shortcut to close addcards window

### DIFF
--- a/qt/aqt/addcards.py
+++ b/qt/aqt/addcards.py
@@ -21,6 +21,7 @@ from aqt.qt import *
 from aqt.sound import av_player
 from aqt.utils import (
     HelpPage,
+    add_close_shortcut,
     askUser,
     downArrow,
     openHelp,
@@ -48,6 +49,7 @@ class AddCards(QMainWindow):
         self.setup_choosers()
         self.setupEditor()
         self.setupButtons()
+        add_close_shortcut(self)
         self._load_new_note()
         self.history: list[NoteId] = []
         self._last_added_note: Optional[Note] = None

--- a/qt/aqt/utils.py
+++ b/qt/aqt/utils.py
@@ -848,6 +848,13 @@ def addCloseShortcut(widg: QDialog) -> None:
     setattr(widg, "_closeShortcut", shortcut)
 
 
+def add_close_shortcut(widg: QWidget) -> None:
+    if not is_mac:
+        return
+    shortcut = QShortcut(QKeySequence("Ctrl+W"), widg)
+    qconnect(shortcut.activated, widg.close)
+
+
 def downArrow() -> str:
     if is_win:
         return "▼"


### PR DESCRIPTION
Fixes #2026 

(This will show a confirmation window to the user if the window has text in the field, since closeEvent() is overridden in AddCards)