### PR TITLE
fix wrong rich-text-widget offset

### DIFF
--- a/ts/editor/FieldDescription.svelte
+++ b/ts/editor/FieldDescription.svelte
@@ -40,9 +40,6 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         opacity: 0.4;
         pointer-events: none;
 
-        /* same as in ContentEditable */
-        padding: 6px;
-
         /* stay a on single line */
         overflow-x: hidden;
         white-space: nowrap;

--- a/ts/editor/rich-text-input/RichTextInput.svelte
+++ b/ts/editor/rich-text-input/RichTextInput.svelte
@@ -244,7 +244,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 <style lang="scss">
     .rich-text-input {
         position: relative;
-        padding: 6px;
+        margin: 6px;
     }
 
     .hidden {


### PR DESCRIPTION
Fixes incorrect rich-text-widget (image/mathjax overlay) positioning

<img width="262" alt="image" src="https://user-images.githubusercontent.com/50060875/186841399-7b56a3bd-c35b-42c6-8608-62f32d3f33de.png">

### Details

```html
<div class="rich-text-input">
  <div class="rich-text-editable"><img src="..."></div>
  <div class="rich-text-widgets">
    <div class="image-overlay"/>
  </div>
</div>

<style>
.rich-text-input{
  position: relative;
  padding: 6px;
}

.image-overlay{
  position: absolute;
  left: 0px;
  top: 0px;
}
</style>
```

Above is the basic html structure. `.image-overlay`'s `left` and `top` is rendered based on `.rich-text-input` position, which is the position without padding. However, its value is calculated relative to `.rich-text-editable` position which is the position after padding.

This PR fixes it by making `.rich-text-input` and `.rich-text-editable` position identical, using `margin` instead of `padding`.