### PR TITLE
Make dvipng use transparent background by default

### DIFF
--- a/pylib/anki/latex.py
+++ b/pylib/anki/latex.py
@@ -17,7 +17,7 @@ from anki.utils import call, is_mac, namedtmp, tmpdir
 
 pngCommands = [
     ["latex", "-interaction=nonstopmode", "tmp.tex"],
-    ["dvipng", "-D", "200", "-T", "tight", "tmp.dvi", "-o", "tmp.png"],
+    ["dvipng", "-bg", "Transparent", "-D", "200", "-T", "tight", "tmp.dvi", "-o", "tmp.png"],
 ]
 
 svgCommands = [

--- a/pylib/anki/latex.py
+++ b/pylib/anki/latex.py
@@ -17,7 +17,18 @@ from anki.utils import call, is_mac, namedtmp, tmpdir
 
 pngCommands = [
     ["latex", "-interaction=nonstopmode", "tmp.tex"],
-    ["dvipng", "-bg", "Transparent", "-D", "200", "-T", "tight", "tmp.dvi", "-o", "tmp.png"],
+    [
+        "dvipng",
+        "-bg",
+        "Transparent",
+        "-D",
+        "200",
+        "-T",
+        "tight",
+        "tmp.dvi",
+        "-o",
+        "tmp.png",
+    ],
 ]
 
 svgCommands = [


### PR DESCRIPTION
As a result, it will look better, and strange black background in dark mode will be gone. Note that if using all-lowercase 'transparent', it will give "a simple fully transparent background with non-transparent antialiased pixels", which is unnecessary.