### PR TITLE
Some import/export features and fixes

### DIFF
--- a/rslib/src/import_export/gather.rs
+++ b/rslib/src/import_export/gather.rs
@@ -42,7 +42,7 @@ impl ExchangeData {
         self.notes = notes;
         let (cards, guard) = guard.col.gather_cards()?;
         self.cards = cards;
-        self.decks = guard.col.gather_decks()?;
+        self.decks = guard.col.gather_decks(with_scheduling)?;
         self.notetypes = guard.col.gather_notetypes()?;
         self.check_ids()?;
 
@@ -191,8 +191,12 @@ impl Collection {
             .map(|cards| (cards, guard))
     }
 
-    fn gather_decks(&mut self) -> Result<Vec<Deck>> {
-        let decks = self.storage.get_decks_for_search_cards()?;
+    fn gather_decks(&mut self, with_original: bool) -> Result<Vec<Deck>> {
+        let decks = if with_original {
+            self.storage.get_decks_and_original_for_search_cards()
+        } else {
+            self.storage.get_decks_for_search_cards()
+        }?;
         let parents = self.get_parent_decks(&decks)?;
         Ok(decks
             .into_iter()

--- a/rslib/src/import_export/gather.rs
+++ b/rslib/src/import_export/gather.rs
@@ -204,8 +204,8 @@ impl Collection {
         let parents = self.get_parent_decks(&decks)?;
         Ok(decks
             .into_iter()
-            .filter(|deck| with_scheduling || deck.id != DeckId(1))
             .chain(parents)
+            .filter(|deck| with_scheduling || deck.id != DeckId(1))
             .collect())
     }
 

--- a/rslib/src/import_export/package/apkg/import/cards.rs
+++ b/rslib/src/import_export/package/apkg/import/cards.rs
@@ -122,7 +122,7 @@ impl CardContext<'_> {
 
     fn add_card(&mut self, card: &mut Card, keep_filtered: bool) -> Result<()> {
         card.usn = self.usn;
-        self.remap_deck_id(card);
+        self.remap_deck_ids(card);
         card.shift_collection_relative_dates(self.collection_delta);
         if !keep_filtered {
             card.maybe_remove_from_filtered_deck(self.scheduler_version);
@@ -144,9 +144,12 @@ impl CardContext<'_> {
         original
     }
 
-    fn remap_deck_id(&self, card: &mut Card) {
+    fn remap_deck_ids(&self, card: &mut Card) {
         if let Some(did) = self.remapped_decks.get(&card.deck_id) {
             card.deck_id = *did;
+        }
+        if let Some(did) = self.remapped_decks.get(&card.original_deck_id) {
+            card.original_deck_id = *did;
         }
     }
 }

--- a/rslib/src/import_export/package/apkg/import/mod.rs
+++ b/rslib/src/import_export/package/apkg/import/mod.rs
@@ -15,7 +15,6 @@ use zip::ZipArchive;
 use zstd::stream::copy_decode;
 
 use crate::{
-    card::CardQueue,
     collection::CollectionBuilder,
     import_export::{
         gather::ExchangeData, package::Meta, ImportProgress, IncrementableProgress, NoteLog,
@@ -118,7 +117,7 @@ impl ExchangeData {
     }
 
     fn contains_scheduling(&self) -> bool {
-        self.cards.iter().any(|c| c.queue != CardQueue::New)
+        !(self.revlog.is_empty() && self.deck_configs.is_empty())
     }
 
     fn contains_all_original_decks(&self) -> bool {

--- a/rslib/src/import_export/package/apkg/import/mod.rs
+++ b/rslib/src/import_export/package/apkg/import/mod.rs
@@ -6,7 +6,7 @@ mod decks;
 mod media;
 mod notes;
 
-use std::{fs::File, io, path::Path};
+use std::{collections::HashSet, fs::File, io, path::Path};
 
 pub(crate) use notes::NoteMeta;
 use rusqlite::OptionalExtension;
@@ -15,6 +15,7 @@ use zip::ZipArchive;
 use zstd::stream::copy_decode;
 
 use crate::{
+    card::CardQueue,
     collection::CollectionBuilder,
     import_export::{
         gather::ExchangeData, package::Meta, ImportProgress, IncrementableProgress, NoteLog,
@@ -82,8 +83,9 @@ impl<'a> Context<'a> {
     fn import(&mut self) -> Result<NoteLog> {
         let mut media_map = self.prepare_media()?;
         let note_imports = self.import_notes_and_notetypes(&mut media_map)?;
-        let imported_decks = self.import_decks_and_configs()?;
-        self.import_cards_and_revlog(&note_imports.id_map, &imported_decks)?;
+        let keep_filtered = self.data.enables_filtered_decks();
+        let imported_decks = self.import_decks_and_configs(keep_filtered)?;
+        self.import_cards_and_revlog(&note_imports.id_map, &imported_decks, keep_filtered)?;
         self.copy_media(&mut media_map)?;
         Ok(note_imports.log)
     }
@@ -106,6 +108,26 @@ impl ExchangeData {
         data.gather_data(&mut col, search, with_scheduling)?;
 
         Ok(data)
+    }
+
+    fn enables_filtered_decks(&self) -> bool {
+        // Earlier versions relied on the importer handling filtered decks by converting
+        // them into regular ones, so there is no guarantee that all original decks
+        // are included.
+        self.contains_scheduling() && self.contains_all_original_decks()
+    }
+
+    fn contains_scheduling(&self) -> bool {
+        self.cards.iter().any(|c| c.queue != CardQueue::New)
+    }
+
+    fn contains_all_original_decks(&self) -> bool {
+        let deck_ids: HashSet<_> = self.decks.iter().map(|d| d.id).collect();
+        self.cards.iter().all(|c| {
+            c.original_deck_id.0 == 0
+                || c.original_deck_id.0 == 1
+                || deck_ids.contains(&c.original_deck_id)
+        })
     }
 }
 

--- a/rslib/src/import_export/package/apkg/import/mod.rs
+++ b/rslib/src/import_export/package/apkg/import/mod.rs
@@ -122,11 +122,9 @@ impl ExchangeData {
 
     fn contains_all_original_decks(&self) -> bool {
         let deck_ids: HashSet<_> = self.decks.iter().map(|d| d.id).collect();
-        self.cards.iter().all(|c| {
-            c.original_deck_id.0 == 0
-                || c.original_deck_id.0 == 1
-                || deck_ids.contains(&c.original_deck_id)
-        })
+        self.cards
+            .iter()
+            .all(|c| c.original_deck_id.0 == 0 || deck_ids.contains(&c.original_deck_id))
     }
 }
 

--- a/rslib/src/import_export/text/csv/import.rs
+++ b/rslib/src/import_export/text/csv/import.rs
@@ -158,10 +158,10 @@ impl ColumnContext {
 
     fn foreign_note_from_record(&self, record: &csv::StringRecord) -> ForeignNote {
         ForeignNote {
-            notetype: str_from_record_column(self.notetype_column, record).into(),
+            notetype: name_or_id_from_record_column(self.notetype_column, record),
             fields: self.gather_note_fields(record),
             tags: self.gather_tags(record),
-            deck: str_from_record_column(self.deck_column, record).into(),
+            deck: name_or_id_from_record_column(self.deck_column, record),
             guid: str_from_record_column(self.guid_column, record),
             ..Default::default()
         }
@@ -190,6 +190,10 @@ fn str_from_record_column(column: Option<usize>, record: &csv::StringRecord) -> 
         .and_then(|i| record.get(i - 1))
         .unwrap_or_default()
         .to_string()
+}
+
+fn name_or_id_from_record_column(column: Option<usize>, record: &csv::StringRecord) -> NameOrId {
+    NameOrId::parse(column.and_then(|i| record.get(i - 1)).unwrap_or_default())
 }
 
 pub(super) fn build_csv_reader(

--- a/rslib/src/import_export/text/import.rs
+++ b/rslib/src/import_export/text/import.rs
@@ -259,16 +259,17 @@ impl<'a> Context<'a> {
     }
 
     fn find_duplicates(&self, notetype: &Notetype, note: &ForeignNote) -> Result<Vec<Duplicate>> {
-        if let Some(nid) = self.existing_guids.get(&note.guid) {
-            self.get_guid_dupe(*nid, note).map(|dupe| vec![dupe])
-        } else if let Some(nids) = note
-            .checksum()
-            .and_then(|csum| self.existing_checksums.get(&(notetype.id, csum)))
-        {
-            self.get_first_field_dupes(note, nids)
-        } else {
-            Ok(Vec::new())
+        if note.guid.is_empty() {
+            if let Some(nids) = note
+                .checksum()
+                .and_then(|csum| self.existing_checksums.get(&(notetype.id, csum)))
+            {
+                return self.get_first_field_dupes(note, nids);
+            }
+        } else if let Some(nid) = self.existing_guids.get(&note.guid) {
+            return self.get_guid_dupe(*nid, note).map(|dupe| vec![dupe]);
         }
+        Ok(Vec::new())
     }
 
     fn get_guid_dupe(&self, nid: NoteId, original: &ForeignNote) -> Result<Duplicate> {

--- a/rslib/src/storage/deck/all_decks_and_original_of_search_cards.sql
+++ b/rslib/src/storage/deck/all_decks_and_original_of_search_cards.sql
@@ -1,0 +1,12 @@
+WITH cids AS (
+  SELECT cid
+  FROM search_cids
+)
+SELECT DISTINCT did
+FROM cards
+WHERE id IN cids
+UNION
+SELECT DISTINCT odid
+FROM cards
+WHERE odid != 0
+  AND id IN cids

--- a/rslib/src/storage/deck/all_decks_and_original_of_search_cards.sql
+++ b/rslib/src/storage/deck/all_decks_and_original_of_search_cards.sql
@@ -2,11 +2,11 @@ WITH cids AS (
   SELECT cid
   FROM search_cids
 )
-SELECT DISTINCT did
+SELECT did
 FROM cards
 WHERE id IN cids
 UNION
-SELECT DISTINCT odid
+SELECT odid
 FROM cards
 WHERE odid != 0
   AND id IN cids

--- a/rslib/src/storage/deck/mod.rs
+++ b/rslib/src/storage/deck/mod.rs
@@ -131,6 +131,18 @@ impl SqliteStorage {
             .collect()
     }
 
+    pub(crate) fn get_decks_and_original_for_search_cards(&self) -> Result<Vec<Deck>> {
+        self.db
+            .prepare_cached(concat!(
+                include_str!("get_deck.sql"),
+                " WHERE id IN (",
+                include_str!("all_decks_and_original_of_search_cards.sql"),
+                ")",
+            ))?
+            .query_and_then([], row_to_deck)?
+            .collect()
+    }
+
     /// Returns the deck id of the first existing card of every searched note.
     pub(crate) fn all_decks_of_search_notes(&self) -> Result<HashMap<NoteId, DeckId>> {
         self.db


### PR DESCRIPTION
- Support export/import of filtered decks without conversion if scheduling is included.
- Create referenced decks on CSV import, if necessary.
- Fix meta column being mapped to tags.
- Fix ids in CSV deck and notetype columns being read as names. (See caveat in 65ba8c9bc61ffcf1ee4bcd7892f9c3d399c6900d.)
- Fix duplicate with same GUID being created
- ...

Do you think we need an option to turn off automatic deck creation when importing a CSV?

Do you know why we don't export the default deck and deck config? I've adopted that from the old exporter, but if I ever knew why, I have forgotten!