### PR TITLE
Break long words in CodeMirror

### DIFF
--- a/ts/editor/CodeMirror.svelte
+++ b/ts/editor/CodeMirror.svelte
@@ -88,7 +88,12 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 </div>
 
 <style lang="scss">
-    .code-mirror :global(.CodeMirror) {
-        height: auto;
+    .code-mirror {
+        :global(.CodeMirror) {
+            height: auto;
+        }
+        :global(.CodeMirror-wrap pre) {
+            word-break: break-word;
+        }
     }
 </style>

--- a/ts/editor/plain-text-input/PlainTextInput.svelte
+++ b/ts/editor/plain-text-input/PlainTextInput.svelte
@@ -177,9 +177,6 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         :global(.CodeMirror) {
             background: var(--code-bg);
         }
-        :global(.CodeMirror-wrap pre) {
-            word-break: break-word;
-        }
         :global(.CodeMirror-lines) {
             padding: 8px 0;
         }

--- a/ts/editor/plain-text-input/PlainTextInput.svelte
+++ b/ts/editor/plain-text-input/PlainTextInput.svelte
@@ -174,9 +174,11 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
             border: none;
             border-radius: 5px;
         }
-
         :global(.CodeMirror) {
             background: var(--code-bg);
+        }
+        :global(.CodeMirror-wrap pre) {
+            word-break: break-word;
         }
         :global(.CodeMirror-lines) {
             padding: 8px 0;


### PR DESCRIPTION
Long words or codes inside `PlainTextInput` clip the fields currently:

![image](https://user-images.githubusercontent.com/62722460/187878768-06480ded-ba89-48b4-a024-279229ba1221.png)

I got the selector from this answer by Marko Letic: https://stackoverflow.com/a/57377527