### PR TITLE
Enable state-dependent custom scheduling data

### DIFF
--- a/proto/anki/scheduler.proto
+++ b/proto/anki/scheduler.proto
@@ -305,8 +305,19 @@ message RepositionDefaultsResponse {
   bool shift = 2;
 }
 
-// Data required to support the v3 scheduler's custom scheduling feature
-message CustomScheduling {
+// Data required to support the v3 scheduler's custom scheduling feature.
+// Consumed by the custom scheduling mutator.
+message CurrentCustomScheduling {
   NextCardStates states = 1;
   string custom_data = 2;
+}
+
+// Data required to support the v3 scheduler's custom scheduling feature.enum
+// Returned by the custom scheduling mutator.
+message NextCustomScheduling {
+  NextCardStates states = 1;
+  string again_custom_data = 2;
+  string hard_custom_data = 3;
+  string good_custom_data = 4;
+  string easy_custom_data = 5;
 }

--- a/proto/anki/scheduler.proto
+++ b/proto/anki/scheduler.proto
@@ -93,8 +93,9 @@ message SchedulingState {
     Filtered filtered = 2;
   }
   // The backend does not populate this field in GetQueuedCards; the front-end
-  // is expected to populate it based on the provided Card.
-  string custom_data = 3;
+  // is expected to populate it based on the provided Card. If it's not set when
+  // answering a card, the existing custom data will not be updated.
+  optional string custom_data = 3;
 }
 
 message QueuedCards {

--- a/proto/anki/scheduler.proto
+++ b/proto/anki/scheduler.proto
@@ -37,8 +37,8 @@ service SchedulerService {
   rpc SetDueDate(SetDueDateRequest) returns (collection.OpChanges);
   rpc SortCards(SortCardsRequest) returns (collection.OpChangesWithCount);
   rpc SortDeck(SortDeckRequest) returns (collection.OpChangesWithCount);
-  rpc GetNextCardStates(cards.CardId) returns (NextCardStates);
-  rpc DescribeNextStates(NextCardStates) returns (generic.StringList);
+  rpc GetSchedulingStates(cards.CardId) returns (SchedulingStates);
+  rpc DescribeNextStates(SchedulingStates) returns (generic.StringList);
   rpc StateIsLeech(SchedulingState) returns (generic.Bool);
   rpc UpgradeScheduler(generic.Empty) returns (generic.Empty);
   rpc CustomStudy(CustomStudyRequest) returns (collection.OpChanges);
@@ -103,7 +103,7 @@ message QueuedCards {
   message QueuedCard {
     cards.Card card = 1;
     Queue queue = 2;
-    NextCardStates next_states = 3;
+    SchedulingStates states = 3;
   }
 
   repeated QueuedCard cards = 1;
@@ -218,7 +218,7 @@ message SortDeckRequest {
   bool randomize = 2;
 }
 
-message NextCardStates {
+message SchedulingStates {
   SchedulingState current = 1;
   SchedulingState again = 2;
   SchedulingState hard = 3;
@@ -308,14 +308,14 @@ message RepositionDefaultsResponse {
 // Data required to support the v3 scheduler's custom scheduling feature.
 // Consumed by the custom scheduling mutator.
 message CurrentCustomScheduling {
-  NextCardStates states = 1;
+  SchedulingStates states = 1;
   string custom_data = 2;
 }
 
 // Data required to support the v3 scheduler's custom scheduling feature.enum
 // Returned by the custom scheduling mutator.
 message NextCustomScheduling {
-  NextCardStates states = 1;
+  SchedulingStates states = 1;
   string again_custom_data = 2;
   string hard_custom_data = 3;
   string good_custom_data = 4;

--- a/proto/anki/scheduler.proto
+++ b/proto/anki/scheduler.proto
@@ -92,6 +92,9 @@ message SchedulingState {
     Normal normal = 1;
     Filtered filtered = 2;
   }
+  // The backend does not populate this field in GetQueuedCards; the front-end
+  // is expected to populate it based on the provided Card.
+  string custom_data = 3;
 }
 
 message QueuedCards {
@@ -240,7 +243,6 @@ message CardAnswer {
   Rating rating = 4;
   int64 answered_at_millis = 5;
   uint32 milliseconds_taken = 6;
-  string custom_data = 7;
 }
 
 message CustomStudyRequest {
@@ -303,21 +305,4 @@ message CustomStudyDefaultsResponse {
 message RepositionDefaultsResponse {
   bool random = 1;
   bool shift = 2;
-}
-
-// Data required to support the v3 scheduler's custom scheduling feature.
-// Consumed by the custom scheduling mutator.
-message CurrentCustomScheduling {
-  SchedulingStates states = 1;
-  string custom_data = 2;
-}
-
-// Data required to support the v3 scheduler's custom scheduling feature.enum
-// Returned by the custom scheduling mutator.
-message NextCustomScheduling {
-  SchedulingStates states = 1;
-  string again_custom_data = 2;
-  string hard_custom_data = 3;
-  string good_custom_data = 4;
-  string easy_custom_data = 5;
 }

--- a/pylib/anki/scheduler/v3.py
+++ b/pylib/anki/scheduler/v3.py
@@ -31,8 +31,6 @@ QueuedCards = scheduler_pb2.QueuedCards
 SchedulingState = scheduler_pb2.SchedulingState
 SchedulingStates = scheduler_pb2.SchedulingStates
 CardAnswer = scheduler_pb2.CardAnswer
-CurrentCustomScheduling = scheduler_pb2.CurrentCustomScheduling
-NextCustomScheduling = scheduler_pb2.NextCustomScheduling
 
 
 class Scheduler(SchedulerBaseWithLegacy):
@@ -67,7 +65,6 @@ class Scheduler(SchedulerBaseWithLegacy):
         *,
         card: Card,
         states: SchedulingStates,
-        custom_data: str,
         rating: CardAnswer.Rating.V,
     ) -> CardAnswer:
         "Build input for answer_card()."
@@ -86,7 +83,6 @@ class Scheduler(SchedulerBaseWithLegacy):
             card_id=card.id,
             current_state=states.current,
             new_state=new_state,
-            custom_data=custom_data,
             rating=rating,
             answered_at_millis=int_time(1000),
             milliseconds_taken=card.time_taken(capped=False),
@@ -171,9 +167,7 @@ class Scheduler(SchedulerBaseWithLegacy):
 
         states = self.col._backend.get_scheduling_states(card.id)
         changes = self.answer_card(
-            self.build_answer(
-                card=card, states=states, custom_data=card.custom_data, rating=rating
-            )
+            self.build_answer(card=card, states=states, rating=rating)
         )
 
         # tests assume card will be mutated, so we need to reload it

--- a/pylib/anki/scheduler/v3.py
+++ b/pylib/anki/scheduler/v3.py
@@ -31,7 +31,8 @@ QueuedCards = scheduler_pb2.QueuedCards
 SchedulingState = scheduler_pb2.SchedulingState
 NextStates = scheduler_pb2.NextCardStates
 CardAnswer = scheduler_pb2.CardAnswer
-CustomScheduling = scheduler_pb2.CustomScheduling
+CurrentCustomScheduling = scheduler_pb2.CurrentCustomScheduling
+NextCustomScheduling = scheduler_pb2.NextCustomScheduling
 
 
 class Scheduler(SchedulerBaseWithLegacy):

--- a/pylib/anki/scheduler/v3.py
+++ b/pylib/anki/scheduler/v3.py
@@ -29,7 +29,7 @@ from anki.utils import int_time
 
 QueuedCards = scheduler_pb2.QueuedCards
 SchedulingState = scheduler_pb2.SchedulingState
-NextStates = scheduler_pb2.NextCardStates
+SchedulingStates = scheduler_pb2.SchedulingStates
 CardAnswer = scheduler_pb2.CardAnswer
 CurrentCustomScheduling = scheduler_pb2.CurrentCustomScheduling
 NextCustomScheduling = scheduler_pb2.NextCustomScheduling
@@ -55,7 +55,7 @@ class Scheduler(SchedulerBaseWithLegacy):
             fetch_limit=fetch_limit, intraday_learning_only=intraday_learning_only
         )
 
-    def describe_next_states(self, next_states: NextStates) -> Sequence[str]:
+    def describe_next_states(self, next_states: SchedulingStates) -> Sequence[str]:
         "Labels for each of the answer buttons."
         return self.col._backend.describe_next_states(next_states)
 
@@ -66,7 +66,7 @@ class Scheduler(SchedulerBaseWithLegacy):
         self,
         *,
         card: Card,
-        states: NextStates,
+        states: SchedulingStates,
         custom_data: str,
         rating: CardAnswer.Rating.V,
     ) -> CardAnswer:
@@ -151,7 +151,7 @@ class Scheduler(SchedulerBaseWithLegacy):
 
     def nextIvlStr(self, card: Card, ease: int, short: bool = False) -> str:
         "Return the next interval for CARD as a string."
-        states = self.col._backend.get_next_card_states(card.id)
+        states = self.col._backend.get_scheduling_states(card.id)
         return self.col._backend.describe_next_states(states)[ease - 1]
 
     # Answering a card (legacy API)
@@ -169,7 +169,7 @@ class Scheduler(SchedulerBaseWithLegacy):
         else:
             raise Exception("invalid ease")
 
-        states = self.col._backend.get_next_card_states(card.id)
+        states = self.col._backend.get_scheduling_states(card.id)
         changes = self.answer_card(
             self.build_answer(
                 card=card, states=states, custom_data=card.custom_data, rating=rating
@@ -225,7 +225,7 @@ class Scheduler(SchedulerBaseWithLegacy):
 
     def nextIvl(self, card: Card, ease: int) -> Any:
         "Don't use this - it is only required by tests, and will be moved in the future."
-        states = self.col._backend.get_next_card_states(card.id)
+        states = self.col._backend.get_scheduling_states(card.id)
         if ease == BUTTON_ONE:
             new_state = states.again
         elif ease == BUTTON_TWO:

--- a/qt/aqt/mediasrv.py
+++ b/qt/aqt/mediasrv.py
@@ -27,7 +27,7 @@ from anki import hooks
 from anki._vendor import stringcase
 from anki.collection import OpChanges
 from anki.decks import DeckConfigsForUpdate, UpdateDeckConfigs
-from anki.scheduler.v3 import NextCustomScheduling
+from anki.scheduler_pb2 import SchedulingStates
 from anki.utils import dev_mode
 from aqt.changenotetype import ChangeNotetypeDialog
 from aqt.deckoptions import DeckOptionsDialog
@@ -412,18 +412,18 @@ def update_deck_configs() -> bytes:
     return b""
 
 
-def get_custom_scheduling() -> bytes:
-    if scheduling := aqt.mw.reviewer.get_custom_scheduling():
-        return scheduling.SerializeToString()
+def get_scheduling_states() -> bytes:
+    if states := aqt.mw.reviewer.get_scheduling_states():
+        return states.SerializeToString()
     else:
         return b""
 
 
-def set_custom_scheduling() -> bytes:
+def set_scheduling_states() -> bytes:
     key = request.headers.get("key", "")
-    input = NextCustomScheduling()
-    input.ParseFromString(request.data)
-    aqt.mw.reviewer.set_custom_scheduling(key, input)
+    states = SchedulingStates()
+    states.ParseFromString(request.data)
+    aqt.mw.reviewer.set_scheduling_states(key, states)
     return b""
 
 
@@ -455,8 +455,8 @@ post_handler_list = [
     congrats_info,
     get_deck_configs_for_update,
     update_deck_configs,
-    get_custom_scheduling,
-    set_custom_scheduling,
+    get_scheduling_states,
+    set_scheduling_states,
     change_notetype,
     import_csv,
 ]

--- a/qt/aqt/mediasrv.py
+++ b/qt/aqt/mediasrv.py
@@ -27,7 +27,7 @@ from anki import hooks
 from anki._vendor import stringcase
 from anki.collection import OpChanges
 from anki.decks import DeckConfigsForUpdate, UpdateDeckConfigs
-from anki.scheduler.v3 import CustomScheduling
+from anki.scheduler.v3 import NextCustomScheduling
 from anki.utils import dev_mode
 from aqt.changenotetype import ChangeNotetypeDialog
 from aqt.deckoptions import DeckOptionsDialog
@@ -421,7 +421,7 @@ def get_custom_scheduling() -> bytes:
 
 def set_custom_scheduling() -> bytes:
     key = request.headers.get("key", "")
-    input = CustomScheduling()
+    input = NextCustomScheduling()
     input.ParseFromString(request.data)
     aqt.mw.reviewer.set_custom_scheduling(key, input)
     return b""

--- a/qt/aqt/reviewer.py
+++ b/qt/aqt/reviewer.py
@@ -87,15 +87,8 @@ class V3CardInfo:
     @staticmethod
     def from_queue(queued_cards: QueuedCards) -> V3CardInfo:
         top_card = queued_cards.cards[0]
-        # currently AnkiWeb and AnkiDroid don't implement custom scheduling,
-        # so we fill these in here as well to ensure that custom_data doesn't
-        # get cleared out if the JS mutation routine fails to run
         states = top_card.states
         states.current.custom_data = top_card.card.custom_data
-        states.again.custom_data = top_card.card.custom_data
-        states.hard.custom_data = top_card.card.custom_data
-        states.good.custom_data = top_card.card.custom_data
-        states.easy.custom_data = top_card.card.custom_data
         return V3CardInfo(
             queued_cards=queued_cards,
             states=states,

--- a/qt/aqt/reviewer.py
+++ b/qt/aqt/reviewer.py
@@ -21,10 +21,10 @@ from anki.scheduler.v3 import (
     CardAnswer,
     CurrentCustomScheduling,
     NextCustomScheduling,
-    NextStates,
     QueuedCards,
 )
 from anki.scheduler.v3 import Scheduler as V3Scheduler
+from anki.scheduler.v3 import SchedulingStates
 from anki.tags import MARKED_TAG
 from anki.types import assert_exhaustive
 from aqt import AnkiQt, gui_hooks
@@ -87,7 +87,7 @@ class V3CardInfo:
     """
 
     queued_cards: QueuedCards
-    next_states: NextStates
+    states: SchedulingStates
     custom_data_states: None | Tuple[
         str,
         str,
@@ -99,7 +99,7 @@ class V3CardInfo:
     def from_queue(queued_cards: QueuedCards) -> V3CardInfo:
         return V3CardInfo(
             queued_cards=queued_cards,
-            next_states=queued_cards.cards[0].next_states,
+            states=queued_cards.cards[0].states,
         )
 
     def top_card(self) -> QueuedCards.QueuedCard:
@@ -283,7 +283,7 @@ class Reviewer:
     def get_custom_scheduling(self) -> CurrentCustomScheduling | None:
         if v3 := self._v3:
             return CurrentCustomScheduling(
-                states=v3.next_states, custom_data=v3.current_custom_data()
+                states=v3.states, custom_data=v3.current_custom_data()
             )
         else:
             return None
@@ -293,7 +293,7 @@ class Reviewer:
             return
 
         if v3 := self._v3:
-            v3.next_states = scheduling.states
+            v3.states = scheduling.states
             v3.custom_data_states = (
                 scheduling.again_custom_data,
                 scheduling.hard_custom_data,
@@ -461,7 +461,7 @@ class Reviewer:
         if (v3 := self._v3) and (sched := cast(V3Scheduler, self.mw.col.sched)):
             answer = sched.build_answer(
                 card=self.card,
-                states=v3.next_states,
+                states=v3.states,
                 custom_data=v3.next_custom_data(ease),
                 rating=v3.rating_from_ease(ease),
             )
@@ -796,7 +796,7 @@ time = %(time)d;
 
         if v3 := self._v3:
             assert isinstance(self.mw.col.sched, V3Scheduler)
-            labels = self.mw.col.sched.describe_next_states(v3.next_states)
+            labels = self.mw.col.sched.describe_next_states(v3.states)
         else:
             labels = None
 

--- a/rslib/src/backend/scheduler/answering.rs
+++ b/rslib/src/backend/scheduler/answering.rs
@@ -39,7 +39,7 @@ impl From<QueuedCard> for pb::queued_cards::QueuedCard {
     fn from(queued_card: QueuedCard) -> Self {
         Self {
             card: Some(queued_card.card.into()),
-            next_states: Some(queued_card.next_states.into()),
+            states: Some(queued_card.states.into()),
             queue: match queued_card.kind {
                 crate::scheduler::queue::QueueEntryKind::New => pb::queued_cards::Queue::New,
                 crate::scheduler::queue::QueueEntryKind::Review => pb::queued_cards::Queue::Review,

--- a/rslib/src/backend/scheduler/answering.rs
+++ b/rslib/src/backend/scheduler/answering.rs
@@ -1,6 +1,8 @@
 // Copyright: Ankitects Pty Ltd and contributors
 // License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
+use std::mem;
+
 use crate::{
     pb,
     prelude::*,
@@ -11,15 +13,17 @@ use crate::{
 };
 
 impl From<pb::CardAnswer> for CardAnswer {
-    fn from(answer: pb::CardAnswer) -> Self {
+    fn from(mut answer: pb::CardAnswer) -> Self {
+        let mut new_state = mem::take(&mut answer.new_state).unwrap_or_default();
+        let custom_data = mem::take(&mut new_state.custom_data);
         CardAnswer {
             card_id: CardId(answer.card_id),
             rating: answer.rating().into(),
             current_state: answer.current_state.unwrap_or_default().into(),
-            new_state: answer.new_state.unwrap_or_default().into(),
+            new_state: new_state.into(),
             answered_at: TimestampMillis(answer.answered_at_millis),
             milliseconds_taken: answer.milliseconds_taken,
-            custom_data: answer.custom_data,
+            custom_data,
         }
     }
 }

--- a/rslib/src/backend/scheduler/mod.rs
+++ b/rslib/src/backend/scheduler/mod.rs
@@ -11,7 +11,7 @@ use crate::{
     prelude::*,
     scheduler::{
         new::NewCardDueOrder,
-        states::{CardState, NextCardStates},
+        states::{CardState, SchedulingStates},
     },
     stats::studied_today,
 };
@@ -168,14 +168,14 @@ impl SchedulerService for Backend {
         })
     }
 
-    fn get_next_card_states(&self, input: pb::CardId) -> Result<pb::NextCardStates> {
+    fn get_scheduling_states(&self, input: pb::CardId) -> Result<pb::SchedulingStates> {
         let cid: CardId = input.into();
-        self.with_col(|col| col.get_next_card_states(cid))
+        self.with_col(|col| col.get_scheduling_states(cid))
             .map(Into::into)
     }
 
-    fn describe_next_states(&self, input: pb::NextCardStates) -> Result<pb::StringList> {
-        let states: NextCardStates = input.into();
+    fn describe_next_states(&self, input: pb::SchedulingStates) -> Result<pb::StringList> {
+        let states: SchedulingStates = input.into();
         self.with_col(|col| col.describe_next_states(states))
             .map(Into::into)
     }

--- a/rslib/src/backend/scheduler/states/mod.rs
+++ b/rslib/src/backend/scheduler/states/mod.rs
@@ -46,7 +46,7 @@ impl From<CardState> for pb::SchedulingState {
                 CardState::Normal(state) => pb::scheduling_state::Value::Normal(state.into()),
                 CardState::Filtered(state) => pb::scheduling_state::Value::Filtered(state.into()),
             }),
-            custom_data: String::new(),
+            custom_data: None,
         }
     }
 }

--- a/rslib/src/backend/scheduler/states/mod.rs
+++ b/rslib/src/backend/scheduler/states/mod.rs
@@ -46,6 +46,7 @@ impl From<CardState> for pb::SchedulingState {
                 CardState::Normal(state) => pb::scheduling_state::Value::Normal(state.into()),
                 CardState::Filtered(state) => pb::scheduling_state::Value::Filtered(state.into()),
             }),
+            custom_data: String::new(),
         }
     }
 }

--- a/rslib/src/backend/scheduler/states/mod.rs
+++ b/rslib/src/backend/scheduler/states/mod.rs
@@ -12,12 +12,12 @@ mod review;
 
 use crate::{
     pb,
-    scheduler::states::{CardState, NewState, NextCardStates, NormalState},
+    scheduler::states::{CardState, NewState, NormalState, SchedulingStates},
 };
 
-impl From<NextCardStates> for pb::NextCardStates {
-    fn from(choices: NextCardStates) -> Self {
-        pb::NextCardStates {
+impl From<SchedulingStates> for pb::SchedulingStates {
+    fn from(choices: SchedulingStates) -> Self {
+        pb::SchedulingStates {
             current: Some(choices.current.into()),
             again: Some(choices.again.into()),
             hard: Some(choices.hard.into()),
@@ -27,9 +27,9 @@ impl From<NextCardStates> for pb::NextCardStates {
     }
 }
 
-impl From<pb::NextCardStates> for NextCardStates {
-    fn from(choices: pb::NextCardStates) -> Self {
-        NextCardStates {
+impl From<pb::SchedulingStates> for SchedulingStates {
+    fn from(choices: pb::SchedulingStates) -> Self {
+        SchedulingStates {
             current: choices.current.unwrap_or_default().into(),
             again: choices.again.unwrap_or_default().into(),
             hard: choices.hard.unwrap_or_default().into(),

--- a/rslib/src/scheduler/answering/mod.rs
+++ b/rslib/src/scheduler/answering/mod.rs
@@ -8,6 +8,8 @@ mod relearning;
 mod review;
 mod revlog;
 
+use std::mem;
+
 use rand::{prelude::*, rngs::StdRng};
 use revlog::RevlogEntryPartial;
 
@@ -274,7 +276,7 @@ impl Collection {
         self.maybe_bury_siblings(&original, &updater.config)?;
         let timing = updater.timing;
         let mut card = updater.into_card();
-        card.custom_data = answer.custom_data.clone();
+        card.custom_data = mem::take(&mut answer.custom_data);
         card.validate_custom_data()?;
         self.update_card_inner(&mut card, original, usn)?;
         if answer.new_state.leeched() {

--- a/rslib/src/scheduler/answering/mod.rs
+++ b/rslib/src/scheduler/answering/mod.rs
@@ -8,8 +8,6 @@ mod relearning;
 mod review;
 mod revlog;
 
-use std::mem;
-
 use rand::{prelude::*, rngs::StdRng};
 use revlog::RevlogEntryPartial;
 
@@ -43,7 +41,7 @@ pub struct CardAnswer {
     pub rating: Rating,
     pub answered_at: TimestampMillis,
     pub milliseconds_taken: u32,
-    pub custom_data: String,
+    pub custom_data: Option<String>,
 }
 
 impl CardAnswer {
@@ -276,8 +274,10 @@ impl Collection {
         self.maybe_bury_siblings(&original, &updater.config)?;
         let timing = updater.timing;
         let mut card = updater.into_card();
-        card.custom_data = mem::take(&mut answer.custom_data);
-        card.validate_custom_data()?;
+        if let Some(data) = answer.custom_data.take() {
+            card.custom_data = data;
+            card.validate_custom_data()?;
+        }
         self.update_card_inner(&mut card, original, usn)?;
         if answer.new_state.leeched() {
             self.add_leech_tag(card.note_id)?;
@@ -424,7 +424,7 @@ pub mod test_helpers {
                 rating,
                 answered_at: TimestampMillis::now(),
                 milliseconds_taken: 0,
-                custom_data: String::new(),
+                custom_data: None,
             })?;
             Ok(PostAnswerState {
                 card_id: queued.card.id,

--- a/rslib/src/scheduler/answering/preview.rs
+++ b/rslib/src/scheduler/answering/preview.rs
@@ -92,7 +92,7 @@ mod test {
             rating: Rating::Again,
             answered_at: TimestampMillis::now(),
             milliseconds_taken: 0,
-            custom_data: String::new(),
+            custom_data: None,
         })?;
 
         c = col.storage.get_card(c.id)?.unwrap();
@@ -107,7 +107,7 @@ mod test {
             rating: Rating::Hard,
             answered_at: TimestampMillis::now(),
             milliseconds_taken: 0,
-            custom_data: String::new(),
+            custom_data: None,
         })?;
         c = col.storage.get_card(c.id)?.unwrap();
         assert_eq!(c.queue, CardQueue::PreviewRepeat);
@@ -121,7 +121,7 @@ mod test {
             rating: Rating::Good,
             answered_at: TimestampMillis::now(),
             milliseconds_taken: 0,
-            custom_data: String::new(),
+            custom_data: None,
         })?;
         c = col.storage.get_card(c.id)?.unwrap();
         assert_eq!(c.queue, CardQueue::PreviewRepeat);
@@ -135,7 +135,7 @@ mod test {
             rating: Rating::Easy,
             answered_at: TimestampMillis::now(),
             milliseconds_taken: 0,
-            custom_data: String::new(),
+            custom_data: None,
         })?;
         c = col.storage.get_card(c.id)?.unwrap();
         assert_eq!(c.queue, CardQueue::DayLearn);

--- a/rslib/src/scheduler/answering/preview.rs
+++ b/rslib/src/scheduler/answering/preview.rs
@@ -70,7 +70,7 @@ mod test {
         col.add_or_update_deck(&mut filtered_deck)?;
         assert_eq!(col.rebuild_filtered_deck(filtered_deck.id)?.output, 1);
 
-        let next = col.get_next_card_states(c.id)?;
+        let next = col.get_scheduling_states(c.id)?;
         assert!(matches!(
             next.current,
             CardState::Filtered(FilteredState::Preview(_))
@@ -99,7 +99,7 @@ mod test {
         assert_eq!(c.queue, CardQueue::PreviewRepeat);
 
         // hard
-        let next = col.get_next_card_states(c.id)?;
+        let next = col.get_scheduling_states(c.id)?;
         col.answer_card(&mut CardAnswer {
             card_id: c.id,
             current_state: next.current,
@@ -113,7 +113,7 @@ mod test {
         assert_eq!(c.queue, CardQueue::PreviewRepeat);
 
         // good
-        let next = col.get_next_card_states(c.id)?;
+        let next = col.get_scheduling_states(c.id)?;
         col.answer_card(&mut CardAnswer {
             card_id: c.id,
             current_state: next.current,
@@ -127,7 +127,7 @@ mod test {
         assert_eq!(c.queue, CardQueue::PreviewRepeat);
 
         // and then it should return to its old state once easy selected
-        let next = col.get_next_card_states(c.id)?;
+        let next = col.get_scheduling_states(c.id)?;
         col.answer_card(&mut CardAnswer {
             card_id: c.id,
             current_state: next.current,

--- a/rslib/src/scheduler/queue/mod.rs
+++ b/rslib/src/scheduler/queue/mod.rs
@@ -15,7 +15,7 @@ pub(crate) use learning::LearningQueueEntry;
 pub(crate) use main::{MainQueueEntry, MainQueueEntryKind};
 
 use self::undo::QueueUpdate;
-use super::{states::NextCardStates, timing::SchedTimingToday};
+use super::{states::SchedulingStates, timing::SchedTimingToday};
 use crate::{prelude::*, timestamp::TimestampSecs};
 
 #[derive(Debug)]
@@ -49,7 +49,7 @@ impl Counts {
 pub struct QueuedCard {
     pub card: Card,
     pub kind: QueueEntryKind,
-    pub next_states: NextCardStates,
+    pub states: SchedulingStates,
 }
 
 #[derive(Debug)]
@@ -96,11 +96,11 @@ impl Collection {
                 }
 
                 // fixme: pass in card instead of id
-                let next_states = self.get_next_card_states(card.id)?;
+                let next_states = self.get_scheduling_states(card.id)?;
 
                 Ok(QueuedCard {
                     card,
-                    next_states,
+                    states: next_states,
                     kind: entry.kind(),
                 })
             })

--- a/rslib/src/scheduler/states/filtered.rs
+++ b/rslib/src/scheduler/states/filtered.rs
@@ -2,7 +2,8 @@
 // License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
 use super::{
-    IntervalKind, NextCardStates, PreviewState, ReschedulingFilterState, ReviewState, StateContext,
+    IntervalKind, PreviewState, ReschedulingFilterState, ReviewState, SchedulingStates,
+    StateContext,
 };
 use crate::revlog::RevlogReviewKind;
 
@@ -27,7 +28,7 @@ impl FilteredState {
         }
     }
 
-    pub(crate) fn next_states(self, ctx: &StateContext) -> NextCardStates {
+    pub(crate) fn next_states(self, ctx: &StateContext) -> SchedulingStates {
         match self {
             FilteredState::Preview(state) => state.next_states(ctx),
             FilteredState::Rescheduling(state) => state.next_states(ctx),

--- a/rslib/src/scheduler/states/learning.rs
+++ b/rslib/src/scheduler/states/learning.rs
@@ -1,7 +1,7 @@
 // Copyright: Ankitects Pty Ltd and contributors
 // License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
-use super::{interval_kind::IntervalKind, CardState, NextCardStates, ReviewState, StateContext};
+use super::{interval_kind::IntervalKind, CardState, ReviewState, SchedulingStates, StateContext};
 use crate::revlog::RevlogReviewKind;
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -19,8 +19,8 @@ impl LearnState {
         RevlogReviewKind::Learning
     }
 
-    pub(crate) fn next_states(self, ctx: &StateContext) -> NextCardStates {
-        NextCardStates {
+    pub(crate) fn next_states(self, ctx: &StateContext) -> SchedulingStates {
+        SchedulingStates {
             current: self.into(),
             again: self.answer_again(ctx).into(),
             hard: self.answer_hard(ctx),

--- a/rslib/src/scheduler/states/mod.rs
+++ b/rslib/src/scheduler/states/mod.rs
@@ -47,7 +47,7 @@ impl CardState {
         }
     }
 
-    pub(crate) fn next_states(self, ctx: &StateContext) -> NextCardStates {
+    pub(crate) fn next_states(self, ctx: &StateContext) -> SchedulingStates {
         match self {
             CardState::Normal(state) => state.next_states(ctx),
             CardState::Filtered(state) => state.next_states(ctx),
@@ -139,7 +139,7 @@ impl<'a> StateContext<'a> {
 }
 
 #[derive(Debug, Clone)]
-pub struct NextCardStates {
+pub struct SchedulingStates {
     pub current: CardState,
     pub again: CardState,
     pub hard: CardState,

--- a/rslib/src/scheduler/states/normal.rs
+++ b/rslib/src/scheduler/states/normal.rs
@@ -2,7 +2,7 @@
 // License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
 use super::{
-    interval_kind::IntervalKind, LearnState, NewState, NextCardStates, RelearnState, ReviewState,
+    interval_kind::IntervalKind, LearnState, NewState, RelearnState, ReviewState, SchedulingStates,
     StateContext,
 };
 use crate::revlog::RevlogReviewKind;
@@ -34,7 +34,7 @@ impl NormalState {
         }
     }
 
-    pub(crate) fn next_states(self, ctx: &StateContext) -> NextCardStates {
+    pub(crate) fn next_states(self, ctx: &StateContext) -> SchedulingStates {
         match self {
             NormalState::New(_) => {
                 // New state acts like answering a failed learning card
@@ -44,7 +44,7 @@ impl NormalState {
                 }
                 .next_states(ctx);
                 // .. but with current as New, not Learning
-                NextCardStates {
+                SchedulingStates {
                     current: self.into(),
                     ..next_states
                 }

--- a/rslib/src/scheduler/states/preview_filter.rs
+++ b/rslib/src/scheduler/states/preview_filter.rs
@@ -1,7 +1,7 @@
 // Copyright: Ankitects Pty Ltd and contributors
 // License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
-use super::{IntervalKind, NextCardStates, StateContext};
+use super::{IntervalKind, SchedulingStates, StateContext};
 use crate::revlog::RevlogReviewKind;
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -19,8 +19,8 @@ impl PreviewState {
         RevlogReviewKind::Filtered
     }
 
-    pub(crate) fn next_states(self, ctx: &StateContext) -> NextCardStates {
-        NextCardStates {
+    pub(crate) fn next_states(self, ctx: &StateContext) -> SchedulingStates {
+        SchedulingStates {
             current: self.into(),
             again: PreviewState {
                 scheduled_secs: ctx.preview_step * 60,

--- a/rslib/src/scheduler/states/relearning.rs
+++ b/rslib/src/scheduler/states/relearning.rs
@@ -2,7 +2,7 @@
 // License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
 use super::{
-    interval_kind::IntervalKind, CardState, LearnState, NextCardStates, ReviewState, StateContext,
+    interval_kind::IntervalKind, CardState, LearnState, ReviewState, SchedulingStates, StateContext,
 };
 use crate::revlog::RevlogReviewKind;
 
@@ -21,8 +21,8 @@ impl RelearnState {
         RevlogReviewKind::Relearning
     }
 
-    pub(crate) fn next_states(self, ctx: &StateContext) -> NextCardStates {
-        NextCardStates {
+    pub(crate) fn next_states(self, ctx: &StateContext) -> SchedulingStates {
+        SchedulingStates {
             current: self.into(),
             again: self.answer_again(ctx),
             hard: self.answer_hard(ctx),

--- a/rslib/src/scheduler/states/rescheduling_filter.rs
+++ b/rslib/src/scheduler/states/rescheduling_filter.rs
@@ -2,7 +2,7 @@
 // License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
 use super::{
-    interval_kind::IntervalKind, normal::NormalState, CardState, NextCardStates, StateContext,
+    interval_kind::IntervalKind, normal::NormalState, CardState, SchedulingStates, StateContext,
 };
 use crate::revlog::RevlogReviewKind;
 
@@ -20,10 +20,10 @@ impl ReschedulingFilterState {
         self.original_state.revlog_kind()
     }
 
-    pub(crate) fn next_states(self, ctx: &StateContext) -> NextCardStates {
+    pub(crate) fn next_states(self, ctx: &StateContext) -> SchedulingStates {
         let normal = self.original_state.next_states(ctx);
         if ctx.in_filtered_deck {
-            NextCardStates {
+            SchedulingStates {
                 current: self.into(),
                 again: maybe_wrap(normal.again),
                 hard: maybe_wrap(normal.hard),

--- a/rslib/src/scheduler/states/review.rs
+++ b/rslib/src/scheduler/states/review.rs
@@ -2,7 +2,8 @@
 // License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
 use super::{
-    interval_kind::IntervalKind, CardState, LearnState, NextCardStates, RelearnState, StateContext,
+    interval_kind::IntervalKind, CardState, LearnState, RelearnState, SchedulingStates,
+    StateContext,
 };
 use crate::revlog::RevlogReviewKind;
 
@@ -52,10 +53,10 @@ impl ReviewState {
         }
     }
 
-    pub(crate) fn next_states(self, ctx: &StateContext) -> NextCardStates {
+    pub(crate) fn next_states(self, ctx: &StateContext) -> SchedulingStates {
         let (hard_interval, good_interval, easy_interval) = self.passing_review_intervals(ctx);
 
-        NextCardStates {
+        SchedulingStates {
             current: self.into(),
             again: self.answer_again(ctx),
             hard: self.answer_hard(hard_interval).into(),

--- a/ts/reviewer/BUILD.bazel
+++ b/ts/reviewer/BUILD.bazel
@@ -19,7 +19,6 @@ typescript(
         "//ts/lib",
         "@npm//css-browser-selector",
         "@npm//jquery",
-        "@npm//lodash-es",
     ],
 )
 

--- a/ts/reviewer/BUILD.bazel
+++ b/ts/reviewer/BUILD.bazel
@@ -19,6 +19,7 @@ typescript(
         "//ts/lib",
         "@npm//css-browser-selector",
         "@npm//jquery",
+        "@npm//lodash-es",
     ],
 )
 

--- a/ts/reviewer/answering.ts
+++ b/ts/reviewer/answering.ts
@@ -1,41 +1,68 @@
 // Copyright: Ankitects Pty Ltd and contributors
 // License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
+import { cloneDeep } from "lodash-es";
+
 import { postRequest } from "../lib/postrequest";
 import { Scheduler } from "../lib/proto";
 
-async function getCustomScheduling(): Promise<Scheduler.CustomScheduling> {
-    return Scheduler.CustomScheduling.decode(
+interface CustomDataStates {
+    again: Record<string, unknown>;
+    hard: Record<string, unknown>;
+    good: Record<string, unknown>;
+    easy: Record<string, unknown>;
+}
+
+async function getCustomScheduling(): Promise<Scheduler.CurrentCustomScheduling> {
+    return Scheduler.CurrentCustomScheduling.decode(
         await postRequest("/_anki/getCustomScheduling", ""),
     );
 }
 
 async function setCustomScheduling(
     key: string,
-    scheduling: Scheduler.CustomScheduling,
+    scheduling: Scheduler.NextCustomScheduling,
 ): Promise<void> {
-    const bytes = Scheduler.CustomScheduling.encode(scheduling).finish();
+    const bytes = Scheduler.NextCustomScheduling.encode(scheduling).finish();
     await postRequest("/_anki/setCustomScheduling", bytes, { key });
+}
+
+function buildCustomDataStates(serializedCustomData: string): CustomDataStates {
+    let currentCustomData = {};
+    try {
+        currentCustomData = JSON.parse(serializedCustomData);
+    } catch {
+        // can't be parsed
+    }
+    const customData = {
+        again: cloneDeep(currentCustomData),
+        hard: cloneDeep(currentCustomData),
+        good: cloneDeep(currentCustomData),
+        easy: currentCustomData,
+    };
+    return customData;
+}
+
+function buildNextCustomScheduling(
+    states: Scheduler.NextCardStates,
+    customData: CustomDataStates,
+): Scheduler.NextCustomScheduling {
+    return Scheduler.NextCustomScheduling.create({
+        states,
+        againCustomData: JSON.stringify(customData.again),
+        hardCustomData: JSON.stringify(customData.hard),
+        goodCustomData: JSON.stringify(customData.good),
+        easyCustomData: JSON.stringify(customData.easy),
+    });
 }
 
 export async function mutateNextCardStates(
     key: string,
-    mutator: (
-        states: Scheduler.NextCardStates,
-        customData: Record<string, unknown>,
-    ) => void,
+    mutator: (states: Scheduler.NextCardStates, customData: CustomDataStates) => void,
 ): Promise<void> {
     const scheduling = await getCustomScheduling();
-    let customData = {};
-    try {
-        customData = JSON.parse(scheduling.customData);
-    } catch {
-        // can't be parsed
-    }
-
+    const customData = buildCustomDataStates(scheduling.customData);
     mutator(scheduling.states!, customData);
-
-    scheduling.customData = JSON.stringify(customData);
-
-    await setCustomScheduling(key, scheduling);
+    const nextScheduling = buildNextCustomScheduling(scheduling.states!, customData);
+    await setCustomScheduling(key, nextScheduling);
 }

--- a/ts/reviewer/answering.ts
+++ b/ts/reviewer/answering.ts
@@ -34,10 +34,10 @@ function unpackCustomData(states: Scheduler.SchedulingStates): CustomDataStates 
         }
     };
     return {
-        again: toObject(states.again!.customData),
-        hard: toObject(states.hard!.customData),
-        good: toObject(states.good!.customData),
-        easy: toObject(states.easy!.customData),
+        again: toObject(states.current!.customData!),
+        hard: toObject(states.current!.customData!),
+        good: toObject(states.current!.customData!),
+        easy: toObject(states.current!.customData!),
     };
 }
 

--- a/ts/reviewer/answering.ts
+++ b/ts/reviewer/answering.ts
@@ -44,7 +44,7 @@ function buildCustomDataStates(serializedCustomData: string): CustomDataStates {
 }
 
 function buildNextCustomScheduling(
-    states: Scheduler.NextCardStates,
+    states: Scheduler.SchedulingStates,
     customData: CustomDataStates,
 ): Scheduler.NextCustomScheduling {
     return Scheduler.NextCustomScheduling.create({
@@ -58,7 +58,7 @@ function buildNextCustomScheduling(
 
 export async function mutateNextCardStates(
     key: string,
-    mutator: (states: Scheduler.NextCardStates, customData: CustomDataStates) => void,
+    mutator: (states: Scheduler.SchedulingStates, customData: CustomDataStates) => void,
 ): Promise<void> {
     const scheduling = await getCustomScheduling();
     const customData = buildCustomDataStates(scheduling.customData);


### PR DESCRIPTION
https://github.com/ankitects/anki/pull/2040#issuecomment-1235288957

I started by adding a `custom_data` field to `SchedulingState`, but since this message is mapped to a Rust enum and included in a whole bunch of data types (which are mostly `Copy`), this would have required a huge refactoring.
The frontend can handle it with a lot less code and redundancy. It's not perfect, but the best I could come up with.