### PR TITLE
Add back overflow:hidden to field descriptions

### DIFF
--- a/ts/editor/FieldDescription.svelte
+++ b/ts/editor/FieldDescription.svelte
@@ -43,6 +43,10 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         /* Stay a on single line */
         white-space: nowrap;
         text-overflow: ellipsis;
+
+        /* The field description is placed absolutely on top of the editor field */
+        /* So we need to make sure it does not escape the editor field if the */
+        /* description is too long */
         overflow: hidden;
     }
 </style>

--- a/ts/editor/FieldDescription.svelte
+++ b/ts/editor/FieldDescription.svelte
@@ -43,5 +43,6 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         /* Stay a on single line */
         white-space: nowrap;
         text-overflow: ellipsis;
+        overflow: hidden;
     }
 </style>


### PR DESCRIPTION
When I was trying to cleanup unnecessary overflow:hidden in #2011, this one got under the bus.


Mentioned in #2056 