### PR TITLE
Fix/autofix empty div

### DIFF
--- a/ts/editor/rich-text-input/transform.ts
+++ b/ts/editor/rich-text-input/transform.ts
@@ -43,7 +43,7 @@ function adjustOutputFragment(fragment: DocumentFragment): void {
         fragment.lastChild.remove();
     }
 
-    for (const divElement of fragment.querySelectorAll('div:empty')) {
+    for (const divElement of fragment.querySelectorAll("div:empty")) {
         divElement.remove();
     }
 }

--- a/ts/editor/rich-text-input/transform.ts
+++ b/ts/editor/rich-text-input/transform.ts
@@ -19,7 +19,7 @@ function adjustInputHTML(html: string): string {
 
 function adjustInputFragment(fragment: DocumentFragment): void {
     if (nodeContainsInlineContent(fragment)) {
-        fragment.appendChild(document.createElement("br"));
+        fragment.append(document.createElement("br"));
     }
 }
 
@@ -35,12 +35,12 @@ export function storedToFragment(storedHTML: string): DocumentFragment {
 
 function adjustOutputFragment(fragment: DocumentFragment): void {
     if (
-        fragment.hasChildNodes() &&
-        nodeIsElement(fragment.lastChild!) &&
         nodeContainsInlineContent(fragment) &&
-        fragment.lastChild!.tagName === "BR"
+        fragment.lastChild &&
+        nodeIsElement(fragment.lastChild) &&
+        fragment.lastChild.tagName === "BR"
     ) {
-        fragment.lastChild!.remove();
+        fragment.lastChild.remove();
     }
 
     for (const divElement of fragment.querySelectorAll('div:empty')) {

--- a/ts/editor/rich-text-input/transform.ts
+++ b/ts/editor/rich-text-input/transform.ts
@@ -42,6 +42,10 @@ function adjustOutputFragment(fragment: DocumentFragment): void {
     ) {
         fragment.lastChild!.remove();
     }
+
+    for (const divElement of fragment.querySelectorAll('div:empty')) {
+        divElement.remove();
+    }
 }
 
 function adjustOutputHTML(html: string): string {


### PR DESCRIPTION
Closes #2065

This will strip out not only single empty divs, but it will strip any empty divs from the field content. I think that should be fine because empty divs are generally invisible in the visual editor