### PR TITLE
Apply border radius of plain text input to code mirror as well

### DIFF
--- a/ts/editor/plain-text-input/PlainTextInput.svelte
+++ b/ts/editor/plain-text-input/PlainTextInput.svelte
@@ -164,19 +164,28 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         border-top: 1px solid var(--border);
         border-radius: 0 0 5px 5px;
 
+        :global(.CodeMirror) {
+            background: var(--code-bg);
+            border-radius: 0 0 5px 5px;
+        }
+
         &.is-default {
             border-top: none;
             border-bottom: 1px solid var(--border);
             border-radius: 5px 5px 0 0;
+
+            :global(.CodeMirror) {
+                border-radius: 5px 5px 0 0;
+            }
         }
 
         &.alone {
             border: none;
             border-radius: 5px;
-        }
 
-        :global(.CodeMirror) {
-            background: var(--code-bg);
+            :global(.CodeMirror) {
+                border-radius: 5px;
+            }
         }
 
         :global(.CodeMirror-lines) {


### PR DESCRIPTION
The code mirrors borders were drawing on top of our rounded corners.

<img width="965" alt="Bildschirmfoto 2022-09-13 um 02 01 41" src="https://user-images.githubusercontent.com/7188844/189779282-658b6fbe-b442-4879-9166-18c0855a48aa.png">
