### PR TITLE
Fix Windows dark mode detection: OpenKey can fail

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -105,6 +105,7 @@ dobefore <1432338032@qq.com>
 Bart Louwers <bart.git@emeel.net>
 Sam Penny <github.com/sam1penny>
 Yutsuten <mateus.etto@gmail.com>
+Zoom <zoomrmc+git@gmail.com>
 
 ********************
 

--- a/qt/aqt/theme.py
+++ b/qt/aqt/theme.py
@@ -297,11 +297,11 @@ def get_windows_dark_mode() -> bool:
         QueryValueEx,
     )
 
-    key = OpenKey(
-        HKEY_CURRENT_USER,
-        r"Software\Microsoft\Windows\CurrentVersion\Themes\Personalize",
-    )
     try:
+        key = OpenKey(
+            HKEY_CURRENT_USER,
+            r"Software\Microsoft\Windows\CurrentVersion\Themes\Personalize",
+        )
         return not QueryValueEx(key, "AppsUseLightTheme")[0]
     except Exception as err:
         # key reportedly missing or set to wrong type on some systems


### PR DESCRIPTION
#1497 introduced reading hardcoded Windows Registry key, which assumes key exists. This is not true on Windows 7. Later addition of `try-except` block missed that winreg.OpenKey might fail.

This fix allows launching current version of Anki on Windows 7 when installed with Pip with the [modified Python 3.9](https://github.com/NulAsh/cpython) installation.