### PR TITLE
Fix Qt styles getting duplicated with every stylesheet

### DIFF
--- a/qt/aqt/stylesheets.py
+++ b/qt/aqt/stylesheets.py
@@ -26,8 +26,8 @@ qlineargradient(
     """
 
 
-def general_styles(tm: ThemeManager, buf: str) -> str:
-    buf += f"""
+def general_styles(tm: ThemeManager) -> str:
+    return f"""
 QFrame {{
     background: none;
 }}
@@ -59,11 +59,10 @@ QToolTip {{
     background: {tm.var(colors.CANVAS_OVERLAY)};
 }}
     """
-    return buf
 
 
-def button_styles(tm: ThemeManager, buf: str) -> str:
-    buf += f"""
+def button_styles(tm: ThemeManager) -> str:
+    return f"""
 QPushButton,
 QTabBar::tab:!selected,
 QComboBox:!editable {{
@@ -96,11 +95,10 @@ QComboBox:!editable:pressed {{
     };
 }}
     """
-    return buf
 
 
-def splitter_styles(tm: ThemeManager, buf: str) -> str:
-    buf += f"""
+def splitter_styles(tm: ThemeManager) -> str:
+    return f"""
 QSplitter::handle,
 QMainWindow::separator {{
     height: 16px;
@@ -114,11 +112,10 @@ QMainWindow::separator:vertical {{
     image: url({tm.themed_icon("mdi:drag-vertical-FG_SUBTLE")});
 }}
 """
-    return buf
 
 
-def combobox_styles(tm: ThemeManager, buf: str) -> str:
-    buf += f"""
+def combobox_styles(tm: ThemeManager) -> str:
+    return f"""
 QComboBox {{
     padding: 1px 4px 2px 6px;
 }}
@@ -175,11 +172,10 @@ QComboBox::drop-down:hover {{
     };
 }}
     """
-    return buf
 
 
-def tabwidget_styles(tm: ThemeManager, buf: str) -> str:
-    buf += f"""
+def tabwidget_styles(tm: ThemeManager) -> str:
+    return f"""
 QTabWidget {{
   border-radius: {tm.var(props.BORDER_RADIUS)};
   background: none;
@@ -223,11 +219,10 @@ QTabBar::tab:selected {{
     };
 }}
     """
-    return buf
 
 
-def table_styles(tm: ThemeManager, buf: str) -> str:
-    buf += f"""
+def table_styles(tm: ThemeManager) -> str:
+    return f"""
 QTableView {{
     border-radius: {tm.var(props.BORDER_RADIUS)};
     gridline-color: {tm.var(colors.BORDER)};
@@ -294,11 +289,10 @@ QHeaderView::down-arrow {{
     image: url({tm.themed_icon("mdi:menu-down")});
 }}
     """
-    return buf
 
 
-def spinbox_styles(tm: ThemeManager, buf: str) -> str:
-    buf += f"""
+def spinbox_styles(tm: ThemeManager) -> str:
+    return f"""
 QSpinBox::up-button,
 QSpinBox::down-button {{
     subcontrol-origin: border;
@@ -370,11 +364,10 @@ QSpinBox::down-arrow:off {{
     image: url({tm.themed_icon("mdi:chevron-down-FG_DISABLED")});
 }}
      """
-    return buf
 
 
-def checkbox_styles(tm: ThemeManager, buf: str) -> str:
-    buf += f"""
+def checkbox_styles(tm: ThemeManager) -> str:
+    return f"""
 QCheckBox {{
     spacing: 8px;
     margin: 2px 0;
@@ -399,11 +392,10 @@ QCheckBox::indicator:indeterminate {{
     image: url({tm.themed_icon("mdi:minus-thick")});
 }}
     """
-    return buf
 
 
-def scrollbar_styles(tm: ThemeManager, buf: str) -> str:
-    buf += f"""
+def scrollbar_styles(tm: ThemeManager) -> str:
+    return f"""
 QAbstractScrollArea::corner {{
     background: none;
     border: none;
@@ -443,32 +435,28 @@ QScrollBar::sub-line {{
       background: none;
 }}
     """
-    return buf
 
 
-def win10_styles(tm: ThemeManager, buf: str) -> str:
-
-    # day mode is missing a bottom border; background must be
-    # also set for border to apply
-    buf += f"""
+def win10_styles(tm: ThemeManager) -> str:
+    styles = f"""
+/* day mode is missing a bottom border; background must be
+   also set for border to apply */
 QMenuBar {{
   border-bottom: 1px solid {tm.var(colors.BORDER)};
   background: {tm.var(colors.CANVAS) if tm.night_mode else "white"};
 }}
-    """
 
-    # qt bug? setting the above changes the browser sidebar
-    # to white as well, so set it back
-    buf += f"""
+/* qt bug? setting the above changes the browser sidebar
+   to white as well, so set it back */
 QTreeWidget {{
   background: {tm.var(colors.CANVAS)};
 }}
     """
 
     if tm.night_mode:
-        buf += """
+        styles += """
 QToolTip {
   border: 0;
 }
         """
-    return buf
+    return styles

--- a/qt/aqt/theme.py
+++ b/qt/aqt/theme.py
@@ -206,7 +206,7 @@ class ThemeManager:
     def _apply_style(self, app: QApplication) -> None:
         from aqt.stylesheets import splitter_styles
 
-        buf = splitter_styles(self, "")
+        buf = splitter_styles(self)
 
         if not is_mac:
             from aqt.stylesheets import (
@@ -223,19 +223,19 @@ class ThemeManager:
 
             buf += "".join(
                 [
-                    general_styles(self, buf),
-                    button_styles(self, buf),
-                    combobox_styles(self, buf),
-                    tabwidget_styles(self, buf),
-                    table_styles(self, buf),
-                    spinbox_styles(self, buf),
-                    checkbox_styles(self, buf),
-                    scrollbar_styles(self, buf),
+                    general_styles(self),
+                    button_styles(self),
+                    combobox_styles(self),
+                    tabwidget_styles(self),
+                    table_styles(self),
+                    spinbox_styles(self),
+                    checkbox_styles(self),
+                    scrollbar_styles(self),
                 ]
             )
 
         if is_win and platform.release() == "10":
-            buf += win10_styles(self, buf)
+            buf += win10_styles(self)
 
         # allow addons to modify the styling
         buf = gui_hooks.style_did_init(buf)


### PR DESCRIPTION
I used the `buf +=` approach in `stylesheets.py` without much thought. Yesterday I noticed I'm concatenating the styles in `theme.py` anyway, so it is absolutely not necessary to pass `buf`, which actually duplicated the styles over and over again resulting in a huge stylesheet.