### PR TITLE
Fix pm.night_mode()

### DIFF
--- a/qt/aqt/profiles.py
+++ b/qt/aqt/profiles.py
@@ -15,6 +15,7 @@ from typing import TYPE_CHECKING, Any
 import anki.lang
 import aqt.forms
 import aqt.sound
+from anki._legacy import deprecated
 from anki.collection import Collection
 from anki.db import DB
 from anki.lang import without_unicode_isolation
@@ -534,6 +535,7 @@ create table if not exists profiles
     def set_last_addon_update_check(self, secs: int) -> None:
         self.meta["last_addon_update_check"] = secs
 
+    @deprecated(info="use theme_manager.night_mode")
     def night_mode(self) -> bool:
         return theme_manager.night_mode
 

--- a/qt/aqt/profiles.py
+++ b/qt/aqt/profiles.py
@@ -22,7 +22,7 @@ from anki.sync import SyncAuth
 from anki.utils import int_time, is_mac, is_win, point_version
 from aqt import appHelpSite
 from aqt.qt import *
-from aqt.theme import Theme
+from aqt.theme import Theme, theme_manager
 from aqt.utils import disable_help_button, send_to_trash, showWarning, tr
 
 if TYPE_CHECKING:
@@ -535,10 +535,7 @@ create table if not exists profiles
         self.meta["last_addon_update_check"] = secs
 
     def night_mode(self) -> bool:
-        return self.meta.get("night_mode", False)
-
-    def set_night_mode(self, on: bool) -> None:
-        self.meta["night_mode"] = on
+        return theme_manager.night_mode
 
     def theme(self) -> Theme:
         return Theme(self.meta.get("theme", 0))


### PR DESCRIPTION
`pm.night_mode()` is used by some add-ons, but it now always returns False. Looks like it should have been updated in #1497. I've also removed `set_night_mode()` as it doesn't appear to be used by any add-ons.