### PR TITLE
Add API shim for webview.get_window_bg_color

### DIFF
--- a/qt/aqt/webview.py
+++ b/qt/aqt/webview.py
@@ -717,8 +717,6 @@ html {{ {font} }}
 """
         )
 
-    @deprecated(
-        info="webview.get_window_bg_color() is deprecated. Use theme_manager.qcolor() instead"
-    )
+    @deprecated(info="use theme_manager.qcolor() instead")
     def get_window_bg_color(self, night_mode: Optional[bool] = None) -> QColor:
         return theme_manager.qcolor(colors.CANVAS)

--- a/qt/aqt/webview.py
+++ b/qt/aqt/webview.py
@@ -9,6 +9,7 @@ from typing import Any, Callable, Optional, Sequence, cast
 
 import anki
 import anki.lang
+from anki._legacy import deprecated
 from anki.lang import is_rtl
 from anki.utils import is_lin, is_mac, is_win
 from aqt import colors, gui_hooks
@@ -715,3 +716,9 @@ html {{ {font} }}
 }})();
 """
         )
+
+    @deprecated(
+        info="webview.get_window_bg_color() is deprecated. Use theme_manager.qcolor() instead"
+    )
+    def get_window_bg_color(self, night_mode: Optional[bool] = None) -> QColor:
+        return theme_manager.qcolor(colors.CANVAS)


### PR DESCRIPTION
@dae, it looks like there was a small breakage with the AMBOSS add-on after all, but in `WebView` APIs rather than `ThemeManager`. Hope this is OK to add for now while the add-on transitions away from this API.

----

*Copyright disclosure: This patch was written as part of my work for AMBOSS. Its rights of use lie with AMBOSS MD Inc and it is being submitted in agreement with Anki's contributor license agreement, as signed by AMBOSS MD Inc. (see the `CONTRIBUTORS` file).*