### PR TITLE
Fix scrolling with keys / keyboard event listeners not working on answer side

### DIFF
--- a/qt/aqt/reviewer.py
+++ b/qt/aqt/reviewer.py
@@ -653,12 +653,6 @@ class Reviewer:
     def _onTypedAnswer(self, val: None) -> None:
         self.typedAnswer = val or ""
         self._showAnswer()
-        self.unfocus_typing_box()
-
-    def unfocus_typing_box(self) -> None:
-        # shifting focus to the bottom area works around a WebEngine/IME bug
-        # https://github.com/ankitects/anki/issues/1952
-        self.bottom.web.setFocus()
 
     # Bottom bar
     ##########################################################################

--- a/qt/aqt/webview.py
+++ b/qt/aqt/webview.py
@@ -293,8 +293,9 @@ class AnkiWebView(QWebEngineView):
                     w.close()
                 else:
                     # in the main window, removes focus from type in area
-                    if mw.state == "review":
-                        mw.reviewer.unfocus_typing_box()
+                    parent = self.parent()
+                    assert isinstance(parent, QWidget)
+                    parent.setFocus()
                 break
             w = w.parent()
 

--- a/ts/reviewer/index.ts
+++ b/ts/reviewer/index.ts
@@ -237,3 +237,17 @@ export function _blockDefaultDragDropBehavior(): void {
     document.ondragover = handler;
     document.ondrop = handler;
 }
+
+// work around WebEngine/IME bug in Qt6
+// https://github.com/ankitects/anki/issues/1952
+const dummyButton = document.createElement("button");
+dummyButton.style.position = "absolute";
+dummyButton.style.left = "-9999px";
+document.addEventListener("focusout", (event) => {
+    const target = event.target;
+    if (target instanceof HTMLInputElement || target instanceof HTMLTextAreaElement) {
+        document.body.appendChild(dummyButton);
+        dummyButton.focus();
+        document.body.removeChild(dummyButton);
+    }
+});


### PR DESCRIPTION
### Issue
Page scrolling with arrow keys or PageUp/Down does not work on the answer side. Also, keyboard event listeners set in the card template do not work on the answer side.

The issue appears to have been introduced in the commit 5bf031f. I have come up with a better workaround for #1952, inspired by 5bf031f. Not only does this not cause the above issue, it also works around #1952 a little better. With 5bf031f, once you turn the IME on, clicking somewhere other than the type box to take focus away from the type box does not turn the IME off, so you cannot use the shortcut keys. However, with this workaround, the IME will be  turned off.

### Tested with
| OS | Input Method | Note |
| ---- | ---- | ---- |
| Win10 | MS Japanese IME | |
| Win10 | Google Japanese Input | |
| Lubuntu 22.04 | iBus + Mozc | Even after this PR, when the focus is lost from the type box, the task tray icon of Mozc remains <kbd>あ</kbd> (i.e., it does not change to <kbd>A</kbd>) so it does not look like the IME is turned off, but the shortcut keys will actually work. |