### PR TITLE
Fix duplicate highlight and improve its look

### DIFF
--- a/ts/editor/EditingArea.svelte
+++ b/ts/editor/EditingArea.svelte
@@ -199,7 +199,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
             inset: 0;
             pointer-events: none;
             border-radius: 5px;
-            box-shadow: 0 0 2px 1px var(--shadow);
+            box-shadow: 0 0 0 3px var(--dupes-color), 0 0 2px 1px var(--shadow);
             transition: box-shadow 80ms cubic-bezier(0.33, 1, 0.68, 1);
         }
 
@@ -208,7 +208,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
             &::after {
                 border: none;
                 inset: 1px;
-                box-shadow: 0 0 0 2px var(--border-focus);
+                box-shadow: 0 0 0 3px var(--dupes-color), 0 0 0 2px var(--border-focus);
             }
         }
     }

--- a/ts/editor/LabelContainer.svelte
+++ b/ts/editor/LabelContainer.svelte
@@ -44,8 +44,6 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         top: 0;
         z-index: 10;
 
-        background: var(--label-color);
-
         .clickable {
             cursor: pointer;
         }

--- a/ts/editor/NoteEditor.svelte
+++ b/ts/editor/NoteEditor.svelte
@@ -416,9 +416,9 @@ the AddCards dialog) should be implemented in the user of this component.
                                 $hoveredField = null;
                             }}
                             collapsed={fieldsCollapsed[index]}
-                            --label-color={cols[index] === "dupe"
-                                ? "palette-of(flag-1)"
-                                : "palette-of(canvas)"}
+                            --dupes-color={cols[index] === "dupe"
+                                ? "var(--accent-danger)"
+                                : "transparent"}
                         >
                             <svelte:fragment slot="field-label">
                                 <LabelContainer


### PR DESCRIPTION
Closes #2098.

The big red highlight bar looks off on the new fields. To keep that look, I would have had to manage border-radii with variables (or cut overflow, but that's no good either). I went for a box-shadow color change on `EditingArea` instead, which looks more elegant anyway.