### PR TITLE
Use showText to show add-on import errors

### DIFF
--- a/qt/aqt/addons.py
+++ b/qt/aqt/addons.py
@@ -45,6 +45,7 @@ from aqt.utils import (
     send_to_trash,
     show_info,
     showInfo,
+    showText,
     showWarning,
     tooltip,
     tr,
@@ -246,11 +247,15 @@ class AddonManager:
             except AbortAddonImport:
                 pass
             except:
-                showWarning(
-                    tr.addons_failed_to_load(
-                        name=addon.human_name(),
-                        traceback=traceback.format_exc(),
-                    )
+                error = tr.addons_failed_to_load(
+                    name=addon.human_name(),
+                    traceback=traceback.format_exc(),
+                )
+                txt = f"<h1>{tr.qt_misc_error()}</h1><div style='white-space: pre-wrap'>{error}</div>"
+                showText(
+                    txt,
+                    type="html",
+                    copyBtn=True,
                 )
 
     def onAddonsDialog(self) -> None:


### PR DESCRIPTION
Long error messages can be completely unreadable as QMessageBox doesn't show a scrollbar and the text can't be selected and copied by default (on Windows at least).