### PR TITLE
fix css var not renamed

### DIFF
--- a/ts/components/FloatingArrow.svelte
+++ b/ts/components/FloatingArrow.svelte
@@ -12,7 +12,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     @use "sass/elevation" as elevation;
 
     .arrow {
-        background-color: var(--frame-bg);
+        background-color: var(--canvas-elevated);
         width: 10px;
         height: 10px;
         z-index: 60;


### PR DESCRIPTION
This PR fixes a variable that should have been renamed in #2016

I think you also missed `--highlight-fg` and `--highlight-bg` in `DropDownItem.svelte`, but I wasn't sure which color this should reference instead.