### PR TITLE
Decrease minimum value of interval modifier

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -106,6 +106,7 @@ Bart Louwers <bart.git@emeel.net>
 Sam Penny <github.com/sam1penny>
 Yutsuten <mateus.etto@gmail.com>
 Zoom <zoomrmc+git@gmail.com>
+Taylor Raack <taylor@raack.info>
 
 ********************
 

--- a/ts/deck-options/AdvancedOptions.svelte
+++ b/ts/deck-options/AdvancedOptions.svelte
@@ -62,7 +62,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
             <SpinBoxFloatRow
                 bind:value={$config.intervalMultiplier}
                 defaultValue={defaults.intervalMultiplier}
-                min={0.5}
+                min={0.1}
                 max={2}
                 markdownTooltip={tr.deckConfigIntervalModifierTooltip()}
             >


### PR DESCRIPTION
I'm proposing a change to the minimum value of the interval modifier in the advanced settings for a deck.

[The interval modifier documentation suggests that retaining 90% of knowledge of mature cards is a reasonable target](https://docs.ankiweb.net/deck-options.html#interval-modifier). Further, it suggests that by computing `log(desired retention%) / log(current retention%)`, the resulting value can be used as an interval modifier. For example, if the current retention is 60%, and the target is 90%, the interval modifier should be `log(0.9)/log(0.6) = 0.21`.

The minimum value of the interval modifier is currently 0.5. This minimum prevents using an appropriately calculated interval modifier for any current retention value less than 81% (`log(0.9)/log(0.81) = 0.5`).

I believe it's reasonable that some users might have a current retention value less than 81% (I do on some decks). Rather than forcing a user to restructure or ignore certain notes rather than set an artificially high interval modifier, I propose that the minimum value be lowered. I've arbitrarily chosen a new minimum value of 0.1. This would allow a user whose target is 90% and current retention of 35% or higher to set an appropriately calculated interval modifier (`log(0.9)/log(0.35)=0.1`).