### PR TITLE
Add min-width to QPushButton stylesheet

### DIFF
--- a/qt/aqt/stylesheets.py
+++ b/qt/aqt/stylesheets.py
@@ -63,6 +63,9 @@ QToolTip {{
 
 def button_styles(tm: ThemeManager) -> str:
     return f"""
+QPushButton {{
+    min-width: 75px;
+}}
 QPushButton,
 QTabBar::tab:!selected,
 QComboBox:!editable {{


### PR DESCRIPTION
[Quote](https://forums.ankiweb.net/t/anki-2-1-55-beta/23470/5?u=kleinerpirat) from forum user jcznk:
> Regarding the design, I like most changes, but I I think some buttons are a little bit too small. To make a comparison:
>
>![image](https://user-images.githubusercontent.com/62722460/194719984-0be338f3-d89e-4ce1-bd90-09076b5f8c1e.png)

## Before
![image](https://user-images.githubusercontent.com/62722460/194720223-935da12e-84ff-4b2d-935a-7a2c1845e5b5.png)
## After
![image](https://user-images.githubusercontent.com/62722460/194720262-0ec4929f-766d-4869-a235-1a16e7e9f400.png)

I couldn't set up a dev build on Windows so far (hard to debug under bombardment of forced updates and loud fan noises :), but I'm confident this works regardless.