### PR TITLE
Experiment with labelled note view switch

### DIFF
--- a/ftl/core/browsing.ftl
+++ b/ftl/core/browsing.ftl
@@ -12,6 +12,7 @@ browsing-browser-appearance = Browser Appearance
 browsing-browser-options = Browser Options
 browsing-buried = Buried
 browsing-card = Card
+browsing-cards = Cards
 # Exactly one character representing 'Cards'; should differ from browsing-note-initial.
 browsing-card-initial = C
 browsing-card-list = Card List
@@ -59,6 +60,7 @@ browsing-new-note-type = New note type:
 browsing-no-flag = No Flag
 browsing-no-selection = No cards or notes selected.
 browsing-note = Note
+browsing-notes = Notes
 # Exactly one character representing 'Notes'; should differ from browsing-card-initial.
 browsing-note-initial = N
 browsing-optional-filter = Optional filter:

--- a/qt/aqt/browser/browser.py
+++ b/qt/aqt/browser/browser.py
@@ -496,7 +496,7 @@ class Browser(QMainWindow):
     def setup_table(self) -> None:
         self.table = Table(self)
         self.table.set_view(self.form.tableView)
-        switch = Switch(11, tr.browsing_card_initial(), tr.browsing_note_initial())
+        switch = Switch(12, tr.browsing_cards(), tr.browsing_notes())
         switch.setChecked(self.table.is_notes_mode())
         switch.setToolTip(tr.browsing_toggle_showing_cards_notes())
         qconnect(self.form.action_toggle_mode.triggered, switch.toggle)

--- a/qt/aqt/switch.py
+++ b/qt/aqt/switch.py
@@ -32,7 +32,7 @@ class Switch(QAbstractButton):
         self._left_color = left_color
         self._right_color = right_color
         self._path_radius = radius
-        self._knob_radius = radius - 1
+        self._knob_radius = radius - 2
         self._label_padding = 4
         self._left_knob_position = self._position = radius
         self._right_knob_position = self.width - self._path_radius
@@ -130,7 +130,7 @@ class Switch(QAbstractButton):
     def _current_knob_rectangle(self) -> QRectF:
         return QRectF(
             self.position - self._knob_radius,  # type: ignore
-            1,
+            2,
             2 * self._knob_radius,
             2 * self._knob_radius,
         )

--- a/qt/aqt/switch.py
+++ b/qt/aqt/switch.py
@@ -72,7 +72,8 @@ class Switch(QAbstractButton):
     @property
     def label_width(self) -> int:
         font = QFont()
-        font.setPixelSize(int(self._path_radius))
+        font.setPixelSize(int(self._knob_radius))
+        font.setWeight(QFont.Weight.Bold)
         fm = QFontMetrics(font)
         return (
             max(
@@ -150,7 +151,8 @@ class Switch(QAbstractButton):
     def _paint_label(self, painter: QPainter) -> None:
         painter.setPen(theme_manager.qcolor(colors.CANVAS))
         font = painter.font()
-        font.setPixelSize(int(self._path_radius))
+        font.setPixelSize(int(self._knob_radius))
+        font.setWeight(QFont.Weight.Bold)
         painter.setFont(font)
         painter.drawText(
             self._current_label_rectangle(), Qt.AlignmentFlag.AlignCenter, self.label

--- a/sass/_vars.scss
+++ b/sass/_vars.scss
@@ -195,8 +195,8 @@ $vars: (
         ),
         accent: (
             card: (
-                light: palette(blue, 3),
-                dark: palette(blue, 4),
+                light: palette(blue, 4),
+                dark: palette(blue, 3),
             ),
             note: (
                 light: palette(green, 5),


### PR DESCRIPTION
This [comment](https://forums.ankiweb.net/t/anki-2-1-55-beta/23470/30?u=kleinerpirat) by @RumovZ made me revisit the switch:
> I would make the knob smaller or the path larger, like the toggles in deck options. Curved hair lines can’t be rendered evenly.

I'm struggling to see the issue here. The line looks even to me and I think it's more elegant when the knob fits the path with minimal margin (like a well-fitted clockwork). But I'm happy to discuss this here.

## The idea of this PR
Initial letters don't convey the message to first-time users that well, so I thought a full text label would be preferable.

## Light
![image](https://user-images.githubusercontent.com/62722460/194763598-dbe3183e-7ee0-44c3-b05f-de259b3d251b.png) ![image](https://user-images.githubusercontent.com/62722460/194764538-79a25d1e-0aa5-48d4-9f14-d9e52b89dcf8.png)
![image](https://user-images.githubusercontent.com/62722460/194763627-395032c8-907d-4355-bf51-3abbbfba7b70.png) ![image](https://user-images.githubusercontent.com/62722460/194764549-55c2b14b-c374-44c2-906b-44b4414940f1.png)

## Dark
![image](https://user-images.githubusercontent.com/62722460/194763585-67fd0657-a9d0-47ff-8aa9-962c933b6e6f.png) ![image](https://user-images.githubusercontent.com/62722460/194764518-df9349f3-c8c1-4b8d-a86f-82c2e9b76d75.png)
![image](https://user-images.githubusercontent.com/62722460/194763633-8cfc16bb-a37b-40dc-bc6e-51089c8e9f4c.png) ![image](https://user-images.githubusercontent.com/62722460/194764526-2d65ce94-93d2-47f6-bf5d-5da29dfa1c52.png)

The longer of the two words sets the path length, so the switch won't change width on toggle.

I'm a bit torn because on the one hand, the status quo is smaller and drags less attention (better for advanced users), but on the other hand a full text label might make it easier to provide help to inexperienced users. WDYT?