### PR TITLE
Darken border colors in dark theme

### DIFF
--- a/sass/_vars.scss
+++ b/sass/_vars.scss
@@ -67,11 +67,11 @@ $vars: (
         border: (
             default: (
                 light: palette(lightgray, 6),
-                dark: palette(darkgray, 6),
+                dark: palette(darkgray, 7),
             ),
             subtle: (
                 light: palette(lightgray, 5),
-                dark: palette(darkgray, 4),
+                dark: palette(darkgray, 6),
             ),
             strong: (
                 light: palette(lightgray, 9),


### PR DESCRIPTION
Point 3 of https://forums.ankiweb.net/t/anki-2-1-55-beta/23470/30
## Before
![image](https://user-images.githubusercontent.com/62722460/194766858-13f41dee-1e98-44c7-8395-ca030da7acd4.png)
## After
![image](https://user-images.githubusercontent.com/62722460/194766852-8027bdf3-d2e9-41ef-ae56-a00bc075e70f.png)

I made the default border one shade darker here. @dae, you once suggested to make borders brighter than the background. Personally, I'd like to keep borders darker than the background. WDYT about this PR?