### PR TITLE
Fix QToolTip styling issue on Windows

### DIFF
--- a/qt/aqt/stylesheets.py
+++ b/qt/aqt/stylesheets.py
@@ -56,7 +56,9 @@ QSpinBox {{
     padding: 2px 6px;
 }}
 QToolTip {{
-    background: {tm.var(colors.CANVAS_OVERLAY)};
+    border: 1px solid {tm.var(colors.BORDER_STRONG)};
+    border-radius: {tm.var(props.BORDER_RADIUS)};
+    color: {tm.var(colors.FG)};
 }}
     """
 
@@ -448,7 +450,7 @@ QScrollBar::sub-line {{
 
 
 def win10_styles(tm: ThemeManager) -> str:
-    styles = f"""
+    return f"""
 /* day mode is missing a bottom border; background must be
    also set for border to apply */
 QMenuBar {{
@@ -462,11 +464,3 @@ QTreeWidget {{
   background: {tm.var(colors.CANVAS)};
 }}
     """
-
-    if tm.night_mode:
-        styles += """
-QToolTip {
-  border: 0;
-}
-        """
-    return styles


### PR DESCRIPTION
Point 4 of https://forums.ankiweb.net/t/anki-2-1-55-beta/23470/30

![image](https://user-images.githubusercontent.com/62722460/194767514-2b20722b-f4ad-47a7-bb44-bf671dbd2d71.png)

## PR
![image](https://user-images.githubusercontent.com/62722460/194767570-17756710-8541-4da7-9300-1c81719037cc.png)

@RumovZ does this fix the issue you mentioned on the forum?