### PR TITLE
Add stylesheet for QMenu

### DIFF
--- a/qt/aqt/__init__.py
+++ b/qt/aqt/__init__.py
@@ -345,27 +345,19 @@ class AnkiApp(QApplication):
     ##################################################
 
     def eventFilter(self, src: Any, evt: QEvent) -> bool:
+        pointer_classes = (
+            QPushButton,
+            QCheckBox,
+            QRadioButton,
+            QMenu,
+            # classes with PyQt5 compatibility proxy
+            without_qt5_compat_wrapper(QToolButton),
+            without_qt5_compat_wrapper(QTabBar),
+        )
         if evt.type() in [QEvent.Type.Enter, QEvent.Type.HoverEnter]:
-            if (
-                (
-                    isinstance(
-                        src,
-                        (
-                            QPushButton,
-                            QCheckBox,
-                            QRadioButton,
-                            QMenu,
-                            # classes with PyQt5 compatibility proxy
-                            without_qt5_compat_wrapper(QToolButton),
-                            without_qt5_compat_wrapper(QTabBar),
-                        ),
-                    )
-                )
-                and src.isEnabled()
-                or (
-                    isinstance(src, without_qt5_compat_wrapper(QComboBox))
-                    and not src.isEditable()
-                )
+            if (isinstance(src, pointer_classes) and src.isEnabled()) or (
+                isinstance(src, without_qt5_compat_wrapper(QComboBox))
+                and not src.isEditable()
             ):
                 self.setOverrideCursor(QCursor(Qt.CursorShape.PointingHandCursor))
             else:

--- a/qt/aqt/__init__.py
+++ b/qt/aqt/__init__.py
@@ -345,7 +345,7 @@ class AnkiApp(QApplication):
     ##################################################
 
     def eventFilter(self, src: Any, evt: QEvent) -> bool:
-        if evt.type() == QEvent.Type.HoverEnter:
+        if evt.type() in [QEvent.Type.Enter, QEvent.Type.HoverEnter]:
             if (
                 (
                     isinstance(
@@ -354,6 +354,7 @@ class AnkiApp(QApplication):
                             QPushButton,
                             QCheckBox,
                             QRadioButton,
+                            QMenu,
                             # classes with PyQt5 compatibility proxy
                             without_qt5_compat_wrapper(QToolButton),
                             without_qt5_compat_wrapper(QTabBar),

--- a/qt/aqt/addons.py
+++ b/qt/aqt/addons.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import html
 import io
 import json
 import os
@@ -45,6 +46,7 @@ from aqt.utils import (
     send_to_trash,
     show_info,
     showInfo,
+    showText,
     showWarning,
     tooltip,
     tr,
@@ -246,11 +248,17 @@ class AddonManager:
             except AbortAddonImport:
                 pass
             except:
-                showWarning(
+                error = html.escape(
                     tr.addons_failed_to_load(
                         name=addon.human_name(),
                         traceback=traceback.format_exc(),
                     )
+                )
+                txt = f"<h1>{tr.qt_misc_error()}</h1><div style='white-space: pre-wrap'>{error}</div>"
+                showText(
+                    txt,
+                    type="html",
+                    copyBtn=True,
                 )
 
     def onAddonsDialog(self) -> None:

--- a/qt/aqt/data/web/css/deckbrowser.scss
+++ b/qt/aqt/data/web/css/deckbrowser.scss
@@ -16,7 +16,7 @@ a.deck:hover {
 }
 
 tr.deck td {
-    border-bottom: 1px solid var(--border-subtle);
+    border-bottom: 1px solid var(--border-faint);
 }
 
 tr.top-level-drag-row td {

--- a/qt/aqt/stylesheets.py
+++ b/qt/aqt/stylesheets.py
@@ -39,7 +39,7 @@ QLineEdit,
 QListWidget,
 QTreeWidget,
 QListView {{
-    border: 1px solid {tm.var(colors.BORDER)};
+    border: 1px solid {tm.var(colors.BORDER_SUBTLE)};
     border-radius: {tm.var(props.BORDER_RADIUS)};
 }}
 QLineEdit {{
@@ -64,13 +64,17 @@ QToolTip {{
 
 def menu_styles(tm: ThemeManager) -> str:
     return f"""
-QMenuBar::item:selected {{
-    background-color: {tm.var(colors.HIGHLIGHT_BG)};
+QMenuBar::item {{
+    background-color: transparent;
+    padding: 2px 4px;
     border-radius: {tm.var(props.BORDER_RADIUS)};
+}}
+QMenuBar::item:selected {{
+    background-color: {tm.var(colors.CANVAS_ELEVATED)};
 }}
 QMenu {{
     background-color: {tm.var(colors.CANVAS_OVERLAY)};
-    border: 1px solid {tm.var(colors.BORDER)};
+    border: 1px solid {tm.var(colors.BORDER_SUBTLE)};
     padding: 4px;
 }}
 QMenu::item {{
@@ -79,16 +83,17 @@ QMenu::item {{
     margin-bottom: 4px;
 }}
 QMenu::item:selected {{
-    background-color: {tm.var(colors.HIGHLIGHT_BG)};
+    background-color: {tm.var(colors.CANVAS_INSET)};
     color: {tm.var(colors.HIGHLIGHT_FG)};
     border-radius: {tm.var(props.BORDER_RADIUS)};
 }}
 QMenu::separator {{
     height: 1px;
-    background: {tm.var(colors.BORDER)};
+    background: {tm.var(colors.BORDER_SUBTLE)};
     margin: 0 8px 4px 8px;
 }}
 QMenu::indicator {{
+    border: 1px solid {tm.var(colors.BORDER)};
     margin-left: 6px;
     margin-right: -6px;
 }}
@@ -221,7 +226,7 @@ QTabWidget::pane {{
   top: -15px;
   padding-top: 1em;
   background: {tm.var(colors.CANVAS_ELEVATED)};
-  border: 1px solid {tm.var(colors.BORDER)};
+  border: 1px solid {tm.var(colors.BORDER_SUBTLE)};
   border-radius: {tm.var(props.BORDER_RADIUS)};
 }}
 QTabWidget::tab-bar {{
@@ -233,7 +238,7 @@ QTabBar::tab {{
   min-width: 8ex;
 }}
 QTabBar::tab {{
-  border: 1px solid {tm.var(colors.BORDER)};
+  border: 1px solid {tm.var(colors.BORDER_SUBTLE)};
 }}
 QTabBar::tab:first {{
   border-top-{tm.left()}-radius: {tm.var(props.BORDER_RADIUS)};
@@ -262,7 +267,7 @@ def table_styles(tm: ThemeManager) -> str:
     return f"""
 QTableView {{
     border-radius: {tm.var(props.BORDER_RADIUS)};
-    gridline-color: {tm.var(colors.BORDER)};
+    gridline-color: {tm.var(colors.BORDER_SUBTLE)};
     selection-background-color: {tm.var(colors.SELECTION_BG)};
     selection-color: {tm.var(colors.SELECTION_FG)};
 }}
@@ -270,7 +275,7 @@ QHeaderView {{
     background: {tm.var(colors.CANVAS)};
 }}
 QHeaderView::section {{
-    border: 1px solid {tm.var(colors.BORDER)};
+    border: 1px solid {tm.var(colors.BORDER_SUBTLE)};
     background: {
         button_gradient(
             tm.var(colors.BUTTON_GRADIENT_START),
@@ -298,19 +303,19 @@ QHeaderView::section:hover {{
     };
 }}
 QHeaderView::section:first {{
-    border-left: 1px solid {tm.var(colors.BORDER)}; 
+    border-left: 1px solid {tm.var(colors.BORDER_SUBTLE)}; 
     border-top-left-radius: {tm.var(props.BORDER_RADIUS)};
 }}
 QHeaderView::section:!first {{
     border-left: none;
 }}
 QHeaderView::section:last {{
-    border-right: 1px solid {tm.var(colors.BORDER)}; 
+    border-right: 1px solid {tm.var(colors.BORDER_SUBTLE)}; 
     border-top-right-radius: {tm.var(props.BORDER_RADIUS)};
 }}
 QHeaderView::section:only-one {{
-    border-left: 1px solid {tm.var(colors.BORDER)}; 
-    border-right: 1px solid {tm.var(colors.BORDER)};
+    border-left: 1px solid {tm.var(colors.BORDER_SUBTLE)}; 
+    border-right: 1px solid {tm.var(colors.BORDER_SUBTLE)};
     border-top-left-radius: {tm.var(props.BORDER_RADIUS)};
     border-top-right-radius: {tm.var(props.BORDER_RADIUS)};
 }}
@@ -490,7 +495,7 @@ def win10_styles(tm: ThemeManager) -> str:
 /* day mode is missing a bottom border; background must be
    also set for border to apply */
 QMenuBar {{
-  border-bottom: 1px solid {tm.var(colors.BORDER)};
+  border-bottom: 1px solid {tm.var(colors.BORDER_SUBTLE)};
   background: {tm.var(colors.CANVAS) if tm.night_mode else "white"};
 }}
 

--- a/qt/aqt/stylesheets.py
+++ b/qt/aqt/stylesheets.py
@@ -85,7 +85,6 @@ QMenu::separator {{
     margin: 0 8px 4px 8px;
 }}
 QMenu::indicator {{
-    border-color: {tm.var(colors.BORDER_STRONG)};
     margin-left: 2px;
 }}
     """

--- a/qt/aqt/stylesheets.py
+++ b/qt/aqt/stylesheets.py
@@ -28,7 +28,8 @@ qlineargradient(
 
 def general_styles(tm: ThemeManager) -> str:
     return f"""
-QFrame {{
+QFrame,
+QWidget {{
     background: none;
 }}
 QPushButton,
@@ -57,6 +58,36 @@ QSpinBox {{
 }}
 QToolTip {{
     background: {tm.var(colors.CANVAS_OVERLAY)};
+}}
+    """
+
+
+def menu_styles(tm: ThemeManager()) -> str:
+    return f"""
+QMenu {{
+    background-color: {tm.var(colors.CANVAS_OVERLAY)};
+    border: 1px solid {tm.var(colors.BORDER)};
+    padding: 4px;
+}}
+QMenu::item {{
+    background-color: transparent;
+    padding: 3px 10px;
+    margin-bottom: 4px;
+    min-width: 120px;
+}}
+QMenu::item:selected {{
+    background-color: {tm.var(colors.HIGHLIGHT_BG)};
+    color: {tm.var(colors.HIGHLIGHT_FG)};
+    border-radius: {tm.var(props.BORDER_RADIUS)};
+}}
+QMenu::separator {{
+    height: 1px;
+    background: {tm.var(colors.BORDER)};
+    margin: 0 8px 4px 8px;
+}}
+QMenu::indicator {{
+    border-color: {tm.var(colors.BORDER_STRONG)};
+    margin-left: 2px;
 }}
     """
 
@@ -374,16 +405,16 @@ QRadioButton {{
     margin: 2px 0;
 }}
 QCheckBox::indicator,
-QRadioButton::indicator {{
+QRadioButton::indicator,
+QMenu::indicator {{
     border: 1px solid {tm.var(colors.BUTTON_BORDER)};
+    border-radius: {tm.var(props.BORDER_RADIUS)};
     background: {tm.var(colors.CANVAS_INSET)};
     width: 16px;
     height: 16px;
 }}
-QCheckBox::indicator {{
-    border-radius: {tm.var(props.BORDER_RADIUS)};
-}}
-QRadioButton::indicator {{
+QRadioButton::indicator,
+QMenu::indicator:exclusive {{
     border-radius: 8px;
 }}
 QCheckBox::indicator:hover,
@@ -395,7 +426,8 @@ QRadioButton::indicator:checked:hover {{
     height: 14px;
 }}
 QCheckBox::indicator:checked,
-QRadioButton::indicator:checked {{
+QRadioButton::indicator:checked,
+QMenu::indicator:checked {{
     image: url({tm.themed_icon("mdi:check")});
 }}
 QCheckBox::indicator:indeterminate {{

--- a/qt/aqt/stylesheets.py
+++ b/qt/aqt/stylesheets.py
@@ -64,6 +64,19 @@ QToolTip {{
 
 def menu_styles(tm: ThemeManager()) -> str:
     return f"""
+QMenuBar {{
+    background-color: {tm.var(colors.CANVAS)};
+    border-bottom: 1px solid {tm.var(colors.BORDER)};
+}}
+QMenuBar::item {{
+    background-color: transparent;
+    padding: 6px;
+    margin: 2px;
+}}
+QMenuBar::item:selected {{
+    background-color: {tm.var(colors.HIGHLIGHT_BG)};
+    border-radius: {tm.var(props.BORDER_RADIUS)};
+}}
 QMenu {{
     background-color: {tm.var(colors.CANVAS_OVERLAY)};
     border: 1px solid {tm.var(colors.BORDER)};

--- a/qt/aqt/stylesheets.py
+++ b/qt/aqt/stylesheets.py
@@ -73,7 +73,6 @@ QMenu::item {{
     background-color: transparent;
     padding: 3px 10px;
     margin-bottom: 4px;
-    min-width: 120px;
 }}
 QMenu::item:selected {{
     background-color: {tm.var(colors.HIGHLIGHT_BG)};

--- a/qt/aqt/stylesheets.py
+++ b/qt/aqt/stylesheets.py
@@ -64,6 +64,9 @@ QToolTip {{
 
 def menu_styles(tm: ThemeManager) -> str:
     return f"""
+QMenuBar {{
+    border-bottom: 1px solid {tm.var(colors.BORDER_FAINT)};
+}}
 QMenuBar::item {{
     background-color: transparent;
     padding: 2px 4px;

--- a/qt/aqt/stylesheets.py
+++ b/qt/aqt/stylesheets.py
@@ -75,7 +75,7 @@ QMenu {{
 }}
 QMenu::item {{
     background-color: transparent;
-    padding: 3px 10px;
+    padding: 3px 14px;
     margin-bottom: 4px;
 }}
 QMenu::item:selected {{
@@ -89,7 +89,8 @@ QMenu::separator {{
     margin: 0 8px 4px 8px;
 }}
 QMenu::indicator {{
-    margin-left: 2px;
+    margin-left: 6px;
+    margin-right: -6px;
 }}
     """
 

--- a/qt/aqt/stylesheets.py
+++ b/qt/aqt/stylesheets.py
@@ -62,7 +62,7 @@ QToolTip {{
     """
 
 
-def menu_styles(tm: ThemeManager()) -> str:
+def menu_styles(tm: ThemeManager) -> str:
     return f"""
 QMenuBar {{
     background-color: {tm.var(colors.CANVAS)};

--- a/qt/aqt/stylesheets.py
+++ b/qt/aqt/stylesheets.py
@@ -64,6 +64,10 @@ QToolTip {{
 
 def menu_styles(tm: ThemeManager) -> str:
     return f"""
+QMenuBar::item:selected {{
+    background-color: {tm.var(colors.HIGHLIGHT_BG)};
+    border-radius: {tm.var(props.BORDER_RADIUS)};
+}}
 QMenu {{
     background-color: {tm.var(colors.CANVAS_OVERLAY)};
     border: 1px solid {tm.var(colors.BORDER)};

--- a/qt/aqt/stylesheets.py
+++ b/qt/aqt/stylesheets.py
@@ -64,19 +64,6 @@ QToolTip {{
 
 def menu_styles(tm: ThemeManager) -> str:
     return f"""
-QMenuBar {{
-    background-color: {tm.var(colors.CANVAS)};
-    border-bottom: 1px solid {tm.var(colors.BORDER)};
-}}
-QMenuBar::item {{
-    background-color: transparent;
-    padding: 6px;
-    margin: 2px;
-}}
-QMenuBar::item:selected {{
-    background-color: {tm.var(colors.HIGHLIGHT_BG)};
-    border-radius: {tm.var(props.BORDER_RADIUS)};
-}}
 QMenu {{
     background-color: {tm.var(colors.CANVAS_OVERLAY)};
     border: 1px solid {tm.var(colors.BORDER)};

--- a/qt/aqt/stylesheets.py
+++ b/qt/aqt/stylesheets.py
@@ -488,28 +488,3 @@ QScrollBar::sub-line {{
       background: none;
 }}
     """
-
-
-def win10_styles(tm: ThemeManager) -> str:
-    styles = f"""
-/* day mode is missing a bottom border; background must be
-   also set for border to apply */
-QMenuBar {{
-  border-bottom: 1px solid {tm.var(colors.BORDER_SUBTLE)};
-  background: {tm.var(colors.CANVAS) if tm.night_mode else "white"};
-}}
-
-/* qt bug? setting the above changes the browser sidebar
-   to white as well, so set it back */
-QTreeWidget {{
-  background: {tm.var(colors.CANVAS)};
-}}
-    """
-
-    if tm.night_mode:
-        styles += """
-QToolTip {
-  border: 0;
-}
-        """
-    return styles

--- a/qt/aqt/theme.py
+++ b/qt/aqt/theme.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 import enum
 import os
-import platform
 import re
 import subprocess
 from dataclasses import dataclass

--- a/qt/aqt/theme.py
+++ b/qt/aqt/theme.py
@@ -218,6 +218,7 @@ class ThemeManager:
                 checkbox_styles,
                 combobox_styles,
                 general_styles,
+                menu_styles,
                 scrollbar_styles,
                 spinbox_styles,
                 table_styles,
@@ -229,11 +230,12 @@ class ThemeManager:
                 [
                     general_styles(self),
                     button_styles(self),
+                    checkbox_styles(self),
+                    menu_styles(self),
                     combobox_styles(self),
                     tabwidget_styles(self),
                     table_styles(self),
                     spinbox_styles(self),
-                    checkbox_styles(self),
                     scrollbar_styles(self),
                 ]
             )

--- a/qt/aqt/theme.py
+++ b/qt/aqt/theme.py
@@ -234,7 +234,6 @@ class ThemeManager:
                 spinbox_styles,
                 table_styles,
                 tabwidget_styles,
-                win10_styles,
             )
 
             buf += "".join(
@@ -250,9 +249,6 @@ class ThemeManager:
                     scrollbar_styles(self),
                 ]
             )
-
-        if is_win and platform.release() == "10":
-            buf += win10_styles(self)
 
         # allow addons to modify the styling
         buf = gui_hooks.style_did_init(buf)

--- a/sass/_vars.scss
+++ b/sass/_vars.scss
@@ -67,15 +67,19 @@ $vars: (
         border: (
             default: (
                 light: palette(lightgray, 6),
-                dark: palette(darkgray, 7),
-            ),
-            subtle: (
-                light: palette(lightgray, 5),
-                dark: palette(darkgray, 6),
+                dark: palette(darkgray, 4),
             ),
             strong: (
                 light: palette(lightgray, 9),
                 dark: palette(darkgray, 1),
+            ),
+            subtle: (
+                light: palette(lightgray, 5),
+                dark: palette(darkgray, 7),
+            ),
+            faint: (
+                light: palette(lightgray, 3),
+                dark: palette(darkgray, 6),
             ),
             focus: (
                 light: palette(blue, 5),

--- a/sass/_vars.scss
+++ b/sass/_vars.scss
@@ -67,11 +67,11 @@ $vars: (
         border: (
             default: (
                 light: palette(lightgray, 6),
-                dark: palette(darkgray, 6),
+                dark: palette(darkgray, 7),
             ),
             subtle: (
                 light: palette(lightgray, 5),
-                dark: palette(darkgray, 4),
+                dark: palette(darkgray, 6),
             ),
             strong: (
                 light: palette(lightgray, 9),

--- a/sass/_vars.scss
+++ b/sass/_vars.scss
@@ -269,8 +269,8 @@ $vars: (
         ),
         highlight: (
             bg: (
-                light: palette(blue, 3),
-                dark: palette(blue, 4),
+                light: color.scale(palette(blue, 3), $alpha: -33%),
+                dark: color.scale(palette(blue, 4), $alpha: -33%),
             ),
             fg: (
                 light: black,

--- a/sass/_vars.scss
+++ b/sass/_vars.scss
@@ -78,7 +78,7 @@ $vars: (
                 dark: palette(darkgray, 7),
             ),
             faint: (
-                light: palette(lightgray, 3),
+                light: palette(lightgray, 4),
                 dark: palette(darkgray, 6),
             ),
             focus: (

--- a/sass/_vars.scss
+++ b/sass/_vars.scss
@@ -56,8 +56,8 @@ $vars: (
                 dark: palette(darkgray, 6),
             ),
             overlay: (
-                light: white,
-                dark: black,
+                light: palette(lightgray, 0),
+                dark: palette(darkgray, 5),
             ),
             code: (
                 light: white,


### PR DESCRIPTION
Following forum user MIZMU's suggestion: https://forums.ankiweb.net/t/anki-2-1-55-beta/23470/23

![image](https://user-images.githubusercontent.com/62722460/194781662-6176612e-cc28-4651-a2c9-8718f649151a.png)

## Changes
- `cursor: pointer` for QMenu
- border-radius applied to items and checkboxes
- improved visibility of checkboxes and highlights
- increased QMenuBar height for touch accessibility

---
MIZMU, if you're reading this: Sadly it [isn't possible to apply a border-radius to the QMenu via stylesheet](https://www.pythonfixing.com/2021/11/fixed-rounded-corners-for-qmenu-in-pyqt.html), as it is a top-level element. It would look like this:

![image](https://user-images.githubusercontent.com/62722460/194781850-8f457b18-4d66-4f5a-b627-54d6ee5270bf.png)
