### PR TITLE
Make resizer snap to closest end and improve toggle

### DIFF
--- a/ts/components/HorizontalResizer.svelte
+++ b/ts/components/HorizontalResizer.svelte
@@ -3,6 +3,9 @@ Copyright: Ankitects Pty Ltd and contributors
 License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 -->
 <script lang="ts">
+    import { createEventDispatcher } from "svelte";
+    import { fly } from "svelte/transition";
+
     import { on } from "../lib/events";
     import { Callback, singleCallback } from "../lib/typing";
     import IconConstrain from "./IconConstrain.svelte";
@@ -12,7 +15,12 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     export let panes: ResizablePane[];
     export let index = 0;
     export let tip = "";
+    export let showIndicator = false;
     export let clientHeight: number;
+
+    const rtl = window.getComputedStyle(document.body).direction == "rtl";
+
+    const dispatch = createEventDispatcher();
 
     let destroy: Callback;
 
@@ -77,18 +85,31 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
         destroy = singleCallback(
             on(window, "pointermove", onMove),
-            on(window, "pointerup", releasePointer),
+            on(window, "pointerup", () => {
+                releasePointer.call(window);
+                dispatch("release");
+            }),
         );
     }
 </script>
 
 <div
     class="horizontal-resizer"
+    class:rtl
     title={tip}
     bind:clientHeight={resizerHeight}
     on:pointerdown|preventDefault={lockPointer}
-    on:dblclick
+    on:dblclick|preventDefault
 >
+    {#if showIndicator}
+        <div
+            class="resize-indicator"
+            transition:fly={{ x: rtl ? 25 : -25, duration: 200 }}
+        >
+            <slot />
+        </div>
+    {/if}
+
     <div class="drag-handle">
         <IconConstrain iconSize={80}>{@html horizontalHandle}</IconConstrain>
     </div>
@@ -99,7 +120,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         width: 100%;
         cursor: row-resize;
         position: relative;
-        height: 10px;
+        height: 25px;
         border-top: 1px solid var(--border);
 
         z-index: 20;
@@ -112,6 +133,16 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         }
         &:hover .drag-handle {
             opacity: 0.8;
+        }
+
+        .resize-indicator {
+            position: absolute;
+            font-size: small;
+            bottom: 0;
+        }
+        &.rtl .resize-indicator {
+            padding: 0.5rem 0 0 0.5rem;
+            right: 0;
         }
     }
 </style>

--- a/ts/components/Pane.svelte
+++ b/ts/components/Pane.svelte
@@ -59,5 +59,6 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
     .pane {
         @include panes.resizable(column, true, true);
+        opacity: var(--opacity, 1);
     }
 </style>

--- a/ts/editor/NoteEditor.svelte
+++ b/ts/editor/NoteEditor.svelte
@@ -602,11 +602,13 @@ the AddCards dialog) should be implemented in the user of this component.
                 snapTags = tagsPane.height < tagsPane.maxHeight / 2;
             }
         }}
-        --opacity={!$tagsCollapsed
-            ? 1
-            : snapTags
-            ? tagsPane.height / tagsPane.maxHeight
-            : 1}
+        --opacity={(() => {
+            if (!$tagsCollapsed) {
+                return 1;
+            } else {
+                return snapTags ? tagsPane.height / tagsPane.maxHeight : 1;
+            }
+        })()}
     >
         <PaneContent scroll={false}>
             <TagEditor

--- a/ts/editor/NoteEditor.svelte
+++ b/ts/editor/NoteEditor.svelte
@@ -367,6 +367,8 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         $tagsCollapsed = snapTags = false;
     }
 
+    window.addEventListener("resize", (e) => snapResizer(snapTags));
+
     function snapResizer(collapse: boolean): void {
         if (collapse) {
             collapseTags();

--- a/ts/editor/NoteEditor.svelte
+++ b/ts/editor/NoteEditor.svelte
@@ -367,7 +367,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         $tagsCollapsed = snapTags = false;
     }
 
-    window.addEventListener("resize", (e) => snapResizer(snapTags));
+    window.addEventListener("resize", () => snapResizer(snapTags));
 
     function snapResizer(collapse: boolean): void {
         if (collapse) {

--- a/ts/tag-editor/tag-options-button/TagOptionsButton.svelte
+++ b/ts/tag-editor/tag-options-button/TagOptionsButton.svelte
@@ -25,6 +25,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
 <style lang="scss">
     .tag-options-button {
-        padding: 6px 3px 0;
+        transition: opacity 0.2s linear;
+        opacity: var(--button-opacity, 1);
     }
 </style>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/62722460/195358447-de26ad1f-2e6a-4982-9ba6-1020550d61fc.png)
###### Side note: See how the cursor doesn't adjust? This also started with the Qt 6.4.0 update.

## Changes
- resizer snaps to closer end on pointer release
- resizer adjusts on window resize event
- there is no more stage in the resizing process where the tag icon is hidden
- tag icon is now absolutely positioned because it messed with resizing calculations
- tag icon is animated and tag editor fades when it reaches snapping size

## Fixes
- https://forums.ankiweb.net/t/anki-2-1-55-beta/23470/20
- https://forums.ankiweb.net/t/anki-2-1-55-beta/23470/37