### PR TITLE
Add background to tag editor and de-uglify autocomplete items

### DIFF
--- a/ts/tag-editor/AutocompleteItem.svelte
+++ b/ts/tag-editor/AutocompleteItem.svelte
@@ -6,7 +6,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     export let selected = false;
     export let active = false;
 
-    let buttonRef: HTMLButtonElement;
+    let buttonRef: HTMLElement;
 
     $: if (selected && buttonRef) {
         /* buttonRef.scrollIntoView({ behavior: "smooth", block: "start" }); */
@@ -18,7 +18,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     }
 </script>
 
-<button
+<div
     bind:this={buttonRef}
     tabindex="-1"
     class="autocomplete-item"
@@ -30,21 +30,27 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     on:mouseleave
 >
     <slot />
-</button>
+</div>
 
 <style lang="scss">
     @use "sass/vars";
     @use "sass/button-mixins" as button;
 
     .autocomplete-item {
-        @include button.base($with-disabled: false, $active-class: active);
-        padding: 1px 7px 2px;
+        padding: 4px 8px;
 
         text-align: start;
         white-space: nowrap;
         flex-grow: 1;
         border-radius: 0;
+        border: 1px solid transparent;
+        &:not(:first-child) {
+            border-top-color: var(--border-subtle);
+        }
 
+        &:hover {
+            @include button.base($with-disabled: false, $active-class: active);
+        }
         &.selected {
             @include button.base(
                 $primary: true,

--- a/ts/tag-editor/TagEditor.svelte
+++ b/ts/tag-editor/TagEditor.svelte
@@ -490,6 +490,9 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         display: flex;
         flex-flow: row wrap;
         align-items: flex-end;
+        background: var(--canvas-inset);
+        border-radius: var(--border-radius);
+        padding: 6px;
     }
 
     .tag-relative {

--- a/ts/tag-editor/WithAutocomplete.svelte
+++ b/ts/tag-editor/WithAutocomplete.svelte
@@ -186,9 +186,9 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         flex-flow: column nowrap;
 
         width: 80vw;
-        max-height: 7rem;
+        max-height: 30vh;
 
-        font-size: 11px;
+        font-size: 13px;
         overflow-x: hidden;
         text-overflow: ellipsis;
         overflow-y: auto;


### PR DESCRIPTION
## Motivation
The button gradient looked awful on the Autocomplete items and the font size was pretty small.

## Changes
- tag editor has `canvas-inset` background color and a border radius
- autocomplete popup can take up to `30vh` in height now
- autocomplete items do not have a gradient except on hover and select
- font size increased from 11 to 13
- increased padding

![image](https://user-images.githubusercontent.com/62722460/195359761-c9ccc0c0-647d-4309-82aa-6e1997fd69a7.png)
