### PR TITLE
Center add-on icons and allow text buttons to expand in width

### DIFF
--- a/ts/editor/legacy.scss
+++ b/ts/editor/legacy.scss
@@ -11,7 +11,7 @@ $padding: 2px;
     @include button.base;
     @include button.border-radius;
 
-    width: $size;
+    min-width: $size;
     height: $size;
     padding: $padding;
     font-size: calc($size * 0.6);

--- a/ts/editor/legacy.scss
+++ b/ts/editor/legacy.scss
@@ -4,24 +4,27 @@
 @use "sass:color";
 @use "sass/button-mixins" as button;
 
-$size: var(--buttons-size);
-$padding: 2px;
-
 .linkb {
+    $size: var(--buttons-size);
+
     @include button.base;
     @include button.border-radius;
 
     min-width: $size;
     height: $size;
-    padding: $padding;
     font-size: calc($size * 0.6);
-}
+    position: relative;
 
-img.topbut {
-    max-width: calc($size - 2 * $padding);
-    max-height: calc($size - 2 * $padding);
-    vertical-align: baseline;
-    .nightMode & {
-        filter: invert(1);
+    img.topbut {
+        $padding: 4px;
+        $icon-size: calc(100% - 2 * $padding);
+
+        position: absolute;
+        height: $icon-size;
+        width: $icon-size;
+        inset: $padding;
+        .nightMode & {
+            filter: invert(1);
+        }
     }
 }


### PR DESCRIPTION
On some forum screenshots, I saw that the icons of add-on buttons were too big and not centered properly. This PR aligns them better with the native buttons and also fixes text buttons not expanding in width.

### Before
![image](https://user-images.githubusercontent.com/62722460/197328576-329fe99b-385f-42e5-9a6e-9f68a467d83f.png)

### After
![image](https://user-images.githubusercontent.com/62722460/197328193-1743b7ca-394b-49a6-bc87-56d81ffb3504.png)