### PR TITLE
Fix some issues with tag reparenting

### DIFF
--- a/rslib/src/tags/reparent.rs
+++ b/rslib/src/tags/reparent.rs
@@ -38,7 +38,9 @@ impl Collection {
         let usn = self.usn()?;
         let mut matcher = TagMatcher::new(&join_tags(tags_to_reparent))?;
         let old_to_new_names = old_to_new_names(tags_to_reparent, new_parent);
-
+        if old_to_new_names.is_empty() {
+            return Ok(0);
+        }
         let matched_notes = self
             .storage
             .get_note_tags_by_predicate(|tags| matcher.is_match(tags))?;

--- a/rslib/src/tags/reparent.rs
+++ b/rslib/src/tags/reparent.rs
@@ -129,6 +129,8 @@ mod test {
         let mut col = open_test_collection();
         let nt = col.get_notetype_by_name("Basic")?.unwrap();
         for tag in &[
+            "a",
+            "ab",
             "another",
             "parent1::child1::grandchild1",
             "parent1::child1",
@@ -151,6 +153,8 @@ mod test {
         assert_eq!(
             alltags(&col),
             &[
+                "a",
+                "ab",
                 "parent1",
                 "parent1::another",
                 "parent1::child1",
@@ -168,6 +172,8 @@ mod test {
         assert_eq!(
             alltags(&col),
             &[
+                "a",
+                "ab",
                 "parent1",
                 "parent1::another",
                 "parent2",
@@ -182,6 +188,43 @@ mod test {
         assert_eq!(
             alltags(&col),
             &[
+                "a",
+                "ab",
+                "another",
+                "parent1",
+                "parent2",
+                "parent2::child1",
+                "parent2::child1::grandchild1",
+            ]
+        );
+
+        // parent1 onto parent1::child1 -> no-op
+        col.reparent_tags(
+            &["parent1".to_string()],
+            Some("parent1::child1".to_string()),
+        )?;
+
+        assert_eq!(
+            alltags(&col),
+            &[
+                "a",
+                "ab",
+                "another",
+                "parent1",
+                "parent2",
+                "parent2::child1",
+                "parent2::child1::grandchild1",
+            ]
+        );
+
+        // tags that are prefixes of the new parent are handled correctly
+        col.reparent_tags(&["a".to_string()], Some("ab".to_string()))?;
+
+        assert_eq!(
+            alltags(&col),
+            &[
+                "ab",
+                "ab::a",
                 "another",
                 "parent1",
                 "parent2",

--- a/rslib/src/tags/reparent.rs
+++ b/rslib/src/tags/reparent.rs
@@ -92,8 +92,10 @@ fn old_to_new_names(
 /// Returns None if new parent is a child of the tag to be reparented.
 fn reparented_name(existing_name: &str, new_parent: Option<&str>) -> Option<String> {
     let existing_base = existing_name.rsplit("::").next().unwrap();
+    let existing_root = existing_name.split("::").next().unwrap();
     if let Some(new_parent) = new_parent {
-        if new_parent.starts_with(existing_name) {
+        let new_parent_root = new_parent.split("::").next().unwrap();
+        if new_parent_root == existing_root {
             // foo onto foo::bar, or foo onto itself -> no-op
             None
         } else {


### PR DESCRIPTION
This fixes two issues with tag reparenting:

## First issue

If a source tag is a prefix of the target tag (e.g. `a` and `ab`), reparented_name() incorrectly returns None, resulting in a panic in reparent_tags_inner(). This can be reproduced easily from the sidebar.

<details>
<summary>Stack trace</summary>

```
thread '<unnamed>' panicked at 'called `Option::unwrap()` on a `None` value', rslib/src\tags\reparent.rs:63:78
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
Caught exception:
Traceback (most recent call last):
  File "aqt.taskman", line 122, in _on_closures_pending
  File "aqt.taskman", line 71, in <lambda>
  File "aqt.taskman", line 90, in wrapped_done
  File "aqt.operations", line 120, in wrapped_done
  File "concurrent.futures._base", line 438, in result
  File "concurrent.futures._base", line 390, in __get_result
  File "concurrent.futures.thread", line 52, in run
  File "aqt.operations", line 105, in wrapped_op
  File "aqt.operations.tag", line 81, in <lambda>
  File "anki.tags", line 105, in reparent
  File "anki._backend.generated", line 1389, in reparent_tags
  File "anki._backend", line 140, in _run_command
pyo3_runtime.PanicException: called `Option::unwrap()` on a `None` value

thread '<unnamed>' panicked at 'called `Result::unwrap()` on an `Err` value: PoisonError { .. }', rslib/src\backend\mod.rs:181:18
Error in atexit._run_exitfuncs:
Error in atexit._run_exitfuncs:
Traceback (most recent call last):
```

</details>

## Second issue

If a source tag is the parent of the target tag (e.g. `foo` and `foo::bar`), reparent_tags_inner() also panics at the same line it panics at in the first issue.
