### PR TITLE
Fix CSS vars not being included in reviewer

### DIFF
--- a/qt/aqt/data/web/css/webview.scss
+++ b/qt/aqt/data/web/css/webview.scss
@@ -1,6 +1,7 @@
 /* Copyright: Ankitects Pty Ltd and contributors
  * License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html */
 
+@use "sass/root-vars";
 @use "sass/scrollbar";
 @use "sass/buttons";
 


### PR DESCRIPTION
When I reverted the CSS-vars-from-Python-side commits in #2137, I seem to have missed this.

- This will fix a couple of issues described here: https://forums.ankiweb.net/t/anki-2-1-55-beta-3/24295/14
- It should also fix the About window mentioned here: https://forums.ankiweb.net/t/anki-2-1-55-beta-3/24295/32