### PR TITLE
Fix indicator positioning of Reviewer bottom toolbar

### DIFF
--- a/qt/aqt/data/web/css/reviewer-bottom.scss
+++ b/qt/aqt/data/web/css/reviewer-bottom.scss
@@ -31,6 +31,7 @@ button {
     min-width: 60px;
     white-space: nowrap;
     margin: 0.5em;
+    position: relative;
 }
 
 .hitem {
@@ -50,10 +51,6 @@ button {
     font-weight: normal;
 }
 
-.stattxt {
-    white-space: nowrap;
-}
-
 #ansbut {
     margin-bottom: 1em;
 }
@@ -66,9 +63,10 @@ button {
 .stattxt {
     position: absolute;
     white-space: nowrap;
-    top: -5px;
+    font-size: medium;
+    top: -3px;
     left: 50%;
-    transform: translateX(-50%);
+    transform: translate(-50%, -100%);
     font-weight: normal;
     display: inline-block;
 }

--- a/qt/aqt/data/web/css/reviewer-bottom.scss
+++ b/qt/aqt/data/web/css/reviewer-bottom.scss
@@ -65,6 +65,7 @@ button {
 .nobold,
 .stattxt {
     position: absolute;
+    white-space: nowrap;
     top: -5px;
     left: 50%;
     transform: translateX(-50%);

--- a/qt/aqt/reviewer.py
+++ b/qt/aqt/reviewer.py
@@ -782,14 +782,14 @@ time = %(time)d;
                 extra = ""
             due = self._buttonTime(i, v3_labels=labels)
             return """
-<td align=center>%s<button %s title="%s" data-ease="%s" onclick='pycmd("ease%d");'>\
-%s</button></td>""" % (
-                due,
+<td align=center><button %s title="%s" data-ease="%s" onclick='pycmd("ease%d");'>\
+%s%s</button></td>""" % (
                 extra,
                 tr.actions_shortcut_key(val=i),
                 i,
                 i,
                 label,
+                due,
             )
 
         buf = "<center><table cellpading=0 cellspacing=0><tr>"

--- a/qt/aqt/reviewer.py
+++ b/qt/aqt/reviewer.py
@@ -662,13 +662,15 @@ class Reviewer:
 <center id=outer>
 <table id=innertable width=100%% cellspacing=0 cellpadding=0>
 <tr>
-<td align=left width=50 valign=top class=stat>
+<td align=left valign=top class=stat>
 <button title="%(editkey)s" onclick="pycmd('edit');">%(edit)s</button></td>
 <td align=center valign=top id=middle>
 </td>
-<td width=50 align=right valign=top class=stat><span id=time class=stattxt>
-</span>
-<button onclick="pycmd('more');">%(more)s %(downArrow)s</button>
+<td align=right valign=top class=stat>
+<button onclick="pycmd('more');">
+%(more)s %(downArrow)s
+<span id=time class=stattxt></span>
+</button>
 </td>
 </tr>
 </table>
@@ -687,11 +689,10 @@ time = %(time)d;
 
     def _showAnswerButton(self) -> None:
         middle = """
-<span class=stattxt>{}</span>
-<button title="{}" id="ansbut" onclick='pycmd("ans");'>{}</button>""".format(
-            self._remaining(),
+<button title="{}" id="ansbut" onclick='pycmd("ans");'>{}<span class=stattxt>{}</span></button>""".format(
             tr.actions_shortcut_key(val=tr.studying_space()),
             tr.studying_show_answer(),
+            self._remaining(),
         )
         # wrap it in a table so it has the same top margin as the ease buttons
         middle = (


### PR DESCRIPTION
The stat indicators are now located inside the buttons, allowing absolute positioning relative to the button.

### Fixes:
- second issue mentioned here: https://forums.ankiweb.net/t/anki-2-1-55-beta-3/24295/10
- timer not being positioned correctly (couldn't find the forum post rn)

### Changes:
- indicator font-size slightly increased

## Before
![image](https://user-images.githubusercontent.com/62722460/199029584-e65eeb6a-6eb3-417d-acdb-b5bee1db5f5e.png)

## After
![image](https://user-images.githubusercontent.com/62722460/199029695-6cf04f5b-a8a0-4ff6-ab40-749c3192ca82.png)