### PR TITLE
Fix browser color issues

### DIFF
--- a/qt/aqt/browser/table/__init__.py
+++ b/qt/aqt/browser/table/__init__.py
@@ -2,6 +2,7 @@
 # License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 from __future__ import annotations
 
+import copy
 import time
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Generator, Sequence, Union
@@ -103,9 +104,12 @@ def backend_color_to_aqt_color(color: BrowserRow.Color.V) -> dict[str, str] | No
 
 def adjusted_bg_color(color: dict[str, str]) -> dict[str, str]:
     if color:
-        color["light"] = QColor(color["light"]).lighter(150).name()
-        color["dark"] = QColor(color["dark"]).darker(150).name()
-        return color
+        adjusted_color = copy.copy(color)
+        light = QColor(color["light"]).lighter(150)
+        adjusted_color["light"] = light.name()
+        dark = QColor(color["dark"]).darker(150)
+        adjusted_color["dark"] = dark.name()
+        return adjusted_color
     else:
         return None
 


### PR DESCRIPTION
The changes I made when switching to the dict datatype for colors had the side effect of making color adjustments permanent across the app.

I fixed this by creating a shallow copy of the original. This stops flag and card state colors from getting increasingly lighter/darker and also makes the effect exclusive to the cell rows.

---
Fixes https://forums.ankiweb.net/t/anki-2-1-55-beta-3/24295/28