### PR TITLE
Use circle icon for QRadioButton

### DIFF
--- a/qt/aqt/data/qt/icons/BUILD.bazel
+++ b/qt/aqt/data/qt/icons/BUILD.bazel
@@ -59,6 +59,9 @@ copy_mdi_icons(
         # checkbox
         "check.svg",
         "minus-thick.svg",
+
+        # QRadioButton
+        "circle-medium.svg",
     ],
 )
 
@@ -106,6 +109,9 @@ color_svg(
 color_svg(
     name = "minus-thick",
 )
+color_svg(
+    name = "circle-medium",
+)
 
 filegroup(
     name = "icons",
@@ -121,6 +127,7 @@ filegroup(
         "drag-horizontal",
         "check",
         "minus-thick",
+        "circle-medium",
     ] + glob([
         "*.svg",
         "*.png",

--- a/qt/aqt/stylesheets.py
+++ b/qt/aqt/stylesheets.py
@@ -455,6 +455,9 @@ QRadioButton::indicator:checked,
 QMenu::indicator:checked {{
     image: url({tm.themed_icon("mdi:check")});
 }}
+QRadioButton::indicator:checked {{
+    image: url({tm.themed_icon("mdi:circle-medium")});
+}}
 QCheckBox::indicator:indeterminate {{
     image: url({tm.themed_icon("mdi:minus-thick")});
 }}


### PR DESCRIPTION
https://forums.ankiweb.net/t/anki-2-1-55-beta-3/24295/20

![image](https://user-images.githubusercontent.com/62722460/199273872-498ea34a-4c6a-4093-bed4-031f2790bd67.png)

Forum user [MIZMU](https://forums.ankiweb.net/u/MIZMU):
> In addition, I still think that QRadiobutton should have a circle inside the marked circle, not a V. This distinguishes it from a regular check box and it does not reflect its behavior the user expects since the user will think that to cancel the option he has to click the box once more instead of moving the check to the corresponding box.