### PR TITLE
Make fg-subtle (= placeholder color) more subtle

### DIFF
--- a/sass/_vars.scss
+++ b/sass/_vars.scss
@@ -40,8 +40,8 @@ $vars: (
             subtle: (
                 "Placeholder text, icons in idle state",
                 (
-                    light: palette(darkgray, 6),
-                    dark: palette(lightgray, 3),
+                    light: palette(darkgray, 0),
+                    dark: palette(lightgray, 9),
                 ),
             ),
             disabled: (

--- a/ts/editor/FieldDescription.svelte
+++ b/ts/editor/FieldDescription.svelte
@@ -37,7 +37,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         right: 0;
         bottom: 0;
 
-        opacity: 0.4;
+        color: var(--fg-subtle);
         pointer-events: none;
 
         /* Stay a on single line */


### PR DESCRIPTION
Meant to do this for a while (since I removed fg-faint). This addresses the complaints about placeholder text in Qt inputs not being gray.

![image](https://user-images.githubusercontent.com/62722460/199351238-1249e5dc-f398-4b08-ab32-c79557094912.png)

![image](https://user-images.githubusercontent.com/62722460/199351274-e30ab360-4089-4c63-a59f-683ebf2bd695.png)
