### PR TITLE
Maybe preload images

### DIFF
--- a/ts/reviewer/images.ts
+++ b/ts/reviewer/images.ts
@@ -49,3 +49,17 @@ export function preloadAnswerImages(qHtml: string, aHtml: string): void {
         diff.forEach((src) => injectPreloadLink(src, "image"));
     }
 }
+
+export async function maybePreloadImages(html: string): Promise<void> {
+    const srcs = extractImageSrcs(html);
+    await Promise.race([
+        Promise.all(
+            srcs.map((src) => {
+                const img = new Image();
+                img.src = src;
+                return imageLoaded(img);
+            }),
+        ),
+        new Promise((r) => setTimeout(r, 100)),
+    ]);
+}

--- a/ts/reviewer/index.ts
+++ b/ts/reviewer/index.ts
@@ -16,7 +16,7 @@ globalThis.anki.mutateNextCardStates = mutateNextCardStates;
 
 import { bridgeCommand } from "../lib/bridgecommand";
 import { maybePreloadExternalCss } from "./css";
-import { allImagesLoaded, preloadAnswerImages } from "./images";
+import { allImagesLoaded, maybePreloadImages, preloadAnswerImages } from "./images";
 
 declare const MathJax: any;
 
@@ -132,6 +132,9 @@ export async function _updateQA(
 
     // prevent flash of unstyled content when external css used
     await maybePreloadExternalCss(html);
+
+    // prevent flickering & layout shift on image load
+    await maybePreloadImages(html);
 
     qa.style.opacity = "0";
 


### PR DESCRIPTION
As it seems to have some visible effect, I'd like to suggest to maybe delay setInnerHTML for up to 100ms to preload images (if necessary) to prevent flickering & layout shift on image load. It's for the front side of the card.

I tested a different delay on SDD and HDD. The delay of 50ms looked good on SSD, but didn't help much with flickering on HDD where the same image could take about 50-90ms to load.

As a side affect, the code will be also executed on the answer side too, but by that time any answer images will be already preloaded and the code shouldn't wait much time (maybe 1-5ms according to console.time). For cards with no images, the delay probably will be < 1ms or maybe 1-5 ms.

I didn't notice any visible difference in responsiveness except for some cards with images if they take some time to load. In this case, the card will be displayed with a bit of delay and the image will be already visible or will be loaded later.

### Test apkg file from the screencast

[Custom Study Session - Issue with Images.zip](https://github.com/ankitects/anki/files/9913135/Custom.Study.Session.-.Issue.with.Images.zip)

### Before

[Screencast from 01.11.2022 19_29_40.webm](https://user-images.githubusercontent.com/16260735/199311691-b895d376-b305-4049-9f18-df124687d01d.webm)

### After

[Screencast from 01.11.2022 19_56_00.webm](https://user-images.githubusercontent.com/16260735/199311721-6226f589-5485-4038-a550-96594a6522e7.webm)