### PR TITLE
Fix short deck options help texts appearing next to the title

### DIFF
--- a/ts/deck-options/HelpSection.svelte
+++ b/ts/deck-options/HelpSection.svelte
@@ -46,6 +46,7 @@
 <style lang="scss">
     h2 {
         margin-bottom: 1em;
+        width: 100%;
     }
 
     .chapter-redirect {


### PR DESCRIPTION
@abdnh https://forums.ankiweb.net/t/anki-2-1-55-beta-3/24295/31

I got a much larger base font size on Linux compared to Windows, so I couldn't spot the issue at first. Making `<h2>` full width prevents short texts from flowing up there.