### PR TITLE
Set same font size for all platforms and make editor UI a bit smaller

### DIFF
--- a/sass/base.scss
+++ b/sass/base.scss
@@ -44,6 +44,7 @@ html {
 }
 
 body {
+    --base-font-size: 13px;
     overscroll-behavior: none;
     &:not(.isMac),
     &:not(.isMac) * {
@@ -62,18 +63,6 @@ code,
 kbd,
 samp {
     unicode-bidi: normal !important;
-}
-
-.isWin {
-    --base-font-size: 12px;
-}
-
-.isMac {
-    --base-font-size: 13px;
-}
-
-.isLin {
-    --base-font-size: 14px;
 }
 
 [dir="rtl"] {

--- a/ts/components/Switch.svelte
+++ b/ts/components/Switch.svelte
@@ -30,7 +30,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
     .form-check-input {
         -webkit-appearance: none;
-        height: 1.6em;
+        height: 1.5em;
         /* otherwise the switch circle shows slightly off-centered */
         margin-top: 0;
 

--- a/ts/editor/NoteEditor.svelte
+++ b/ts/editor/NoteEditor.svelte
@@ -79,7 +79,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         return fontFamily;
     }
 
-    const size = 1.6;
+    const size = 1.5;
     const wrap = true;
 
     const fieldStores: Writable<string>[] = [];

--- a/ts/editor/image-overlay/FloatButtons.svelte
+++ b/ts/editor/image-overlay/FloatButtons.svelte
@@ -27,7 +27,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     const dispatch = createEventDispatcher();
 </script>
 
-<ButtonGroup size={1.6} wrap={false}>
+<ButtonGroup size={1.5} wrap={false}>
     <IconButton
         tooltip={tr.editingFloatLeft()}
         active={floatStyle === "left"}

--- a/ts/editor/image-overlay/SizeSelect.svelte
+++ b/ts/editor/image-overlay/SizeSelect.svelte
@@ -22,7 +22,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     const dispatch = createEventDispatcher();
 </script>
 
-<ButtonGroup size={1.6}>
+<ButtonGroup size={1.5}>
     <IconButton
         disabled={shrinkingDisabled}
         flipX={$direction === "rtl"}

--- a/ts/editor/mathjax-overlay/MathjaxButtons.svelte
+++ b/ts/editor/mathjax-overlay/MathjaxButtons.svelte
@@ -17,7 +17,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     const dispatch = createEventDispatcher();
 </script>
 
-<ButtonToolbar size={1.6} wrap={false}>
+<ButtonToolbar size={1.5} wrap={false}>
     <ButtonGroup>
         <IconButton
             tooltip={tr.editingMathjaxInline()}


### PR DESCRIPTION
https://forums.ankiweb.net/t/anki-2-1-55-beta-3/24295/4

# Changes
- use base font size of 13px (macOS value) for all platforms
- decrement `1.6em` in various editor components to `1.5em`

## Before
![image](https://user-images.githubusercontent.com/62722460/199437513-8343b1f1-8199-45a0-86df-449a1f0365b0.png)

## After
![image](https://user-images.githubusercontent.com/62722460/199437878-9bc8c529-a04b-428d-b84d-cec6e3c031a3.png)

---
@dae Could you send me similar screenshots of Mac and Windows for comparison? :pray: 