### PR TITLE
Equalize browser panes on splitter double-click

### DIFF
--- a/qt/aqt/browser/browser.py
+++ b/qt/aqt/browser/browser.py
@@ -71,7 +71,7 @@ from aqt.utils import (
 from ..changenotetype import change_notetype_dialog
 from .card_info import BrowserCardInfo
 from .find_and_replace import FindAndReplaceDialog
-from .layout import BrowserLayout
+from .layout import BrowserLayout, QSplitterHandleEventFilter
 from .previewer import BrowserPreviewer as PreviewDialog
 from .previewer import Previewer
 from .sidebar import SidebarTreeView
@@ -127,6 +127,8 @@ class Browser(QMainWindow):
         self.form = aqt.forms.browser.Ui_Dialog()
         self.form.setupUi(self)
         self.form.splitter.setChildrenCollapsible(False)
+        splitter_handle_event_filter = QSplitterHandleEventFilter(self.form.splitter)
+        self.form.splitter.handle(1).installEventFilter(splitter_handle_event_filter)
         # set if exactly 1 row is selected; used by the previewer
         self.card: Card | None = None
         self.current_card: Card | None = None

--- a/qt/aqt/browser/layout.py
+++ b/qt/aqt/browser/layout.py
@@ -3,8 +3,30 @@
 
 from enum import Enum
 
+from aqt.qt import QEvent, QObject, QSplitter, Qt
+
 
 class BrowserLayout(Enum):
     AUTO = "auto"
     VERTICAL = "vertical"
     HORIZONTAL = "horizontal"
+
+
+class QSplitterHandleEventFilter(QObject):
+    """Event filter that equalizes QSplitter panes on double-clicking the handle"""
+
+    def __init__(self, splitter: QSplitter):
+        super().__init__(splitter)
+        self._splitter = splitter
+
+    def eventFilter(self, object: QObject, event: QEvent) -> bool:
+        if event.type() == QEvent.Type.MouseButtonDblClick:
+            splitter_parent = self._splitter.parentWidget()
+            if self._splitter.orientation() == Qt.Orientation.Horizontal:
+                half_size = splitter_parent.width() // 2
+            else:
+                half_size = splitter_parent.height() // 2
+            self._splitter.setSizes([half_size, half_size])
+            return True
+
+        return super().eventFilter(object, event)


### PR DESCRIPTION
Adds the ability to quickly resize the editor and table view to equal width/height by double-clicking on the splitter handle (similar to window tiling on Windows and various Linux WMs):


https://user-images.githubusercontent.com/5459332/199632911-8cef9e49-6367-48aa-9a5a-51495cfe5f6c.mp4

