### PR TITLE
Fix RTL arrangement of browser views

### DIFF
--- a/qt/aqt/browser/browser.py
+++ b/qt/aqt/browser/browser.py
@@ -138,9 +138,14 @@ class Browser(QMainWindow):
 
         # restoreXXX() should be called after all child widgets have been created
         # and attached to QMainWindow
-        restoreGeom(self, "editor", 0)
+        self._editor_state_key = (
+            "editorRTL"
+            if self.layoutDirection() == Qt.LayoutDirection.RightToLeft
+            else "editor"
+        )
+        restoreGeom(self, self._editor_state_key, 0)
         restoreSplitter(self.form.splitter, "editor3")
-        restoreState(self, "editor")
+        restoreState(self, self._editor_state_key)
 
         # responsive layout
         self.aspect_ratio = self.width() / self.height()
@@ -346,8 +351,8 @@ class Browser(QMainWindow):
         self.table.cleanup()
         self.sidebar.cleanup()
         saveSplitter(self.form.splitter, "editor3")
-        saveGeom(self, "editor")
-        saveState(self, "editor")
+        saveGeom(self, self._editor_state_key)
+        saveState(self, self._editor_state_key)
         self.teardownHooks()
         self.mw.maybeReset()
         aqt.dialogs.markClosed("Browser")


### PR DESCRIPTION
This just implement your suggestion in https://github.com/ankitects/anki/pull/2172#issuecomment-1300190664 so that @kleinerpirat has less on his plate.

> Regarding the RTL dock layout, commenting out restoreState() seems to fix it, so I guess we should include rtl/ltr in the browser state key name so that the states are saved separately.

I fixed this a year ago in #1453 but it was reintroduced recently in #2132

The sidebar highlight issue seems to be a Qt issue; it disappears after scrolling.