### PR TITLE
Hide note/card switch label during animation

### DIFF
--- a/qt/aqt/switch.py
+++ b/qt/aqt/switch.py
@@ -38,6 +38,7 @@ class Switch(QAbstractButton):
         self._right_knob_position = self.width - self._path_radius
         self._left_label_position = self._label_padding / 2
         self._right_label_position = 2 * self._knob_radius
+        self._hide_label: bool = False
 
     @pyqtProperty(int)  # type: ignore
     def position(self) -> int:
@@ -107,7 +108,8 @@ class Switch(QAbstractButton):
         painter.setRenderHint(QPainter.RenderHint.Antialiasing, True)
         painter.setPen(Qt.PenStyle.NoPen)
         self._paint_path(painter)
-        self._paint_label(painter)
+        if not self._hide_label:
+            self._paint_label(painter)
         self._paint_knob(painter)
 
     def _current_path_rectangle(self) -> QRectF:
@@ -176,5 +178,14 @@ class Switch(QAbstractButton):
         animation.setDuration(100)
         animation.setStartValue(self.start_position)
         animation.setEndValue(self.end_position)
+        # hide label during animation
+        self._hide_label = True
+        self.update()
+
+        def on_animation_finished():
+            self._hide_label = False
+            self.update()
+
+        qconnect(animation.finished, on_animation_finished)
         # make triggered events execute first so the animation runs smoothly afterwards
         QTimer.singleShot(50, animation.start)

--- a/qt/aqt/switch.py
+++ b/qt/aqt/switch.py
@@ -182,7 +182,7 @@ class Switch(QAbstractButton):
         self._hide_label = True
         self.update()
 
-        def on_animation_finished():
+        def on_animation_finished() -> None:
             self._hide_label = False
             self.update()
 


### PR DESCRIPTION
This introduces a tiny change to the card/note switch animation that hides the label while the knob is traversing over it. With the switch to the full text label in #2117, to me this behavior feels slightly smoother.

Here's a quick comparison to show the difference (the previews don't work for these tiny videos, so you'll have to open them in a separate tab / start playback with space):

Before: https://user-images.githubusercontent.com/5459332/199638786-c88188b2-f289-49a7-9413-7411a701be6a.mp4

After: https://user-images.githubusercontent.com/5459332/199638676-5ba72840-3e0c-4741-ad42-828fa850a240.mp4



