### PR TITLE
Adjust QTableWidget stylesheet

### DIFF
--- a/qt/aqt/browser/table/table.py
+++ b/qt/aqt/browser/table/table.py
@@ -11,7 +11,6 @@ from anki.cards import Card, CardId
 from anki.collection import Collection, Config, OpChanges
 from anki.consts import *
 from anki.notes import Note, NoteId
-from anki.utils import is_win
 from aqt import gui_hooks
 from aqt.browser.table import Columns, ItemId, SearchContext
 from aqt.browser.table.model import DataModel

--- a/qt/aqt/browser/table/table.py
+++ b/qt/aqt/browser/table/table.py
@@ -367,9 +367,8 @@ class Table:
     def _setup_headers(self) -> None:
         vh = self._view.verticalHeader()
         hh = self._view.horizontalHeader()
-        if not is_win:
-            vh.hide()
-            hh.show()
+        vh.hide()
+        hh.show()
         hh.setHighlightSections(False)
         hh.setMinimumSectionSize(50)
         hh.setSectionsMovable(True)

--- a/qt/aqt/data/web/css/toolbar.scss
+++ b/qt/aqt/data/web/css/toolbar.scss
@@ -8,6 +8,7 @@
 
 #header {
     padding-bottom: 4px;
+    margin-top: -3px;
 }
 
 .tdcenter {

--- a/qt/aqt/stylesheets.py
+++ b/qt/aqt/stylesheets.py
@@ -315,6 +315,7 @@ QHeaderView::up-arrow,
 QHeaderView::down-arrow {{
     width: 20px;
     height: 20px;
+    margin-left: -20px;
 }}
 QHeaderView::up-arrow {{
     image: url({tm.themed_icon("mdi:menu-up")});

--- a/qt/aqt/stylesheets.py
+++ b/qt/aqt/stylesheets.py
@@ -264,7 +264,7 @@ def table_styles(tm: ThemeManager) -> str:
     return f"""
 QTableView {{
     border-radius: {tm.var(props.BORDER_RADIUS)};
-    border-left: 1px solid {tm.var(colors.BORDER_SUBTLE)};
+    border-{tm.left()}: 1px solid {tm.var(colors.BORDER_SUBTLE)};
     border-bottom: 1px solid {tm.var(colors.BORDER_SUBTLE)};
     border-bottom-left-radius: 0;
     border-bottom-right-radius: 0;
@@ -276,8 +276,8 @@ QHeaderView {{
     background: {tm.var(colors.CANVAS)};
 }}
 QHeaderView::section {{
-    padding-left: 0px;
-    padding-right: 15px;
+    padding-{tm.left()}: 0px;
+    padding-{tm.right()}: 15px;
     border: 1px solid {tm.var(colors.BORDER_SUBTLE)};
     background: {tm.var(colors.BUTTON_BG)};
 }}
@@ -324,7 +324,7 @@ QHeaderView::up-arrow,
 QHeaderView::down-arrow {{
     width: 20px;
     height: 20px;
-    margin-left: -20px;
+    margin-{tm.left()}: -20px;
 }}
 QHeaderView::up-arrow {{
     image: url({tm.themed_icon("mdi:menu-up")});

--- a/qt/aqt/stylesheets.py
+++ b/qt/aqt/stylesheets.py
@@ -272,6 +272,8 @@ QHeaderView {{
     background: {tm.var(colors.CANVAS)};
 }}
 QHeaderView::section {{
+    padding-left: 0px;
+    padding-right: 10px;
     border: 1px solid {tm.var(colors.BORDER_SUBTLE)};
     background: {tm.var(colors.BUTTON_BG)};
 }}

--- a/qt/aqt/stylesheets.py
+++ b/qt/aqt/stylesheets.py
@@ -264,6 +264,10 @@ def table_styles(tm: ThemeManager) -> str:
     return f"""
 QTableView {{
     border-radius: {tm.var(props.BORDER_RADIUS)};
+    border-left: 1px solid {tm.var(colors.BORDER_SUBTLE)};
+    border-bottom: 1px solid {tm.var(colors.BORDER_SUBTLE)};
+    border-bottom-left-radius: 0;
+    border-bottom-right-radius: 0;
     gridline-color: {tm.var(colors.BORDER_SUBTLE)};
     selection-background-color: {tm.var(colors.SELECTED_BG)};
     selection-color: {tm.var(colors.SELECTED_FG)};
@@ -273,9 +277,12 @@ QHeaderView {{
 }}
 QHeaderView::section {{
     padding-left: 0px;
-    padding-right: 10px;
+    padding-right: 15px;
     border: 1px solid {tm.var(colors.BORDER_SUBTLE)};
     background: {tm.var(colors.BUTTON_BG)};
+}}
+QHeaderView::section:first {{
+    margin-left: -1px;
 }}
 QHeaderView::section:pressed,
 QHeaderView::section:pressed:!first {{


### PR DESCRIPTION
Closes #2109.

---
## Changes
- remove vertical header on Windows
- center table headers
- add border to empty area below table cells

@RumovZ this is as good as I could get it. The reason I didn't use a border on `QTableWidget` itself is that it would wrap around the scrollbar. That would not look good with its custom minimal design.