### PR TITLE
Fix error while compiling rslib

### DIFF
--- a/rslib/build/protobuf.rs
+++ b/rslib/build/protobuf.rs
@@ -104,6 +104,7 @@ pub fn write_backend_proto_rs() {
     let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
     let mut config = prost_build::Config::new();
     config
+        .protoc_arg("--experimental_allow_proto3_optional")
         .out_dir(&out_dir)
         .service_generator(service_generator())
         .type_attribute(
@@ -112,7 +113,7 @@ pub fn write_backend_proto_rs() {
         )
         .type_attribute(
             "Deck.Normal.DayLimit",
-            "#[derive(Copy, serde_derive::Deserialize, serde_derive::Serialize)]",
+            "#[derive(Copy, Eq, serde_derive::Deserialize, serde_derive::Serialize)]",
         )
         .type_attribute("HelpPageLinkRequest.HelpPage", "#[derive(strum::EnumIter)]")
         .type_attribute("CsvMetadata.Delimiter", "#[derive(strum::EnumIter)]")

--- a/rslib/build/protobuf.rs
+++ b/rslib/build/protobuf.rs
@@ -104,7 +104,6 @@ pub fn write_backend_proto_rs() {
     let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
     let mut config = prost_build::Config::new();
     config
-        .protoc_arg("--experimental_allow_proto3_optional")
         .out_dir(&out_dir)
         .service_generator(service_generator())
         .type_attribute(

--- a/rslib/src/import_export/text/mod.rs
+++ b/rslib/src/import_export/text/mod.rs
@@ -22,7 +22,7 @@ pub struct ForeignData {
     updated_tags: Vec<String>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 #[serde(default)]
 pub struct ForeignNote {
     guid: String,


### PR DESCRIPTION
1. pass `--experimental_allow_proto3_optional` to protoc
2. add missing derive trait `Eq` to protobuf-generated struct `DayLimit`
3. delete derive trait Eq` from `ForeignNote`