### PR TITLE
Call browser_will_show before restoring state

### DIFF
--- a/qt/aqt/browser/browser.py
+++ b/qt/aqt/browser/browser.py
@@ -137,6 +137,7 @@ class Browser(QMainWindow):
         self.setupMenus()
         self.setupHooks()
         self.setupEditor()
+        gui_hooks.browser_will_show(self)
 
         # restoreXXX() should be called after all child widgets have been created
         # and attached to QMainWindow
@@ -156,7 +157,6 @@ class Browser(QMainWindow):
         self.on_undo_state_change(mw.undo_actions_info())
         # legacy alias
         self.model = MockModel(self)
-        gui_hooks.browser_will_show(self)
         self.setupSearch(card, search)
         self.show()
 


### PR DESCRIPTION
This is to fix a recent issue that started to appear in the Fastbar add-on where the layout of the toolbar is broken.

![image](https://user-images.githubusercontent.com/41397710/202876126-0ea78cd2-3964-425e-8356-fa4f641d1dc1.png)


Looks like this area of the browser is a minefield. Hopefully this one-line change won't cause more problems.