### PR TITLE
fix body class names when changing theme

### DIFF
--- a/qt/aqt/webview.py
+++ b/qt/aqt/webview.py
@@ -708,12 +708,14 @@ html {{ {font} }}
     const body = document.body.classList;
     if ({1 if theme_manager.night_mode else 0}) {{
         doc.add("night-mode");
-        body.add("night-mode");
+        body.add("night_mode");
         body.add("nightMode");
+        {"body.add('macos-dark-mode');" if theme_manager.macos_dark_mode() else ""}
     }} else {{
         doc.remove("night-mode");
-        body.remove("night-mode");
+        body.remove("night_mode");
         body.remove("nightMode");
+        body.remove("macos-dark-mode");
     }}
 }})();
 """


### PR DESCRIPTION
body uses 'night_mode' class instead of 'night-mode'. Also adds and removes 'macos-dark-mode'.