### PR TITLE
Add browser hook setup and teardown hooks

### DIFF
--- a/qt/aqt/browser/browser.py
+++ b/qt/aqt/browser/browser.py
@@ -985,6 +985,7 @@ class Browser(QMainWindow):
         gui_hooks.focus_did_change.append(self.on_focus_change)
         gui_hooks.flag_label_did_change.append(self._update_flag_labels)
         gui_hooks.collection_will_temporarily_close.append(self._on_temporary_close)
+        gui_hooks.browser_did_setup_hooks(self)
 
     def teardownHooks(self) -> None:
         gui_hooks.undo_state_did_change.remove(self.on_undo_state_change)
@@ -994,6 +995,7 @@ class Browser(QMainWindow):
         gui_hooks.focus_did_change.remove(self.on_focus_change)
         gui_hooks.flag_label_did_change.remove(self._update_flag_labels)
         gui_hooks.collection_will_temporarily_close.remove(self._on_temporary_close)
+        gui_hooks.browser_did_teardown_hooks(self)
 
     def _on_temporary_close(self, col: Collection) -> None:
         # we could reload browser columns in the future; for now we just close

--- a/qt/tools/genhooks_gui.py
+++ b/qt/tools/genhooks_gui.py
@@ -519,6 +519,18 @@ hooks = [
         Every column in the dictionary will be toggleable by the user.
         """,
     ),
+    Hook(
+        name="browser_did_setup_hooks",
+        args=["browser: aqt.browser.Browser"],
+        doc="""Allows you to connect per-instance hook subscribers.
+        Executed after native hooks are connected and before browser is shown.""",
+    ),
+    Hook(
+        name="browser_did_teardown_hooks",
+        args=["browser: aqt.browser.Browser"],
+        doc="""Allows you to disconnect per-instance hook subscribers.
+        Executed after native hooks are disconnected and before browser is closed.""",
+    ),
     # Previewer
     ###################
     Hook(


### PR DESCRIPTION
Makes it easier for add-ons to subscribe to events such as `browser_did_change_row` with closures that refer to the current browser instance or child objects thereof, e.g. addon-provided UI elements.

The concrete use case that spawned this: As part of a new feature, the AMBOSS add-on needs to add a button to the card browser that responds to the number of cards currently selected. As `gui_hooks.browser_did_change_row` is a global, but both the button and browser instance will likely be deleted during the session lifetime, adding a hook like `browser_did_teardown_hooks` allows the add-on to sever the connection at the appropriate time.

Debug console sanity check snippet:

```python
from aqt import gui_hooks
gui_hooks.browser_did_setup_hooks.append(lambda *args: print(f"did_setup: {args}"))
gui_hooks.browser_did_teardown_hooks.append(lambda *args: print(f"did_teardown: {args}"))
```

**A quick thought before merging**: I'm wondering if instead you'd also be open to adding a Qt signal to `Browser`, e.g. `selection_changed`. That would make it even easier for add-ons to listen to selection state changes without having to clean up after themselves (as Qt takes care of severing the signal/slot connections). *But*, it throws more Qt-specificity into the mix and from what I can tell, Anki only uses a handful of custom Qt signals and I don't think they were ever explicitly regarded as add-on APIs.



----

*Copyright disclosure: This patch was written as part of my work for AMBOSS. Its rights of use lie with AMBOSS MD Inc and it is being submitted in agreement with Anki's contributor license agreement, as signed by AMBOSS MD Inc. (see the `CONTRIBUTORS` file).*