### PR TITLE
Pass addon name to config edit hook

### DIFF
--- a/qt/aqt/addons.py
+++ b/qt/aqt/addons.py
@@ -1601,7 +1601,7 @@ class ConfigEditor(QDialog):
 
     def accept(self) -> None:
         txt = self.form.editor.toPlainText()
-        txt = gui_hooks.addon_config_editor_will_save_json(txt)
+        txt = gui_hooks.addon_config_editor_will_save_json(txt, self.addon)
         try:
             new_conf = json.loads(txt)
             jsonschema.validate(new_conf, self.mgr._addon_schema(self.addon))

--- a/qt/aqt/addons.py
+++ b/qt/aqt/addons.py
@@ -1601,7 +1601,13 @@ class ConfigEditor(QDialog):
 
     def accept(self) -> None:
         txt = self.form.editor.toPlainText()
-        txt = gui_hooks.addon_config_editor_will_save_json(txt, self.addon)
+        txt = gui_hooks.addon_config_editor_will_update_json(txt, self.addon)
+        if gui_hooks.addon_config_editor_will_save_json.count() > 0:
+            print(
+                "The hook addon_config_editor_will_save_json is deprecated.\n"
+                "Use addon_config_editor_will_update_json instead."
+            )
+            txt = gui_hooks.addon_config_editor_will_save_json(txt)
         try:
             new_conf = json.loads(txt)
             jsonschema.validate(new_conf, self.mgr._addon_schema(self.addon))

--- a/qt/tools/genhooks_gui.py
+++ b/qt/tools/genhooks_gui.py
@@ -1107,6 +1107,15 @@ gui_hooks.webview_did_inject_style_into_page.append(mytest)
     ),
     Hook(
         name="addon_config_editor_will_save_json",
+        args=["text: str"],
+        return_type="str",
+        doc="""Deprecated. Use addon_config_editor_will_update_json instead.
+        Allows changing the text of the json configuration that was
+        received from the user before actually reading it. For
+        example, you can replace new line in strings by some "\\\\n".""",
+    ),
+    Hook(
+        name="addon_config_editor_will_update_json",
         args=["text: str", "addon: str"],
         return_type="str",
         doc="""Allows changing the text of the json configuration that was

--- a/qt/tools/genhooks_gui.py
+++ b/qt/tools/genhooks_gui.py
@@ -271,7 +271,7 @@ hooks = [
         as possible, instead opting to append your own changes, e.g.:
         
             def on_deck_browser_will_render_content(deck_browser, content):
-                content.stats += "\n<div>my html</div>"
+                content.stats += "\\n<div>my html</div>"
         """,
     ),
     # Deck options (legacy screen)
@@ -1107,7 +1107,7 @@ gui_hooks.webview_did_inject_style_into_page.append(mytest)
     ),
     Hook(
         name="addon_config_editor_will_save_json",
-        args=["text: str"],
+        args=["text: str", "addon: str"],
         return_type="str",
         doc="""Allows changing the text of the json configuration that was
         received from the user before actually reading it. For


### PR DESCRIPTION
Only the config schema is currently available to check which add-on was edited. [Example](https://github.com/zjosua/anki-mc/commit/a9aca96acfe263314d2b8323c5291a6076af0b49)
This is cumbersome and not quite safe (similar add-ons might have the same config schema).