### PR TITLE
Fix Floating Ui error causing freezes on image resize

### DIFF
--- a/ts/components/Select.svelte
+++ b/ts/components/Select.svelte
@@ -26,7 +26,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
 <WithFloating
     show={showFloating}
-    placement="bottom"
+    preferredPlacement="bottom"
     offset={0}
     shift={0}
     hideArrow

--- a/ts/components/Select.svelte
+++ b/ts/components/Select.svelte
@@ -26,7 +26,6 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
 <WithFloating
     show={showFloating}
-    preferredPlacement="bottom"
     offset={0}
     shift={0}
     hideArrow

--- a/ts/components/WithFloating.svelte
+++ b/ts/components/WithFloating.svelte
@@ -27,7 +27,8 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
     export let portalTarget: HTMLElement | null = null;
 
-    export let placement: Placement | Placement[] | "auto" = "bottom";
+    let placement: Placement = "bottom";
+    export { placement as preferredPlacement };
     export let offset = 5;
     /* 30px box shadow from elevation(8) */
     export let shift = 30;

--- a/ts/editor/editor-toolbar/BlockButtons.svelte
+++ b/ts/editor/editor-toolbar/BlockButtons.svelte
@@ -101,7 +101,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         <ButtonGroupItem>
             <WithFloating
                 show={showFloating && !disabled}
-                placement="bottom"
+                preferredPlacement="bottom"
                 inline
                 on:close={() => (showFloating = false)}
                 let:asReference

--- a/ts/editor/editor-toolbar/BlockButtons.svelte
+++ b/ts/editor/editor-toolbar/BlockButtons.svelte
@@ -101,7 +101,6 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         <ButtonGroupItem>
             <WithFloating
                 show={showFloating && !disabled}
-                preferredPlacement="bottom"
                 inline
                 on:close={() => (showFloating = false)}
                 let:asReference

--- a/ts/editor/editor-toolbar/OptionsButton.svelte
+++ b/ts/editor/editor-toolbar/OptionsButton.svelte
@@ -35,12 +35,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     }
 </script>
 
-<WithFloating
-    show={showFloating}
-    preferredPlacement="bottom"
-    inline
-    on:close={() => (showFloating = false)}
->
+<WithFloating show={showFloating} inline on:close={() => (showFloating = false)}>
     <IconButton
         slot="reference"
         tooltip={tr.actionsOptions()}

--- a/ts/editor/editor-toolbar/OptionsButton.svelte
+++ b/ts/editor/editor-toolbar/OptionsButton.svelte
@@ -37,7 +37,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
 <WithFloating
     show={showFloating}
-    placement="bottom"
+    preferredPlacement="bottom"
     inline
     on:close={() => (showFloating = false)}
 >

--- a/ts/editor/editor-toolbar/RemoveFormatButton.svelte
+++ b/ts/editor/editor-toolbar/RemoveFormatButton.svelte
@@ -116,7 +116,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
 <WithFloating
     show={showFloating && !disabled}
-    placement="bottom"
+    preferredPlacement="bottom"
     inline
     on:close={() => (showFloating = false)}
 >

--- a/ts/editor/editor-toolbar/RemoveFormatButton.svelte
+++ b/ts/editor/editor-toolbar/RemoveFormatButton.svelte
@@ -116,7 +116,6 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
 <WithFloating
     show={showFloating && !disabled}
-    preferredPlacement="bottom"
     inline
     on:close={() => (showFloating = false)}
 >

--- a/ts/editor/image-overlay/ImageOverlay.svelte
+++ b/ts/editor/image-overlay/ImageOverlay.svelte
@@ -266,7 +266,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         <WithOverlay reference={activeImage} inline let:position={positionOverlay}>
             <WithFloating
                 reference={activeImage}
-                placement="auto"
+                placement="bottom"
                 offset={20}
                 inline
                 hideIfReferenceHidden

--- a/ts/editor/image-overlay/ImageOverlay.svelte
+++ b/ts/editor/image-overlay/ImageOverlay.svelte
@@ -266,7 +266,6 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         <WithOverlay reference={activeImage} inline let:position={positionOverlay}>
             <WithFloating
                 reference={activeImage}
-                preferredPlacement="bottom"
                 offset={20}
                 inline
                 hideIfReferenceHidden

--- a/ts/editor/image-overlay/ImageOverlay.svelte
+++ b/ts/editor/image-overlay/ImageOverlay.svelte
@@ -266,7 +266,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         <WithOverlay reference={activeImage} inline let:position={positionOverlay}>
             <WithFloating
                 reference={activeImage}
-                placement="bottom"
+                preferredPlacement="bottom"
                 offset={20}
                 inline
                 hideIfReferenceHidden

--- a/ts/editor/mathjax-overlay/MathjaxOverlay.svelte
+++ b/ts/editor/mathjax-overlay/MathjaxOverlay.svelte
@@ -202,7 +202,6 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         >
             <WithFloating
                 reference={activeImage}
-                preferredPlacement="bottom"
                 offset={20}
                 keepOnKeyup
                 let:position={positionFloating}

--- a/ts/editor/mathjax-overlay/MathjaxOverlay.svelte
+++ b/ts/editor/mathjax-overlay/MathjaxOverlay.svelte
@@ -202,7 +202,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         >
             <WithFloating
                 reference={activeImage}
-                placement="auto"
+                placement="bottom"
                 offset={20}
                 keepOnKeyup
                 let:position={positionFloating}

--- a/ts/editor/mathjax-overlay/MathjaxOverlay.svelte
+++ b/ts/editor/mathjax-overlay/MathjaxOverlay.svelte
@@ -202,7 +202,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         >
             <WithFloating
                 reference={activeImage}
-                placement="bottom"
+                preferredPlacement="bottom"
                 offset={20}
                 keepOnKeyup
                 let:position={positionFloating}

--- a/ts/editor/symbols-overlay/SymbolsOverlay.svelte
+++ b/ts/editor/symbols-overlay/SymbolsOverlay.svelte
@@ -380,11 +380,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
 <div class="symbols-overlay">
     {#if referenceRange}
-        <WithFloating
-            reference={referenceRange}
-            placement="top"
-            offset={10}
-        >
+        <WithFloating reference={referenceRange} preferredPlacement="top" offset={10}>
             <Popover slot="floating" --popover-padding-inline="0">
                 <div class="symbols-menu">
                     {#each foundSymbols as found, index (found.symbol)}

--- a/ts/editor/symbols-overlay/SymbolsOverlay.svelte
+++ b/ts/editor/symbols-overlay/SymbolsOverlay.svelte
@@ -382,7 +382,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     {#if referenceRange}
         <WithFloating
             reference={referenceRange}
-            placement={["top", "bottom"]}
+            placement="top"
             offset={10}
         >
             <Popover slot="floating" --popover-padding-inline="0">

--- a/ts/sveltelib/position/position-floating.ts
+++ b/ts/sveltelib/position/position-floating.ts
@@ -21,7 +21,7 @@ import {
 import type { PositionAlgorithm } from "./position-algorithm";
 
 export interface PositionFloatingArgs {
-    placement: Placement | Placement[] | "auto";
+    placement: Placement;
     arrow: HTMLElement;
     shift: number;
     offset: number;
@@ -46,7 +46,6 @@ function positionFloating({
         floating: FloatingElement,
     ): Promise<void> {
         const middleware: Middleware[] = [
-            // the .shift() lines below expect flip() to be first
             flip(),
             offset(offsetArg),
             shift({ padding: shiftArg }),
@@ -59,18 +58,8 @@ function positionFloating({
 
         const computeArgs: Partial<ComputePositionConfig> = {
             middleware,
+            placement,
         };
-
-        if (Array.isArray(placement)) {
-            const fallbackPlacements = placement;
-            middleware.shift();
-            middleware.push(flip({ fallbackPlacements }));
-        } else if (placement === "auto") {
-            middleware.shift();
-            middleware.push(flip());
-        } else {
-            computeArgs.placement = placement;
-        }
 
         if (hideIfEscaped) {
             middleware.push(hide({ strategy: "escaped" }));

--- a/ts/sveltelib/position/position-floating.ts
+++ b/ts/sveltelib/position/position-floating.ts
@@ -10,7 +10,6 @@ import type {
 } from "@floating-ui/dom";
 import {
     arrow,
-    autoPlacement,
     computePosition,
     flip,
     hide,
@@ -63,13 +62,12 @@ function positionFloating({
         };
 
         if (Array.isArray(placement)) {
-            const allowedPlacements = placement;
-            // flip() is incompatible with autoPlacement
+            const fallbackPlacements = placement;
             middleware.shift();
-            middleware.push(autoPlacement({ allowedPlacements }));
+            middleware.push(flip({ fallbackPlacements }));
         } else if (placement === "auto") {
             middleware.shift();
-            middleware.push(autoPlacement());
+            middleware.push(flip());
         } else {
             computeArgs.placement = placement;
         }

--- a/ts/tag-editor/TagWithTooltip.svelte
+++ b/ts/tag-editor/TagWithTooltip.svelte
@@ -70,7 +70,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
             <slot {selectMode} {hoverClass} />
         </Tag>
     {:else if shorten && hasMultipleParts(name)}
-        <WithTooltip {tooltip} trigger="hover" placement="auto" let:createTooltip>
+        <WithTooltip {tooltip} trigger="hover" placement="top" let:createTooltip>
             <Tag
                 class={className}
                 bind:flash

--- a/ts/tag-editor/WithAutocomplete.svelte
+++ b/ts/tag-editor/WithAutocomplete.svelte
@@ -127,7 +127,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 <WithFloating
     keepOnKeyup
     show={$show}
-    placement="top-start"
+    preferredPlacement="top-start"
     portalTarget={document.body}
     let:asReference
     on:close={() => show.set(false)}

--- a/ts/tag-editor/tag-options-button/TagsSelectedButton.svelte
+++ b/ts/tag-editor/tag-options-button/TagsSelectedButton.svelte
@@ -25,7 +25,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
 <WithFloating
     {show}
-    placement="top"
+    preferredPlacement="top"
     portalTarget={document.body}
     shift={0}
     let:asReference


### PR DESCRIPTION
Fixes #2190.
Also fixes elements briefly moving in the wrong direction before flipping.

According to Floating UI's docs, `flip()` is an alternative to `autoPlacement()` and both mustn't be used together.

> You’ll want to use autoPlacement() instead of flip() if you **don't want** to give the floating element a “preferred” placement and let it choose a placement for you.
https://floating-ui.com/docs/autoplacement

Flip is the better option for us, so I made the following changes:

- replace the usage of `autoPlacement()` with `flip()`
- adjust user components of `<WithFloating>` accordingly
