### PR TITLE
Set overscroll-behavior to none for html in base.scss

### DIFF
--- a/sass/base.scss
+++ b/sass/base.scss
@@ -40,6 +40,7 @@ body {
 
 html {
     overflow-x: hidden;
+    overscroll-behavior: none;
 }
 
 button {


### PR DESCRIPTION
To fix buggy scroll behavior on macOS.

From what I've read about this property (https://developer.mozilla.org/en-US/docs/Web/CSS/overscroll-behavior), we probably want to set it to `none` on all platforms anyway.