### PR TITLE
Make dropdown text smaller than page text by default

### DIFF
--- a/ts/components/DropdownItem.svelte
+++ b/ts/components/DropdownItem.svelte
@@ -49,7 +49,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         justify-content: start;
         width: 100%;
 
-        font-size: var(--dropdown-font-size, var(--font-size));
+        font-size: var(--dropdown-font-size, small);
 
         background: none;
         box-shadow: none !important;


### PR DESCRIPTION
This should address some complaints about font size being too big.