### PR TITLE
use BUTTON_BG for button background

### DIFF
--- a/qt/aqt/theme.py
+++ b/qt/aqt/theme.py
@@ -293,9 +293,7 @@ class ThemeManager:
         palette.setColor(QPalette.ColorRole.Window, canvas)
         palette.setColor(QPalette.ColorRole.AlternateBase, canvas)
 
-        palette.setColor(
-            QPalette.ColorRole.Button, self.qcolor(colors.BUTTON_GRADIENT_START)
-        )
+        palette.setColor(QPalette.ColorRole.Button, self.qcolor(colors.BUTTON_BG))
 
         input_base = self.qcolor(colors.CANVAS_CODE)
         palette.setColor(QPalette.ColorRole.Base, input_base)


### PR DESCRIPTION
Using `BUTTON_BG` seems more appropriate here.

It doesn't change anything in vanilla Anki since `BUTTON_BG` and `BUTTON_GRADIENT_START` is identical in default palette, but it's slightly confusing when using [ReColor add-on](https://ankiweb.net/shared/info/688199788) to modify theme.