### PR TITLE
Give containers brighter color than canvas

### DIFF
--- a/qt/aqt/data/web/css/deckbrowser.scss
+++ b/qt/aqt/data/web/css/deckbrowser.scss
@@ -3,6 +3,20 @@
 @use "sass/root-vars";
 @use "sass/vars" as *;
 @use "sass/card-counts";
+@use "sass/elevation" as *;
+
+table {
+    padding: 1rem;
+    background: var(--canvas-elevated);
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--border-radius-large);
+
+    @include elevation(1, $opacity-boost: -0.08);
+    &:hover {
+        @include elevation(2);
+    }
+    transition: box-shadow 0.2s ease-in-out;
+}
 
 a.deck {
     color: color(fg);
@@ -44,7 +58,7 @@ body {
 .current,
 tr:hover:not(.top-level-drag-row) {
     td {
-        background: color(canvas-inset);
+        background: color(border-subtle);
         &:first-child {
             border-top-left-radius: prop(border-radius-large);
             border-bottom-left-radius: prop(border-radius-large);

--- a/qt/aqt/data/web/css/toolbar.scss
+++ b/qt/aqt/data/web/css/toolbar.scss
@@ -19,11 +19,12 @@
     @include button.base($with-hover: false, $with-active: false);
     overflow: hidden;
     padding: 0;
+
     @include elevation(1, $opacity-boost: -0.08);
     &:hover {
         @include elevation(2);
-        transition: box-shadow 0.2s linear;
     }
+    transition: box-shadow 0.2s ease-in-out;
 }
 
 body {

--- a/sass/_vars.scss
+++ b/sass/_vars.scss
@@ -80,17 +80,17 @@ $vars: (
                 ),
             ),
             elevated: (
-                "Slightly brighter than window background",
+                "Background of containers",
                 (
                     light: white,
                     dark: palette(darkgray, 4),
                 ),
             ),
             inset: (
-                "Slightly darker than window background",
+                "Background of inputs inside containers",
                 (
-                    light: palette(lightgray, 3),
-                    dark: palette(darkgray, 6),
+                    light: white,
+                    dark: palette(darkgray, 5),
                 ),
             ),
             overlay: (

--- a/sass/bootstrap-dark.scss
+++ b/sass/bootstrap-dark.scss
@@ -6,11 +6,11 @@
 @mixin night-mode {
     input,
     select {
-        background-color: var(--canvas-elevated);
+        background-color: var(--canvas-inset);
         border-color: var(--border);
 
         &:focus {
-            background-color: var(--canvas);
+            background-color: var(--canvas-inset);
         }
     }
 }

--- a/sass/night-mode.scss
+++ b/sass/night-mode.scss
@@ -2,10 +2,10 @@
  * License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html */
 
 @mixin input {
-    background-color: var(--canvas-elevated);
+    background-color: var(--canvas-inset);
     border-color: var(--border);
 
     &:focus {
-        background-color: var(--canvas);
+        background-color: var(--canvas-inset);
     }
 }

--- a/ts/components/SpinBox.svelte
+++ b/ts/components/SpinBox.svelte
@@ -151,7 +151,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         input {
             width: 100%;
             padding: 0.2rem 1.5rem 0.2rem 0.75rem;
-            background: var(--canvas-elevated);
+            background: var(--canvas-inset);
             color: var(--fg);
             border: none;
             outline: none;

--- a/ts/components/TitledContainer.svelte
+++ b/ts/components/TitledContainer.svelte
@@ -36,12 +36,13 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     @use "sass/elevation" as *;
     .container {
         width: 100%;
+        background: var(--canvas-elevated);
+        border: 1px solid var(--border-subtle);
         border-radius: var(--border-radius-large, 10px);
         padding: 1rem 1.75rem 0.75rem 1.25rem;
         &.rtl {
             padding: 1rem 1.25rem 0.75rem 1.75rem;
         }
-        border: var(--border-subtle);
         &:hover,
         &:focus-within {
             .help-badge {
@@ -49,11 +50,20 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
             }
         }
         &.light {
-            @include elevation(2);
+            @include elevation(2, $opacity-boost: -0.08);
+            &:hover,
+            &:focus-within {
+                @include elevation(3);
+            }
         }
         &.dark {
-            @include elevation(3);
+            @include elevation(3, $opacity-boost: -0.08);
+            &:hover,
+            &:focus-within {
+                @include elevation(4);
+            }
         }
+        transition: box-shadow 0.2s ease-in-out;
     }
     h1 {
         border-bottom: 1px solid var(--border);

--- a/ts/editor/EditorField.svelte
+++ b/ts/editor/EditorField.svelte
@@ -129,7 +129,8 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
     .editor-field {
         overflow: hidden;
-        margin: 1px 3px 0 3px;
+        /* make room for thicker focus border */
+        margin: 1px;
 
         border-radius: 5px;
         border: 1px solid var(--border);

--- a/ts/editor/EditorField.svelte
+++ b/ts/editor/EditorField.svelte
@@ -120,6 +120,13 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 <style lang="scss">
     @use "sass/elevation" as *;
 
+    /* Make sure labels are readable on custom Qt backgrounds */
+    .field-container {
+        background: var(--canvas);
+        border-radius: var(--border-radius);
+        overflow: hidden;
+    }
+
     .editor-field {
         overflow: hidden;
         margin: 1px 3px 0 3px;

--- a/ts/editor/LabelContainer.svelte
+++ b/ts/editor/LabelContainer.svelte
@@ -39,6 +39,8 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         display: flex;
         justify-content: space-between;
         background: var(--canvas);
+        border-top-right-radius: var(--border-radius);
+        border-top-left-radius: var(--border-radius);
         padding: 0 3px 1px;
 
         position: sticky;

--- a/ts/import-csv/Preview.svelte
+++ b/ts/import-csv/Preview.svelte
@@ -55,7 +55,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
         tr {
             &:nth-child(even) {
-                background: var(--canvas-elevated);
+                background: var(--canvas);
             }
         }
 


### PR DESCRIPTION
Making containers stand out from the background has been on my to-do list for some time. In order to make this work with inputs I had to tweak the CSS variables a bit.

![image](https://user-images.githubusercontent.com/62722460/204390141-8f32586b-0efa-4ef5-a25b-187ad12f6a6a.png)


I also gave the deck table on the main page the *elevated* look:

![image](https://user-images.githubusercontent.com/62722460/204389673-879ce83e-c456-4532-8535-7818d6b155cc.png)

---

## Extra
Re: https://forums.ankiweb.net/t/anki-2-1-55-beta-5/24870/45

I gave the `.field-container` element a background and rounded the corners of `LabelContainer`, so the fields will not look as awful with custom backgrounds as they otherwise would. Making the webviews transparent proved difficult, because some pages would only render on resize, so I don't want to pursue this any further right now.