### PR TITLE
Make button color and hover gradient fit together

### DIFF
--- a/qt/aqt/stylesheets.py
+++ b/qt/aqt/stylesheets.py
@@ -107,13 +107,17 @@ QPushButton {{
 QPushButton,
 QTabBar::tab:!selected,
 QComboBox:!editable,
-QComboBox::drop-down:editable {{
+QComboBox::drop-down:editable,
+QSpinBox::up-button,
+QSpinBox::down-button {{
     background: {tm.var(colors.BUTTON_GRADIENT_END)};
     border-bottom: 1px solid {tm.var(colors.SHADOW)};
 }}
 QPushButton:hover,
 QTabBar::tab:hover,
-QComboBox:!editable:hover {{
+QComboBox:!editable:hover,
+QSpinBox::up-button,
+QSpinBox::down-button {{
     background: {
         button_gradient(
             tm.var(colors.BUTTON_GRADIENT_START),
@@ -121,7 +125,9 @@ QComboBox:!editable:hover {{
         )
     };
 }}
-QPushButton:pressed {{
+QPushButton:pressed,
+QSpinBox::up-button,
+QSpinBox::down-button {{
     background: {
         button_pressed_gradient(
             tm.var(colors.BUTTON_GRADIENT_START),
@@ -337,27 +343,6 @@ QSpinBox::up-button,
 QSpinBox::down-button {{
     subcontrol-origin: border;
     width: 16px;
-    border: 1px solid {tm.var(colors.BORDER_SUBTLE)};
-    background: {tm.var(colors.BUTTON_BG)};
-}}
-QSpinBox::up-button:pressed,
-QSpinBox::down-button:pressed {{
-    background: {
-        button_pressed_gradient(
-            tm.var(colors.BUTTON_GRADIENT_START),
-            tm.var(colors.BUTTON_GRADIENT_END),
-            tm.var(colors.SHADOW)
-        )
-    }
-}}
-QSpinBox::up-button:hover,
-QSpinBox::down-button:hover {{
-    background: {
-        button_gradient(
-            tm.var(colors.BUTTON_GRADIENT_START),
-            tm.var(colors.BUTTON_GRADIENT_END),
-        )
-    };
 }}
 QSpinBox::up-button {{
     margin-bottom: -1px;

--- a/qt/aqt/stylesheets.py
+++ b/qt/aqt/stylesheets.py
@@ -110,7 +110,7 @@ QComboBox:!editable,
 QComboBox::drop-down:editable,
 QSpinBox::up-button,
 QSpinBox::down-button {{
-    background: {tm.var(colors.BUTTON_GRADIENT_END)};
+    background: {tm.var(colors.BUTTON_BG)};
     border-bottom: 1px solid {tm.var(colors.SHADOW)};
 }}
 QPushButton:hover,

--- a/qt/aqt/stylesheets.py
+++ b/qt/aqt/stylesheets.py
@@ -185,9 +185,10 @@ QComboBox::item::icon:selected {{
     position: absolute;
 }}
 QComboBox::drop-down {{
-    margin: -1px;
-    subcontrol-origin: padding;
+    subcontrol-origin: border;
     padding: 2px;
+    padding-left: 4px;
+    padding-right: 4px;
     width: 16px;
     subcontrol-position: top right;
     border: 1px solid {tm.var(colors.BORDER_SUBTLE)};

--- a/qt/aqt/stylesheets.py
+++ b/qt/aqt/stylesheets.py
@@ -83,8 +83,7 @@ QMenu::item {{
     margin-bottom: 4px;
 }}
 QMenu::item:selected {{
-    background-color: {tm.var(colors.CANVAS_INSET)};
-    color: {tm.var(colors.HIGHLIGHT_FG)};
+    background-color: {tm.var(colors.CANVAS_ELEVATED)};
     border-radius: {tm.var(props.BORDER_RADIUS)};
 }}
 QMenu::separator {{

--- a/qt/aqt/stylesheets.py
+++ b/qt/aqt/stylesheets.py
@@ -122,7 +122,6 @@ QComboBox:!editable:hover {{
 }}
 QPushButton:pressed,
 QComboBox:!editable:pressed {{
-    border: 1px solid {tm.var(colors.BORDER_STRONG)};
     background: {
         button_pressed_gradient(
             tm.var(colors.BUTTON_GRADIENT_START),
@@ -285,7 +284,6 @@ QHeaderView::section:first {{
 }}
 QHeaderView::section:pressed,
 QHeaderView::section:pressed:!first {{
-    border: 1px solid {tm.var(colors.BORDER_STRONG)};
     background: {
         button_pressed_gradient(
             tm.var(colors.BUTTON_GRADIENT_START),
@@ -345,7 +343,6 @@ QSpinBox::down-button {{
 }}
 QSpinBox::up-button:pressed,
 QSpinBox::down-button:pressed {{
-    border: 1px solid {tm.var(colors.BORDER_STRONG)};
     background: {
         button_pressed_gradient(
             tm.var(colors.BUTTON_GRADIENT_START),

--- a/qt/aqt/stylesheets.py
+++ b/qt/aqt/stylesheets.py
@@ -106,8 +106,9 @@ QPushButton {{
 }}
 QPushButton,
 QTabBar::tab:!selected,
-QComboBox:!editable {{
-    background: {tm.var(colors.BUTTON_BG)};
+QComboBox:!editable,
+QComboBox::drop-down:editable {{
+    background: {tm.var(colors.BUTTON_GRADIENT_END)};
     border-bottom: 1px solid {tm.var(colors.SHADOW)};
 }}
 QPushButton:hover,
@@ -120,8 +121,7 @@ QComboBox:!editable:hover {{
         )
     };
 }}
-QPushButton:pressed,
-QComboBox:!editable:pressed {{
+QPushButton:pressed {{
     background: {
         button_pressed_gradient(
             tm.var(colors.BUTTON_GRADIENT_START),
@@ -188,21 +188,20 @@ QComboBox::drop-down {{
     border-top-{tm.right()}-radius: {tm.var(props.BORDER_RADIUS)};
     border-bottom-{tm.right()}-radius: {tm.var(props.BORDER_RADIUS)};
 }}
+QComboBox::drop-down:!editable {{
+    background: none;
+    border-color: transparent;
+}}
 QComboBox::down-arrow {{
     image: url({tm.themed_icon("mdi:chevron-down")});
 }}
-QComboBox::drop-down {{
-    background: {tm.var(colors.BUTTON_BG)};
-    border-bottom: 1px solid {tm.var(colors.SHADOW)};
-}}
-QComboBox::drop-down:hover {{
+QComboBox::drop-down:hover:editable {{
     background: {
         button_gradient(
             tm.var(colors.BUTTON_GRADIENT_START),
             tm.var(colors.BUTTON_GRADIENT_END),
         )
     };
-    border-bottom: 1px solid {tm.var(colors.SHADOW)};
 }}
     """
 

--- a/sass/_vars.scss
+++ b/sass/_vars.scss
@@ -142,7 +142,7 @@ $vars: (
             bg: (
                 "Background color of buttons",
                 (
-                    light: white,
+                    light: palette(lightgray, 0),
                     dark: palette(darkgray, 4),
                 ),
             ),
@@ -151,14 +151,14 @@ $vars: (
                     "Start value of default button gradient",
                     (
                         light: white,
-                        dark: palette(darkgray, 4),
+                        dark: color.scale(palette(darkgray, 4), $lightness: 10%),
                     ),
                 ),
                 end: (
                     "End value of default button gradient",
                     (
-                        light: palette(lightgray, 3),
-                        dark: palette(darkgray, 5),
+                        light: palette(lightgray, 0),
+                        dark: color.scale(palette(darkgray, 4), $lightness: 5%),
                     ),
                 ),
             ),

--- a/sass/_vars.scss
+++ b/sass/_vars.scss
@@ -143,7 +143,7 @@ $vars: (
                 "Background color of buttons",
                 (
                     light: palette(lightgray, 0),
-                    dark: palette(darkgray, 4),
+                    dark: color.scale(palette(darkgray, 4), $lightness: 5%),
                 ),
             ),
             gradient: (


### PR DESCRIPTION
These are cherry-picked commits from #2228 + some additinal tiny CSS changes that I'd like to see in the release.

I thought since the other PR is still being discussed, I don't want to risk not having those in the next beta.

## Changes

- QComboBox and Select components are now slightly brighter than their container, which usually has `--canvas-elevated` as background color. This makes them seem more clickable. The new color also ensures a better transition to the hover effect, as it's the same value as `--button-gradient-end`.
- The QComboBox arrow has slightly more padding
- Qt buttons don't have the aggressive border change in the pressed state anymore

## Before vs After
![image](https://user-images.githubusercontent.com/62722460/205447633-4e9b0537-0983-48a3-93bf-3c280ee0ec06.png)

### After
![image](https://user-images.githubusercontent.com/62722460/205447573-cfbd9ff5-67b2-4e50-861b-b686440aa40d.png)
