### PR TITLE
Add profile manager setting to force custom qt stylesheets

### DIFF
--- a/qt/aqt/profiles.py
+++ b/qt/aqt/profiles.py
@@ -546,6 +546,12 @@ create table if not exists profiles
     def set_theme(self, theme: Theme) -> None:
         self.meta["theme"] = theme.value
 
+    def force_custom_styles(self) -> bool:
+        return self.meta.get("force_custom_styles", False)
+
+    def set_force_custom_styles(self, enabled: bool) -> None:
+        self.meta["force_custom_styles"] = enabled
+
     def browser_layout(self) -> BrowserLayout:
         from aqt.browser.layout import BrowserLayout
 

--- a/qt/aqt/theme.py
+++ b/qt/aqt/theme.py
@@ -231,7 +231,7 @@ class ThemeManager:
 
         buf = splitter_styles(self)
 
-        if not is_mac:
+        if not is_mac or aqt.mw.pm.force_custom_styles():
             from aqt.stylesheets import (
                 button_styles,
                 checkbox_styles,
@@ -266,7 +266,7 @@ class ThemeManager:
     def _apply_palette(self, app: QApplication) -> None:
         set_macos_dark_mode(self.night_mode)
 
-        if is_mac:
+        if is_mac and not aqt.mw.pm.force_custom_styles():
             app.setStyle(QStyleFactory.create(self._default_style))  # type: ignore
             self.default_palette.setColor(
                 QPalette.ColorRole.Window, self.qcolor(colors.CANVAS)


### PR DESCRIPTION
Closes #2204.

I used `custom_styles` over `fusion`, because altough the base style is Fusion, the widgets styled in `stylesheets.py` are fully custom. Changing one property requires styling every other property too:

> **Note:** With complex widgets such as [QComboBox](https://doc.qt.io/qt-6/qcombobox.html) and [QScrollBar](https://doc.qt.io/qt-6/qscrollbar.html), if one property or sub-control is customized, all the other properties or sub-controls must be customized as well.
https://doc.qt.io/qt-6/stylesheet-syntax.html

WDYT?