### PR TITLE
Allow Nested filtered decks

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -107,6 +107,7 @@ Sam Penny <github.com/sam1penny>
 Yutsuten <mateus.etto@gmail.com>
 Zoom <zoomrmc+git@gmail.com>
 Stefan Kangas <stefankangas@gmail.com>
+Harsha Raghu N. <narnindi.raghu@gmail.com>
 
 ********************
 

--- a/qt/aqt/filtered_deck.py
+++ b/qt/aqt/filtered_deck.py
@@ -210,7 +210,6 @@ class FilteredDeckConfigDialog(QDialog):
             SearchNode(card_state=SearchNode.CARD_STATE_SUSPENDED),
             SearchNode(card_state=SearchNode.CARD_STATE_BURIED),
             *self._learning_search_node(),
-            *self._filtered_search_node(),
         )
         manual_filter = self.col.group_searches(*manual_filters, joiner="OR")
         implicit_filter = self.col.group_searches(*implicit_filters, joiner="OR")
@@ -240,18 +239,6 @@ class FilteredDeckConfigDialog(QDialog):
                 )
             return (SearchNode(card_state=SearchNode.CARD_STATE_LEARN),)
         return ()
-
-    def _filtered_search_node(self) -> tuple[SearchNode]:
-        """Return a search node that matches cards in filtered decks, if applicable excluding those
-        in the deck being rebuild."""
-        if self.deck.id:
-            return (
-                self.col.group_searches(
-                    SearchNode(deck="filtered"),
-                    SearchNode(negated=SearchNode(deck=self.deck.name)),
-                ),
-            )
-        return (SearchNode(deck="filtered"),)
 
     def _onReschedToggled(self, _state: int) -> None:
         self.form.previewDelayWidget.setVisible(

--- a/rslib/src/scheduler/filtered/card.rs
+++ b/rslib/src/scheduler/filtered/card.rs
@@ -27,15 +27,13 @@ impl Card {
 
     pub(crate) fn move_into_filtered_deck(&mut self, ctx: &DeckFilterContext, position: i32) {
         // filtered and v1 learning cards are excluded, so odue should be guaranteed to be zero
-        if self.original_due != 0 {
-            println!("bug: odue was set");
-            return;
+        if self.original_due == 0 {
+            // Case for non-Nested filtered decks only. Getting a card from filtered deck would imply odue and odid already being set - hence no need to touch them again
+            self.original_deck_id = self.deck_id;
+            self.original_due = self.due;
         }
 
-        self.original_deck_id = self.deck_id;
         self.deck_id = ctx.target_deck;
-
-        self.original_due = self.due;
 
         if ctx.scheduler == SchedulerVersion::V1 {
             if self.ctype == CardType::Review && self.due <= ctx.today as i32 {

--- a/rslib/src/scheduler/filtered/mod.rs
+++ b/rslib/src/scheduler/filtered/mod.rs
@@ -121,7 +121,7 @@ impl Collection {
         mut position: i32,
     ) -> Result<i32> {
         let search = format!(
-            "{} -is:suspended -is:buried -deck:filtered {}",
+            "{} -is:suspended -is:buried {}", // -deck:filtered
             if term.search.trim().is_empty() {
                 "".to_string()
             } else {

--- a/rslib/src/scheduler/filtered/mod.rs
+++ b/rslib/src/scheduler/filtered/mod.rs
@@ -121,12 +121,19 @@ impl Collection {
         mut position: i32,
     ) -> Result<i32> {
         let search = format!(
-            "{} -is:suspended -is:buried {}", // -deck:filtered
+            "{} -is:suspended -is:buried -deck:\"{}\" {}", // -deck:filtered
             if term.search.trim().is_empty() {
                 "".to_string()
             } else {
                 format!("({})", term.search)
             },
+            regex::escape(
+                self.storage
+                    .get_deck(ctx.target_deck)?
+                    .map(|d| d.name)
+                    .unwrap()
+                    .as_native_str(),
+            ),
             if ctx.scheduler == SchedulerVersion::V1 {
                 "-is:learn"
             } else {


### PR DESCRIPTION
mostly from here: https://forums.ankiweb.net/t/allow-nested-filter-decks/25089

This will give extreme flexibility to custom study schedules. 
One can also use many `search_terms` for finetuning their study, many `limits` too !

Note: Emptying the filter deck(at any level) will always revert cards to the original deck
