### PR TITLE
Close MathJax editor when Esc is pressed

### DIFF
--- a/qt/aqt/data/web/js/webview.ts
+++ b/qt/aqt/data/web/js/webview.ts
@@ -1,9 +1,11 @@
 /* Copyright: Ankitects Pty Ltd and contributors
  * License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html */
 
-// prevent backspace key from going back a page
 document.addEventListener("keydown", function(evt: KeyboardEvent) {
-    if (evt.keyCode !== 8) {
+    if (evt.keyCode === 27) {
+        pycmd("close");
+    } // prevent backspace key from going back a page
+    else if (evt.keyCode !== 8) {
         return;
     }
     let isText = 0;

--- a/qt/aqt/webview.py
+++ b/qt/aqt/webview.py
@@ -247,12 +247,6 @@ class AnkiWebView(QWebEngineView):
 
         self.resetHandlers()
         self._filterSet = False
-        QShortcut(  # type: ignore
-            QKeySequence("Esc"),
-            self,
-            context=Qt.ShortcutContext.WidgetWithChildrenShortcut,
-            activated=self.onEsc,
-        )
         gui_hooks.theme_did_change.append(self.on_theme_did_change)
 
     def set_title(self, title: str) -> None:
@@ -601,6 +595,8 @@ html {{ {font} }}
         if cmd == "domDone":
             self._domDone = True
             self._maybeRunActions()
+        elif cmd == "close":
+            self.onEsc()
         else:
             handled, result = gui_hooks.webview_did_receive_js_message(
                 (False, None), cmd, self._bridge_context

--- a/ts/editor/mathjax-overlay/MathjaxEditor.svelte
+++ b/ts/editor/mathjax-overlay/MathjaxEditor.svelte
@@ -51,7 +51,10 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         editor.on(
             "keydown",
             (_instance: CodeMirrorLib.Editor, event: KeyboardEvent): void => {
-                if (isArrowLeft(event)) {
+                if (event.key === "Escape") {
+                    dispatch("close");
+                    event.stopPropagation();
+                } else if (isArrowLeft(event)) {
                     direction = "start";
                 } else if (isArrowRight(event)) {
                     direction = "end";

--- a/ts/editor/mathjax-overlay/MathjaxOverlay.svelte
+++ b/ts/editor/mathjax-overlay/MathjaxOverlay.svelte
@@ -228,6 +228,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
                             // the user has to click twice (focus is called before blur?)
                             resetHandle();
                         }}
+                        on:close={resetHandle}
                         let:editor={mathjaxEditor}
                     >
                         <Shortcut


### PR DESCRIPTION
Closes #2235

Maybe the field should be refocused after the editor is closed. I didn't look into that in this PR.