### PR TITLE
Fix some more RTL issues

### DIFF
--- a/pylib/anki/stats.py
+++ b/pylib/anki/stats.py
@@ -63,7 +63,7 @@ class CardStats:
         self.txt += self.makeLine(k, v)
 
     def makeLine(self, k: str, v: str | int) -> str:
-        txt = "<tr><td align=left style='padding-right: 3px;'>"
+        txt = "<tr><td align=start style='padding-right: 3px;'>"
         txt += f"<b>{k}</b></td><td>{v}</td></tr>"
         return txt
 
@@ -909,12 +909,12 @@ when you answer "good" on a review."""
         colon = ":"
         if bold:
             i.append(
-                ("<tr><td width=200 align=right>%s%s</td><td><b>%s</b></td></tr>")
+                ("<tr><td width=200 align=start>%s%s</td><td><b>%s</b></td></tr>")
                 % (a, colon, b)
             )
         else:
             i.append(
-                ("<tr><td width=200 align=right>%s%s</td><td>%s</td></tr>")
+                ("<tr><td width=200 align=end>%s%s</td><td>%s</td></tr>")
                 % (a, colon, b)
             )
 

--- a/qt/aqt/deckbrowser.py
+++ b/qt/aqt/deckbrowser.py
@@ -241,7 +241,7 @@ class DeckBrowser:
         review = nonzeroColour(node.review_count, "review-count")
         learn = nonzeroColour(node.learn_count, "learn-count")
 
-        buf += ("<td align=right>%s</td>" * 3) % (
+        buf += ("<td align=end>%s</td>" * 3) % (
             nonzeroColour(node.new_count, "new-count"),
             learn,
             review,

--- a/qt/aqt/reviewer.py
+++ b/qt/aqt/reviewer.py
@@ -662,11 +662,11 @@ class Reviewer:
 <center id=outer>
 <table id=innertable width=100%% cellspacing=0 cellpadding=0>
 <tr>
-<td align=left valign=top class=stat>
+<td align=start valign=top class=stat>
 <button title="%(editkey)s" onclick="pycmd('edit');">%(edit)s</button></td>
 <td align=center valign=top id=middle>
 </td>
-<td align=right valign=top class=stat>
+<td align=end valign=top class=stat>
 <button title="%(morekey)s" onclick="pycmd('more');">
 %(more)s %(downArrow)s
 <span id=time class=stattxt></span>

--- a/ts/graphs/reviews.ts
+++ b/ts/graphs/reviews.ts
@@ -254,7 +254,7 @@ export function renderReviews(
         const day = dayLabel(d.x0!, d.x1!);
         const totals = totalsForBin(d);
         const dayTotal = valueLabel(sum(totals));
-        let buf = `<table><tr><td>${day}</td><td align=right>${dayTotal}</td></tr>`;
+        let buf = `<table><tr><td>${day}</td><td align=end>${dayTotal}</td></tr>`;
         const lines: [BinIndex | null, string][] = [
             [BinIndex.Filtered, tr.statisticsCountsFilteredCards()],
             [BinIndex.Learn, tr.statisticsCountsLearningCards()],
@@ -275,7 +275,7 @@ export function renderReviews(
             }
             buf += `<tr>
             <td><span style="color: ${color};">■</span> ${label}</td>
-            <td align=right>${detail}</td>
+            <td align=end>${detail}</td>
             </tr>`;
         }
         return buf;

--- a/ts/reviewer/reviewer.scss
+++ b/ts/reviewer/reviewer.scss
@@ -1,7 +1,7 @@
 /* Copyright: Ankitects Pty Ltd and contributors
  * License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html */
 
- @use "sass/vars";
+@use "sass/vars";
 
 hr {
     background-color: vars.palette(darkgray, 0);
@@ -31,7 +31,12 @@ li {
 
 #_flag {
     position: fixed;
-    right: 10px;
+    [dir="ltr"] & {
+        right: 10px;
+    }
+    [dir="rtl"] & {
+        left: 10px;
+    }
     top: 0;
     font-size: 30px;
     -webkit-text-stroke-width: 1px;
@@ -40,7 +45,12 @@ li {
 
 #_mark {
     position: fixed;
-    left: 10px;
+    [dir="ltr"] & {
+        left: 10px;
+    }
+    [dir="rtl"] & {
+        right: 10px;
+    }
     top: 0;
     font-size: 30px;
     color: yellow;


### PR DESCRIPTION
Fixes points 2 and 3 of https://forums.ankiweb.net/t/anki-2-1-55-beta-5-6/24870/102

The point about the editor gear menu in https://forums.ankiweb.net/t/anki-2-1-55-beta-5-6/24870/90 has to wait a bit, though. Removing the hard-coded `dir="ltr"` from `ButtonGroup` means all buttons in the editor toolbar and elsewhere are rounded on the wrong side. This will be fixed with a continuation of #2069 that I'm working on.