### PR TITLE
Replace pct-str with percent_encoding crate

### DIFF
--- a/.deny.toml
+++ b/.deny.toml
@@ -54,10 +54,6 @@ ignore = true
 unknown-registry = "warn"
 unknown-git = "warn"
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
-allow-git = [
-  # https://github.com/timothee-haudebourg/pct-str/issues/5
-  "https://github.com/timothee-haudebourg/pct-str.git",
-]
 
 [sources.allow-org]
 github = ["ankitects"]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,7 +108,7 @@ dependencies = [
  "num_cpus",
  "num_enum",
  "once_cell",
- "pct-str",
+ "percent-encoding",
  "pin-project",
  "prost",
  "prost-build",
@@ -141,7 +141,7 @@ dependencies = [
  "which",
  "workspace-hack",
  "zip",
- "zstd 0.12.0+zstd.1.5.2",
+ "zstd 0.12.1+zstd.1.5.2",
 ]
 
 [[package]]
@@ -210,7 +210,7 @@ dependencies = [
  "workspace-hack",
  "xz2",
  "zip",
- "zstd 0.12.0+zstd.1.5.2",
+ "zstd 0.12.1+zstd.1.5.2",
 ]
 
 [[package]]
@@ -985,9 +985,9 @@ dependencies = [
 
 [[package]]
 name = "filetime"
-version = "0.2.18"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b9663d381d07ae25dc88dbdf27df458faa83a9b25336bcac83d5e452b5fc9d3"
+checksum = "4e884668cd0c7480504233e951174ddc3b382f7c2666e3b7310b5c4e7b0c37f9"
 dependencies = [
  "cfg-if",
  "libc",
@@ -1623,9 +1623,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.5.1"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f88c5561171189e69df9d98bcf18fd5f9558300f7ea7b801eb8a0fd748bd8745"
+checksum = "ec947b7a4ce12e3b87e353abae7ce124d025b6c7d6c5aea5cc0bcf92e9510ded"
 
 [[package]]
 name = "is-terminal"
@@ -2134,9 +2134,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
-version = "0.10.43"
+version = "0.10.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020433887e44c27ff16365eaa2d380547a94544ad509aff6eb5b6e3e0b27b376"
+checksum = "29d971fd5722fec23977260f6e81aa67d2f22cadbdc2aa049f1022d9a3be1566"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -2166,9 +2166,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.78"
+version = "0.9.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07d5c8cb6e57b3a3612064d7b18b117912b4ce70955c2504d4b741c9e244b132"
+checksum = "5454462c0eced1e97f2ec09036abc8da362e66802f66fd20f86854d9d8cbcbc4"
 dependencies = [
  "autocfg",
  "cc",
@@ -2254,14 +2254,6 @@ dependencies = [
  "hmac",
  "password-hash",
  "sha2",
-]
-
-[[package]]
-name = "pct-str"
-version = "1.1.0"
-source = "git+https://github.com/timothee-haudebourg/pct-str.git?rev=4adccd8d4a222ab2672350a102f06ae832a0572d#4adccd8d4a222ab2672350a102f06ae832a0572d"
-dependencies = [
- "utf8-decode",
 ]
 
 [[package]]
@@ -3014,9 +3006,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.36.4"
+version = "0.36.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb93e85278e08bb5788653183213d3a60fc242b10cb9be96586f5a73dcb67c23"
+checksum = "a3807b5d10909833d3e9acd1eb5fb988f79376ff10fce42937de71a449c4c588"
 dependencies = [
  "bitflags",
  "errno",
@@ -3693,9 +3685,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.22.0"
+version = "1.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d76ce4a75fb488c605c54bf610f221cea8b0dafb53333c1a67e8ee199dcd2ae3"
+checksum = "eab6d665857cc6ca78d6e80303a02cea7a7851e85dfbd77cbdc09bd129f1ef46"
 dependencies = [
  "autocfg",
  "bytes",
@@ -3708,7 +3700,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "winapi",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -4042,12 +4034,6 @@ name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
-
-[[package]]
-name = "utf8-decode"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca61eb27fa339aa08826a29f03e87b99b4d8f0fc2255306fd266bb1b6a9de498"
 
 [[package]]
 name = "utime"
@@ -4394,7 +4380,7 @@ dependencies = [
  "tokio",
  "url",
  "zip",
- "zstd 0.12.0+zstd.1.5.2",
+ "zstd 0.12.1+zstd.1.5.2",
  "zstd-safe 6.0.2+zstd.1.5.2",
  "zstd-sys",
 ]
@@ -4463,9 +4449,9 @@ dependencies = [
 
 [[package]]
 name = "zstd"
-version = "0.12.0+zstd.1.5.2"
+version = "0.12.1+zstd.1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8148aa921e9d53217ab9322f8553bd130f7ae33489db68b381d76137d2e6374"
+checksum = "5c947d2adc84ff9a59f2e3c03b81aa4128acf28d6ad7d56273f7e8af14e47bea"
 dependencies = [
  "zstd-safe 6.0.2+zstd.1.5.2",
 ]

--- a/cargo/licenses.json
+++ b/cargo/licenses.json
@@ -1054,7 +1054,7 @@
   },
   {
     "name": "ipnet",
-    "version": "2.5.1",
+    "version": "2.6.0",
     "authors": "Kris Price <kris@krisprice.nz>",
     "repository": "https://github.com/krisprice/ipnet",
     "license": "Apache-2.0 OR MIT",
@@ -1396,7 +1396,7 @@
   },
   {
     "name": "openssl",
-    "version": "0.10.43",
+    "version": "0.10.44",
     "authors": "Steven Fackler <sfackler@gmail.com>",
     "repository": "https://github.com/sfackler/rust-openssl",
     "license": "Apache-2.0",
@@ -1423,7 +1423,7 @@
   },
   {
     "name": "openssl-sys",
-    "version": "0.9.78",
+    "version": "0.9.79",
     "authors": "Alex Crichton <alex@alexcrichton.com>|Steven Fackler <sfackler@gmail.com>",
     "repository": "https://github.com/sfackler/rust-openssl",
     "license": "MIT",
@@ -1465,15 +1465,6 @@
     "license": "Apache-2.0 OR MIT",
     "license_file": null,
     "description": "Generic implementation of PBKDF2"
-  },
-  {
-    "name": "pct-str",
-    "version": "1.1.0",
-    "authors": "Timothée Haudebourg <author@haudebourg.net>",
-    "repository": "https://github.com/timothee-haudebourg/pct-str",
-    "license": "Apache-2.0 OR MIT",
-    "license_file": null,
-    "description": "Percent-encoded strings for URL, URI, IRI, etc."
   },
   {
     "name": "percent-encoding",
@@ -1846,7 +1837,7 @@
   },
   {
     "name": "rustix",
-    "version": "0.36.4",
+    "version": "0.36.5",
     "authors": "Dan Gohman <dev@sunfishcode.online>|Jakub Konka <kubkon@jakubkonka.com>",
     "repository": "https://github.com/bytecodealliance/rustix",
     "license": "Apache-2.0 OR Apache-2.0 WITH LLVM-exception OR MIT",
@@ -2359,7 +2350,7 @@
   },
   {
     "name": "tokio",
-    "version": "1.22.0",
+    "version": "1.23.0",
     "authors": "Tokio Contributors <team@tokio.rs>",
     "repository": "https://github.com/tokio-rs/tokio",
     "license": "MIT",
@@ -2644,15 +2635,6 @@
     "license": "Apache-2.0 OR MIT",
     "license_file": null,
     "description": "Incremental, zero-copy UTF-8 decoding with error handling"
-  },
-  {
-    "name": "utf8-decode",
-    "version": "1.0.1",
-    "authors": "Timothée Haudebourg <author@haudebourg.net>",
-    "repository": "https://github.com/timothee-haudebourg/utf8-decode",
-    "license": "Apache-2.0 OR MIT",
-    "license_file": null,
-    "description": "UTF-8 incremental decoding iterators."
   },
   {
     "name": "utime",
@@ -2989,7 +2971,7 @@
   },
   {
     "name": "zstd",
-    "version": "0.12.0+zstd.1.5.2",
+    "version": "0.12.1+zstd.1.5.2",
     "authors": "Alexandre Bury <alexandre.bury@gmail.com>",
     "repository": "https://github.com/gyscos/zstd-rs",
     "license": "MIT",

--- a/rslib/Cargo.toml
+++ b/rslib/Cargo.toml
@@ -43,7 +43,6 @@ features = ["json", "socks", "stream", "multipart"]
 anki_i18n = { path = "i18n" }
 
 csv = { git = "https://github.com/ankitects/rust-csv.git", rev = "1c9d3aab6f79a7d815c69f925a46a4590c115f90" }
-pct-str = { git = "https://github.com/timothee-haudebourg/pct-str.git", rev = "4adccd8d4a222ab2672350a102f06ae832a0572d" }
 
 # pinned as any changes could invalidate sqlite indexes
 unicase = "=2.6.0"
@@ -73,6 +72,7 @@ num-integer = "0.1.45"
 num_cpus = "1.14.0"
 num_enum = "0.5.7"
 once_cell = "1.16.0"
+percent-encoding = "2.2.0"
 pin-project = "1.0.12"
 prost = "0.11.3"
 pulldown-cmark = "0.9.2"

--- a/rslib/src/text.rs
+++ b/rslib/src/text.rs
@@ -4,7 +4,7 @@
 use std::borrow::Cow;
 
 use lazy_static::lazy_static;
-use pct_str::{IriReserved, PctStr, PctString};
+use percent_encoding::{percent_decode_str, utf8_percent_encode, AsciiSet, CONTROLS};
 use regex::{Captures, Regex};
 use unicase::eq as uni_eq;
 use unicode_normalization::{
@@ -487,25 +487,26 @@ lazy_static! {
     pub(crate) static ref REMOTE_FILENAME: Regex = Regex::new("(?i)^https?://").unwrap();
 }
 
+/// https://url.spec.whatwg.org/#fragment-percent-encode-set
+const FRAGMENT_QUERY_UNION: &AsciiSet = &CONTROLS
+    .add(b' ')
+    .add(b'"')
+    .add(b'<')
+    .add(b'>')
+    .add(b'`')
+    .add(b'#');
+
 /// IRI-encode unescaped local paths in HTML fragment.
 pub(crate) fn encode_iri_paths(unescaped_html: &str) -> Cow<str> {
     transform_html_paths(unescaped_html, |fname| {
-        PctString::encode(fname.chars(), IriReserved::Segment)
-            .into_string()
-            .into()
+        utf8_percent_encode(fname, FRAGMENT_QUERY_UNION).into()
     })
 }
 
 /// URI-decode escaped local paths in HTML fragment.
 pub(crate) fn decode_iri_paths(escaped_html: &str) -> Cow<str> {
     transform_html_paths(escaped_html, |fname| {
-        match PctStr::new(fname) {
-            Ok(s) => s.decode().into(),
-            Err(_e) => {
-                // invalid percent encoding; return unchanged
-                fname.into()
-            }
-        }
+        percent_decode_str(fname).decode_utf8_lossy()
     })
 }
 


### PR DESCRIPTION
Whereas pct-str seems to encode everything possible and use opaque Unicode code point ranges to do so, percent_encoding only has a single predefined encoding set and encourages you to define your own, pinpoint set.
I experimented with the characters listed on https://url.spec.whatwg.org/#fragment-percent-encode-set (at least the ones Windows lets me put in a filename) and arrived at the set below. Maybe unlike me you're actually knowledgable in this area and know if we indeed only need the query and fragment sets.