### PR TITLE
Fix popover animation causing placement switching loop

### DIFF
--- a/ts/components/Popover.svelte
+++ b/ts/components/Popover.svelte
@@ -22,7 +22,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     const placementStore = getContext<Writable<Promise<Placement>>>(floatingKey);
 
     /* await computed placement of floating element to determine animation direction */
-    $: if ($placementStore !== undefined) {
+    $: if ($placementStore !== undefined && hidden) {
         $placementStore.then((computedPlacement) => {
             if (placement != computedPlacement) {
                 placement = computedPlacement;


### PR DESCRIPTION
Should fix https://forums.ankiweb.net/t/mathjax-flash-error/25231.

This uses the initially true `hidden` variable as a guard to prevent a loop, which was probably caused by asynchronous loading of the CodeMirror instance.