### PR TITLE
Fix dropdown items wrapping

### DIFF
--- a/ts/components/DropdownItem.svelte
+++ b/ts/components/DropdownItem.svelte
@@ -49,7 +49,8 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         display: flex;
         justify-content: start;
         width: 100%;
-
+        padding: 0.25rem 1rem;
+        white-space: nowrap;
         font-size: var(--dropdown-font-size, small);
 
         background: none;


### PR DESCRIPTION
Re: https://github.com/ankitects/anki/pull/2239#issuecomment-1343702450

When I removed `bootstrap/scss/dropdown` in #2239, two important styles got lost: `padding` and `white-space`. This PR adds those back.