### PR TITLE
Remove dark theme exclusive inset shadow from FloatingArrow

### DIFF
--- a/ts/components/FloatingArrow.svelte
+++ b/ts/components/FloatingArrow.svelte
@@ -2,11 +2,7 @@
 Copyright: Ankitects Pty Ltd and contributors
 License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 -->
-<script lang="ts">
-    import { pageTheme } from "../sveltelib/theme";
-</script>
-
-<div class="arrow" class:dark={$pageTheme.isDark} />
+<div class="arrow" />
 
 <style lang="scss">
     @use "sass/elevation" as elevation;
@@ -23,9 +19,5 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         /* Rotate the box to indicate the different directions */
         border-right: none;
         border-bottom: none;
-
-        &.dark {
-            box-shadow: inset 1px 1px 0 0 #565656;
-        }
     }
 </style>


### PR DESCRIPTION
I must have been in light mode when I changed the popover look, so I didn't notice this at first:

## Before
![image](https://user-images.githubusercontent.com/62722460/206704236-71c90bda-7e24-4316-bf45-743d2855a5c0.png)

## After
![image](https://user-images.githubusercontent.com/62722460/206704077-9a1e7ad0-28a7-477a-a54e-cd8f50b515b1.png)

General note: We should be able to safely remove most uses of `$pageTheme.isDark` because all colors are defined in `_vars.scss` now.