### PR TITLE
Add slight inset shadow to hovered buttons

### DIFF
--- a/sass/_button-mixins.scss
+++ b/sass/_button-mixins.scss
@@ -30,7 +30,6 @@
                     var(--button-primary-gradient-start) 0%,
                     var(--button-primary-gradient-end) 100%
                 );
-                border-color: var(--button-hover-border);
             }
         }
     } @else {
@@ -42,7 +41,8 @@
                     var(--button-gradient-start) 0%,
                     var(--button-gradient-end) 100%
                 );
-                border-color: var(--button-hover-border);
+                /* Makes distinguishing hover state in light theme easier */
+                @include impressed-shadow(0.2);
             }
         }
     }

--- a/sass/_vars.scss
+++ b/sass/_vars.scss
@@ -182,7 +182,7 @@ $vars: (
                 bg: (
                     "Background color of primary button",
                     (
-                        light: palette(blue, 5),
+                        light: color.scale(palette(blue, 6), $lightness: 5%),
                         dark: color.scale(palette(blue, 7), $saturation: -10%),
                     ),
                 ),
@@ -190,15 +190,15 @@ $vars: (
                     start: (
                         "Start value of primary button gradient",
                         (
-                            light: palette(blue, 4),
+                            light: palette(blue, 5),
                             dark: color.scale(palette(blue, 6), $saturation: -10%),
                         ),
                     ),
                     end: (
                         "End value of primary button gradient",
                         (
-                            light: palette(blue, 6),
-                            dark: color.scale(palette(blue, 8), $saturation: -10%),
+                            light: color.scale(palette(blue, 6), $lightness: 5%),
+                            dark: color.scale(palette(blue, 7), $saturation: -10%),
                         ),
                     ),
                 ),


### PR DESCRIPTION
Re: https://forums.ankiweb.net/t/anki-2-1-55-beta-7-rc1/25130/20

This subtle change makes the hover state more visible without the need to make the base color darker.

![image](https://user-images.githubusercontent.com/62722460/206909266-a2b56edf-8eb4-47fe-860d-b5feed34b399.png)