### PR TITLE
Tweak focus highlight of some widgets

### DIFF
--- a/qt/aqt/about.py
+++ b/qt/aqt/about.py
@@ -210,7 +210,7 @@ def show(mw: aqt.AnkiQt) -> QDialog:
             "Ijgnd",
             "Evandro Coan",
             "Alan Du",
-            "ANH",
+            "Abdo",
             "Junseo Park",
             "Gustavo Costa",
             "余时行",

--- a/qt/aqt/stylesheets.py
+++ b/qt/aqt/stylesheets.py
@@ -83,7 +83,7 @@ QMenu::item {{
     margin-bottom: 4px;
 }}
 QMenu::item:selected {{
-    background-color: {tm.var(colors.CANVAS_ELEVATED)};
+    background-color: {tm.var(colors.HIGHLIGHT_BG)};
     border-radius: {tm.var(props.BORDER_RADIUS)};
 }}
 QMenu::separator {{

--- a/qt/aqt/stylesheets.py
+++ b/qt/aqt/stylesheets.py
@@ -161,6 +161,9 @@ def combobox_styles(tm: ThemeManager) -> str:
 QComboBox {{
     padding: {"1px 6px 2px 4px" if tm.rtl() else "1px 4px 2px 6px"};
 }}
+QComboBox:focus {{
+    border-color: {tm.var(colors.BORDER_FOCUS)};
+}}
 QComboBox:editable:on,
 QComboBox:editable:focus,
 QComboBox::drop-down:focus:editable,


### PR DESCRIPTION
This fixes the following issues:

1. Focused combo boxes have no visual feedback. Guess which combo box is focused in this image:
![image](https://user-images.githubusercontent.com/41397710/208581636-60aceb1d-3751-424e-9a1e-885d333d04ad.png)

2. Similar thing for menu items, especially in light mode:
![image](https://user-images.githubusercontent.com/41397710/208581880-568468a4-bd57-4600-a2cd-2535bf472f06.png)


## After

![image](https://user-images.githubusercontent.com/41397710/208582578-0d304c05-7929-47e1-bd46-f6598b2678ff.png)
![image](https://user-images.githubusercontent.com/41397710/208582584-5b3d02aa-02a6-48a2-83a7-fe0f7516d159.png)
