### PR TITLE
Use a webview to show add-on's config help

### DIFF
--- a/qt/aqt/addons.py
+++ b/qt/aqt/addons.py
@@ -1550,6 +1550,7 @@ class ConfigEditor(QDialog):
         self.updateHelp()
         self.updateText(self.conf)
         restoreGeom(self, "addonconf")
+        self.form.splitter.setSizes([2 * self.width() // 3, self.width() // 3])
         restoreSplitter(self.form.splitter, "addonconf")
         self.setWindowTitle(
             without_unicode_isolation(

--- a/qt/aqt/addons.py
+++ b/qt/aqt/addons.py
@@ -1575,9 +1575,9 @@ class ConfigEditor(QDialog):
     def updateHelp(self) -> None:
         txt = self.mgr.addonConfigHelp(self.addon)
         if txt:
-            self.form.label.stdHtml(txt, js=[], context=self)
+            self.form.help.stdHtml(txt, js=[], css=["css/addonconf.css"], context=self)
         else:
-            self.form.scrollArea.setVisible(False)
+            self.form.help.setVisible(False)
 
     def updateText(self, conf: dict[str, Any]) -> None:
         text = json.dumps(

--- a/qt/aqt/addons.py
+++ b/qt/aqt/addons.py
@@ -1574,7 +1574,7 @@ class ConfigEditor(QDialog):
     def updateHelp(self) -> None:
         txt = self.mgr.addonConfigHelp(self.addon)
         if txt:
-            self.form.label.setText(txt)
+            self.form.label.stdHtml(txt, js=[], context=self)
         else:
             self.form.scrollArea.setVisible(False)
 

--- a/qt/aqt/data/web/css/addonconf.scss
+++ b/qt/aqt/data/web/css/addonconf.scss
@@ -1,0 +1,7 @@
+/* Copyright: Ankitects Pty Ltd and contributors
+ * License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html */
+
+body {
+    margin: 5px;
+    font-size: 13px;
+}

--- a/qt/aqt/forms/addonconf.ui
+++ b/qt/aqt/forms/addonconf.ui
@@ -33,7 +33,7 @@
        <enum>QPlainTextEdit::NoWrap</enum>
       </property>
      </widget>
-     <widget class="AnkiWebView" name="label" native="true">
+     <widget class="AnkiWebView" name="help" native="true">
       <property name="url" stdset="0">
        <url>
         <string>about:blank</string>

--- a/qt/aqt/forms/addonconf.ui
+++ b/qt/aqt/forms/addonconf.ui
@@ -33,52 +33,12 @@
        <enum>QPlainTextEdit::NoWrap</enum>
       </property>
      </widget>
-     <widget class="QScrollArea" name="scrollArea">
-      <property name="sizePolicy">
-       <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-        <horstretch>1</horstretch>
-        <verstretch>0</verstretch>
-       </sizepolicy>
+     <widget class="AnkiWebView" name="label" native="true">
+      <property name="url" stdset="0">
+       <url>
+        <string>about:blank</string>
+       </url>
       </property>
-      <property name="frameShape">
-       <enum>QFrame::NoFrame</enum>
-      </property>
-      <property name="widgetResizable">
-       <bool>true</bool>
-      </property>
-      <widget class="QWidget" name="scrollAreaWidgetContents">
-       <property name="geometry">
-        <rect>
-         <x>0</x>
-         <y>0</y>
-         <width>80</width>
-         <height>470</height>
-        </rect>
-       </property>
-       <layout class="QVBoxLayout" name="verticalLayout_2">
-        <property name="leftMargin">
-         <number>6</number>
-        </property>
-        <property name="topMargin">
-         <number>0</number>
-        </property>
-        <property name="rightMargin">
-         <number>0</number>
-        </property>
-        <property name="bottomMargin">
-         <number>0</number>
-        </property>
-        <item>
-         <widget class="AnkiWebView" name="label" native="true">
-          <property name="url" stdset="0">
-            <url>
-             <string notr="true">about:blank</string>
-            </url>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </widget>
      </widget>
     </widget>
    </item>
@@ -96,10 +56,10 @@
  </widget>
  <customwidgets>
   <customwidget>
-    <class>AnkiWebView</class>
-    <extends>QWidget</extends>
-    <header location="global">aqt/webview</header>
-    <container>1</container>
+   <class>AnkiWebView</class>
+   <extends>QWidget</extends>
+   <header location="global">aqt/webview</header>
+   <container>1</container>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/qt/aqt/forms/addonconf.ui
+++ b/qt/aqt/forms/addonconf.ui
@@ -69,24 +69,11 @@
          <number>0</number>
         </property>
         <item>
-         <widget class="QLabel" name="label">
-          <property name="text">
-           <string/>
-          </property>
-          <property name="textFormat">
-           <enum>Qt::RichText</enum>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
-          </property>
-          <property name="wordWrap">
-           <bool>true</bool>
-          </property>
-          <property name="openExternalLinks">
-           <bool>true</bool>
-          </property>
-          <property name="textInteractionFlags">
-           <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
+         <widget class="AnkiWebView" name="label" native="true">
+          <property name="url" stdset="0">
+            <url>
+             <string notr="true">about:blank</string>
+            </url>
           </property>
          </widget>
         </item>
@@ -107,6 +94,14 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+    <class>AnkiWebView</class>
+    <extends>QWidget</extends>
+    <header location="global">aqt/webview</header>
+    <container>1</container>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections>
   <connection>


### PR DESCRIPTION
This allows add-ons to embed images for example. Some of @AnKingMed's add-ons has local links to social media icons in [config.md](https://raw.githubusercontent.com/AnKingMed/The-KING-of-Button-Add-ons/master/config.md) that somehow used to work in older Anki versions.

This also brings other improvements like zooming support and gives add-ons more flexibility to modify the display using the webview_will_set_content hook for example.