### PR TITLE
Tweak toolbar styles to fix previous regressions

### DIFF
--- a/qt/aqt/data/web/css/toolbar.scss
+++ b/qt/aqt/data/web/css/toolbar.scss
@@ -6,25 +6,18 @@
 @use "sass/elevation" as *;
 @use "sass/button-mixins" as button;
 
-#header {
-    padding-bottom: 4px;
-    margin-top: -3px;
+#header,
+#header tbody {
+    padding: 0px;
+    margin: 0px;
+    border-spacing: 0px;
 }
 
 .tdcenter {
     white-space: nowrap;
-    border-radius: prop(border-radius);
-    border-bottom-left-radius: prop(border-radius-large);
-    border-bottom-right-radius: prop(border-radius-large);
-    @include button.base($with-hover: false, $with-active: false);
     overflow: hidden;
     padding: 0;
-
-    @include elevation(1, $opacity-boost: -0.08);
-    &:hover {
-        @include elevation(2);
-    }
-    transition: box-shadow 0.2s ease-in-out;
+    background-color: transparent;
 }
 
 body {
@@ -40,17 +33,22 @@ body {
 
 .hitem {
     font-weight: bold;
-    padding: 8px 14px;
+    padding: 4px 6px;
     text-decoration: none;
     color: color(fg);
     display: inline-block;
-    @include button.base;
     border: none;
     &:first-child {
         padding-left: 18px;
     }
     &:last-child {
         padding-right: 18px;
+    }
+    border-radius: 5px;
+    background-color: transparent;
+    &:hover {
+        background-color: hsl(0, 0, 0, 0.1);
+        cursor: pointer;
     }
 }
 

--- a/qt/aqt/data/web/css/toolbar.scss
+++ b/qt/aqt/data/web/css/toolbar.scss
@@ -31,17 +31,11 @@ body {
 
 .hitem {
     font-weight: bold;
-    padding: 4px 12px;
+    padding: 4px clamp(4px, 1.2vw, 1.5rem);
     text-decoration: none;
     color: color(fg);
     display: inline-block;
     border: none;
-    &:first-child {
-        padding-left: 18px;
-    }
-    &:last-child {
-        padding-right: 18px;
-    }
     background-color: transparent;
     transition: box-shadow 0.2s ease-in-out, background-color 0.2s ease-in-out;
     &:hover {

--- a/qt/aqt/data/web/css/toolbar.scss
+++ b/qt/aqt/data/web/css/toolbar.scss
@@ -39,7 +39,7 @@ body {
     background-color: transparent;
     transition: box-shadow 0.2s ease-in-out, background-color 0.2s ease-in-out;
     &:hover {
-        background-color: white;
+        background: var(--button-bg);
         @include button.impressed-shadow(0.35);
         cursor: pointer;
     }

--- a/qt/aqt/data/web/css/toolbar.scss
+++ b/qt/aqt/data/web/css/toolbar.scss
@@ -31,7 +31,7 @@ body {
 
 .hitem {
     font-weight: bold;
-    padding: 4px clamp(4px, 1.2vw, 1.5rem);
+    padding: 6px clamp(4px, 1.2vw, 1.5rem) 5px;
     text-decoration: none;
     color: color(fg);
     display: inline-block;

--- a/qt/aqt/data/web/css/toolbar.scss
+++ b/qt/aqt/data/web/css/toolbar.scss
@@ -13,6 +13,10 @@
     border-spacing: 0px;
 }
 
+center#outer {
+    border-block-end: 1px solid color(border);
+}
+
 .tdcenter {
     white-space: nowrap;
     overflow: hidden;
@@ -33,7 +37,7 @@ body {
 
 .hitem {
     font-weight: bold;
-    padding: 4px 6px;
+    padding: 4px 10px;
     text-decoration: none;
     color: color(fg);
     display: inline-block;
@@ -44,10 +48,11 @@ body {
     &:last-child {
         padding-right: 18px;
     }
-    border-radius: 5px;
     background-color: transparent;
+    transition: box-shadow 0.2s ease-in-out, background-color 0.2s ease-in-out;
     &:hover {
-        background-color: hsl(0, 0, 0, 0.1);
+        background-color: white;
+        @include button.impressed-shadow(0.35);
         cursor: pointer;
     }
 }

--- a/qt/aqt/data/web/css/toolbar.scss
+++ b/qt/aqt/data/web/css/toolbar.scss
@@ -6,24 +6,6 @@
 @use "sass/elevation" as *;
 @use "sass/button-mixins" as button;
 
-#header,
-#header tbody {
-    padding: 0px;
-    margin: 0px;
-    border-spacing: 0px;
-}
-
-center#outer {
-    border-block-end: 1px solid color(border);
-}
-
-.tdcenter {
-    white-space: nowrap;
-    overflow: hidden;
-    padding: 0;
-    background-color: transparent;
-}
-
 body {
     margin: 0;
     padding: 0;
@@ -35,9 +17,21 @@ body {
     -webkit-user-drag: none;
 }
 
+.top_toolbar {
+    padding: 0;
+    margin: 0;
+    border-block-end: 1px solid color(border);
+    white-space: nowrap;
+    overflow: hidden;
+    background-color: transparent;
+    display: flex;
+    flex-flow: row nowrap;
+    justify-content: center;
+}
+
 .hitem {
     font-weight: bold;
-    padding: 4px 10px;
+    padding: 4px 12px;
     text-decoration: none;
     color: color(fg);
     display: inline-block;

--- a/qt/aqt/toolbar.py
+++ b/qt/aqt/toolbar.py
@@ -195,12 +195,9 @@ class Toolbar:
     ######################################################################
 
     _body = """
-<center id=outer>
-<table id=header>
-<tr>
-<td class=tdcenter align=center>%s</td>
-</tr></table>
-</center>
+<div class="top_toolbar">
+%s
+</div>
 """
 
 


### PR DESCRIPTION
This PR fixes a regression with the toolbar that occurred in 2.1.55.

**Main problems with the current look:**

* It has grown noticeably taller.
* There’s a gap between the end of the shadow and the upper edge of the card

![notch](https://global.discourse-cdn.com/business7/uploads/anki2/original/2X/2/2cc23d4796c3cc2e0eb3457c43937370e46aa77e.png)

**New version (screencast):**

https://user-images.githubusercontent.com/69171671/209826215-75684d24-4811-4353-b02a-7d1a1a7b2e9f.mp4

The toolbar buttons behave more similarly to what was in 2.1.54 and earlier. Because add-ons often print on the toolbar, it is important to keep it compact, so the paddings were reduced. 

I have seen a PR that makes it possible to hide the toolbar. I think it's fine for someone who don't use any addons that add extra buttons to the toolbar. However, without this PR those who want the toolbar to stay visible would have to accept its intrusive look.

There are probably alternative ways to fix the issue, but I would assume they require more work. For example, the toolbar could be moved to a completely different location.