### PR TITLE
Work around issue with entering text around MathJax via IME

### DIFF
--- a/ts/editable/frame-handle.ts
+++ b/ts/editable/frame-handle.ts
@@ -53,7 +53,6 @@ function restoreHandleContent(mutations: MutationRecord[]): void {
             }
 
             const handleElement = target;
-            const placement = handleElement instanceof FrameStart ? "beforebegin" : "afterend";
             const frameElement = handleElement.parentElement as FrameElement;
 
             for (const node of mutation.addedNodes) {
@@ -75,7 +74,7 @@ function restoreHandleContent(mutations: MutationRecord[]): void {
                     referenceNode = moveChildOutOfElement(
                         frameElement,
                         node,
-                        placement,
+                        handleElement.placement,
                     );
                 }
             }
@@ -114,6 +113,8 @@ function restoreHandleContent(mutations: MutationRecord[]): void {
 const handleObserver = new MutationObserver(restoreHandleContent);
 const handles: Set<FrameHandle> = new Set();
 
+type Placement = Extract<InsertPosition, "beforebegin" | "afterend">;
+
 export abstract class FrameHandle extends HTMLElement {
     static get observedAttributes(): string[] {
         return ["data-frames"];
@@ -128,6 +129,7 @@ export abstract class FrameHandle extends HTMLElement {
      */
     partiallySelected = false;
     frames?: string;
+    abstract placement: Placement;
 
     constructor() {
         super();
@@ -204,6 +206,12 @@ export abstract class FrameHandle extends HTMLElement {
 
 export class FrameStart extends FrameHandle {
     static tagName = "frame-start";
+    placement: Placement;
+
+    constructor() {
+        super();
+        this.placement = "beforebegin";
+    }
 
     getFrameRange(): Range {
         const range = new Range();
@@ -245,6 +253,12 @@ export class FrameStart extends FrameHandle {
 
 export class FrameEnd extends FrameHandle {
     static tagName = "frame-end";
+    placement: Placement;
+
+    constructor() {
+        super();
+        this.placement = "afterend";
+    }
 
     getFrameRange(): Range {
         const range = new Range();

--- a/ts/editable/frame-handle.ts
+++ b/ts/editable/frame-handle.ts
@@ -87,21 +87,7 @@ function restoreHandleContent(mutations: MutationRecord[]): void {
                 continue;
             }
 
-            const handleElement = target.parentElement;
-            const placement = handleElement instanceof FrameStart ? "beforebegin" : "afterend";
-            const frameElement = handleElement.parentElement! as FrameElement;
-
-            const cleaned = target.data.replace(spaceRegex, "");
-            const text = new Text(cleaned);
-
-            if (placement === "beforebegin") {
-                frameElement.before(text);
-            } else {
-                frameElement.after(text);
-            }
-
-            handleElement.refreshSpace();
-            referenceNode = text;
+            referenceNode = target.parentElement.moveTextOutOfFrame();
         }
     }
 
@@ -202,6 +188,20 @@ export abstract class FrameHandle extends HTMLElement {
     }
 
     abstract notifyMoveIn(offset: number): void;
+
+    moveTextOutOfFrame(): Text {
+        const frameElement = this.parentElement! as FrameElement;
+        const cleaned = this.innerHTML.replace(spaceRegex, "");
+        const text = new Text(cleaned);
+
+        if (this.placement === "beforebegin") {
+            frameElement.before(text);
+        } else if (this.placement === "afterend") {
+            frameElement.after(text);
+        }
+        this.refreshSpace();
+        return text;
+    }
 }
 
 export class FrameStart extends FrameHandle {

--- a/ts/editable/frame-handle.ts
+++ b/ts/editable/frame-handle.ts
@@ -86,6 +86,7 @@ function restoreHandleContent(mutations: MutationRecord[]): void {
                 !nodeIsText(target)
                 || !isFrameHandle(target.parentElement)
                 || skippableNode(target.parentElement, target)
+                || target.parentElement.unsubscribe
             ) {
                 continue;
             }
@@ -220,13 +221,12 @@ export abstract class FrameHandle extends HTMLElement {
      * is active, and moving the final output from IME only after the session ends.
      */
     subscribeToCompositionEvent(): void {
-        this.unsubscribe = this.unsubscribe
-            || isComposing.subscribe((composing) => {
-                if (!composing) {
-                    placeCaretAfter(this.moveTextOutOfFrame());
-                    this.unsubscribeToCompositionEvent();
-                }
-            });
+        this.unsubscribe = isComposing.subscribe((composing) => {
+            if (!composing) {
+                placeCaretAfter(this.moveTextOutOfFrame());
+                this.unsubscribeToCompositionEvent();
+            }
+        });
     }
 
     unsubscribeToCompositionEvent(): void {

--- a/ts/editor/mathjax-overlay/MathjaxOverlay.svelte
+++ b/ts/editor/mathjax-overlay/MathjaxOverlay.svelte
@@ -11,6 +11,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     import type CodeMirrorLib from "codemirror";
     import { tick } from "svelte";
     import { writable } from "svelte/store";
+    import { isComposing } from "sveltelib/composition";
 
     import Popover from "../../components/Popover.svelte";
     import Shortcut from "../../components/Shortcut.svelte";
@@ -79,6 +80,11 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     const code = writable("");
 
     function showOverlay(image: HTMLImageElement, pos?: CodeMirrorLib.Position) {
+        if ($isComposing) {
+            // Should be canceled while an IME composition session is active
+            return;
+        }
+
         const [promise, allowResolve] = promiseWithResolver<void>();
 
         allowPromise = promise;

--- a/ts/sveltelib/composition.ts
+++ b/ts/sveltelib/composition.ts
@@ -1,0 +1,12 @@
+// Copyright: Ankitects Pty Ltd and contributors
+// License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
+
+import { writable } from "svelte/store";
+
+/**
+ * Indicates whether an IME composition session is currently active
+ */
+export const isComposing = writable(false);
+
+window.addEventListener("compositionstart", () => isComposing.set(true));
+window.addEventListener("compositionend", () => isComposing.set(false));


### PR DESCRIPTION
This works around #2251.

I don't think this is an ideal solution, and it would be better to find a way to eliminate the need to move the text node in the first place, but I have not been able to come up with one at this time, so I have created this as a tentative workaround.

( I used the phrase 'around MathJax' in the title of the PR because the issue occurs not only when entering text after a MathJax element, but also before one. )

I tested this on Win10 with the following three IMEs and it worked with all of them.
- Microsoft Pinyin (Simplified Chinese)
- Microsoft Japanese IME
- Google Japanese Input

I also tested this on Linux with **iBus+Mozc**, and the issue did not occur even on the current `main` branch. This is probably because unlike the three IMEs above, no changes are made to `<anki-editable>` while the IME composition session is active.