### PR TITLE
Fix toolbar add-on breakages and introduce toolbar tray layout & API

### DIFF
--- a/qt/aqt/data/web/css/toolbar.scss
+++ b/qt/aqt/data/web/css/toolbar.scss
@@ -27,7 +27,7 @@
     align-self: start;
     display: flex;
     flex-direction: row;
-    align-items: center;
+    align-items: start;
 }
 
 .toolbar {

--- a/qt/aqt/data/web/css/toolbar.scss
+++ b/qt/aqt/data/web/css/toolbar.scss
@@ -6,8 +6,33 @@
 @use "sass/elevation" as *;
 @use "sass/button-mixins" as button;
 
+.header {
+    height: 41px;
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    align-items: start;
+    align-content: space-between;
+}
+
+.left-tray {
+    justify-self: start;
+}
+
+.right-tray {
+    justify-self: end;
+}
+
+.left-tray,
+.right-tray {
+    align-self: center;
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+}
+
 .toolbar {
-    display: inline-block;
+    height: 31px;
+    justify-self: center;
     white-space: nowrap;
     overflow: hidden;
     border-bottom-left-radius: prop(border-radius-large);

--- a/qt/aqt/data/web/css/toolbar.scss
+++ b/qt/aqt/data/web/css/toolbar.scss
@@ -24,7 +24,7 @@
 
 .left-tray,
 .right-tray {
-    align-self: center;
+    align-self: start;
     display: flex;
     flex-direction: row;
     align-items: center;

--- a/qt/aqt/data/web/js/toolbar.ts
+++ b/qt/aqt/data/web/js/toolbar.ts
@@ -27,3 +27,58 @@ function updateSyncColor(state: SyncState) {
             break;
     }
 }
+
+// Dealing with legacy add-ons that used CSS to absolutely position
+// themselves at toolbar edges
+
+function isAbsolutelyPositioned(node: Node): boolean {
+    if (!(node instanceof HTMLElement)) {
+        return false;
+    }
+    return getComputedStyle(node).position === "absolute";
+}
+
+function isLegacyAddonElement(node: Node): boolean {
+    if (isAbsolutelyPositioned(node)) {
+        return true;
+    }
+    for (const child of node.childNodes) {
+        if (isAbsolutelyPositioned(child)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+function getElementDimensions(element: HTMLElement): [number, number] {
+    const widths = [element.offsetWidth];
+    const heights = [element.offsetHeight];
+    for (const child of element.childNodes) {
+        if (!(child instanceof HTMLElement)) {
+            continue;
+        }
+        widths.push(child.offsetWidth);
+        heights.push(child.offsetHeight);
+    }
+    return [Math.max(...widths), Math.max(...heights)];
+}
+
+function moveLegacyAddonsToTray() {
+    const rightTray = document.getElementsByClassName("right-tray")[0];
+    const links = document.querySelectorAll<HTMLAnchorElement>(".toolbar > *");
+    const legacyAddonElements: HTMLAnchorElement[] = Array.from(links)
+        .reverse()
+        .filter(isLegacyAddonElement);
+
+    for (const element of legacyAddonElements) {
+        const wrapperElement = document.createElement("div");
+        const dimensions = getElementDimensions(element);
+        wrapperElement.append(element);
+        wrapperElement.style.cssText = `\
+width: ${dimensions[0]}px; height: ${dimensions[1]}}px;
+margin-left: 5px; margin-right: 5px; position: relative;`;
+        rightTray.append(wrapperElement);
+    }
+}
+
+document.addEventListener("DOMContentLoaded", moveLegacyAddonsToTray);

--- a/qt/aqt/data/web/js/toolbar.ts
+++ b/qt/aqt/data/web/js/toolbar.ts
@@ -81,6 +81,7 @@ function moveLegacyAddonsToTray() {
         wrapperElement.style.cssText = `\
 width: ${dimensions[0]}px; height: ${dimensions[1]}}px;
 margin-left: 5px; margin-right: 5px; position: relative;`;
+        wrapperElement.className = "tray-item tray-item-legacy";
         rightTray.append(wrapperElement);
     }
 }

--- a/qt/aqt/data/web/js/toolbar.ts
+++ b/qt/aqt/data/web/js/toolbar.ts
@@ -53,6 +53,9 @@ function isLegacyAddonElement(node: Node): boolean {
 function getElementDimensions(element: HTMLElement): [number, number] {
     const widths = [element.offsetWidth];
     const heights = [element.offsetHeight];
+    // Some add-ons inject spans or anchors into the toolbar whose dimensions,
+    // as reported by the properties above are zero, but still occupy space due
+    // to their child elements:
     for (const child of element.childNodes) {
         if (!(child instanceof HTMLElement)) {
             continue;
@@ -65,9 +68,9 @@ function getElementDimensions(element: HTMLElement): [number, number] {
 
 function moveLegacyAddonsToTray() {
     const rightTray = document.getElementsByClassName("right-tray")[0];
-    const links = document.querySelectorAll<HTMLAnchorElement>(".toolbar > *");
-    const legacyAddonElements: HTMLAnchorElement[] = Array.from(links)
-        .reverse()
+    const toolbarChildren = document.querySelectorAll<HTMLElement>(".toolbar > *");
+    const legacyAddonElements: HTMLElement[] = Array.from(toolbarChildren)
+        .reverse() // restore original add-on load order
         .filter(isLegacyAddonElement);
 
     for (const element of legacyAddonElements) {

--- a/qt/aqt/data/web/js/toolbar.ts
+++ b/qt/aqt/data/web/js/toolbar.ts
@@ -73,6 +73,7 @@ function moveLegacyAddonsToTray() {
     for (const element of legacyAddonElements) {
         const wrapperElement = document.createElement("div");
         const dimensions = getElementDimensions(element);
+        element.style.right = "0px"; // remove manual padding
         wrapperElement.append(element);
         wrapperElement.style.cssText = `\
 width: ${dimensions[0]}px; height: ${dimensions[1]}}px;

--- a/qt/aqt/toolbar.py
+++ b/qt/aqt/toolbar.py
@@ -114,8 +114,13 @@ class Toolbar:
         web_context = web_context or TopToolbar(self)
         link_handler = link_handler or self._linkHandler
         self.web.set_bridge_command(link_handler, web_context)
+        body = self._body.format(
+            toolbar_content=self._centerLinks(),
+            left_tray_content=self._left_tray_content(),
+            right_tray_content=self._right_tray_content(),
+        )
         self.web.stdHtml(
-            self._body % self._centerLinks(),
+            body,
             css=["css/toolbar.css"],
             js=["js/vendor/jquery.min.js", "js/toolbar.js"],
             context=web_context,
@@ -204,6 +209,19 @@ class Toolbar:
 
         return "\n".join(links)
 
+    # Add-ons
+    ######################################################################
+
+    def _left_tray_content(self) -> str:
+        left_tray_content: list[str] = []
+        gui_hooks.top_toolbar_will_set_left_tray_content(left_tray_content, self)
+        return "\n".join(left_tray_content)
+
+    def _right_tray_content(self) -> str:
+        right_tray_content: list[str] = []
+        gui_hooks.top_toolbar_will_set_right_tray_content(right_tray_content, self)
+        return "\n".join(right_tray_content)
+
     # Sync
     ######################################################################
 
@@ -266,9 +284,9 @@ class Toolbar:
 
     _body = """
 <div class="header">
-  <div class="left-tray"></div>
-  <div class="toolbar">%s</div>
-  <div class="right-tray"></div>
+  <div class="left-tray">{left_tray_content}</div>
+  <div class="toolbar">{toolbar_content}</div>
+  <div class="right-tray">{right_tray_content}</div>
 </div>
 """
 

--- a/qt/aqt/toolbar.py
+++ b/qt/aqt/toolbar.py
@@ -265,11 +265,11 @@ class Toolbar:
     ######################################################################
 
     _body = """
-<center id="outer">
-<div id="header">
-<div class="toolbar">%s<div>
+<div class="header">
+  <div class="left-tray"></div>
+  <div class="toolbar">%s</div>
+  <div class="right-tray"></div>
 </div>
-</center>
 """
 
 

--- a/qt/aqt/toolbar.py
+++ b/qt/aqt/toolbar.py
@@ -215,12 +215,15 @@ class Toolbar:
     def _left_tray_content(self) -> str:
         left_tray_content: list[str] = []
         gui_hooks.top_toolbar_will_set_left_tray_content(left_tray_content, self)
-        return "\n".join(left_tray_content)
+        return self._process_tray_content(left_tray_content)
 
     def _right_tray_content(self) -> str:
         right_tray_content: list[str] = []
         gui_hooks.top_toolbar_will_set_right_tray_content(right_tray_content, self)
-        return "\n".join(right_tray_content)
+        return self._process_tray_content(right_tray_content)
+
+    def _process_tray_content(self, content: list[str]) -> str:
+        return "\n".join(f"""<div class="tray-item">{item}</div>""" for item in content)
 
     # Sync
     ######################################################################

--- a/qt/tools/genhooks_gui.py
+++ b/qt/tools/genhooks_gui.py
@@ -796,6 +796,28 @@ gui_hooks.webview_did_inject_style_into_page.append(mytest)
         """,
     ),
     Hook(
+        name="top_toolbar_will_set_left_tray_content",
+        args=["content: list[str]", "top_toolbar: aqt.toolbar.Toolbar"],
+        doc="""Used to add custom add-on components to the *left* area of Anki's main
+        window toolbar
+
+        'content' is a list of HTML strings added by add-ons which you can append your
+        own components or elements to. To equip your components with logic and styling
+        please see `webview_will_set_content` and `webview_did_receive_js_message`.
+        """,
+    ),
+    Hook(
+        name="top_toolbar_will_set_right_tray_content",
+        args=["content: list[str]", "top_toolbar: aqt.toolbar.Toolbar"],
+        doc="""Used to add custom add-on components to the *right* area of Anki's main
+        window toolbar
+
+        'content' is a list of HTML strings added by add-ons which you can append your
+        own components or elements to. To equip your components with logic and styling
+        please see `webview_will_set_content` and `webview_did_receive_js_message`.
+        """,
+    ),
+    Hook(
         name="top_toolbar_did_redraw",
         args=["top_toolbar: aqt.toolbar.Toolbar"],
         doc="""Executed when the top toolbar is redrawn""",

--- a/qt/tools/genhooks_gui.py
+++ b/qt/tools/genhooks_gui.py
@@ -804,6 +804,10 @@ gui_hooks.webview_did_inject_style_into_page.append(mytest)
         'content' is a list of HTML strings added by add-ons which you can append your
         own components or elements to. To equip your components with logic and styling
         please see `webview_will_set_content` and `webview_did_receive_js_message`.
+        
+        Please note that Anki's main screen is due to undergo a significant refactor
+        in the future and, as a result, add-ons subscribing to this hook will likely
+        require changes to continue working.
         """,
     ),
     Hook(
@@ -815,6 +819,10 @@ gui_hooks.webview_did_inject_style_into_page.append(mytest)
         'content' is a list of HTML strings added by add-ons which you can append your
         own components or elements to. To equip your components with logic and styling
         please see `webview_will_set_content` and `webview_did_receive_js_message`.
+        
+        Please note that Anki's main screen is due to undergo a significant refactor
+        in the future and, as a result, add-ons subscribing to this hook will likely
+        require changes to continue working.
         """,
     ),
     Hook(


### PR DESCRIPTION
Pending merge of #2262 ([actual diff](https://github.com/kleinerpirat/anki/compare/auto-hide-toolbar...glutanimate:anki:extend-toolbar-layout-and-addon-api)).

This PR has two main goals:

- work around breakages that add-ons using absolute positioning in the toolbar would otherwise experience after #2262
- introduce proper APIs for extending Anki's header area beyond just the center toolbar

To do so it performs the following changes:

- refactor the header layout into a grid with three areas: The existing center toolbar and two tray areas to the left and right of it
- introduce Python hooks that allow add-ons to inject their own HTML into both tray areas – these could be replaced by a JS API in the future
- add a workaround to migrate over add-on components which were previously using CSS hacks that no longer work past the toolbar redesign

AMBOSS add-on and Study Timer before these changes:

![Screenshot_20230106_061001](https://user-images.githubusercontent.com/5459332/210934575-e9383a1a-cabd-4b48-bc03-c71618a8e8cc.png)

afterwards:

![Screenshot_20230106_061045](https://user-images.githubusercontent.com/5459332/210934594-e252931f-10b6-463c-81bb-ffa18e1098cc.png)


To explain the custom logic in `toolbar.ts`: I wasn't able to find a reasonable CSS-only solution that would maintain the structure of the current design, while also positioning these addon-injected elements properly. So I opted for adding this workaround as short-term solution to avoid add-on breakages, while also providing a new canonical API for the affected add-ons to slowly transition to.

These changes do fundamentally modify the composition of the toolbar body, but from what I can see, the only working add-on that would be affected by this is [Move Stats and sync buttons to the right (2.1.20)](https://ankiweb.net/shared/info/1594467075).

----

*Copyright disclosure: This patch was written as part of my work for AMBOSS. Its rights of use lie with AMBOSS MD Inc and it is being submitted in agreement with Anki's contributor license agreement, as signed by AMBOSS MD Inc. (see the `CONTRIBUTORS` file).*