### PR TITLE
Vertically center text inside toolbar

### DIFF
--- a/qt/aqt/data/web/css/toolbar.scss
+++ b/qt/aqt/data/web/css/toolbar.scss
@@ -72,7 +72,7 @@ body {
 
 .hitem {
     font-weight: bold;
-    padding: 6px 12px 8px;
+    padding: 5px 12px;
     text-decoration: none;
     color: color(fg);
     display: inline-block;


### PR DESCRIPTION
After #2301 I found the text to be a little too low inside the toolbar. This tweak centers the text:

## Before
![image](https://user-images.githubusercontent.com/62722460/211491855-eaf84706-c599-4238-b19c-11f6f8301224.png)

## After
![image](https://user-images.githubusercontent.com/62722460/211491799-608ef675-cdb1-46c2-a3d1-46cbe73ac7c2.png)
