### PR TITLE
Make QCheckBox more visible

### DIFF
--- a/qt/aqt/stylesheets.py
+++ b/qt/aqt/stylesheets.py
@@ -401,9 +401,9 @@ QRadioButton {{
 QCheckBox::indicator,
 QRadioButton::indicator,
 QMenu::indicator {{
-    border: 1px solid {tm.var(colors.BORDER_SUBTLE)};
+    border: 1px solid {tm.var(colors.BORDER)};
     border-radius: {tm.var(props.BORDER_RADIUS)};
-    background: {tm.var(colors.CANVAS_INSET)};
+    background: {tm.var(colors.CANVAS_ELEVATED)};
     width: 16px;
     height: 16px;
 }}


### PR DESCRIPTION
Uses `border` instead of `border-subtle` for the border
and `canvas-elevated` instead of `canvas-inset` for the background.

|  Before | After   |
|---|---|
| ![image](https://user-images.githubusercontent.com/62722460/211850532-9db6518c-d5eb-432d-9f02-0a830d20fa72.png)  |  ![image](https://user-images.githubusercontent.com/62722460/211850019-02977c2c-c7e4-4f52-a390-06e7a4dd45e6.png)  |
| ![image](https://user-images.githubusercontent.com/62722460/211858987-5162536c-3a63-4614-acde-438015841a70.png) |  ![image](https://user-images.githubusercontent.com/62722460/211858461-0e620baa-31e1-4d2f-b506-c1fc893512e0.png) |
|  ![image](https://user-images.githubusercontent.com/62722460/211850848-1986fd3f-3c41-4569-be63-8a54f0ceb0d5.png)  | ![image](https://user-images.githubusercontent.com/62722460/211851109-fd3f7249-4e45-41d6-8166-68fe6da5e94d.png)  |

In the third screenshot (Preferences), visibility is actually slightly decreased on the different background, but the stronger border partly compensates for that.