### PR TITLE
Update Options Groups dialog

### DIFF
--- a/ftl/core/preferences.ftl
+++ b/ftl/core/preferences.ftl
@@ -49,3 +49,4 @@ preferences-minutes-between-backups = Minutes between automatic backups:
 preferences-reduce-motion = Reduce motion
 preferences-reduce-motion-tooltip = Disable various animations and transitions of the user interface
 preferences-collapse-toolbar = Hide top bar during review
+preferences-enable-webview-based-deck-options-dialog = Use WebView-based Options Groups dialog

--- a/pylib/anki/consts.py
+++ b/pylib/anki/consts.py
@@ -142,6 +142,19 @@ def new_gather_priority_choices(
     }
 
 
+def new_sort_order_choices(
+    col: anki.collection.Collection | None,
+) -> dict[int, Any]:
+    tr = _tr(col)
+    return {
+        0: tr.deck_config_sort_order_template_then_gather(),
+        1: tr.deck_config_sort_order_gather(),
+        2: tr.deck_config_sort_order_card_template_then_random(),
+        3: tr.deck_config_sort_order_random_note_then_template(),
+        4: tr.deck_config_sort_order_random(),
+    }
+
+
 _deprecated_names = DeprecatedNamesMixinForModule(globals())
 
 

--- a/pylib/anki/consts.py
+++ b/pylib/anki/consts.py
@@ -155,6 +155,17 @@ def new_sort_order_choices(
     }
 
 
+def review_mix_choices(
+    col: anki.collection.Collection | None,
+) -> dict[int, Any]:
+    tr = _tr(col)
+    return {
+        0: tr.deck_config_review_mix_mix_with_reviews(),
+        1: tr.deck_config_review_mix_show_after_reviews(),
+        2: tr.deck_config_review_mix_show_before_reviews(),
+    }
+
+
 _deprecated_names = DeprecatedNamesMixinForModule(globals())
 
 

--- a/pylib/anki/consts.py
+++ b/pylib/anki/consts.py
@@ -129,6 +129,19 @@ def new_card_scheduling_labels(
     }
 
 
+def new_gather_priority_choices(
+    col: anki.collection.Collection | None,
+) -> dict[int, Any]:
+    tr = _tr(col)
+    return {
+        0: tr.deck_config_new_gather_priority_deck(),
+        1: tr.deck_config_new_gather_priority_position_lowest_first(),
+        2: tr.deck_config_new_gather_priority_position_highest_first(),
+        3: tr.deck_config_new_gather_priority_random_notes(),
+        4: tr.deck_config_new_gather_priority_random_cards(),
+    }
+
+
 _deprecated_names = DeprecatedNamesMixinForModule(globals())
 
 

--- a/pylib/anki/consts.py
+++ b/pylib/anki/consts.py
@@ -166,6 +166,22 @@ def review_mix_choices(
     }
 
 
+def review_order_choices(
+    col: anki.collection.Collection | None,
+) -> dict[int, Any]:
+    tr = _tr(col)
+    return {
+        0: tr.deck_config_sort_order_due_date_then_random(),
+        1: tr.deck_config_sort_order_due_date_then_deck(),
+        2: tr.deck_config_sort_order_deck_then_due_date(),
+        3: tr.deck_config_sort_order_ascending_intervals(),
+        4: tr.deck_config_sort_order_descending_intervals(),
+        5: tr.deck_config_sort_order_ascending_ease(),
+        6: tr.deck_config_sort_order_descending_ease(),
+        7: tr.deck_config_sort_order_relative_overdueness(),
+    }
+
+
 _deprecated_names = DeprecatedNamesMixinForModule(globals())
 
 

--- a/qt/aqt/deckconf.py
+++ b/qt/aqt/deckconf.py
@@ -77,30 +77,39 @@ class DeckConf(QDialog):
         f.lrnEasyInt.setToolTip(tr.deck_config_easy_interval_tooltip())
         f.lrnFactor.setToolTip(tr.deck_config_starting_ease_tooltip())
         f.newPerDay.setToolTip(
-            f"{tr.deck_config_new_limit_tooltip()}"
-            "\n\n"
-            f"{tr.deck_config_limit_new_bound_by_reviews()}"
-            "\n\n"
-            f"{tr.deck_config_limit_interday_bound_by_reviews()}"
-            "\n\n"
-            f"{tr.deck_config_limit_deck_v3()}"
-            "\n\n"
-            f"{tr.deck_config_tab_description()}"
+            "\n\n".join(
+                (
+                    tr.deck_config_new_limit_tooltip(),
+                    tr.deck_config_limit_new_bound_by_reviews(),
+                    tr.deck_config_limit_interday_bound_by_reviews(),
+                    tr.deck_config_limit_deck_v3(),
+                    tr.deck_config_tab_description(),
+                )
+            )
         )
         f.newGatherPriority.setToolTip(
-            f"{tr.deck_config_new_gather_priority_tooltip_2()}"
-            "\n\n"
-            f"{tr.deck_config_display_order_will_use_current_deck()}"
+            "\n\n".join(
+                (
+                    tr.deck_config_new_gather_priority_tooltip_2(),
+                    tr.deck_config_display_order_will_use_current_deck(),
+                )
+            )
         )
         f.newSortOrder.setToolTip(
-            f"{tr.deck_config_new_card_sort_order_tooltip_2()}"
-            "\n\n"
-            f"{tr.deck_config_display_order_will_use_current_deck()}"
+            "\n\n".join(
+                (
+                    tr.deck_config_new_card_sort_order_tooltip_2(),
+                    tr.deck_config_display_order_will_use_current_deck(),
+                )
+            )
         )
         f.newMix.setToolTip(
-            f"{tr.deck_config_new_review_priority_tooltip()}"
-            "\n\n"
-            f"{tr.deck_config_display_order_will_use_current_deck()}"
+            "\n\n".join(
+                (
+                    tr.deck_config_new_review_priority_tooltip(),
+                    tr.deck_config_display_order_will_use_current_deck(),
+                )
+            )
         )
 
         # review
@@ -109,26 +118,32 @@ class DeckConf(QDialog):
         f.maxIvl.setToolTip(tr.deck_config_maximum_interval_tooltip())
         f.hardFactor.setToolTip(tr.deck_config_hard_interval_tooltip())
         f.revPerDay.setToolTip(
-            f"{tr.deck_config_review_limit_tooltip()}"
-            "\n\n"
-            f"{tr.deck_config_limit_new_bound_by_reviews()}"
-            "\n\n"
-            f"{tr.deck_config_limit_interday_bound_by_reviews()}"
-            "\n\n"
-            f"{tr.deck_config_limit_deck_v3()}"
-            "\n\n"
-            f"{tr.deck_config_tab_description()}"
+            "\n\n".join(
+                (
+                    tr.deck_config_review_limit_tooltip(),
+                    tr.deck_config_limit_new_bound_by_reviews(),
+                    tr.deck_config_limit_interday_bound_by_reviews(),
+                    tr.deck_config_limit_deck_v3(),
+                    tr.deck_config_tab_description(),
+                )
+            )
         )
         f.buryRev.setToolTip(tr.deck_config_bury_review_tooltip())
         f.interdayLearningMix.setToolTip(
-            f"{tr.deck_config_interday_step_priority_tooltip()}"
-            "\n\n"
-            f"{tr.deck_config_display_order_will_use_current_deck()}"
+            "\n\n".join(
+                (
+                    tr.deck_config_interday_step_priority_tooltip(),
+                    tr.deck_config_display_order_will_use_current_deck(),
+                )
+            )
         )
         f.reviewOrder.setToolTip(
-            f"{tr.deck_config_review_sort_order_tooltip()}"
-            "\n\n"
-            f"{tr.deck_config_display_order_will_use_current_deck()}"
+            "\n\n".join(
+                (
+                    tr.deck_config_review_sort_order_tooltip(),
+                    tr.deck_config_display_order_will_use_current_deck(),
+                )
+            )
         )
 
         # lapse

--- a/qt/aqt/deckconf.py
+++ b/qt/aqt/deckconf.py
@@ -223,6 +223,7 @@ class DeckConf(QDialog):
         if self.mw.col.sched_ver() == 1:
             f.hardFactor.setVisible(False)
             f.hardFactorLabel.setVisible(False)
+
         # lapse
         c = self.conf["lapse"]
         f.lapSteps.setText(self.listToUser(c["delays"]))
@@ -230,6 +231,7 @@ class DeckConf(QDialog):
         f.lapMinInt.setValue(c["minInt"])
         f.leechThreshold.setValue(c["leechFails"])
         f.leechAction.setCurrentIndex(c["leechAction"])
+
         # general
         c = self.conf
         f.maxTaken.setValue(c["maxTaken"])
@@ -299,6 +301,7 @@ class DeckConf(QDialog):
             else:
                 self.mw.col.sched.order_cards(self.deck["id"])
         self.conf["buryInterdayLearning"] = f.buryInterdayLearningSiblings.isChecked()
+
         # rev
         c = self.conf["rev"]
         c["perDay"] = f.revPerDay.value()
@@ -307,6 +310,7 @@ class DeckConf(QDialog):
         c["maxIvl"] = f.maxIvl.value()
         c["bury"] = f.buryRev.isChecked()
         c["hardFactor"] = f.hardFactor.value() / 100.0
+
         # lapse
         c = self.conf["lapse"]
         self.updateList(c, "delays", f.lapSteps, minSize=0)
@@ -314,6 +318,7 @@ class DeckConf(QDialog):
         c["minInt"] = f.lapMinInt.value()
         c["leechFails"] = f.leechThreshold.value()
         c["leechAction"] = f.leechAction.currentIndex()
+
         # general
         c = self.conf
         c["maxTaken"] = f.maxTaken.value()

--- a/qt/aqt/deckconf.py
+++ b/qt/aqt/deckconf.py
@@ -67,6 +67,12 @@ class DeckConf(QDialog):
         f.buryInterdayLearningSiblings.setToolTip(tr.deck_config_bury_interday_learning_tooltip())
         f.newGatherPriority.setToolTip(tr.deck_config_new_gather_priority_tooltip_2())
         f.newSortOrder.setToolTip(tr.deck_config_new_card_sort_order_tooltip_2())
+        f.newMix.setToolTip(
+            f"{tr.deck_config_new_review_priority_tooltip()}"
+            "\n\n"
+            f"{tr.deck_config_display_order_will_use_current_deck()}"
+        )
+        f.interdayLearningMix.setToolTip(tr.deck_config_interday_step_priority_tooltip())
 
     def setupCombos(self) -> None:
         import anki.consts as cs
@@ -78,6 +84,8 @@ class DeckConf(QDialog):
 
         f.newGatherPriority.addItems(list(cs.new_gather_priority_choices(self.mw.col).values()))
         f.newSortOrder.addItems(list(cs.new_sort_order_choices(self.mw.col).values()))
+        f.newMix.addItems(list(cs.review_mix_choices(self.mw.col).values()))
+        f.interdayLearningMix.addItems(list(cs.review_mix_choices(self.mw.col).values()))
 
     # Conf list
     ######################################################################
@@ -224,6 +232,7 @@ class DeckConf(QDialog):
         f.buryInterdayLearningSiblings.setChecked(self.conf["buryInterdayLearning"])
         f.newGatherPriority.setCurrentIndex(self.conf["newGatherPriority"])
         f.newSortOrder.setCurrentIndex(self.conf["newSortOrder"])
+        f.newMix.setCurrentIndex(self.conf["newMix"])
 
         # rev
         c = self.conf["rev"]
@@ -237,6 +246,7 @@ class DeckConf(QDialog):
         if self.mw.col.sched_ver() == 1:
             f.hardFactor.setVisible(False)
             f.hardFactorLabel.setVisible(False)
+        f.interdayLearningMix.setCurrentIndex(self.conf["interdayLearningMix"])
 
         # lapse
         c = self.conf["lapse"]
@@ -317,6 +327,7 @@ class DeckConf(QDialog):
         self.conf["buryInterdayLearning"] = f.buryInterdayLearningSiblings.isChecked()
         self.conf["newGatherPriority"] = f.newGatherPriority.currentIndex()
         self.conf["newSortOrder"] = f.newSortOrder.currentIndex()
+        self.conf["newMix"] = f.newMix.currentIndex()
 
         # rev
         c = self.conf["rev"]
@@ -326,6 +337,7 @@ class DeckConf(QDialog):
         c["maxIvl"] = f.maxIvl.value()
         c["bury"] = f.buryRev.isChecked()
         c["hardFactor"] = f.hardFactor.value() / 100.0
+        self.conf["interdayLearningMix"] = f.interdayLearningMix.currentIndex()
 
         # lapse
         c = self.conf["lapse"]

--- a/qt/aqt/deckconf.py
+++ b/qt/aqt/deckconf.py
@@ -65,13 +65,17 @@ class DeckConf(QDialog):
     def setTooltips(self):
         f = self.form
         f.buryInterdayLearningSiblings.setToolTip(tr.deck_config_bury_interday_learning_tooltip())
+        f.newGatherPriority.setToolTip(tr.deck_config_new_gather_priority_tooltip_2())
 
     def setupCombos(self) -> None:
         import anki.consts as cs
 
         f = self.form
+
         f.newOrder.addItems(list(cs.new_card_order_labels(self.mw.col).values()))
         qconnect(f.newOrder.currentIndexChanged, self.onNewOrderChanged)
+
+        f.newGatherPriority.addItems(list(cs.new_gather_priority_choices(self.mw.col).values()))
 
     # Conf list
     ######################################################################
@@ -216,6 +220,8 @@ class DeckConf(QDialog):
         f.bury.setChecked(c.get("bury", True))
         f.newplim.setText(self.parentLimText("new"))
         f.buryInterdayLearningSiblings.setChecked(self.conf["buryInterdayLearning"])
+        f.newGatherPriority.setCurrentIndex(self.conf["newGatherPriority"])
+
         # rev
         c = self.conf["rev"]
         f.revPerDay.setValue(c["perDay"])
@@ -306,6 +312,7 @@ class DeckConf(QDialog):
             else:
                 self.mw.col.sched.order_cards(self.deck["id"])
         self.conf["buryInterdayLearning"] = f.buryInterdayLearningSiblings.isChecked()
+        self.conf["newGatherPriority"] = f.newGatherPriority.currentIndex()
 
         # rev
         c = self.conf["rev"]

--- a/qt/aqt/deckconf.py
+++ b/qt/aqt/deckconf.py
@@ -29,6 +29,8 @@ from aqt.utils import (
 
 
 class DeckConf(QDialog):
+    name = "deckconf"
+
     def __init__(self, mw: aqt.AnkiQt, deck: dict) -> None:
         QDialog.__init__(self, mw)
         self.mw = mw
@@ -57,10 +59,9 @@ class DeckConf(QDialog):
         )
         disable_help_button(self)
         # qt doesn't size properly with altered fonts otherwise
-        restoreGeom(self, "deckconf", adjustSize=True)
+        restoreGeom(self, self.name, adjustSize=True)
         gui_hooks.deck_conf_will_show(self)
         self.open()
-        saveGeom(self, "deckconf")
 
     def setTooltips(self):
         f = self.form
@@ -392,3 +393,7 @@ class DeckConf(QDialog):
         self.saveConf()
         self.mw.reset()
         QDialog.accept(self)
+
+    def done(self, *args, **kwargs) -> None:
+        saveGeom(self, self.name)
+        return super().done(*args, **kwargs)

--- a/qt/aqt/deckconf.py
+++ b/qt/aqt/deckconf.py
@@ -39,6 +39,7 @@ class DeckConf(QDialog):
         self.form.setupUi(self)
         gui_hooks.deck_conf_did_setup_ui_form(self)
         self.mw.checkpoint(tr.actions_options())
+        self.setTooltips()
         self.setupCombos()
         self.setupConfs()
         qconnect(
@@ -60,6 +61,10 @@ class DeckConf(QDialog):
         gui_hooks.deck_conf_will_show(self)
         self.open()
         saveGeom(self, "deckconf")
+
+    def setTooltips(self):
+        f = self.form
+        f.buryInterdayLearningSiblings.setToolTip(tr.deck_config_bury_interday_learning_tooltip())
 
     def setupCombos(self) -> None:
         import anki.consts as cs

--- a/qt/aqt/deckconf.py
+++ b/qt/aqt/deckconf.py
@@ -70,7 +70,9 @@ class DeckConf(QDialog):
         f.lrnSteps.setToolTip(tr.deck_config_learning_steps_tooltip())
         f.newOrder.setToolTip(tr.deck_config_new_insertion_order_tooltip())
         f.bury.setToolTip(tr.deck_config_bury_new_tooltip())
-        f.buryInterdayLearningSiblings.setToolTip(tr.deck_config_bury_interday_learning_tooltip())
+        f.buryInterdayLearningSiblings.setToolTip(
+            tr.deck_config_bury_interday_learning_tooltip()
+        )
         f.lrnGradInt.setToolTip(tr.deck_config_graduating_interval_tooltip())
         f.lrnEasyInt.setToolTip(tr.deck_config_easy_interval_tooltip())
         f.lrnFactor.setToolTip(tr.deck_config_starting_ease_tooltip())
@@ -140,7 +142,9 @@ class DeckConf(QDialog):
         f.maxTaken.setToolTip(tr.deck_config_maximum_answer_secs_tooltip())
         f.showTimer.setToolTip(tr.deck_config_show_answer_timer_tooltip())
         # f.autoplaySounds.setToolTip(missing)
-        f.replayQuestion.setToolTip(tr.deck_config_always_include_question_audio_tooltip())
+        f.replayQuestion.setToolTip(
+            tr.deck_config_always_include_question_audio_tooltip()
+        )
 
     def setupCombos(self) -> None:
         import anki.consts as cs
@@ -151,12 +155,16 @@ class DeckConf(QDialog):
         f.newOrder.addItems(list(cs.new_card_order_labels(self.mw.col).values()))
         qconnect(f.newOrder.currentIndexChanged, self.onNewOrderChanged)
 
-        f.newGatherPriority.addItems(list(cs.new_gather_priority_choices(self.mw.col).values()))
+        f.newGatherPriority.addItems(
+            list(cs.new_gather_priority_choices(self.mw.col).values())
+        )
         f.newSortOrder.addItems(list(cs.new_sort_order_choices(self.mw.col).values()))
         f.newMix.addItems(list(cs.review_mix_choices(self.mw.col).values()))
 
         # review
-        f.interdayLearningMix.addItems(list(cs.review_mix_choices(self.mw.col).values()))
+        f.interdayLearningMix.addItems(
+            list(cs.review_mix_choices(self.mw.col).values())
+        )
         f.reviewOrder.addItems(list(cs.review_order_choices(self.mw.col).values()))
 
     # Conf list

--- a/qt/aqt/deckconf.py
+++ b/qt/aqt/deckconf.py
@@ -210,6 +210,7 @@ class DeckConf(QDialog):
         f.newPerDay.setValue(c["perDay"])
         f.bury.setChecked(c.get("bury", True))
         f.newplim.setText(self.parentLimText("new"))
+        f.buryInterdayLearningSiblings.setChecked(self.conf["buryInterdayLearning"])
         # rev
         c = self.conf["rev"]
         f.revPerDay.setValue(c["perDay"])
@@ -297,6 +298,7 @@ class DeckConf(QDialog):
                 self.mw.col.sched.randomize_cards(self.deck["id"])
             else:
                 self.mw.col.sched.order_cards(self.deck["id"])
+        self.conf["buryInterdayLearning"] = f.buryInterdayLearningSiblings.isChecked()
         # rev
         c = self.conf["rev"]
         c["perDay"] = f.revPerDay.value()

--- a/qt/aqt/deckconf.py
+++ b/qt/aqt/deckconf.py
@@ -66,6 +66,7 @@ class DeckConf(QDialog):
         f = self.form
         f.buryInterdayLearningSiblings.setToolTip(tr.deck_config_bury_interday_learning_tooltip())
         f.newGatherPriority.setToolTip(tr.deck_config_new_gather_priority_tooltip_2())
+        f.newSortOrder.setToolTip(tr.deck_config_new_card_sort_order_tooltip_2())
 
     def setupCombos(self) -> None:
         import anki.consts as cs
@@ -76,6 +77,7 @@ class DeckConf(QDialog):
         qconnect(f.newOrder.currentIndexChanged, self.onNewOrderChanged)
 
         f.newGatherPriority.addItems(list(cs.new_gather_priority_choices(self.mw.col).values()))
+        f.newSortOrder.addItems(list(cs.new_sort_order_choices(self.mw.col).values()))
 
     # Conf list
     ######################################################################
@@ -221,6 +223,7 @@ class DeckConf(QDialog):
         f.newplim.setText(self.parentLimText("new"))
         f.buryInterdayLearningSiblings.setChecked(self.conf["buryInterdayLearning"])
         f.newGatherPriority.setCurrentIndex(self.conf["newGatherPriority"])
+        f.newSortOrder.setCurrentIndex(self.conf["newSortOrder"])
 
         # rev
         c = self.conf["rev"]
@@ -313,6 +316,7 @@ class DeckConf(QDialog):
                 self.mw.col.sched.order_cards(self.deck["id"])
         self.conf["buryInterdayLearning"] = f.buryInterdayLearningSiblings.isChecked()
         self.conf["newGatherPriority"] = f.newGatherPriority.currentIndex()
+        self.conf["newSortOrder"] = f.newSortOrder.currentIndex()
 
         # rev
         c = self.conf["rev"]

--- a/qt/aqt/deckconf.py
+++ b/qt/aqt/deckconf.py
@@ -64,28 +64,53 @@ class DeckConf(QDialog):
 
     def setTooltips(self):
         f = self.form
+
+        # new
         f.buryInterdayLearningSiblings.setToolTip(tr.deck_config_bury_interday_learning_tooltip())
-        f.newGatherPriority.setToolTip(tr.deck_config_new_gather_priority_tooltip_2())
-        f.newSortOrder.setToolTip(tr.deck_config_new_card_sort_order_tooltip_2())
+        f.newGatherPriority.setToolTip(
+            f"{tr.deck_config_new_gather_priority_tooltip_2()}"
+            "\n\n"
+            f"{tr.deck_config_display_order_will_use_current_deck()}"
+        )
+        f.newSortOrder.setToolTip(
+            f"{tr.deck_config_new_card_sort_order_tooltip_2()}"
+            "\n\n"
+            f"{tr.deck_config_display_order_will_use_current_deck()}"
+        )
         f.newMix.setToolTip(
             f"{tr.deck_config_new_review_priority_tooltip()}"
             "\n\n"
             f"{tr.deck_config_display_order_will_use_current_deck()}"
         )
-        f.interdayLearningMix.setToolTip(tr.deck_config_interday_step_priority_tooltip())
+
+        # review
+        f.interdayLearningMix.setToolTip(
+            f"{tr.deck_config_interday_step_priority_tooltip()}"
+            "\n\n"
+            f"{tr.deck_config_display_order_will_use_current_deck()}"
+        )
+        f.reviewOrder.setToolTip(
+            f"{tr.deck_config_review_sort_order_tooltip()}"
+            "\n\n"
+            f"{tr.deck_config_display_order_will_use_current_deck()}"
+        )
 
     def setupCombos(self) -> None:
         import anki.consts as cs
 
         f = self.form
 
+        # new
         f.newOrder.addItems(list(cs.new_card_order_labels(self.mw.col).values()))
         qconnect(f.newOrder.currentIndexChanged, self.onNewOrderChanged)
 
         f.newGatherPriority.addItems(list(cs.new_gather_priority_choices(self.mw.col).values()))
         f.newSortOrder.addItems(list(cs.new_sort_order_choices(self.mw.col).values()))
         f.newMix.addItems(list(cs.review_mix_choices(self.mw.col).values()))
+
+        # review
         f.interdayLearningMix.addItems(list(cs.review_mix_choices(self.mw.col).values()))
+        f.reviewOrder.addItems(list(cs.review_order_choices(self.mw.col).values()))
 
     # Conf list
     ######################################################################
@@ -218,6 +243,7 @@ class DeckConf(QDialog):
 
     def loadConf(self) -> None:
         self.conf = self.mw.col.decks.config_dict_for_deck_id(self.deck["id"])
+
         # new
         c = self.conf["new"]
         f = self.form
@@ -247,6 +273,7 @@ class DeckConf(QDialog):
             f.hardFactor.setVisible(False)
             f.hardFactorLabel.setVisible(False)
         f.interdayLearningMix.setCurrentIndex(self.conf["interdayLearningMix"])
+        f.reviewOrder.setCurrentIndex(self.conf["reviewOrder"])
 
         # lapse
         c = self.conf["lapse"]
@@ -338,6 +365,7 @@ class DeckConf(QDialog):
         c["bury"] = f.buryRev.isChecked()
         c["hardFactor"] = f.hardFactor.value() / 100.0
         self.conf["interdayLearningMix"] = f.interdayLearningMix.currentIndex()
+        self.conf["reviewOrder"] = f.reviewOrder.currentIndex()
 
         # lapse
         c = self.conf["lapse"]

--- a/qt/aqt/deckconf.py
+++ b/qt/aqt/deckconf.py
@@ -67,7 +67,24 @@ class DeckConf(QDialog):
         f = self.form
 
         # new
+        f.lrnSteps.setToolTip(tr.deck_config_learning_steps_tooltip())
+        f.newOrder.setToolTip(tr.deck_config_new_insertion_order_tooltip())
+        f.bury.setToolTip(tr.deck_config_bury_new_tooltip())
         f.buryInterdayLearningSiblings.setToolTip(tr.deck_config_bury_interday_learning_tooltip())
+        f.lrnGradInt.setToolTip(tr.deck_config_graduating_interval_tooltip())
+        f.lrnEasyInt.setToolTip(tr.deck_config_easy_interval_tooltip())
+        f.lrnFactor.setToolTip(tr.deck_config_starting_ease_tooltip())
+        f.newPerDay.setToolTip(
+            f"{tr.deck_config_new_limit_tooltip()}"
+            "\n\n"
+            f"{tr.deck_config_limit_new_bound_by_reviews()}"
+            "\n\n"
+            f"{tr.deck_config_limit_interday_bound_by_reviews()}"
+            "\n\n"
+            f"{tr.deck_config_limit_deck_v3()}"
+            "\n\n"
+            f"{tr.deck_config_tab_description()}"
+        )
         f.newGatherPriority.setToolTip(
             f"{tr.deck_config_new_gather_priority_tooltip_2()}"
             "\n\n"
@@ -85,6 +102,22 @@ class DeckConf(QDialog):
         )
 
         # review
+        f.easyBonus.setToolTip(tr.deck_config_easy_bonus_tooltip())
+        f.fi1.setToolTip(tr.deck_config_interval_modifier_tooltip())
+        f.maxIvl.setToolTip(tr.deck_config_maximum_interval_tooltip())
+        f.hardFactor.setToolTip(tr.deck_config_hard_interval_tooltip())
+        f.revPerDay.setToolTip(
+            f"{tr.deck_config_review_limit_tooltip()}"
+            "\n\n"
+            f"{tr.deck_config_limit_new_bound_by_reviews()}"
+            "\n\n"
+            f"{tr.deck_config_limit_interday_bound_by_reviews()}"
+            "\n\n"
+            f"{tr.deck_config_limit_deck_v3()}"
+            "\n\n"
+            f"{tr.deck_config_tab_description()}"
+        )
+        f.buryRev.setToolTip(tr.deck_config_bury_review_tooltip())
         f.interdayLearningMix.setToolTip(
             f"{tr.deck_config_interday_step_priority_tooltip()}"
             "\n\n"
@@ -95,6 +128,19 @@ class DeckConf(QDialog):
             "\n\n"
             f"{tr.deck_config_display_order_will_use_current_deck()}"
         )
+
+        # lapse
+        f.lapSteps.setToolTip(tr.deck_config_relearning_steps_tooltip())
+        f.lapMult.setToolTip(tr.deck_config_new_interval_tooltip())
+        f.lapMinInt.setToolTip(tr.deck_config_minimum_interval_tooltip())
+        f.leechThreshold.setToolTip(tr.deck_config_leech_threshold_tooltip())
+        f.leechAction.setToolTip(tr.deck_config_leech_action_tooltip())
+
+        # general
+        f.maxTaken.setToolTip(tr.deck_config_maximum_answer_secs_tooltip())
+        f.showTimer.setToolTip(tr.deck_config_show_answer_timer_tooltip())
+        # f.autoplaySounds.setToolTip(missing)
+        f.replayQuestion.setToolTip(tr.deck_config_always_include_question_audio_tooltip())
 
     def setupCombos(self) -> None:
         import anki.consts as cs

--- a/qt/aqt/deckoptions.py
+++ b/qt/aqt/deckoptions.py
@@ -106,8 +106,10 @@ def display_options_for_deck_id(deck_id: DeckId) -> None:
 def display_options_for_deck(deck: DeckDict) -> None:
     if not deck["dyn"]:
         webview_dialog_requested = (
-            aqt.mw.pm.webview_based_deck_options() and not KeyboardModifiersPressed().shift
-            or not aqt.mw.pm.webview_based_deck_options() and KeyboardModifiersPressed().shift
+            aqt.mw.pm.webview_based_deck_options()
+            and not KeyboardModifiersPressed().shift
+            or not aqt.mw.pm.webview_based_deck_options()
+            and KeyboardModifiersPressed().shift
         )
 
         if webview_dialog_requested and aqt.mw.col.sched_ver() > 1:

--- a/qt/aqt/deckoptions.py
+++ b/qt/aqt/deckoptions.py
@@ -105,10 +105,15 @@ def display_options_for_deck_id(deck_id: DeckId) -> None:
 
 def display_options_for_deck(deck: DeckDict) -> None:
     if not deck["dyn"]:
-        if KeyboardModifiersPressed().shift or aqt.mw.col.sched_ver() == 1:
+        webview_dialog_requested = (
+            aqt.mw.pm.webview_based_deck_options() and not KeyboardModifiersPressed().shift
+            or not aqt.mw.pm.webview_based_deck_options() and KeyboardModifiersPressed().shift
+        )
+
+        if webview_dialog_requested and aqt.mw.col.sched_ver() > 1:
+            DeckOptionsDialog(aqt.mw, deck)
+        else:
             deck_legacy = aqt.mw.col.decks.get(DeckId(deck["id"]))
             aqt.deckconf.DeckConf(aqt.mw, deck_legacy)
-        else:
-            DeckOptionsDialog(aqt.mw, deck)
     else:
         aqt.dialogs.open("FilteredDeckConfigDialog", aqt.mw, deck_id=deck["id"])

--- a/qt/aqt/forms/dconf.ui
+++ b/qt/aqt/forms/dconf.ui
@@ -94,14 +94,14 @@
          <property name="spacing">
           <number>12</number>
          </property>
-         <item row="6" column="0">
+         <item row="7" column="0">
           <widget class="QLabel" name="label_24">
            <property name="text">
             <string>scheduling_starting_ease</string>
            </property>
           </widget>
          </item>
-         <item row="6" column="1">
+         <item row="7" column="1">
           <widget class="QSpinBox" name="lrnFactor">
            <property name="suffix">
             <string notr="true">%</string>
@@ -131,14 +131,21 @@
            </property>
           </widget>
          </item>
-         <item row="5" column="1">
+         <item row="3" column="0">
+          <widget class="QLabel" name="label_39">
+           <property name="text">
+            <string>deck_config_new_card_sort_order</string>
+           </property>
+          </widget>
+         </item>
+         <item row="6" column="1">
           <widget class="QSpinBox" name="lrnEasyInt">
            <property name="minimum">
             <number>1</number>
            </property>
           </widget>
          </item>
-         <item row="4" column="1">
+         <item row="5" column="1">
           <widget class="QSpinBox" name="lrnGradInt">
            <property name="minimum">
             <number>1</number>
@@ -152,28 +159,28 @@
            </property>
           </widget>
          </item>
-         <item row="5" column="0">
+         <item row="6" column="0">
           <widget class="QLabel" name="label_5">
            <property name="text">
             <string>scheduling_easy_interval</string>
            </property>
           </widget>
          </item>
-         <item row="4" column="0">
+         <item row="5" column="0">
           <widget class="QLabel" name="label_4">
            <property name="text">
             <string>scheduling_graduating_interval</string>
            </property>
           </widget>
          </item>
-         <item row="3" column="1">
+         <item row="4" column="1">
           <widget class="QSpinBox" name="newPerDay">
            <property name="maximum">
             <number>9999</number>
            </property>
           </widget>
          </item>
-         <item row="3" column="0">
+         <item row="4" column="0">
           <widget class="QLabel" name="label_6">
            <property name="text">
             <string>scheduling_new_cardsday</string>
@@ -196,28 +203,31 @@
          <item row="2" column="1" colspan="2">
           <widget class="QComboBox" name="newGatherPriority"/>
          </item>
-         <item row="7" column="0" colspan="3"  alignment="Qt::AlignLeft">
+         <item row="3" column="1" colspan="2">
+          <widget class="QComboBox" name="newSortOrder"/>
+         </item>
+         <item row="8" column="0" colspan="3"  alignment="Qt::AlignLeft">
           <widget class="QCheckBox" name="bury">
            <property name="text">
             <string>scheduling_bury_related_new_cards_until_the</string>
            </property>
           </widget>
          </item>
-         <item row="8" column="0" colspan="3"  alignment="Qt::AlignLeft">
+         <item row="9" column="0" colspan="3"  alignment="Qt::AlignLeft">
           <widget class="QCheckBox" name="buryInterdayLearningSiblings">
            <property name="text">
             <string>deck_config_bury_interday_learning_siblings</string>
            </property>
           </widget>
          </item>
-         <item row="5" column="2">
+         <item row="6" column="2">
           <widget class="QLabel" name="label_9">
            <property name="text">
             <string>scheduling_days</string>
            </property>
           </widget>
          </item>
-         <item row="4" column="2">
+         <item row="5" column="2">
           <widget class="QLabel" name="label_7">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Expanding" vsizetype="Preferred">

--- a/qt/aqt/forms/dconf.ui
+++ b/qt/aqt/forms/dconf.ui
@@ -94,14 +94,14 @@
          <property name="spacing">
           <number>12</number>
          </property>
-         <item row="7" column="0">
+         <item row="8" column="0">
           <widget class="QLabel" name="label_24">
            <property name="text">
             <string>scheduling_starting_ease</string>
            </property>
           </widget>
          </item>
-         <item row="7" column="1">
+         <item row="8" column="1">
           <widget class="QSpinBox" name="lrnFactor">
            <property name="suffix">
             <string notr="true">%</string>
@@ -138,14 +138,21 @@
            </property>
           </widget>
          </item>
-         <item row="6" column="1">
+         <item row="4" column="0">
+          <widget class="QLabel" name="label_40">
+           <property name="text">
+            <string>deck_config_new_review_priority</string>
+           </property>
+          </widget>
+         </item>
+         <item row="7" column="1">
           <widget class="QSpinBox" name="lrnEasyInt">
            <property name="minimum">
             <number>1</number>
            </property>
           </widget>
          </item>
-         <item row="5" column="1">
+         <item row="6" column="1">
           <widget class="QSpinBox" name="lrnGradInt">
            <property name="minimum">
             <number>1</number>
@@ -159,28 +166,28 @@
            </property>
           </widget>
          </item>
-         <item row="6" column="0">
+         <item row="7" column="0">
           <widget class="QLabel" name="label_5">
            <property name="text">
             <string>scheduling_easy_interval</string>
            </property>
           </widget>
          </item>
-         <item row="5" column="0">
+         <item row="6" column="0">
           <widget class="QLabel" name="label_4">
            <property name="text">
             <string>scheduling_graduating_interval</string>
            </property>
           </widget>
          </item>
-         <item row="4" column="1">
+         <item row="5" column="1">
           <widget class="QSpinBox" name="newPerDay">
            <property name="maximum">
             <number>9999</number>
            </property>
           </widget>
          </item>
-         <item row="4" column="0">
+         <item row="5" column="0">
           <widget class="QLabel" name="label_6">
            <property name="text">
             <string>scheduling_new_cardsday</string>
@@ -206,28 +213,31 @@
          <item row="3" column="1" colspan="2">
           <widget class="QComboBox" name="newSortOrder"/>
          </item>
-         <item row="8" column="0" colspan="3"  alignment="Qt::AlignLeft">
+         <item row="4" column="1" colspan="2">
+          <widget class="QComboBox" name="newMix"/>
+         </item>
+         <item row="9" column="0" colspan="3"  alignment="Qt::AlignLeft">
           <widget class="QCheckBox" name="bury">
            <property name="text">
             <string>scheduling_bury_related_new_cards_until_the</string>
            </property>
           </widget>
          </item>
-         <item row="9" column="0" colspan="3"  alignment="Qt::AlignLeft">
+         <item row="10" column="0" colspan="3"  alignment="Qt::AlignLeft">
           <widget class="QCheckBox" name="buryInterdayLearningSiblings">
            <property name="text">
             <string>deck_config_bury_interday_learning_siblings</string>
            </property>
           </widget>
          </item>
-         <item row="6" column="2">
+         <item row="7" column="2">
           <widget class="QLabel" name="label_9">
            <property name="text">
             <string>scheduling_days</string>
            </property>
           </widget>
          </item>
-         <item row="5" column="2">
+         <item row="6" column="2">
           <widget class="QLabel" name="label_7">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
@@ -382,7 +392,7 @@
            </property>
           </widget>
          </item>
-         <item row="5" column="0" colspan="3"  alignment="Qt::AlignLeft">
+         <item row="6" column="0" colspan="3"  alignment="Qt::AlignLeft">
           <widget class="QCheckBox" name="buryRev">
            <property name="text">
             <string>scheduling_bury_related_reviews_until_the_next</string>
@@ -393,6 +403,13 @@
           <widget class="QLabel" name="hardFactorLabel">
            <property name="text">
             <string>scheduling_hard_interval</string>
+           </property>
+          </widget>
+         </item>
+         <item row="5" column="0">
+          <widget class="QLabel" name="interdayLearningMixLabel">
+           <property name="text">
+            <string>deck_config_interday_step_priority</string>
            </property>
           </widget>
          </item>
@@ -408,6 +425,9 @@
             <number>120</number>
            </property>
           </widget>
+         </item>
+         <item row="5" column="1" colspan="2">
+          <widget class="QComboBox" name="interdayLearningMix"/>
          </item>
         </layout>
        </item>

--- a/qt/aqt/forms/dconf.ui
+++ b/qt/aqt/forms/dconf.ui
@@ -193,6 +193,13 @@
            </property>
           </widget>
          </item>
+         <item row="7" column="0" colspan="3"  alignment="Qt::AlignLeft">
+          <widget class="QCheckBox" name="buryInterdayLearningSiblings">
+           <property name="text">
+            <string>deck_config_bury_interday_learning_siblings</string>
+           </property>
+          </widget>
+         </item>
          <item row="4" column="2">
           <widget class="QLabel" name="label_9">
            <property name="text">

--- a/qt/aqt/forms/dconf.ui
+++ b/qt/aqt/forms/dconf.ui
@@ -392,7 +392,7 @@
            </property>
           </widget>
          </item>
-         <item row="6" column="0" colspan="3"  alignment="Qt::AlignLeft">
+         <item row="7" column="0" colspan="3"  alignment="Qt::AlignLeft">
           <widget class="QCheckBox" name="buryRev">
            <property name="text">
             <string>scheduling_bury_related_reviews_until_the_next</string>
@@ -413,6 +413,13 @@
            </property>
           </widget>
          </item>
+         <item row="6" column="0">
+          <widget class="QLabel" name="reviewOrderLabel">
+           <property name="text">
+            <string>deck_config_review_sort_order</string>
+           </property>
+          </widget>
+         </item>
          <item row="4" column="1">
           <widget class="QSpinBox" name="hardFactor">
            <property name="suffix">
@@ -428,6 +435,9 @@
          </item>
          <item row="5" column="1" colspan="2">
           <widget class="QComboBox" name="interdayLearningMix"/>
+         </item>
+         <item row="6" column="1" colspan="2">
+          <widget class="QComboBox" name="reviewOrder"/>
          </item>
         </layout>
        </item>

--- a/qt/aqt/forms/dconf.ui
+++ b/qt/aqt/forms/dconf.ui
@@ -94,14 +94,14 @@
          <property name="spacing">
           <number>12</number>
          </property>
-         <item row="5" column="0">
+         <item row="6" column="0">
           <widget class="QLabel" name="label_24">
            <property name="text">
             <string>scheduling_starting_ease</string>
            </property>
           </widget>
          </item>
-         <item row="5" column="1">
+         <item row="6" column="1">
           <widget class="QSpinBox" name="lrnFactor">
            <property name="suffix">
             <string notr="true">%</string>
@@ -124,49 +124,56 @@
            </property>
           </widget>
          </item>
-         <item row="4" column="1">
+         <item row="2" column="0">
+          <widget class="QLabel" name="label_38">
+           <property name="text">
+            <string>deck_config_new_gather_priority</string>
+           </property>
+          </widget>
+         </item>
+         <item row="5" column="1">
           <widget class="QSpinBox" name="lrnEasyInt">
            <property name="minimum">
             <number>1</number>
            </property>
           </widget>
          </item>
-         <item row="3" column="1">
+         <item row="4" column="1">
           <widget class="QSpinBox" name="lrnGradInt">
            <property name="minimum">
             <number>1</number>
            </property>
           </widget>
          </item>
-         <item row="2" column="2">
+         <item row="3" column="2">
           <widget class="QLabel" name="newplim">
            <property name="text">
             <string/>
            </property>
           </widget>
          </item>
-         <item row="4" column="0">
+         <item row="5" column="0">
           <widget class="QLabel" name="label_5">
            <property name="text">
             <string>scheduling_easy_interval</string>
            </property>
           </widget>
          </item>
-         <item row="3" column="0">
+         <item row="4" column="0">
           <widget class="QLabel" name="label_4">
            <property name="text">
             <string>scheduling_graduating_interval</string>
            </property>
           </widget>
          </item>
-         <item row="2" column="1">
+         <item row="3" column="1">
           <widget class="QSpinBox" name="newPerDay">
            <property name="maximum">
             <number>9999</number>
            </property>
           </widget>
          </item>
-         <item row="2" column="0">
+         <item row="3" column="0">
           <widget class="QLabel" name="label_6">
            <property name="text">
             <string>scheduling_new_cardsday</string>
@@ -186,28 +193,31 @@
          <item row="1" column="1" colspan="2">
           <widget class="QComboBox" name="newOrder"/>
          </item>
-         <item row="6" column="0" colspan="3"  alignment="Qt::AlignLeft">
+         <item row="2" column="1" colspan="2">
+          <widget class="QComboBox" name="newGatherPriority"/>
+         </item>
+         <item row="7" column="0" colspan="3"  alignment="Qt::AlignLeft">
           <widget class="QCheckBox" name="bury">
            <property name="text">
             <string>scheduling_bury_related_new_cards_until_the</string>
            </property>
           </widget>
          </item>
-         <item row="7" column="0" colspan="3"  alignment="Qt::AlignLeft">
+         <item row="8" column="0" colspan="3"  alignment="Qt::AlignLeft">
           <widget class="QCheckBox" name="buryInterdayLearningSiblings">
            <property name="text">
             <string>deck_config_bury_interday_learning_siblings</string>
            </property>
           </widget>
          </item>
-         <item row="4" column="2">
+         <item row="5" column="2">
           <widget class="QLabel" name="label_9">
            <property name="text">
             <string>scheduling_days</string>
            </property>
           </widget>
          </item>
-         <item row="3" column="2">
+         <item row="4" column="2">
           <widget class="QLabel" name="label_7">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Expanding" vsizetype="Preferred">

--- a/qt/aqt/forms/preferences.ui
+++ b/qt/aqt/forms/preferences.ui
@@ -120,6 +120,13 @@
          </property>
         </widget>
        </item>
+       <item alignment="Qt::AlignLeft">
+        <widget class="QCheckBox" name="webview_based_deck_options">
+         <property name="text">
+          <string>preferences_enable_webview_based_deck_options_dialog</string>
+         </property>
+        </widget>
+       </item>
        <item>
         <widget class="QComboBox" name="useCurrent">
          <item>

--- a/qt/aqt/preferences.py
+++ b/qt/aqt/preferences.py
@@ -209,6 +209,7 @@ class Preferences(QDialog):
         "Setup options global to all profiles."
         self.form.reduce_motion.setChecked(self.mw.pm.reduced_motion())
         self.form.collapse_toolbar.setChecked(self.mw.pm.collapse_toolbar())
+        self.form.webview_based_deck_options.setChecked(self.mw.pm.webview_based_deck_options())
         self.form.uiScale.setValue(int(self.mw.pm.uiScale() * 100))
         themes = [
             tr.preferences_theme_label(theme=theme)
@@ -240,6 +241,7 @@ class Preferences(QDialog):
 
         self.mw.pm.set_reduced_motion(self.form.reduce_motion.isChecked())
         self.mw.pm.set_collapse_toolbar(self.form.collapse_toolbar.isChecked())
+        self.mw.pm.set_webview_based_deck_options(self.form.webview_based_deck_options.isChecked())
         self.mw.pm.set_legacy_import_export(self.form.legacy_import_export.isChecked())
 
         if restart_required:

--- a/qt/aqt/preferences.py
+++ b/qt/aqt/preferences.py
@@ -209,7 +209,9 @@ class Preferences(QDialog):
         "Setup options global to all profiles."
         self.form.reduce_motion.setChecked(self.mw.pm.reduced_motion())
         self.form.collapse_toolbar.setChecked(self.mw.pm.collapse_toolbar())
-        self.form.webview_based_deck_options.setChecked(self.mw.pm.webview_based_deck_options())
+        self.form.webview_based_deck_options.setChecked(
+            self.mw.pm.webview_based_deck_options()
+        )
         self.form.uiScale.setValue(int(self.mw.pm.uiScale() * 100))
         themes = [
             tr.preferences_theme_label(theme=theme)
@@ -241,7 +243,9 @@ class Preferences(QDialog):
 
         self.mw.pm.set_reduced_motion(self.form.reduce_motion.isChecked())
         self.mw.pm.set_collapse_toolbar(self.form.collapse_toolbar.isChecked())
-        self.mw.pm.set_webview_based_deck_options(self.form.webview_based_deck_options.isChecked())
+        self.mw.pm.set_webview_based_deck_options(
+            self.form.webview_based_deck_options.isChecked()
+        )
         self.mw.pm.set_legacy_import_export(self.form.legacy_import_export.isChecked())
 
         if restart_required:

--- a/qt/aqt/profiles.py
+++ b/qt/aqt/profiles.py
@@ -527,8 +527,14 @@ create table if not exists profiles
     def collapse_toolbar(self) -> bool:
         return self.meta.get("collapse_toolbar", False)
 
+    def webview_based_deck_options(self) -> bool:
+        return self.meta.get("webview_based_deck_options", False)
+
     def set_collapse_toolbar(self, on: bool) -> None:
         self.meta["collapse_toolbar"] = on
+
+    def set_webview_based_deck_options(self, on: bool) -> None:
+        self.meta["webview_based_deck_options"] = on
 
     def last_addon_update_check(self) -> int:
         return self.meta.get("last_addon_update_check", 0)


### PR DESCRIPTION
I noticed that there are additional Options Groups settings that weren't added to the Options Groups dialog, so I have added them in.

![screenshot-2023-01-14-00-40-23](https://user-images.githubusercontent.com/69171671/212442228-4eb3074a-9324-4564-8505-336cb8e9ccdb.png)
![screenshot-2023-01-14-00-40-26](https://user-images.githubusercontent.com/69171671/212442227-b9e120a8-c988-4b2e-ba49-406cb44aefd8.png)

I'm not sure why [here](https://github.com/ankitects/anki/blob/main/pylib/anki/consts.py#L115) a dict is returned instead of a list, but I have followed the pattern anyway.

Added missing tooltips, except for one which has no appropriate translation. Not sure what to do with it.

There's a new field called "custom scheduling", but I couldn't find any references to it in the Options Groups dict. Maybe it would be better to have it under Preferences instead?

It's a little annoying to have to press <kbd>shift</kbd> every time, so I have added a checkbox that swaps the Webview-based dialog with the Qtwidgets-based dialog.

Finally, the dialog used to always fail to save its geometry. I have moved `saveGeom()` under `done()`
