### PR TITLE
Replace dissimilar crate with difflib

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,7 +92,7 @@ dependencies = [
  "convert_case 0.6.0",
  "criterion",
  "csv",
- "dissimilar",
+ "difflib",
  "env_logger",
  "flate2",
  "fluent",
@@ -823,6 +823,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
 name = "digest"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -843,12 +849,6 @@ dependencies = [
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "dissimilar"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c97b9233581d84b8e1e689cdd3a47b6f69770084fc246e86a7f78b0d9c1d4a5"
 
 [[package]]
 name = "doc-comment"

--- a/rslib/Cargo.toml
+++ b/rslib/Cargo.toml
@@ -57,7 +57,7 @@ bytes = "1.3.0"
 chrono = { version = "0.4.19", default-features = false, features = ["std", "clock"] }
 coarsetime = "0.1.22"
 convert_case = "0.6.0"
-dissimilar = "1.0.4"
+difflib = "0.4.0"
 flate2 = "1.0.25"
 fluent = "0.16.0"
 fluent-bundle = "0.15.2"


### PR DESCRIPTION
Here is an experiment with difflib. It makes a lot of allocations:
1. A new string is created for every `Opcode`. 😮 
2. It only works with slices, so we have to create a `Vec<char>`.
3. For the output, I currently collect the chars into a string again, but this can be optimised to slicing the original strings.

However, I guess performance is not of the essence here and it works well enough. I've added unit tests for the two issues with dissimilar mentioned in #2305 and difflib handles them fine.

WDYT? Should I clean this up for a merge?