### PR TITLE
Create field options to store media file path

### DIFF
--- a/ftl/core/fields.ftl
+++ b/ftl/core/fields.ftl
@@ -12,6 +12,7 @@ fields-notes-require-at-least-one-field = Notes require at least one field.
 fields-reverse-text-direction-rtl = Reverse text direction (RTL)
 fields-collapse-by-default = Collapse by default
 fields-html-by-default = Use HTML editor by default
+fields-media-only = Use it to only store media file paths
 fields-size = Size:
 fields-sort-by-this-field-in-the = Sort by this field in the browser
 fields-that-field-name-is-already-used = That field name is already used.

--- a/proto/anki/notetypes.proto
+++ b/proto/anki/notetypes.proto
@@ -74,6 +74,7 @@ message Notetype {
       string description = 5;
       bool plain_text = 6;
       bool collapsed = 7;
+      bool media_only = 8;
 
       bytes other = 255;
     }

--- a/qt/aqt/fields.py
+++ b/qt/aqt/fields.py
@@ -231,13 +231,11 @@ class FieldDialog(QDialog):
     def onMediaOnlyField(self) -> None:
         if self.form.mediaOnly.isChecked():
             self.form.plainTextByDefault.setChecked(True)
-        self.saveField()
 
     def onPlainTextByDefaultField(self) -> None:
         # file paths should always be plain text, so ensure it is checked
         if self.form.mediaOnly.isChecked():
             self.form.plainTextByDefault.setChecked(True)
-        self.saveField()
 
     def moveField(self, pos: int) -> None:
         if not self.change_tracker.mark_schema():

--- a/qt/aqt/fields.py
+++ b/qt/aqt/fields.py
@@ -107,6 +107,8 @@ class FieldDialog(QDialog):
         qconnect(f.fieldRename.clicked, self.onRename)
         qconnect(f.fieldPosition.clicked, self.onPosition)
         qconnect(f.sortField.clicked, self.onSortField)
+        qconnect(f.mediaOnly.clicked, self.onMediaOnlyField)
+        qconnect(f.plainTextByDefault.clicked, self.onPlainTextByDefaultField)
         qconnect(f.buttonBox.helpRequested, self.onHelp)
 
     def onDrop(self, ev: QDropEvent) -> None:
@@ -226,6 +228,17 @@ class FieldDialog(QDialog):
         self.form.sortField.setChecked(True)
         self.mm.set_sort_index(self.model, self.form.fieldList.currentRow())
 
+    def onMediaOnlyField(self) -> None:
+        if self.form.mediaOnly.isChecked():
+            self.form.plainTextByDefault.setChecked(True)
+        self.saveField()
+
+    def onPlainTextByDefaultField(self) -> None:
+        # file paths should always be plain text, so ensure it is checked
+        if self.form.mediaOnly.isChecked():
+            self.form.plainTextByDefault.setChecked(True)
+        self.saveField()
+
     def moveField(self, pos: int) -> None:
         if not self.change_tracker.mark_schema():
             return
@@ -244,6 +257,7 @@ class FieldDialog(QDialog):
         f.sortField.setChecked(self.model["sortf"] == fld["ord"])
         f.rtl.setChecked(fld["rtl"])
         f.plainTextByDefault.setChecked(fld["plainText"])
+        f.mediaOnly.setChecked(fld["mediaOnly"])
         f.collapseByDefault.setChecked(fld["collapsed"])
         f.fieldDescription.setText(fld.get("description", ""))
 
@@ -270,6 +284,9 @@ class FieldDialog(QDialog):
         if fld["plainText"] != plain_text:
             fld["plainText"] = plain_text
             self.change_tracker.mark_basic()
+        media_only = f.mediaOnly.isChecked()
+        if fld["mediaOnly"] != media_only:
+            fld["mediaOnly"] = media_only
         collapsed = f.collapseByDefault.isChecked()
         if fld["collapsed"] != collapsed:
             fld["collapsed"] = collapsed

--- a/qt/aqt/forms/fields.ui
+++ b/qt/aqt/forms/fields.ui
@@ -148,6 +148,16 @@
        </property>
       </widget>
      </item>
+     <item row="6" column="1" alignment="Qt::AlignLeft">
+      <widget class="QCheckBox" name="mediaOnly">
+       <property name="enabled">
+        <bool>true</bool>
+       </property>
+       <property name="text">
+        <string>fields_media_only</string>
+       </property>
+      </widget>
+     </item>
      <item row="0" column="1" colspan="2">
       <widget class="QLineEdit" name="fieldDescription">
        <property name="placeholderText">

--- a/rslib/src/media/check.rs
+++ b/rslib/src/media/check.rs
@@ -25,6 +25,7 @@ use crate::{
         MediaManager,
     },
     notes::Note,
+    notetype::Notetype,
     text::{extract_media_refs, normalize_to_nfc, MediaRef, REMOTE_FILENAME},
 };
 
@@ -372,8 +373,10 @@ where
             let nt = notetypes.get(&note.notetype_id).ok_or_else(|| {
                 AnkiError::db_error("missing note type", DbErrorKind::MissingEntity)
             })?;
+
             if fix_and_extract_media_refs(
                 &mut note,
+                nt,
                 &mut referenced_files,
                 renamed,
                 &self.mgr.media_folder,
@@ -402,6 +405,7 @@ where
 /// Returns true if note was modified.
 fn fix_and_extract_media_refs(
     note: &mut Note,
+    notetype: &Notetype,
     seen_files: &mut HashSet<String>,
     renamed: &HashMap<String, String>,
     media_folder: &Path,
@@ -417,8 +421,7 @@ fn fix_and_extract_media_refs(
             media_folder,
         );
 
-        // For fields only with media names
-        if field.len() < 2000 && allfiles.contains(&field.to_string()) {
+        if notetype.fields[idx].config.media_only && allfiles.contains(&field.to_string()) {
             seen_files.insert(field.to_string());
         }
 

--- a/rslib/src/notetype/fields.rs
+++ b/rslib/src/notetype/fields.rs
@@ -40,6 +40,7 @@ impl NoteField {
                 sticky: false,
                 rtl: false,
                 plain_text: false,
+                media_only: false,
                 font_name: "Arial".into(),
                 font_size: 20,
                 description: "".into(),

--- a/rslib/src/notetype/mod.rs
+++ b/rslib/src/notetype/mod.rs
@@ -89,7 +89,6 @@ impl Default for Notetype {
             mtime_secs: TimestampSecs(0),
             usn: Usn(0),
             fields: vec![],
-
             templates: vec![],
             config: NotetypeConfig::new(),
         }

--- a/rslib/src/notetype/mod.rs
+++ b/rslib/src/notetype/mod.rs
@@ -89,6 +89,7 @@ impl Default for Notetype {
             mtime_secs: TimestampSecs(0),
             usn: Usn(0),
             fields: vec![],
+
             templates: vec![],
             config: NotetypeConfig::new(),
         }

--- a/rslib/src/notetype/schema11.rs
+++ b/rslib/src/notetype/schema11.rs
@@ -216,6 +216,9 @@ pub struct NoteFieldSchema11 {
     pub(crate) plain_text: bool,
 
     #[serde(default, deserialize_with = "default_on_invalid")]
+    pub(crate) media_only: bool,
+
+    #[serde(default, deserialize_with = "default_on_invalid")]
     pub(crate) collapsed: bool,
 
     #[serde(flatten)]
@@ -230,6 +233,7 @@ impl Default for NoteFieldSchema11 {
             sticky: false,
             rtl: false,
             plain_text: false,
+            media_only: false,
             font: "Arial".to_string(),
             size: 20,
             description: String::new(),
@@ -248,6 +252,7 @@ impl From<NoteFieldSchema11> for NoteField {
                 sticky: f.sticky,
                 rtl: f.rtl,
                 plain_text: f.plain_text,
+                media_only: f.media_only,
                 font_name: f.font,
                 font_size: f.size as u32,
                 description: f.description,
@@ -271,6 +276,7 @@ impl From<NoteField> for NoteFieldSchema11 {
             sticky: conf.sticky,
             rtl: conf.rtl,
             plain_text: conf.plain_text,
+            media_only: conf.media_only,
             font: conf.font_name,
             size: conf.font_size as u16,
             description: conf.description,


### PR DESCRIPTION
Just opened and closed this pull request to save the code somewhere. A better solution was found after writing this pull-request. The new solution would be directly embedding media on the page, the same way images are. For example, I can embed images with `<img src='some.png'>`, therefore I can also embed other HTML5 media with `<audio src='some.mp3'></audio>`.

Initially, this pull-request would be a replacement for https://github.com/ankitects/anki/pull/540 - Added arguments as `[sound:filename|argument1 argument2...]`. Instead of creating options for existent `[sound:file]` tags, it would allow marking a field to store media only.
