### PR TITLE
Explicitly set web view to visible

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -108,6 +108,7 @@ Yutsuten <mateus.etto@gmail.com>
 Zoom <zoomrmc+git@gmail.com>
 TRIAEIOU <github.com/TRIAEIOU>
 Stefan Kangas <stefankangas@gmail.com>
+Alexander Yang <blueputty01@gmail.com>
 
 ********************
 

--- a/qt/aqt/import_export/import_csv_dialog.py
+++ b/qt/aqt/import_export/import_csv_dialog.py
@@ -29,6 +29,7 @@ class ImportCsvDialog(QDialog):
         self._on_accepted = on_accepted
         self._setup_ui(path)
         self.show()
+        self.web.setVisible(True)
 
     def _setup_ui(self, path: str) -> None:
         self.setWindowModality(Qt.WindowModality.ApplicationModal)


### PR DESCRIPTION
This PR attempts to resolve #2285 by proposing:

- Explicitly setting web view of CSV import window to visible

I added a `self.web.setVisible(True)` call after `self.show()` in the constructor instead of changing `self.web.setVisible(False)` to `self.web.setVisible(True)` in the `_setup_ui` function since the former seems to more closely follow the existing design patterns.