### PR TITLE
Bump Linux theme refresh timer back up to 5 minutes

### DIFF
--- a/qt/aqt/main.py
+++ b/qt/aqt/main.py
@@ -1074,8 +1074,10 @@ title="{}" {}>{}</button>""".format(
         theme_manager.apply_style()
         if is_lin:
             # On Linux, the check requires invoking an external binary,
+            # and can potentially produce verbose logs on systems where
+            # the preferred theme cannot be determined,
             # which we don't want to be doing frequently
-            interval_secs = 5
+            interval_secs = 300
         else:
             interval_secs = 2
         self.progress.timer(


### PR DESCRIPTION
On Linux distributions that do not yet support `org.freedesktop.appearance.color-scheme` (most distros released prior to 2022), querying DBus for the missing property produces verbose journal entries over Anki's entire runtime.

I first noticed this in the stdout and was considering to submit a PR that would simply gate printing the error behind an env var, but then discovered that `dbus-send` will also log errors to the journal. Because this happens every five seconds now, this is a bit suboptimal.

Stdout:

![Screenshot_20230118_130422](https://user-images.githubusercontent.com/5459332/213166912-9836bf58-8f5c-4dc2-a741-b45a9a5f0676.png)

System journal entries:

![Screenshot_20230118_123303-1](https://user-images.githubusercontent.com/5459332/213166721-960c97f3-f2a4-4b5a-a9cc-eeaef7c9e4fb.png)


Admittedly, this is a bandaid solution, but it's what we were using previously, so I think it's ok to opt for a conservative timer again. We can potentially follow up with a proper solution that first checks whether the corresponding DBus property exists before querying it (started looking into this a bit, but it's not incredibly straightforward).

