### PR TITLE
fix: remove empty menubar for addcards (#2189)

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -108,6 +108,7 @@ Yutsuten <mateus.etto@gmail.com>
 Zoom <zoomrmc+git@gmail.com>
 TRIAEIOU <github.com/TRIAEIOU>
 Stefan Kangas <stefankangas@gmail.com>
+altafard <altafard.dev>
 
 ********************
 

--- a/qt/aqt/forms/addcards.ui
+++ b/qt/aqt/forms/addcards.ui
@@ -82,16 +82,6 @@
     </item>
    </layout>
   </widget>
-  <widget class="QMenuBar" name="menubar">
-   <property name="geometry">
-    <rect>
-     <x>0</x>
-     <y>0</y>
-     <width>750</width>
-     <height>22</height>
-    </rect>
-   </property>
-  </widget>
  </widget>
  <resources>
   <include location="icons.qrc"/>


### PR DESCRIPTION
Fix #2189

Removing the empty menu bar allows you to use the menu from the parent widget. As a result  It seems that this menubar is a remaining from #1655.