### PR TITLE
Add separate styling for template editor QGroupBoxes

### DIFF
--- a/qt/aqt/clayout.py
+++ b/qt/aqt/clayout.py
@@ -247,7 +247,7 @@ class CardLayout(QDialog):
         tform.front_button.setText(tr.card_templates_front_template())
         tform.back_button.setText(tr.card_templates_back_template())
         tform.style_button.setText(tr.card_templates_template_styling())
-        tform.groupBox.setTitle(tr.card_templates_template_box())
+        tform.template_box.setTitle(tr.card_templates_template_box())
 
         cnt = self.mw.col.models.use_count(self.model)
         tform.changes_affect_label.setText(

--- a/qt/aqt/forms/template.ui
+++ b/qt/aqt/forms/template.ui
@@ -33,7 +33,7 @@
     <number>0</number>
    </property>
    <item>
-    <widget class="QGroupBox" name="groupBox">
+    <widget class="QGroupBox" name="template_box">
      <property name="title">
       <string notr="true">GroupBox</string>
      </property>

--- a/qt/aqt/stylesheets.py
+++ b/qt/aqt/stylesheets.py
@@ -88,6 +88,11 @@ class CustomStyles:
         border-radius: {tm.var(props.BORDER_RADIUS)};
         margin-top: 10px;
     }}
+    QGroupBox#preview_box,
+    QGroupBox#template_box {{
+        background: none;
+        border: none;
+    }}
     QGroupBox::title {{
         subcontrol-origin: margin;
         subcontrol-position: top left;

--- a/qt/aqt/stylesheets.py
+++ b/qt/aqt/stylesheets.py
@@ -99,6 +99,11 @@ class CustomStyles:
         margin: 0 2px;
         left: 15px;
     }}
+    QGroupBox#preview_box::title,
+    QGroupBox#template_box::title {{
+        margin-top: 5px;
+        left: 5px;
+    }}
         """
 
     def menu(self, tm: ThemeManager) -> str:


### PR DESCRIPTION
Point 3 of this comment: https://forums.ankiweb.net/t/anki-2-1-57-beta/26494/4

I thought since those two instances of `QGroupBox` are a bit of an edge case, we can simply remove the background and border definitions and things will look normal again.