### PR TITLE
Create the hook will_show_web to control html5 media elements with Javascript

### DIFF
--- a/qt/aqt/browser/previewer.py
+++ b/qt/aqt/browser/previewer.py
@@ -112,7 +112,8 @@ class Previewer(QDialog):
         self._on_close()
 
     def _on_replay_audio(self) -> None:
-        gui_hooks.will_show_web(self._web, "replay-audio")
+        gui_hooks.audio_will_replay(self._web, self.card(), self._state == "question")
+
         if self._state == "question":
             replay_audio(self.card(), True)
         elif self._state == "answer":

--- a/qt/aqt/browser/previewer.py
+++ b/qt/aqt/browser/previewer.py
@@ -192,10 +192,6 @@ class Previewer(QDialog):
             elif self._card_changed:
                 self._state = "question"
 
-            if not self._show_both_sides and self._state == "answer":
-                gui_hooks.will_show_web(self._web, "skip-render_answer")
-            gui_hooks.will_show_web(self._web, "reset_skip-render")
-
             currentState = self._state_and_mod()
             if currentState == self._last_state:
                 # nothing has changed, avoid refreshing
@@ -229,12 +225,20 @@ class Previewer(QDialog):
             else:
                 audio = []
                 self._web.setPlaybackRequiresGesture(True)
-                gui_hooks.will_show_web(self._web, "autoplay-render")
 
             gui_hooks.av_player_will_play_tags(audio, self._state, self)
             av_player.play_tags(audio)
+            skip_front = not self._show_both_sides and self._state == "answer"
+
             txt = self.mw.prepare_card_text_for_display(txt)
-            txt = gui_hooks.card_will_show(txt, c, f"preview{self._state.capitalize()}")
+            txt = gui_hooks.card_will_show_state(
+                txt,
+                c,
+                f"preview{self._state.capitalize()}",
+                self._web,
+                skip_front,
+                False,
+            )
             self._last_state = self._state_and_mod()
 
         js: str
@@ -245,7 +249,6 @@ class Previewer(QDialog):
             js = f"{func}({json.dumps(txt)}, '{bodyclass}');"
         self._web.eval(js)
         self._card_changed = False
-        gui_hooks.will_show_web(self._web, "skip-render_end")
 
     def _on_show_both_sides(self, toggle: bool) -> None:
         self._show_both_sides = toggle

--- a/qt/aqt/browser/previewer.py
+++ b/qt/aqt/browser/previewer.py
@@ -83,7 +83,7 @@ class Previewer(QDialog):
         self.bbox = QDialogButtonBox()
         self.bbox.setLayoutDirection(Qt.LayoutDirection.LeftToRight)
 
-        gui_hooks.will_show_web(self._web, "enable-previewer")
+        gui_hooks.card_review_webview_did_init(self._web, AnkiWebViewKind.PREVIEWER)
 
         self._replay = self.bbox.addButton(
             tr.actions_replay_audio(), QDialogButtonBox.ButtonRole.ActionRole

--- a/qt/aqt/browser/previewer.py
+++ b/qt/aqt/browser/previewer.py
@@ -254,10 +254,10 @@ class Previewer(QDialog):
     def _on_show_both_sides(self, toggle: bool) -> None:
         self._show_both_sides = toggle
         self.mw.col.set_config_bool(Config.Bool.PREVIEW_BOTH_SIDES, toggle)
-        gui_hooks.will_show_web(self._web, "reset-sides")
+        gui_hooks.previewer_will_redraw_after_show_both_sides_toggled(
+            self._web, self.card(), self._state == "question", toggle
+        )
 
-        if self._state == "question" and toggle:
-            gui_hooks.will_show_web(self._web, "skip-sides")
         if self._state == "answer" and not toggle:
             self._state = "question"
         self.render_card()

--- a/qt/aqt/browser/previewer.py
+++ b/qt/aqt/browser/previewer.py
@@ -83,7 +83,7 @@ class Previewer(QDialog):
         self.bbox = QDialogButtonBox()
         self.bbox.setLayoutDirection(Qt.LayoutDirection.LeftToRight)
 
-        gui_hooks.will_show_web(self._web, "enable")
+        gui_hooks.will_show_web(self._web, "enable-previewer")
 
         self._replay = self.bbox.addButton(
             tr.actions_replay_audio(), QDialogButtonBox.ButtonRole.ActionRole
@@ -112,7 +112,7 @@ class Previewer(QDialog):
         self._on_close()
 
     def _on_replay_audio(self) -> None:
-        gui_hooks.will_show_web(self._web, "replay")
+        gui_hooks.will_show_web(self._web, "replay-audio")
         if self._state == "question":
             replay_audio(self.card(), True)
         elif self._state == "answer":
@@ -193,8 +193,8 @@ class Previewer(QDialog):
                 self._state = "question"
 
             if not self._show_both_sides and self._state == "answer":
-                gui_hooks.will_show_web(self._web, "skip")
-            gui_hooks.will_show_web(self._web, "reset_skip")
+                gui_hooks.will_show_web(self._web, "skip-render_answer")
+            gui_hooks.will_show_web(self._web, "reset_skip-render")
 
             currentState = self._state_and_mod()
             if currentState == self._last_state:
@@ -229,7 +229,7 @@ class Previewer(QDialog):
             else:
                 audio = []
                 self._web.setPlaybackRequiresGesture(True)
-                gui_hooks.will_show_web(self._web, "autoplay")
+                gui_hooks.will_show_web(self._web, "autoplay-render")
 
             gui_hooks.av_player_will_play_tags(audio, self._state, self)
             av_player.play_tags(audio)
@@ -245,15 +245,15 @@ class Previewer(QDialog):
             js = f"{func}({json.dumps(txt)}, '{bodyclass}');"
         self._web.eval(js)
         self._card_changed = False
-        gui_hooks.will_show_web(self._web, "skip")
+        gui_hooks.will_show_web(self._web, "skip-render_end")
 
     def _on_show_both_sides(self, toggle: bool) -> None:
         self._show_both_sides = toggle
         self.mw.col.set_config_bool(Config.Bool.PREVIEW_BOTH_SIDES, toggle)
-        gui_hooks.will_show_web(self._web, "reset")
+        gui_hooks.will_show_web(self._web, "reset-sides")
 
         if self._state == "question" and toggle:
-            gui_hooks.will_show_web(self._web, "skip")
+            gui_hooks.will_show_web(self._web, "skip-sides")
         if self._state == "answer" and not toggle:
             self._state = "question"
         self.render_card()

--- a/qt/aqt/browser/previewer.py
+++ b/qt/aqt/browser/previewer.py
@@ -226,20 +226,10 @@ class Previewer(QDialog):
             else:
                 audio = []
                 self._web.setPlaybackRequiresGesture(True)
-
             gui_hooks.av_player_will_play_tags(audio, self._state, self)
             av_player.play_tags(audio)
-            skip_front = not self._show_both_sides and self._state == "answer"
-
             txt = self.mw.prepare_card_text_for_display(txt)
-            txt = gui_hooks.card_will_show_state(
-                txt,
-                c,
-                f"preview{self._state.capitalize()}",
-                self._web,
-                skip_front,
-                False,
-            )
+            txt = gui_hooks.card_will_show(txt, c, f"preview{self._state.capitalize()}")
             self._last_state = self._state_and_mod()
 
         js: str

--- a/qt/aqt/browser/previewer.py
+++ b/qt/aqt/browser/previewer.py
@@ -83,6 +83,8 @@ class Previewer(QDialog):
         self.bbox = QDialogButtonBox()
         self.bbox.setLayoutDirection(Qt.LayoutDirection.LeftToRight)
 
+        gui_hooks.will_show_web(self._web, "enable")
+
         self._replay = self.bbox.addButton(
             tr.actions_replay_audio(), QDialogButtonBox.ButtonRole.ActionRole
         )

--- a/qt/aqt/clayout.py
+++ b/qt/aqt/clayout.py
@@ -359,7 +359,7 @@ class CardLayout(QDialog):
         self.preview_web.eval("_blockDefaultDragDropBehavior();")
         self.preview_web.set_bridge_command(self._on_bridge_cmd, self)
 
-        gui_hooks.will_show_web(self.preview_web, "enable")
+        gui_hooks.will_show_web(self.preview_web, "enable-clayout")
 
         if self._isCloze():
             nums = list(self.note.cloze_numbers_in_fields())
@@ -529,10 +529,10 @@ class CardLayout(QDialog):
         )
 
         if not self.have_autoplayed:
-            gui_hooks.will_show_web(self.preview_web, "reset")
+            gui_hooks.will_show_web(self.preview_web, "reset-preview")
 
             if not c.autoplay():
-                gui_hooks.will_show_web(self.preview_web, "autoplay")
+                gui_hooks.will_show_web(self.preview_web, "autoplay-preview")
 
         if self.pform.preview_front.isChecked():
             q = ti(self.mw.prepare_card_text_for_display(c.question()))
@@ -542,7 +542,7 @@ class CardLayout(QDialog):
             a = ti(self.mw.prepare_card_text_for_display(c.answer()), type="a")
             a = gui_hooks.card_will_show(a, c, "clayoutAnswer")
             text = a
-            gui_hooks.will_show_web(self.preview_web, "skip")
+            gui_hooks.will_show_web(self.preview_web, "skip-preview")
 
         # use _showAnswer to avoid the longer delay
         self.preview_web.eval(f"_showAnswer({json.dumps(text)},'{bodyclass}');")

--- a/qt/aqt/clayout.py
+++ b/qt/aqt/clayout.py
@@ -530,21 +530,18 @@ class CardLayout(QDialog):
             c.ord, self.night_mode_is_enabled
         )
 
-        if not self.have_autoplayed:
-            gui_hooks.will_show_web(self.preview_web, "reset-preview")
-
-            if not c.autoplay():
-                gui_hooks.will_show_web(self.preview_web, "autoplay-preview")
-
         if self.pform.preview_front.isChecked():
             q = ti(self.mw.prepare_card_text_for_display(c.question()))
-            q = gui_hooks.card_will_show(q, c, "clayoutQuestion")
+            q = gui_hooks.card_will_show_state(
+                q, c, "clayoutQuestion", self.preview_web, False, self.have_autoplayed
+            )
             text = q
         else:
             a = ti(self.mw.prepare_card_text_for_display(c.answer()), type="a")
-            a = gui_hooks.card_will_show(a, c, "clayoutAnswer")
+            a = gui_hooks.card_will_show_state(
+                a, c, "clayoutAnswer", self.preview_web, True, self.have_autoplayed
+            )
             text = a
-            gui_hooks.will_show_web(self.preview_web, "skip-preview")
 
         # use _showAnswer to avoid the longer delay
         self.preview_web.eval(f"_showAnswer({json.dumps(text)},'{bodyclass}');")

--- a/qt/aqt/clayout.py
+++ b/qt/aqt/clayout.py
@@ -359,7 +359,9 @@ class CardLayout(QDialog):
         self.preview_web.eval("_blockDefaultDragDropBehavior();")
         self.preview_web.set_bridge_command(self._on_bridge_cmd, self)
 
-        gui_hooks.will_show_web(self.preview_web, "enable-clayout")
+        gui_hooks.card_review_webview_did_init(
+            self.preview_web, AnkiWebViewKind.CARD_LAYOUT
+        )
 
         if self._isCloze():
             nums = list(self.note.cloze_numbers_in_fields())

--- a/qt/aqt/clayout.py
+++ b/qt/aqt/clayout.py
@@ -532,15 +532,11 @@ class CardLayout(QDialog):
 
         if self.pform.preview_front.isChecked():
             q = ti(self.mw.prepare_card_text_for_display(c.question()))
-            q = gui_hooks.card_will_show_state(
-                q, c, "clayoutQuestion", self.preview_web, False, self.have_autoplayed
-            )
+            q = gui_hooks.card_will_show(q, c, "clayoutQuestion")
             text = q
         else:
             a = ti(self.mw.prepare_card_text_for_display(c.answer()), type="a")
-            a = gui_hooks.card_will_show_state(
-                a, c, "clayoutAnswer", self.preview_web, True, self.have_autoplayed
-            )
+            a = gui_hooks.card_will_show(a, c, "clayoutAnswer")
             text = a
 
         # use _showAnswer to avoid the longer delay

--- a/qt/aqt/clayout.py
+++ b/qt/aqt/clayout.py
@@ -359,6 +359,8 @@ class CardLayout(QDialog):
         self.preview_web.eval("_blockDefaultDragDropBehavior();")
         self.preview_web.set_bridge_command(self._on_bridge_cmd, self)
 
+        gui_hooks.will_show_web(self.preview_web, "enable")
+
         if self._isCloze():
             nums = list(self.note.cloze_numbers_in_fields())
             if self.ord + 1 not in nums:

--- a/qt/aqt/clayout.py
+++ b/qt/aqt/clayout.py
@@ -526,6 +526,12 @@ class CardLayout(QDialog):
             c.ord, self.night_mode_is_enabled
         )
 
+        if not self.have_autoplayed:
+            gui_hooks.will_show_web(self.preview_web, "reset")
+
+            if not c.autoplay():
+                gui_hooks.will_show_web(self.preview_web, "autoplay")
+
         if self.pform.preview_front.isChecked():
             q = ti(self.mw.prepare_card_text_for_display(c.question()))
             q = gui_hooks.card_will_show(q, c, "clayoutQuestion")
@@ -534,6 +540,7 @@ class CardLayout(QDialog):
             a = ti(self.mw.prepare_card_text_for_display(c.answer()), type="a")
             a = gui_hooks.card_will_show(a, c, "clayoutAnswer")
             text = a
+            gui_hooks.will_show_web(self.preview_web, "skip")
 
         # use _showAnswer to avoid the longer delay
         self.preview_web.eval(f"_showAnswer({json.dumps(text)},'{bodyclass}');")

--- a/qt/aqt/main.py
+++ b/qt/aqt/main.py
@@ -901,7 +901,7 @@ title="{}" {}>{}</button>""".format(
             for webview in self.web, self.bottomWeb:
                 webview.force_load_hack()
 
-        gui_hooks.will_show_web(self.web, "enable-main")
+        gui_hooks.card_review_webview_did_init(self.web, AnkiWebViewKind.MAIN)
 
     def closeAllWindows(self, onsuccess: Callable) -> None:
         aqt.dialogs.closeAll(onsuccess)

--- a/qt/aqt/main.py
+++ b/qt/aqt/main.py
@@ -248,6 +248,8 @@ class AnkiQt(QMainWindow):
     def finish_ui_setup(self) -> None:
         "Actions that are deferred until after add-on loading."
         self.toolbar.draw()
+        # add-ons are only available here after setupAddons
+        gui_hooks.reviewer_did_init(self.reviewer)
 
     def setupProfileAfterWebviewsLoaded(self) -> None:
         for w in (self.web, self.bottomWeb):

--- a/qt/aqt/main.py
+++ b/qt/aqt/main.py
@@ -901,6 +901,8 @@ title="{}" {}>{}</button>""".format(
             for webview in self.web, self.bottomWeb:
                 webview.force_load_hack()
 
+        gui_hooks.will_show_web(self.web, "enable")
+
     def closeAllWindows(self, onsuccess: Callable) -> None:
         aqt.dialogs.closeAll(onsuccess)
 

--- a/qt/aqt/main.py
+++ b/qt/aqt/main.py
@@ -901,7 +901,7 @@ title="{}" {}>{}</button>""".format(
             for webview in self.web, self.bottomWeb:
                 webview.force_load_hack()
 
-        gui_hooks.will_show_web(self.web, "enable")
+        gui_hooks.will_show_web(self.web, "enable-main")
 
     def closeAllWindows(self, onsuccess: Callable) -> None:
         aqt.dialogs.closeAll(onsuccess)

--- a/qt/aqt/reviewer.py
+++ b/qt/aqt/reviewer.py
@@ -510,7 +510,7 @@ class Reviewer:
 
     def on_pause_audio(self) -> None:
         av_player.toggle_pause()
-        gui_hooks.will_show_web(self.web, "toggle-pause")
+        gui_hooks.audio_did_pause_or_unpause(self.web)
 
     seek_secs = 5
 

--- a/qt/aqt/reviewer.py
+++ b/qt/aqt/reviewer.py
@@ -359,9 +359,7 @@ class Reviewer:
         av_player.play_tags(sounds)
         # render & update bottom
         q = self._mungeQA(q)
-        q = gui_hooks.card_will_show_state(
-            q, c, "reviewQuestion", self.web, False, False
-        )
+        q = gui_hooks.card_will_show(q, c, "reviewQuestion")
         self._run_state_mutation_hook()
 
         bodyclass = theme_manager.body_classes_for_card_ord(c.ord)
@@ -410,7 +408,7 @@ class Reviewer:
         gui_hooks.av_player_will_play_tags(sounds, self.state, self)
         av_player.play_tags(sounds)
         a = self._mungeQA(a)
-        a = gui_hooks.card_will_show_state(a, c, "reviewAnswer", self.web, True, False)
+        a = gui_hooks.card_will_show(a, c, "reviewAnswer")
         # render and update bottom
         self.web.eval(f"_showAnswer({json.dumps(a)});")
         self._showEaseButtons()

--- a/qt/aqt/reviewer.py
+++ b/qt/aqt/reviewer.py
@@ -291,9 +291,7 @@ class Reviewer:
             replay_audio(self.card, True)
         elif self.state == "answer":
             replay_audio(self.card, False)
-            if not self.card.replay_question_audio_on_answer_side():
-                gui_hooks.will_show_web(self.web, "skip-replay")
-        gui_hooks.will_show_web(self.web, "replay-replay")
+        gui_hooks.audio_will_replay(self.web, self.card, self.state == "question")
 
     # Initializing the webview
     ##########################################################################

--- a/qt/aqt/reviewer.py
+++ b/qt/aqt/reviewer.py
@@ -210,8 +210,6 @@ class Reviewer:
 
     def _redraw_current_card(self) -> None:
         self.card.load()
-        gui_hooks.will_show_web(self.web, "reset-redraw")
-
         if self.state == "answer":
             self._showAnswer()
         else:
@@ -240,7 +238,6 @@ class Reviewer:
         if self._reps is None:
             self._initWeb()
 
-        gui_hooks.will_show_web(self.web, "reset-next")
         self._showQuestion()
 
     def _get_next_v1_v2_card(self) -> None:
@@ -364,14 +361,13 @@ class Reviewer:
         av_player.play_tags(sounds)
         # render & update bottom
         q = self._mungeQA(q)
-        q = gui_hooks.card_will_show(q, c, "reviewQuestion")
+        q = gui_hooks.card_will_show_state(
+            q, c, "reviewQuestion", self.web, False, False
+        )
         self._run_state_mutation_hook()
 
         bodyclass = theme_manager.body_classes_for_card_ord(c.ord)
         a = self.mw.col.media.escape_media_filenames(c.answer())
-
-        if not c.autoplay():
-            gui_hooks.will_show_web(self.web, "autoplay-show")
 
         self.web.eval(
             f"_showQuestion({json.dumps(q)}, {json.dumps(a)}, '{bodyclass}');"
@@ -416,7 +412,7 @@ class Reviewer:
         gui_hooks.av_player_will_play_tags(sounds, self.state, self)
         av_player.play_tags(sounds)
         a = self._mungeQA(a)
-        a = gui_hooks.card_will_show(a, c, "reviewAnswer")
+        a = gui_hooks.card_will_show_state(a, c, "reviewAnswer", self.web, True, False)
         # render and update bottom
         self.web.eval(f"_showAnswer({json.dumps(a)});")
         self._showEaseButtons()

--- a/qt/aqt/reviewer.py
+++ b/qt/aqt/reviewer.py
@@ -210,7 +210,7 @@ class Reviewer:
 
     def _redraw_current_card(self) -> None:
         self.card.load()
-        gui_hooks.will_show_web(self.web, "reset")
+        gui_hooks.will_show_web(self.web, "reset-redraw")
 
         if self.state == "answer":
             self._showAnswer()
@@ -240,7 +240,7 @@ class Reviewer:
         if self._reps is None:
             self._initWeb()
 
-        gui_hooks.will_show_web(self.web, "reset")
+        gui_hooks.will_show_web(self.web, "reset-next")
         self._showQuestion()
 
     def _get_next_v1_v2_card(self) -> None:
@@ -295,8 +295,8 @@ class Reviewer:
         elif self.state == "answer":
             replay_audio(self.card, False)
             if not self.card.replay_question_audio_on_answer_side():
-                gui_hooks.will_show_web(self.web, "skip")
-        gui_hooks.will_show_web(self.web, "replay")
+                gui_hooks.will_show_web(self.web, "skip-replay")
+        gui_hooks.will_show_web(self.web, "replay-replay")
 
     # Initializing the webview
     ##########################################################################
@@ -371,7 +371,7 @@ class Reviewer:
         a = self.mw.col.media.escape_media_filenames(c.answer())
 
         if not c.autoplay():
-            gui_hooks.will_show_web(self.web, "autoplay")
+            gui_hooks.will_show_web(self.web, "autoplay-show")
 
         self.web.eval(
             f"_showQuestion({json.dumps(q)}, {json.dumps(a)}, '{bodyclass}');"
@@ -514,7 +514,7 @@ class Reviewer:
 
     def on_pause_audio(self) -> None:
         av_player.toggle_pause()
-        gui_hooks.will_show_web(self.web, "toggle")
+        gui_hooks.will_show_web(self.web, "toggle-pause")
 
     seek_secs = 5
 

--- a/qt/aqt/reviewer.py
+++ b/qt/aqt/reviewer.py
@@ -210,6 +210,8 @@ class Reviewer:
 
     def _redraw_current_card(self) -> None:
         self.card.load()
+        gui_hooks.will_show_web(self.web, "reset")
+
         if self.state == "answer":
             self._showAnswer()
         else:
@@ -238,6 +240,7 @@ class Reviewer:
         if self._reps is None:
             self._initWeb()
 
+        gui_hooks.will_show_web(self.web, "reset")
         self._showQuestion()
 
     def _get_next_v1_v2_card(self) -> None:
@@ -291,6 +294,9 @@ class Reviewer:
             replay_audio(self.card, True)
         elif self.state == "answer":
             replay_audio(self.card, False)
+            if not self.card.replay_question_audio_on_answer_side():
+                gui_hooks.will_show_web(self.web, "skip")
+        gui_hooks.will_show_web(self.web, "replay")
 
     # Initializing the webview
     ##########################################################################
@@ -363,6 +369,9 @@ class Reviewer:
 
         bodyclass = theme_manager.body_classes_for_card_ord(c.ord)
         a = self.mw.col.media.escape_media_filenames(c.answer())
+
+        if not c.autoplay():
+            gui_hooks.will_show_web(self.web, "autoplay")
 
         self.web.eval(
             f"_showQuestion({json.dumps(q)}, {json.dumps(a)}, '{bodyclass}');"
@@ -505,6 +514,7 @@ class Reviewer:
 
     def on_pause_audio(self) -> None:
         av_player.toggle_pause()
+        gui_hooks.will_show_web(self.web, "toggle")
 
     seek_secs = 5
 

--- a/qt/tools/genhooks_gui.py
+++ b/qt/tools/genhooks_gui.py
@@ -245,6 +245,12 @@ hooks = [
     ),
     # Multiple windows
     ###################
+    # reviewer and previewer
+    Hook(
+        name="audio_will_replay",
+        args=["webview: aqt.webview.AnkiWebView", "card: Card", "is_front_side: bool"],
+        doc="""Called when the user uses the 'replay audio' action, but not when they click on a play button.""",
+    ),
     # reviewer, clayout and browser
     Hook(
         name="card_will_show",

--- a/qt/tools/genhooks_gui.py
+++ b/qt/tools/genhooks_gui.py
@@ -248,6 +248,12 @@ hooks = [
         legacy_hook="prepareQA",
         doc="Can modify card text before review/preview.",
     ),
+    # reviewer, preview and clayout
+    Hook(
+        name="will_show_web",
+        args=["web: aqt.webview.AnkiWebView", "location: str"],
+        doc="Can use the web object in several occasions.",
+    ),
     # Deck browser
     ###################
     Hook(

--- a/qt/tools/genhooks_gui.py
+++ b/qt/tools/genhooks_gui.py
@@ -248,10 +248,19 @@ hooks = [
         legacy_hook="prepareQA",
         doc="Can modify card text before review/preview.",
     ),
+    # reviewer, main and clayout
+    Hook(
+        name="card_review_webview_did_init",
+        args=[
+            "webview: aqt.webview.AnkiWebView",
+            "kind: aqt.webview.AnkiWebViewKind",
+        ],
+        doc="Called when initializing the webview for the review screen, the card layout screen, and the preview screen.",
+    ),
     # reviewer, preview and clayout
     Hook(
         name="will_show_web",
-        args=["web: aqt.webview.AnkiWebView", "location: str"],
+        args=["web_content: aqt.webview.AnkiWebView", "location: str"],
         doc="Can use the web object in several occasions.",
     ),
     # Deck browser

--- a/qt/tools/genhooks_gui.py
+++ b/qt/tools/genhooks_gui.py
@@ -246,6 +246,22 @@ hooks = [
         args=["text: str", "card: Card", "kind: str"],
         return_type="str",
         legacy_hook="prepareQA",
+        doc="""Deprecated. Use card_will_show_state instead.
+        Can modify card text before review/preview.""",
+    ),
+    Hook(
+        name="card_will_show_state",
+        args=[
+            "text: str",
+            "card: Card",
+            "kind: str",
+            "web_content: aqt.webview.AnkiWebView",
+            "skip_front: bool",
+            "has_autoplayed: bool",
+        ],
+        return_type="str",
+        replaces="card_will_show",
+        replaced_hook_args=["text: str", "card: Card", "kind: str"],
         doc="Can modify card text before review/preview.",
     ),
     # reviewer, main and clayout

--- a/qt/tools/genhooks_gui.py
+++ b/qt/tools/genhooks_gui.py
@@ -284,12 +284,6 @@ hooks = [
         ],
         doc="Called when initializing the webview for the review screen, the card layout screen, and the preview screen.",
     ),
-    # reviewer, preview and clayout
-    Hook(
-        name="will_show_web",
-        args=["web_content: aqt.webview.AnkiWebView", "location: str"],
-        doc="Can use the web object in several occasions.",
-    ),
     # Deck browser
     ###################
     Hook(
@@ -568,6 +562,16 @@ hooks = [
         name="previewer_did_init",
         args=["previewer: aqt.browser.previewer.Previewer"],
         doc="""Called after the previewer is initialized.""",
+    ),
+    Hook(
+        name="previewer_will_redraw_after_show_both_sides_toggled",
+        args=[
+            "webview: aqt.webview.AnkiWebView",
+            "card: Card",
+            "is_front_side: bool",
+            "show_both_sides: bool",
+        ],
+        doc="""Called when the checkbox <show both sides> is toggled by the user.""",
     ),
     # Main window states
     ###################

--- a/qt/tools/genhooks_gui.py
+++ b/qt/tools/genhooks_gui.py
@@ -215,6 +215,11 @@ hooks = [
         name="reviewer_will_bury_card",
         args=["id: int"],
     ),
+    Hook(
+        name="audio_did_pause_or_unpause",
+        args=["webview: aqt.webview.AnkiWebView"],
+        doc="""Called when the audio is paused or unpaused.""",
+    ),
     # Debug
     ###################
     Hook(

--- a/qt/tools/genhooks_gui.py
+++ b/qt/tools/genhooks_gui.py
@@ -243,6 +243,13 @@ hooks = [
         doc="""Allow to change the display of the card layout. After most values are
          set and before the window is actually shown.""",
     ),
+    # Reviewer
+    ###################
+    Hook(
+        name="reviewer_did_init",
+        args=["reviewer: aqt.reviewer.Reviewer"],
+        doc="""Called after the reviewer is initialized.""",
+    ),
     # Multiple windows
     ###################
     # reviewer and previewer
@@ -257,22 +264,6 @@ hooks = [
         args=["text: str", "card: Card", "kind: str"],
         return_type="str",
         legacy_hook="prepareQA",
-        doc="""Deprecated. Use card_will_show_state instead.
-        Can modify card text before review/preview.""",
-    ),
-    Hook(
-        name="card_will_show_state",
-        args=[
-            "text: str",
-            "card: Card",
-            "kind: str",
-            "web_content: aqt.webview.AnkiWebView",
-            "skip_front: bool",
-            "has_autoplayed: bool",
-        ],
-        return_type="str",
-        replaces="card_will_show",
-        replaced_hook_args=["text: str", "card: Card", "kind: str"],
         doc="Can modify card text before review/preview.",
     ),
     # reviewer, main and clayout


### PR DESCRIPTION
Replace the changes for the pull-request https://github.com/ankitects/anki/pull/604 with the `will_show_web` to control HTML5 media and be compatible with Preview, Reviewer, and Card Layout window builtin control for mpv or player.

An addon using this hook is available on https://github.com/evandrocoan/AnkiAddons/tree/master/ankimediaqueue. The addon will be published after this hook is accepted.