### PR TITLE
Use Rust nightly for formatting

### DIFF
--- a/build/configure/src/rust.rs
+++ b/build/configure/src/rust.rs
@@ -113,6 +113,7 @@ pub fn check_rust(build: &mut Build) -> Result<()> {
         CargoFormat {
             inputs: inputs.clone(),
             check_only: true,
+            working_dir: Some("cargo/format"),
         },
     )?;
     build.add(
@@ -120,6 +121,7 @@ pub fn check_rust(build: &mut Build) -> Result<()> {
         CargoFormat {
             inputs: inputs.clone(),
             check_only: false,
+            working_dir: Some("cargo/format"),
         },
     )?;
 

--- a/build/ninja_gen/src/cargo.rs
+++ b/build/ninja_gen/src/cargo.rs
@@ -177,13 +177,13 @@ pub struct CargoFormat {
 
 impl BuildAction for CargoFormat {
     fn command(&self) -> &str {
-        // the empty config file prevents warnings about nightly features
-        "cargo fmt $mode -- --config-path=.rustfmt-empty.toml --color always"
+        "cargo fmt $mode --all"
     }
 
     fn files(&mut self, build: &mut impl FilesHandle) {
         build.add_inputs("", &self.inputs);
         build.add_variable("mode", if self.check_only { "--check" } else { "" });
+        build.set_working_dir("cargo/format");
         build.add_output_stamp(format!(
             "tests/cargo_format.{}",
             if self.check_only { "check" } else { "fmt" }

--- a/build/ninja_gen/src/cargo.rs
+++ b/build/ninja_gen/src/cargo.rs
@@ -173,6 +173,7 @@ impl BuildAction for CargoClippy {
 pub struct CargoFormat {
     pub inputs: BuildInput,
     pub check_only: bool,
+    pub working_dir: Option<&'static str>,
 }
 
 impl BuildAction for CargoFormat {
@@ -183,7 +184,10 @@ impl BuildAction for CargoFormat {
     fn files(&mut self, build: &mut impl FilesHandle) {
         build.add_inputs("", &self.inputs);
         build.add_variable("mode", if self.check_only { "--check" } else { "" });
-        build.set_working_dir("cargo/format");
+        if let Some(working_dir) = self.working_dir {
+            build.set_working_dir("$working_dir");
+            build.add_variable("working_dir", working_dir);
+        }
         build.add_output_stamp(format!(
             "tests/cargo_format.{}",
             if self.check_only { "check" } else { "fmt" }

--- a/build/runner/src/build.rs
+++ b/build/runner/src/build.rs
@@ -67,7 +67,7 @@ pub fn run_build(args: BuildArgs) {
         // commands will not show colors by default, as we do not provide a tty
         .env("FORCE_COLOR", "1")
         .env("MYPY_FORCE_COLOR", "1")
-        .env("TERM", "1")
+        .env("TERM", std::env::var("TERM").unwrap_or_default())
         // Prevents 'Warn: You must provide the URL of lib/mappings.wasm'.
         // Updating svelte-check or its deps will likely remove the need for it.
         .env("NODE_OPTIONS", "--no-experimental-fetch");

--- a/build/runner/src/run.rs
+++ b/build/runner/src/run.rs
@@ -13,6 +13,8 @@ pub struct RunArgs {
     stamp: Option<String>,
     #[arg(long, value_parser = split_env)]
     env: Vec<(String, String)>,
+    #[arg(long)]
+    cwd: Option<String>,
     #[arg(trailing_var_arg = true)]
     args: Vec<String>,
 }
@@ -22,7 +24,7 @@ pub struct RunArgs {
 pub fn run_commands(args: RunArgs) {
     let commands = split_args(args.args);
     for command in commands {
-        run_silent(&mut build_command(command, &args.env));
+        run_silent(&mut build_command(command, &args.env, &args.cwd));
     }
     if let Some(stamp_file) = args.stamp {
         std::fs::write(stamp_file, b"").expect("unable to write stamp file");
@@ -37,11 +39,18 @@ fn split_env(s: &str) -> Result<(String, String), std::io::Error> {
     }
 }
 
-fn build_command(command_and_args: Vec<String>, env: &[(String, String)]) -> Command {
+fn build_command(
+    command_and_args: Vec<String>,
+    env: &[(String, String)],
+    cwd: &Option<String>,
+) -> Command {
     let mut command = Command::new(&command_and_args[0]);
     command.args(&command_and_args[1..]);
     for (k, v) in env {
         command.env(k, v);
+    }
+    if let Some(cwd) = cwd {
+        command.current_dir(cwd);
     }
     command
 }

--- a/cargo/README.md
+++ b/cargo/README.md
@@ -1,3 +1,5 @@
 This folder used to contain Bazel-specific Rust integration, but now only
-contains our license-checking script, which should be run when using
-cargo update.
+contains:
+
+- our license-checking script, which should be run when using cargo update.
+- a nightly toolchain definition for formatting

--- a/cargo/format/rust-toolchain.toml
+++ b/cargo/format/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "nightly-2023-01-24"
+profile = "minimal"
+components = ["rustfmt"]

--- a/rslib/src/sync/http_client/io_monitor.rs
+++ b/rslib/src/sync/http_client/io_monitor.rs
@@ -201,9 +201,9 @@ mod test {
     use super::*;
     use crate::sync::error::HttpError;
 
-    /// The delays in the tests are aggressively short, and false positives slip through
-    /// on a loaded system - especially on Windows. Fix by applying a universal
-    /// multiplier.
+    /// The delays in the tests are aggressively short, and false positives slip
+    /// through on a loaded system - especially on Windows. Fix by applying
+    /// a universal multiplier.
     fn millis(millis: u64) -> Duration {
         Duration::from_millis(millis * if cfg!(windows) { 10 } else { 5 })
     }


### PR DESCRIPTION
This will ensure imports and comments are always formatted correctly before merge.