### PR TITLE
Fix 'View Files' not working with a relative base folder

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -54,7 +54,7 @@ neitrinoweb <github.com/neitrinoweb/>
 Andreas Reis <github.com/nwwt>
 Matt Krump <github.com/mkrump>
 Alexander Presnyakov <flagist0@gmail.com>
-abdo <github.com/abdnh>
+Abdo <github.com/abdnh>
 aplaice <plaice.adam+github@gmail.com>
 phwoo <github.com/phwoo>
 Soren Bjornstad <anki@sorenbjornstad.com>

--- a/qt/aqt/profiles.py
+++ b/qt/aqt/profiles.py
@@ -340,7 +340,7 @@ class ProfileManager:
             or ProfileManager._default_base()
         )
         path.mkdir(parents=True, exist_ok=True)
-        return path
+        return path.resolve()
 
     @staticmethod
     def _default_base() -> str:


### PR DESCRIPTION
Probably introduced in 0570cfdf48dbab21e561bcbc0516721d08bdc025
I use the `-b` option often enough to notice this.