### PR TITLE
Allow burying cards in browser

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -110,6 +110,7 @@ TRIAEIOU <github.com/TRIAEIOU>
 Stefan Kangas <stefankangas@gmail.com>
 Fabricio Duarte <fabricio.duarte.jr@gmail.com>
 Mani <github.com/krmanik>
+Kaben Nanlohy <kaben.nanlohy@gmail.com>
 
 ********************
 

--- a/ftl/core/browsing.ftl
+++ b/ftl/core/browsing.ftl
@@ -93,6 +93,7 @@ browsing-suspended = Suspended
 browsing-tag-duplicates = Tag Duplicates
 browsing-tag-rename-warning-empty = You can't rename a tag that has no notes.
 browsing-target-field = Target field:
+browsing-toggle-bury = Toggle Bury
 browsing-toggle-showing-cards-notes = Toggle Cards/Notes
 browsing-toggle-mark = Toggle Mark
 browsing-toggle-suspend = Toggle Suspend

--- a/proto/anki/search.proto
+++ b/proto/anki/search.proto
@@ -182,6 +182,7 @@ message BrowserRow {
     COLOR_FLAG_PINK = 7;
     COLOR_FLAG_TURQUOISE = 8;
     COLOR_FLAG_PURPLE = 9;
+    COLOR_BURIED = 10;
   }
   repeated Cell cells = 1;
   Color color = 2;

--- a/qt/aqt/browser/table/__init__.py
+++ b/qt/aqt/browser/table/__init__.py
@@ -84,6 +84,8 @@ def backend_color_to_aqt_color(color: BrowserRow.Color.V) -> dict[str, str] | No
         temp_color = colors.STATE_MARKED
     if color == BrowserRow.COLOR_SUSPENDED:
         temp_color = colors.STATE_SUSPENDED
+    if color == BrowserRow.COLOR_BURIED:
+        temp_color = colors.STATE_BURIED
     if color == BrowserRow.COLOR_FLAG_RED:
         temp_color = colors.FLAG_1
     if color == BrowserRow.COLOR_FLAG_ORANGE:

--- a/qt/aqt/forms/browser.ui
+++ b/qt/aqt/forms/browser.ui
@@ -209,7 +209,7 @@
      <x>0</x>
      <y>0</y>
      <width>750</width>
-     <height>22</height>
+     <height>23</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuEdit">
@@ -271,6 +271,7 @@
     <addaction name="actionReposition"/>
     <addaction name="separator"/>
     <addaction name="actionToggle_Suspend"/>
+    <addaction name="action_toggle_bury"/>
     <addaction name="separator"/>
     <addaction name="menuFlag"/>
     <addaction name="separator"/>
@@ -737,6 +738,17 @@
   <action name="actionbrowsing_toggle_showing_cards_notes">
    <property name="text">
     <string>browsing_toggle_showing_cards_notes</string>
+   </property>
+  </action>
+  <action name="action_toggle_bury">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>browsing_toggle_bury</string>
+   </property>
+   <property name="shortcut">
+    <string notr="true"/>
    </property>
   </action>
  </widget>

--- a/qt/aqt/forms/browser.ui
+++ b/qt/aqt/forms/browser.ui
@@ -748,7 +748,7 @@
     <string>browsing_toggle_bury</string>
    </property>
    <property name="shortcut">
-    <string notr="true"/>
+    <string notr="true">Ctrl+Shift+J</string>
    </property>
   </action>
  </widget>

--- a/rslib/src/browser_table.rs
+++ b/rslib/src/browser_table.rs
@@ -575,7 +575,9 @@ impl RowContext {
                         Color::Marked
                     } else if self.cards[0].queue == CardQueue::Suspended {
                         Color::Suspended
-                    } else if self.cards[0].queue == CardQueue::UserBuried || self.cards[0].queue == CardQueue::SchedBuried {
+                    } else if self.cards[0].queue == CardQueue::UserBuried
+                        || self.cards[0].queue == CardQueue::SchedBuried
+                    {
                         Color::Buried
                     } else {
                         Color::Default

--- a/rslib/src/browser_table.rs
+++ b/rslib/src/browser_table.rs
@@ -573,14 +573,12 @@ impl RowContext {
                 _ => {
                     if self.note.is_marked() {
                         Color::Marked
-                    } else if self.cards[0].queue == CardQueue::Suspended {
-                        Color::Suspended
-                    } else if self.cards[0].queue == CardQueue::UserBuried
-                        || self.cards[0].queue == CardQueue::SchedBuried
-                    {
-                        Color::Buried
                     } else {
-                        Color::Default
+                        match self.cards[0].queue {
+                            CardQueue::Suspended => Color::Suspended,
+                            CardQueue::UserBuried | CardQueue::SchedBuried => Color::Buried,
+                            _ => Color::Default,
+                        }
                     }
                 }
             }

--- a/rslib/src/browser_table.rs
+++ b/rslib/src/browser_table.rs
@@ -575,6 +575,8 @@ impl RowContext {
                         Color::Marked
                     } else if self.cards[0].queue == CardQueue::Suspended {
                         Color::Suspended
+                    } else if self.cards[0].queue == CardQueue::UserBuried || self.cards[0].queue == CardQueue::SchedBuried {
+                        Color::Buried
                     } else {
                         Color::Default
                     }


### PR DESCRIPTION
Resolves #2295. This code is based on existing "toggle suspend" command in browser.

- Adds "toggle bury" command to browser cards menu.
- Adds "browsing-toggle-bury" to core translation. Only English-language.
- Adds "buried" coloring to rows for buried cards in browser table.

Not yet done:

- Needs discussion: keyboard shortcut for "toggle bury" action.
- Needs non-English translations.