### PR TITLE
Support UTF-8-BOM when importing CSV

### DIFF
--- a/rslib/src/text.rs
+++ b/rslib/src/text.rs
@@ -62,6 +62,10 @@ impl<'a, B: ?Sized + 'a + ToOwned> CowMapping<'a, B> for Cow<'a, B> {
     }
 }
 
+pub(crate) fn strip_utf8_bom(s: &str) -> &str {
+    s.strip_prefix('\u{feff}').unwrap_or(s)
+}
+
 #[derive(Debug, PartialEq)]
 pub enum AvTag {
     SoundOrVideo(String),


### PR DESCRIPTION
https://forums.ankiweb.net/t/control-csv-file-import-via-header-key-value/27031/

By the way, I noticed that it is possible for the user to override the delimiter configured in the file. I'm sure this wasn't possible before and overriding the HTML flag is still disallowed. Did we change this deliberately and I forgot about it?