### PR TITLE
Implement TTS using windows crate

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -44,4 +44,4 @@ good-names =
   ip,
 
 [IMPORTS]
-ignored-modules = anki.*_pb2, anki.sync_pb2, win32file,pywintypes,socket,win32pipe,winrt,pyaudio,anki.scheduler_pb2
+ignored-modules = anki.*_pb2, anki.sync_pb2, win32file,pywintypes,socket,win32pipe,pyaudio,anki.scheduler_pb2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -144,6 +144,7 @@ dependencies = [
  "unicode-normalization",
  "utime",
  "which",
+ "windows",
  "wiremock",
  "workspace-hack",
  "zip",
@@ -4581,10 +4582,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.44.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e745dab35a0c4c77aa3ce42d595e13d2003d6902d6b08c9ef5fc326d08da12b"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
 name = "windows-sys"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2522491fbfcd58cc84d47aeb2958948c4b8982e9a2d8a2a35bbaed431390e7"
 dependencies = [
  "windows_aarch64_gnullvm",
  "windows_aarch64_msvc",

--- a/ftl/qt/errors.ftl
+++ b/ftl/qt/errors.ftl
@@ -39,7 +39,7 @@ errors-unable-open-collection =
     Anki was unable to open your collection file. If problems persist after restarting your computer, please use the Open Backup button in the profile manager.
     
     Debug info:
-errors-windows-tts-runtime-error = The TTS service failed. Please ensure Windows updates are installed, try restarting your computer, and try using a different voice.
+errors-windows-tts-runtime-error = The TTS service failed. Please ensure Windows updates are installed, try restarting your computer, or try a different voice.
 
 ## OBSOLETE; you do not need to translate this
 

--- a/proto/anki/backend.proto
+++ b/proto/anki/backend.proto
@@ -66,6 +66,8 @@ message BackendError {
     DELETED = 17;
     CARD_TYPE_ERROR = 18;
     ANKIDROID_PANIC_ERROR = 19;
+    // Originated from and usually specific to the OS.
+    OS_ERROR = 20;
   }
 
   // error description, usually localized, suitable for displaying to the user

--- a/proto/anki/card_rendering.proto
+++ b/proto/anki/card_rendering.proto
@@ -29,7 +29,7 @@ service CardRenderingService {
   rpc CompareAnswer(CompareAnswerRequest) returns (generic.String);
   rpc ExtractClozeForTyping(ExtractClozeForTypingRequest)
       returns (generic.String);
-  rpc AllTtsVoices(generic.Empty) returns (AllTtsVoicesResponse);
+  rpc AllTtsVoices(generic.Bool) returns (AllTtsVoicesResponse);
   rpc WriteTtsStream(WriteTtsStreamRequest) returns (generic.Empty);
 }
 
@@ -153,6 +153,7 @@ message AllTtsVoicesResponse {
     string id = 1;
     string name = 2;
     string language = 3;
+    optional bool available = 4;
   }
   repeated TtsVoice voices = 1;
 }

--- a/proto/anki/card_rendering.proto
+++ b/proto/anki/card_rendering.proto
@@ -29,6 +29,8 @@ service CardRenderingService {
   rpc CompareAnswer(CompareAnswerRequest) returns (generic.String);
   rpc ExtractClozeForTyping(ExtractClozeForTypingRequest)
       returns (generic.String);
+  rpc AllTtsVoices(generic.Empty) returns (AllTtsVoicesResponse);
+  rpc WriteTtsStream(WriteTtsStreamRequest) returns (generic.Empty);
 }
 
 message ExtractAVTagsRequest {
@@ -144,4 +146,20 @@ message CompareAnswerRequest {
 message ExtractClozeForTypingRequest {
   string text = 1;
   uint32 ordinal = 2;
+}
+
+message AllTtsVoicesResponse {
+  message TtsVoice {
+    string id = 1;
+    string name = 2;
+    string language = 3;
+  }
+  repeated TtsVoice voices = 1;
+}
+
+message WriteTtsStreamRequest {
+  string path = 1;
+  string voice_id = 2;
+  float speed = 3;
+  string text = 4;
 }

--- a/proto/anki/card_rendering.proto
+++ b/proto/anki/card_rendering.proto
@@ -29,7 +29,7 @@ service CardRenderingService {
   rpc CompareAnswer(CompareAnswerRequest) returns (generic.String);
   rpc ExtractClozeForTyping(ExtractClozeForTypingRequest)
       returns (generic.String);
-  rpc AllTtsVoices(generic.Bool) returns (AllTtsVoicesResponse);
+  rpc AllTtsVoices(AllTtsVoicesRequest) returns (AllTtsVoicesResponse);
   rpc WriteTtsStream(WriteTtsStreamRequest) returns (generic.Empty);
 }
 
@@ -146,6 +146,10 @@ message CompareAnswerRequest {
 message ExtractClozeForTypingRequest {
   string text = 1;
   uint32 ordinal = 2;
+}
+
+message AllTtsVoicesRequest {
+  bool validate = 1;
 }
 
 message AllTtsVoicesResponse {

--- a/pylib/anki/collection.py
+++ b/pylib/anki/collection.py
@@ -39,6 +39,7 @@ ImportCsvRequest = import_export_pb2.ImportCsvRequest
 CsvMetadata = import_export_pb2.CsvMetadata
 DupeResolution = CsvMetadata.DupeResolution
 Delimiter = import_export_pb2.CsvMetadata.Delimiter
+TtsVoice = card_rendering_pb2.AllTtsVoicesResponse.TtsVoice
 
 import copy
 import os

--- a/python/requirements.aqt.in
+++ b/python/requirements.aqt.in
@@ -7,4 +7,3 @@ send2trash
 waitress>=2.0.0
 psutil; sys.platform == "win32"
 pywin32; sys.platform == "win32"
-winrt; sys.platform == "win32"

--- a/python/requirements.win.in
+++ b/python/requirements.win.in
@@ -1,3 +1,2 @@
 pywin32
-winrt
 

--- a/python/requirements.win.txt
+++ b/python/requirements.win.txt
@@ -14,11 +14,3 @@ pywin32==305 \
     --hash=sha256:9dd98384da775afa009bc04863426cb30596fd78c6f8e4e2e5bbf4edf8029504 \
     --hash=sha256:a55db448124d1c1484df22fa8bbcbc45c64da5e6eae74ab095b9ea62e6d00496
     # via -r requirements.win.in
-winrt==1.0.21033.1 \
-    --hash=sha256:224e13eb172435aaabdc7066752898a61dae0fcc3022f6f8cbd1ce953be3358c \
-    --hash=sha256:9d7b7d2e48c301855afd3280aaf51ea0d3c683450f46de2db813f71ee1cd5937 \
-    --hash=sha256:ad4afd1c7b041a6b770256d70e07093920fa83eecd80e42cac2704cd03902243 \
-    --hash=sha256:d035570ce2cf7e8caa785abb43f25a6ede600c2cde0378c931495bdbeaf1a075 \
-    --hash=sha256:da3ca3626fb992f2efa4528993d4760b298f399a7f459f7e070a2f8681d82106 \
-    --hash=sha256:f5ab502117da4777ab49b846ad1919fbf448bd5e49b4aca00cc59667bae2c362
-    # via -r requirements.win.in

--- a/qt/aqt/tts.py
+++ b/qt/aqt/tts.py
@@ -583,7 +583,7 @@ if is_win:
         @staticmethod
         def _get_available_voices(validate: bool) -> list[TTSVoice]:
             assert aqt.mw
-            voices = aqt.mw.backend.all_tts_voices(val=validate)
+            voices = aqt.mw.backend.all_tts_voices(validate=validate)
             return list(map(WindowsRTVoice.from_backend_voice, voices))
 
         def _play(self, tag: AVTag) -> None:

--- a/qt/aqt/tts.py
+++ b/qt/aqt/tts.py
@@ -28,11 +28,9 @@ expose the name of the engine, which would mean the user could write
 
 from __future__ import annotations
 
-import asyncio
 import os
 import re
 import subprocess
-import threading
 from concurrent.futures import Future
 from dataclasses import dataclass
 from operator import attrgetter
@@ -40,7 +38,9 @@ from typing import Any, cast
 
 import anki
 import anki.template
+import aqt
 from anki import hooks
+from anki.collection import TtsVoice as BackendVoice
 from anki.sound import AVTag, TTSTag
 from anki.utils import checksum, is_win, tmpdir
 from aqt import gui_hooks
@@ -545,35 +545,26 @@ if is_win:
 
     @dataclass
     class WindowsRTVoice(TTSVoice):
-        id: Any
+        id: str
 
-    class WindowsRTTTSFilePlayer(TTSProcessPlayer):
-        voice_list: list[Any] = []
-        tmppath = os.path.join(tmpdir(), "tts.wav")
-
-        def import_voices(self) -> None:
-            import winrt.windows.media.speechsynthesis as speechsynthesis  # type: ignore
-
-            try:
-                self.voice_list = speechsynthesis.SpeechSynthesizer.get_all_voices()  # type: ignore
-            except Exception as e:
-                print("winrt tts voices unavailable:", e)
-                self.voice_list = []
-
-        def get_available_voices(self) -> list[TTSVoice]:
-            t = threading.Thread(target=self.import_voices)
-            t.start()
-            t.join()
-            return list(map(self._voice_to_object, self.voice_list))
-
-        def _voice_to_object(self, voice: Any) -> TTSVoice:
-            return WindowsRTVoice(
+        @classmethod
+        def from_backend_voice(cls, voice: BackendVoice) -> WindowsRTVoice:
+            return cls(
                 id=voice.id,
-                name=voice.display_name.replace(" ", "_"),
+                name=voice.name.replace(" ", "_"),
                 lang=voice.language.replace("-", "_"),
             )
 
+    class WindowsRTTTSFilePlayer(TTSProcessPlayer):
+        tmppath = os.path.join(tmpdir(), "tts.wav")
+
+        def get_available_voices(self) -> list[TTSVoice]:
+            assert aqt.mw
+            voices = aqt.mw.backend.all_tts_voices()
+            return list(map(WindowsRTVoice.from_backend_voice, voices))
+
         def _play(self, tag: AVTag) -> None:
+            assert aqt.mw
             assert isinstance(tag, TTSTag)
             match = self.voice_for_tag(tag)
             assert match
@@ -582,12 +573,16 @@ if is_win:
             self._taskman.run_on_main(
                 lambda: gui_hooks.av_player_did_begin_playing(self, tag)
             )
-            asyncio.run(self.speakText(tag, voice.id))
+            aqt.mw.backend.write_tts_stream(
+                path=self.tmppath,
+                voice_id=voice.id,
+                speed=tag.speed,
+                text=tag.field_text,
+            )
 
         def _on_done(self, ret: Future, cb: OnDoneCallback) -> None:
-            try:
-                ret.result()
-            except RuntimeError:
+            if exception := ret.exception():
+                print(str(exception))
                 tooltip(tr.errors_windows_tts_runtime_error())
                 return
 
@@ -598,26 +593,3 @@ if is_win:
 
             # then tell player to advance, which will cause the file to be played
             cb()
-
-        async def speakText(self, tag: TTSTag, voice_id: Any) -> None:
-            import winrt.windows.media.speechsynthesis as speechsynthesis  # type: ignore
-            import winrt.windows.storage.streams as streams  # type: ignore
-
-            synthesizer = speechsynthesis.SpeechSynthesizer()
-
-            voices = speechsynthesis.SpeechSynthesizer.get_all_voices()  # type: ignore
-            voice_match = next(filter(lambda v: v.id == voice_id, voices))
-
-            assert voice_match
-
-            synthesizer.voice = voice_match
-            synthesizer.options.speaking_rate = tag.speed
-
-            stream = await synthesizer.synthesize_text_to_stream_async(tag.field_text)
-            inputStream = stream.get_input_stream_at(0)
-            dataReader = streams.DataReader(inputStream)
-            dataReader.load_async(stream.size)
-            f = open(self.tmppath, "wb")
-            for x in range(stream.size):
-                f.write(bytes([dataReader.read_byte()]))
-            f.close()

--- a/qt/aqt/tts.py
+++ b/qt/aqt/tts.py
@@ -584,6 +584,7 @@ if is_win:
             if exception := ret.exception():
                 print(str(exception))
                 tooltip(tr.errors_windows_tts_runtime_error())
+                cb()
                 return
 
             # inject file into the top of the audio queue

--- a/rslib/Cargo.toml
+++ b/rslib/Cargo.toml
@@ -109,3 +109,7 @@ utime = "0.3.1"
 workspace-hack = { version = "0.1", path = "../tools/workspace-hack" }
 zip = { version = "0.6.3", default-features = false, features = ["deflate", "time"] }
 zstd = { version = "0.12.2", features = ["zstdmt"] }
+
+[target.'cfg(windows)'.dependencies.windows]
+version = "0.44.0"
+features = ["Media_SpeechSynthesis", "Foundation_Collections", "Storage_Streams"]

--- a/rslib/src/backend/cardrendering.rs
+++ b/rslib/src/backend/cardrendering.rs
@@ -4,6 +4,7 @@
 use super::Backend;
 use crate::card_rendering::extract_av_tags;
 use crate::card_rendering::strip_av_tags;
+use crate::card_rendering::tts;
 use crate::cloze::extract_cloze_for_typing;
 use crate::latex::extract_latex;
 use crate::latex::extract_latex_expanding_clozes;
@@ -174,6 +175,26 @@ impl CardRenderingService for Backend {
         Ok(extract_cloze_for_typing(&input.text, input.ordinal as u16)
             .to_string()
             .into())
+    }
+
+    fn all_tts_voices(
+        &self,
+        _input: pb::generic::Empty,
+    ) -> Result<pb::card_rendering::AllTtsVoicesResponse> {
+        tts::all_voices().map(|voices| pb::card_rendering::AllTtsVoicesResponse { voices })
+    }
+
+    fn write_tts_stream(
+        &self,
+        request: pb::card_rendering::WriteTtsStreamRequest,
+    ) -> Result<pb::generic::Empty> {
+        tts::write_stream(
+            &request.path,
+            &request.voice_id,
+            request.speed,
+            &request.text,
+        )
+        .map(Into::into)
     }
 }
 

--- a/rslib/src/backend/cardrendering.rs
+++ b/rslib/src/backend/cardrendering.rs
@@ -179,9 +179,10 @@ impl CardRenderingService for Backend {
 
     fn all_tts_voices(
         &self,
-        input: pb::generic::Bool,
+        input: pb::card_rendering::AllTtsVoicesRequest,
     ) -> Result<pb::card_rendering::AllTtsVoicesResponse> {
-        tts::all_voices(input.val).map(|voices| pb::card_rendering::AllTtsVoicesResponse { voices })
+        tts::all_voices(input.validate)
+            .map(|voices| pb::card_rendering::AllTtsVoicesResponse { voices })
     }
 
     fn write_tts_stream(

--- a/rslib/src/backend/cardrendering.rs
+++ b/rslib/src/backend/cardrendering.rs
@@ -179,9 +179,9 @@ impl CardRenderingService for Backend {
 
     fn all_tts_voices(
         &self,
-        _input: pb::generic::Empty,
+        input: pb::generic::Bool,
     ) -> Result<pb::card_rendering::AllTtsVoicesResponse> {
-        tts::all_voices().map(|voices| pb::card_rendering::AllTtsVoicesResponse { voices })
+        tts::all_voices(input.val).map(|voices| pb::card_rendering::AllTtsVoicesResponse { voices })
     }
 
     fn write_tts_stream(

--- a/rslib/src/backend/error.rs
+++ b/rslib/src/backend/error.rs
@@ -40,6 +40,8 @@ impl AnkiError {
             AnkiError::FileIoError { .. } => Kind::IoError,
             AnkiError::MediaCheckRequired => Kind::InvalidInput,
             AnkiError::InvalidId => Kind::InvalidInput,
+            #[cfg(windows)]
+            AnkiError::WindowsError { .. } => Kind::OsError,
         };
 
         pb::backend::BackendError {

--- a/rslib/src/card_rendering/mod.rs
+++ b/rslib/src/card_rendering/mod.rs
@@ -7,6 +7,7 @@ use crate::pb;
 use crate::prelude::*;
 
 mod parser;
+pub mod tts;
 mod writer;
 
 pub fn strip_av_tags<S: Into<String> + AsRef<str>>(txt: S) -> String {

--- a/rslib/src/card_rendering/tts/mod.rs
+++ b/rslib/src/card_rendering/tts/mod.rs
@@ -1,0 +1,20 @@
+// Copyright: Ankitects Pty Ltd and contributors
+// License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
+
+use crate::pb::card_rendering::all_tts_voices_response::TtsVoice;
+use crate::prelude::*;
+
+#[cfg(windows)]
+#[path = "windows.rs"]
+mod inner;
+#[cfg(not(windows))]
+#[path = "other.rs"]
+mod inner;
+
+pub fn all_voices() -> Result<Vec<TtsVoice>> {
+    inner::all_voices()
+}
+
+pub fn write_stream(path: &str, voice_id: &str, speed: f32, text: &str) -> Result<()> {
+    inner::write_stream(path, voice_id, speed, text)
+}

--- a/rslib/src/card_rendering/tts/mod.rs
+++ b/rslib/src/card_rendering/tts/mod.rs
@@ -11,8 +11,8 @@ mod inner;
 #[path = "other.rs"]
 mod inner;
 
-pub fn all_voices() -> Result<Vec<TtsVoice>> {
-    inner::all_voices()
+pub fn all_voices(validate: bool) -> Result<Vec<TtsVoice>> {
+    inner::all_voices(validate)
 }
 
 pub fn write_stream(path: &str, voice_id: &str, speed: f32, text: &str) -> Result<()> {

--- a/rslib/src/card_rendering/tts/other.rs
+++ b/rslib/src/card_rendering/tts/other.rs
@@ -1,0 +1,13 @@
+// Copyright: Ankitects Pty Ltd and contributors
+// License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
+
+use crate::pb::card_rendering::all_tts_voices_response::TtsVoice;
+use crate::prelude::*;
+
+pub(super) fn all_voices() -> Result<Vec<TtsVoice>> {
+    invalid_input!("not implemented for this OS");
+}
+
+pub(super) fn write_stream(_path: &str, _voice_id: &str, _speed: f32, _text: &str) -> Result<()> {
+    invalid_input!("not implemented for this OS");
+}

--- a/rslib/src/card_rendering/tts/other.rs
+++ b/rslib/src/card_rendering/tts/other.rs
@@ -4,7 +4,7 @@
 use crate::pb::card_rendering::all_tts_voices_response::TtsVoice;
 use crate::prelude::*;
 
-pub(super) fn all_voices() -> Result<Vec<TtsVoice>> {
+pub(super) fn all_voices(_validate: bool) -> Result<Vec<TtsVoice>> {
     invalid_input!("not implemented for this OS");
 }
 

--- a/rslib/src/card_rendering/tts/windows.rs
+++ b/rslib/src/card_rendering/tts/windows.rs
@@ -81,12 +81,11 @@ fn write_stream_to_path(stream: SpeechSynthesisStream, path: &str) -> Result<()>
 
 fn write_reader_to_file(reader: DataReader, file: &mut File, stream_size: usize) -> Result<()> {
     let mut bytes_remaining = stream_size;
-    let mut buf = vec![0u8; MAX_BUFFER_SIZE];
+    let mut buf = [0u8; MAX_BUFFER_SIZE];
     while bytes_remaining > 0 {
         let chunk_size = bytes_remaining.min(MAX_BUFFER_SIZE);
-        buf.truncate(chunk_size);
-        reader.ReadBytes(&mut buf)?;
-        file.write_all(&buf)?;
+        reader.ReadBytes(&mut buf[..chunk_size])?;
+        file.write_all(&buf[..chunk_size])?;
         bytes_remaining -= chunk_size;
     }
     Ok(())

--- a/rslib/src/card_rendering/tts/windows.rs
+++ b/rslib/src/card_rendering/tts/windows.rs
@@ -1,0 +1,85 @@
+// Copyright: Ankitects Pty Ltd and contributors
+// License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
+
+use std::io::Write;
+
+use futures::executor::block_on;
+use windows::core::HSTRING;
+use windows::Media::SpeechSynthesis::SpeechSynthesisStream;
+use windows::Media::SpeechSynthesis::SpeechSynthesizer;
+use windows::Media::SpeechSynthesis::VoiceInformation;
+use windows::Storage::Streams::DataReader;
+
+use crate::pb::card_rendering::all_tts_voices_response::TtsVoice;
+use crate::prelude::*;
+
+pub(super) fn all_voices() -> Result<Vec<TtsVoice>> {
+    SpeechSynthesizer::AllVoices()?
+        .into_iter()
+        .map(TryFrom::try_from)
+        .collect()
+}
+
+pub(super) fn write_stream(path: &str, voice_id: &str, speed: f32, text: &str) -> Result<()> {
+    let stream = synthesize_stream(voice_id, speed, text)?;
+    write_stream_to_path(stream, path)?;
+    Ok(())
+}
+
+fn find_voice(voice_id: &str) -> Result<VoiceInformation, AnkiError> {
+    SpeechSynthesizer::AllVoices()?
+        .into_iter()
+        .find(|info| {
+            info.Id()
+                .map(|id| id.to_string_lossy().eq(voice_id))
+                .unwrap_or_default()
+        })
+        .or_invalid("voice id not found")
+}
+
+fn ssml(speed: f32, text: &str) -> Result<HSTRING> {
+    let ssml: Vec<u16> = format!(
+        concat!(
+            r#"<speak version="1.0" xmlns="http://www.w3.org/2001/10/synthesis" xml:lang="en-US">"#,
+            r#"    <prosody rate="{}">{}</prosody>"#,
+            r#"</speak>"#,
+        ),
+        speed, text
+    )
+    .encode_utf16()
+    .collect();
+    HSTRING::from_wide(&ssml).map_err(Into::into)
+}
+
+fn synthesize_stream(voice_id: &str, speed: f32, text: &str) -> Result<SpeechSynthesisStream> {
+    let synthesizer = SpeechSynthesizer::new()?;
+    let voice = find_voice(voice_id)?;
+    synthesizer.SetVoice(&voice)?;
+    let async_op = synthesizer.SynthesizeSsmlToStreamAsync(&ssml(speed, text)?)?;
+    let stream = block_on(async_op)?;
+    Ok(stream)
+}
+
+fn write_stream_to_path(stream: SpeechSynthesisStream, path: &str) -> Result<()> {
+    let input_stream = stream.GetInputStreamAt(0)?;
+    let date_reader = DataReader::CreateDataReader(&input_stream)?;
+    let stream_size = stream.Size()?.try_into().or_invalid("stream too large")?;
+    date_reader.LoadAsync(stream_size)?;
+    let mut file = std::fs::File::create(path)?;
+    let mut buf = vec![0u8; stream_size as usize];
+    date_reader.ReadBytes(&mut buf)?;
+    file.write_all(&buf)?;
+    Ok(())
+}
+
+impl TryFrom<VoiceInformation> for TtsVoice {
+    type Error = AnkiError;
+
+    fn try_from(info: VoiceInformation) -> Result<Self> {
+        Ok(Self {
+            id: info.Id()?.to_string_lossy(),
+            name: info.DisplayName()?.to_string_lossy(),
+            language: info.Language()?.to_string_lossy(),
+        })
+    }
+}

--- a/rslib/src/card_rendering/tts/windows.rs
+++ b/rslib/src/card_rendering/tts/windows.rs
@@ -16,7 +16,7 @@ use crate::error::windows::WindowsSnafu;
 use crate::pb::card_rendering::all_tts_voices_response::TtsVoice;
 use crate::prelude::*;
 
-const MAX_BUFFER_SIZE: usize = 1024 * 1024;
+const MAX_BUFFER_SIZE: usize = 128 * 1024;
 
 pub(super) fn all_voices(validate: bool) -> Result<Vec<TtsVoice>> {
     SpeechSynthesizer::AllVoices()?

--- a/rslib/src/card_rendering/tts/windows.rs
+++ b/rslib/src/card_rendering/tts/windows.rs
@@ -80,18 +80,14 @@ fn write_stream_to_path(stream: SpeechSynthesisStream, path: &str) -> Result<()>
 }
 
 fn write_reader_to_file(reader: DataReader, file: &mut File, stream_size: usize) -> Result<()> {
-    let buffer_size = stream_size.min(MAX_BUFFER_SIZE);
-    let iterations = stream_size / buffer_size;
-    let remainder = stream_size % buffer_size;
-    let mut buf = vec![0u8; buffer_size];
-    for i in 0..iterations + 1 {
-        // unless stream_size is divisable by buffer_size, there are less bytes to write
-        // in the last iteration
-        if i == iterations && remainder != 0 {
-            buf.truncate(remainder);
-        }
+    let mut bytes_remaining = stream_size;
+    let mut buf = vec![0u8; MAX_BUFFER_SIZE];
+    while bytes_remaining > 0 {
+        let chunk_size = bytes_remaining.min(MAX_BUFFER_SIZE);
+        buf.truncate(chunk_size);
         reader.ReadBytes(&mut buf)?;
         file.write_all(&buf)?;
+        bytes_remaining -= chunk_size;
     }
     Ok(())
 }

--- a/rslib/src/card_rendering/tts/windows.rs
+++ b/rslib/src/card_rendering/tts/windows.rs
@@ -64,8 +64,8 @@ fn synthesize_stream(
             details: WindowsErrorDetails::SettingRate(speed),
         })?;
     let async_op = synthesizer.SynthesizeTextToStreamAsync(&to_hstring(text))?;
-    let stream = block_on(async_op).with_context(|_| WindowsSnafu {
-        details: WindowsErrorDetails::Synthesizing(text.to_string()),
+    let stream = block_on(async_op).context(WindowsSnafu {
+        details: WindowsErrorDetails::Synthesizing,
     })?;
     Ok(stream)
 }

--- a/rslib/src/error/mod.rs
+++ b/rslib/src/error/mod.rs
@@ -8,6 +8,8 @@ mod invalid_input;
 pub(crate) mod network;
 mod not_found;
 mod search;
+#[cfg(windows)]
+pub mod windows;
 
 pub use db::DbError;
 pub use db::DbErrorKind;
@@ -33,7 +35,7 @@ use crate::links::HelpPage;
 
 pub type Result<T, E = AnkiError> = std::result::Result<T, E>;
 
-#[derive(Debug, PartialEq, Eq, Snafu)]
+#[derive(Debug, PartialEq, Snafu)]
 pub enum AnkiError {
     #[snafu(context(false))]
     InvalidInput {
@@ -108,7 +110,7 @@ pub enum AnkiError {
     #[cfg(windows)]
     #[snafu(context(false))]
     WindowsError {
-        source: windows::core::Error,
+        source: windows::WindowsError,
     },
 }
 

--- a/rslib/src/error/mod.rs
+++ b/rslib/src/error/mod.rs
@@ -105,6 +105,11 @@ pub enum AnkiError {
         source: ImportError,
     },
     InvalidId,
+    #[cfg(windows)]
+    #[snafu(context(false))]
+    WindowsError {
+        source: windows::core::Error,
+    },
 }
 
 // error helpers
@@ -154,6 +159,8 @@ impl AnkiError {
             AnkiError::FileIoError { source } => source.message(),
             AnkiError::InvalidInput { source } => source.message(),
             AnkiError::NotFound { source } => source.message(tr),
+            #[cfg(windows)]
+            AnkiError::WindowsError { source } => format!("{source:?}"),
         }
     }
 

--- a/rslib/src/error/windows.rs
+++ b/rslib/src/error/windows.rs
@@ -1,0 +1,32 @@
+// Copyright: Ankitects Pty Ltd and contributors
+// License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
+
+use snafu::Snafu;
+
+use super::AnkiError;
+
+#[derive(Debug, PartialEq, Snafu)]
+#[snafu(visibility(pub))]
+pub struct WindowsError {
+    details: WindowsErrorDetails,
+    source: windows::core::Error,
+}
+
+#[derive(Debug, PartialEq)]
+pub enum WindowsErrorDetails {
+    SettingVoice(windows::Media::SpeechSynthesis::VoiceInformation),
+    SettingRate(f32),
+    Synthesizing(String),
+    Other,
+}
+
+impl From<windows::core::Error> for AnkiError {
+    fn from(source: windows::core::Error) -> Self {
+        AnkiError::WindowsError {
+            source: WindowsError {
+                source,
+                details: WindowsErrorDetails::Other,
+            },
+        }
+    }
+}

--- a/rslib/src/error/windows.rs
+++ b/rslib/src/error/windows.rs
@@ -16,7 +16,7 @@ pub struct WindowsError {
 pub enum WindowsErrorDetails {
     SettingVoice(windows::Media::SpeechSynthesis::VoiceInformation),
     SettingRate(f32),
-    Synthesizing(String),
+    Synthesizing,
     Other,
 }
 


### PR DESCRIPTION
I started with directly porting the Python code, which lead to a huge delay. However, this was trivial to improve as that code only wrote 1 byte at a time. Reading in, then writing out the whole stream had the best performance overall:

| Implementation | Time |
| --- | --- |
| Python API (main) | 4.3 s |
| Direct Rust port | 29.4 s |
| This PR | 1.5 s |

These benchmarks are for synthesizing 1000 words of Lorem Ipsum. Afterwards I noticed that the chosen voice also has a significant impact: Hedda was twice as fast as Stefan (German voices). The benchmarks should still hold up since I used the latter voice for all of them.

Open questions / todos:
- [x] Reading in the whole stream requires allocating a lot of memory, 15 MiB in the above case. Should we cap this for the case users put excessive amounts of text in TTS fields? We could also cap the text that gets synthesized. E.g. of 2000 words, only the first 1000 would get read out.
- [x] Error handling needs to be improved. Example: Japanese voices are listed as available on my system, but TTS crashes when I try to use them. Maybe because I uninstalled the language pack some time ago. The error is handled by the frontend, but the backend message is not very informative. Would be good to manually add some context instead of just `into`ing to an AnkiError.
- [x] The Python code checks for the Windows 10 October 2018 update. I couldn't confirm or disprove that this is the minimum required patch. Do you remember what the source is?
- [x] I put the tts in the card_rendering module because I didn't want to add a new backend service just for two methods. Not sure if it's a good fit.
- [x] Passed text is currently pasted into the [SSML](https://learn.microsoft.com/en-us/azure/cognitive-services/speech-service/speech-synthesis-markup-voice) document verbatim. We should probably escape it, but wouldn't it be cool if the user could write their own SSML? Maybe we can add a flag to the new TTS syntax to enable raw input.