### PR TITLE
Deck scoped dupe check

### DIFF
--- a/ftl/core/importing.ftl
+++ b/ftl/core/importing.ftl
@@ -106,7 +106,8 @@ importing-update = Update
 importing-tag-all-notes = Tag all notes
 importing-tag-updated-notes = Tag updated notes
 importing-file = File
-importing-limit-dupe-check-to-deck = Only check for duplicates in same deck
+importing-match-scope = Match scope
+importing-notetype-and-deck = Notetype and deck
 
 ## NO NEED TO TRANSLATE. This text is no longer used by Anki, and will be removed in the future.
 

--- a/ftl/core/importing.ftl
+++ b/ftl/core/importing.ftl
@@ -106,6 +106,7 @@ importing-update = Update
 importing-tag-all-notes = Tag all notes
 importing-tag-updated-notes = Tag updated notes
 importing-file = File
+importing-limit-dupe-check-to-deck = Only check for duplicates in same deck
 
 ## NO NEED TO TRANSLATE. This text is no longer used by Anki, and will be removed in the future.
 

--- a/proto/anki/import_export.proto
+++ b/proto/anki/import_export.proto
@@ -168,6 +168,7 @@ message CsvMetadata {
   repeated generic.StringList preview = 13;
   uint32 guid_column = 14;
   DupeResolution dupe_resolution = 15;
+  bool limit_dupe_check_to_deck = 16;
 }
 
 message ExportCardCsvRequest {

--- a/proto/anki/import_export.proto
+++ b/proto/anki/import_export.proto
@@ -161,6 +161,10 @@ message CsvMetadata {
     // One-based. 0 means n/a.
     uint32 notetype_column = 9;
   }
+  enum MatchScope {
+    NOTETYPE = 0;
+    NOTETYPE_AND_DECK = 1;
+  }
   // One-based. 0 means n/a.
   uint32 tags_column = 10;
   bool force_delimiter = 11;
@@ -168,7 +172,7 @@ message CsvMetadata {
   repeated generic.StringList preview = 13;
   uint32 guid_column = 14;
   DupeResolution dupe_resolution = 15;
-  bool limit_dupe_check_to_deck = 16;
+  MatchScope match_scope = 16;
 }
 
 message ExportCardCsvRequest {

--- a/proto/anki/import_export.proto
+++ b/proto/anki/import_export.proto
@@ -122,8 +122,8 @@ message CsvMetadataRequest {
 message CsvMetadata {
   enum DupeResolution {
     UPDATE = 0;
-    IGNORE = 1;
-    ADD = 2;
+    PRESERVE = 1;
+    DUPLICATE = 2;
     // UPDATE_IF_NEWER = 3;
   }
   // Order roughly in ascending expected frequency in note text, because the

--- a/qt/aqt/import_export/importing.py
+++ b/qt/aqt/import_export/importing.py
@@ -273,10 +273,10 @@ class LogQueue:
 
 
 def first_field_queue(log: ImportLogWithChanges.Log) -> LogQueue:
-    if log.dupe_resolution == DupeResolution.ADD:
+    if log.dupe_resolution == DupeResolution.DUPLICATE:
         summary_template = tr.importing_added_duplicate_with_first_field
         action_string = tr.adding_added()
-    elif log.dupe_resolution == DupeResolution.IGNORE:
+    elif log.dupe_resolution == DupeResolution.PRESERVE:
         summary_template = tr.importing_first_field_matched
         action_string = tr.importing_skipped()
     else:

--- a/rslib/build/protobuf.rs
+++ b/rslib/build/protobuf.rs
@@ -118,6 +118,10 @@ pub fn write_backend_proto_rs() {
             "CsvMetadata.DupeResolution",
             "#[derive(serde_derive::Deserialize, serde_derive::Serialize)]",
         )
+        .type_attribute(
+            "CsvMetadata.MatchScope",
+            "#[derive(serde_derive::Deserialize, serde_derive::Serialize)]",
+        )
         .compile_protos(paths.as_slice(), &[proto_dir])
         .unwrap();
 }

--- a/rslib/src/config/bool.rs
+++ b/rslib/src/config/bool.rs
@@ -33,6 +33,7 @@ pub enum BoolKey {
     ResetCountsReviewer,
     RandomOrderReposition,
     ShiftPositionOfExistingCards,
+    LimitDupeCheckToDeck,
 
     #[strum(to_string = "normalize_note_text")]
     NormalizeNoteText,

--- a/rslib/src/config/bool.rs
+++ b/rslib/src/config/bool.rs
@@ -33,7 +33,6 @@ pub enum BoolKey {
     ResetCountsReviewer,
     RandomOrderReposition,
     ShiftPositionOfExistingCards,
-    LimitDupeCheckToDeck,
 
     #[strum(to_string = "normalize_note_text")]
     NormalizeNoteText,

--- a/rslib/src/config/number.rs
+++ b/rslib/src/config/number.rs
@@ -9,6 +9,7 @@ use crate::prelude::*;
 #[strum(serialize_all = "camelCase")]
 pub enum I32ConfigKey {
     CsvDuplicateResolution,
+    MatchScope,
 }
 
 impl Collection {

--- a/rslib/src/import_export/text/csv/import.rs
+++ b/rslib/src/import_export/text/csv/import.rs
@@ -28,21 +28,28 @@ impl Collection {
         progress_fn: impl 'static + FnMut(ImportProgress, bool) -> bool,
     ) -> Result<OpOutput<NoteLog>> {
         let file = open_file(path)?;
-        let default_deck = metadata.deck()?.name_or_id();
-        let default_notetype = metadata.notetype()?.name_or_id();
         let mut ctx = ColumnContext::new(&metadata)?;
         let notes = ctx.deserialize_csv(file, metadata.delimiter())?;
+        let mut data = ForeignData::from(metadata);
+        data.notes = notes;
+        data.import(self, progress_fn)
+    }
+}
 
+impl From<CsvMetadata> for ForeignData {
+    fn from(metadata: CsvMetadata) -> Self {
         ForeignData {
             dupe_resolution: metadata.dupe_resolution(),
-            default_deck,
-            default_notetype,
-            notes,
+            limit_dupe_check_to_deck: metadata.limit_dupe_check_to_deck,
+            default_deck: metadata.deck().map(|d| d.name_or_id()).unwrap_or_default(),
+            default_notetype: metadata
+                .notetype()
+                .map(|nt| nt.name_or_id())
+                .unwrap_or_default(),
             global_tags: metadata.global_tags,
             updated_tags: metadata.updated_tags,
             ..Default::default()
         }
-        .import(self, progress_fn)
     }
 }
 
@@ -289,6 +296,7 @@ mod test {
                 })),
                 preview: Vec::new(),
                 dupe_resolution: 0,
+                limit_dupe_check_to_deck: false,
             }
         }
     }

--- a/rslib/src/import_export/text/csv/import.rs
+++ b/rslib/src/import_export/text/csv/import.rs
@@ -40,7 +40,7 @@ impl From<CsvMetadata> for ForeignData {
     fn from(metadata: CsvMetadata) -> Self {
         ForeignData {
             dupe_resolution: metadata.dupe_resolution(),
-            limit_dupe_check_to_deck: metadata.limit_dupe_check_to_deck,
+            match_scope: metadata.match_scope(),
             default_deck: metadata.deck().map(|d| d.name_or_id()).unwrap_or_default(),
             default_notetype: metadata
                 .notetype()
@@ -296,7 +296,7 @@ mod test {
                 })),
                 preview: Vec::new(),
                 dupe_resolution: 0,
-                limit_dupe_check_to_deck: false,
+                match_scope: 0,
             }
         }
     }

--- a/rslib/src/import_export/text/csv/metadata.rs
+++ b/rslib/src/import_export/text/csv/metadata.rs
@@ -161,13 +161,17 @@ impl Collection {
                     metadata.guid_column = n;
                 }
             }
-            "limit dupe check to deck" => {
-                if let Ok(limit) = value.to_lowercase().parse() {
-                    metadata.limit_dupe_check_to_deck = limit;
+            "match scope" => match value {
+                "notetype" => {
+                    metadata.limit_dupe_check_to_deck = false;
                 }
-            }
-            "dupe resolution" => {
-                if let Some(resolution) = DupeResolution::from_str_name(&value.to_uppercase()) {
+                "notetype + deck" => {
+                    metadata.limit_dupe_check_to_deck = true;
+                }
+                _ => (),
+            },
+            "if matches" => {
+                if let Some(resolution) = DupeResolution::from_text(value) {
                     metadata.dupe_resolution = resolution as i32;
                 }
             }
@@ -261,6 +265,15 @@ impl CsvMetadata {
 impl DupeResolution {
     fn from_config(col: &Collection) -> Self {
         Self::from_i32(col.get_config_i32(I32ConfigKey::CsvDuplicateResolution)).unwrap_or_default()
+    }
+
+    fn from_text(text: &str) -> Option<Self> {
+        match text {
+            "update current" => Some(Self::Update),
+            "keep current" => Some(Self::Preserve),
+            "keep both" => Some(Self::Duplicate),
+            _ => None,
+        }
     }
 }
 

--- a/rslib/src/import_export/text/csv/metadata.rs
+++ b/rslib/src/import_export/text/csv/metadata.rs
@@ -161,6 +161,16 @@ impl Collection {
                     metadata.guid_column = n;
                 }
             }
+            "limit dupe check to deck" => {
+                if let Ok(limit) = value.to_lowercase().parse() {
+                    metadata.limit_dupe_check_to_deck = limit;
+                }
+            }
+            "dupe resolution" => {
+                if let Some(resolution) = DupeResolution::from_str_name(&value.to_uppercase()) {
+                    metadata.dupe_resolution = resolution as i32;
+                }
+            }
             _ => (),
         }
     }

--- a/rslib/src/import_export/text/csv/metadata.rs
+++ b/rslib/src/import_export/text/csv/metadata.rs
@@ -54,14 +54,7 @@ impl Collection {
         notetype_id: Option<NotetypeId>,
         is_html: Option<bool>,
     ) -> Result<CsvMetadata> {
-        let dupe_resolution =
-            DupeResolution::from_i32(self.get_config_i32(I32ConfigKey::CsvDuplicateResolution))
-                .map(|r| r as i32)
-                .unwrap_or_default();
-        let mut metadata = CsvMetadata {
-            dupe_resolution,
-            ..Default::default()
-        };
+        let mut metadata = CsvMetadata::from_config(self);
         let meta_len = self.parse_meta_lines(&mut reader, &mut metadata)? as u64;
         maybe_set_fallback_delimiter(delimiter, &mut metadata, &mut reader, meta_len)?;
         let records = collect_preview_records(&mut metadata, reader)?;
@@ -241,6 +234,23 @@ impl Collection {
                 .or_invalid("collection has no notetypes")?
                 .0
         })
+    }
+}
+
+impl CsvMetadata {
+    /// Defaults with config values filled in.
+    fn from_config(col: &Collection) -> Self {
+        Self {
+            dupe_resolution: DupeResolution::from_config(col) as i32,
+            limit_dupe_check_to_deck: col.get_config_bool(BoolKey::LimitDupeCheckToDeck),
+            ..Default::default()
+        }
+    }
+}
+
+impl DupeResolution {
+    fn from_config(col: &Collection) -> Self {
+        Self::from_i32(col.get_config_i32(I32ConfigKey::CsvDuplicateResolution)).unwrap_or_default()
     }
 }
 

--- a/rslib/src/import_export/text/import.rs
+++ b/rslib/src/import_export/text/import.rs
@@ -338,15 +338,15 @@ impl<'a> Context<'a> {
     fn import_note(&mut self, ctx: NoteContext, log: &mut NoteLog) -> Result<()> {
         match self.dupe_resolution {
             _ if !ctx.is_dupe() => self.add_note(ctx, log)?,
-            DupeResolution::Add if ctx.is_guid_dupe() => {
+            DupeResolution::Duplicate if ctx.is_guid_dupe() => {
                 log.duplicate.push(ctx.note.into_log_note())
             }
-            DupeResolution::Add if !ctx.has_first_field() => {
+            DupeResolution::Duplicate if !ctx.has_first_field() => {
                 log.empty_first_field.push(ctx.note.into_log_note())
             }
-            DupeResolution::Add => self.add_note(ctx, log)?,
+            DupeResolution::Duplicate => self.add_note(ctx, log)?,
             DupeResolution::Update => self.update_with_note(ctx, log)?,
-            DupeResolution::Ignore => log.first_field_match.push(ctx.note.into_log_note()),
+            DupeResolution::Preserve => log.first_field_match.push(ctx.note.into_log_note()),
         }
         Ok(())
     }
@@ -654,7 +654,7 @@ mod test {
         let mut col = open_test_collection();
         let mut data = ForeignData::with_defaults();
         data.add_note(&["same", "old"]);
-        data.dupe_resolution = DupeResolution::Add;
+        data.dupe_resolution = DupeResolution::Duplicate;
 
         data.clone().import(&mut col, |_, _| true).unwrap();
         data.import(&mut col, |_, _| true).unwrap();
@@ -666,7 +666,7 @@ mod test {
         let mut col = open_test_collection();
         let mut data = ForeignData::with_defaults();
         data.add_note(&["same", "old"]);
-        data.dupe_resolution = DupeResolution::Ignore;
+        data.dupe_resolution = DupeResolution::Preserve;
 
         data.clone().import(&mut col, |_, _| true).unwrap();
         assert_eq!(col.storage.notes_table_len(), 1);

--- a/rslib/src/import_export/text/mod.rs
+++ b/rslib/src/import_export/text/mod.rs
@@ -15,6 +15,7 @@ use crate::pb::import_export::csv_metadata::DupeResolution;
 #[serde(default)]
 pub struct ForeignData {
     dupe_resolution: DupeResolution,
+    limit_dupe_check_to_deck: bool,
     default_deck: NameOrId,
     default_notetype: NameOrId,
     notes: Vec<ForeignNote>,

--- a/rslib/src/import_export/text/mod.rs
+++ b/rslib/src/import_export/text/mod.rs
@@ -10,12 +10,13 @@ use serde_derive::Serialize;
 
 use super::LogNote;
 use crate::pb::import_export::csv_metadata::DupeResolution;
+use crate::pb::import_export::csv_metadata::MatchScope;
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(default)]
 pub struct ForeignData {
     dupe_resolution: DupeResolution,
-    limit_dupe_check_to_deck: bool,
+    match_scope: MatchScope,
     default_deck: NameOrId,
     default_notetype: NameOrId,
     notes: Vec<ForeignNote>,

--- a/rslib/src/storage/note/notes_types_checksums_decks.sql
+++ b/rslib/src/storage/note/notes_types_checksums_decks.sql
@@ -1,0 +1,9 @@
+SELECT DISTINCT notes.id,
+  notes.mid,
+  notes.csum,
+  CASE
+    WHEN cards.odid = 0 THEN cards.did
+    ELSE cards.odid
+  END AS did
+FROM notes
+  JOIN cards ON notes.id = cards.nid

--- a/rslib/src/tests.rs
+++ b/rslib/src/tests.rs
@@ -173,3 +173,37 @@ impl DeckAdder {
         deck
     }
 }
+
+#[derive(Debug, Clone)]
+pub(crate) struct NoteAdder {
+    note: Note,
+    deck: DeckId,
+}
+
+impl NoteAdder {
+    pub(crate) fn new(col: &mut Collection, notetype: &str) -> Self {
+        Self {
+            note: col.new_note(notetype),
+            deck: DeckId(1),
+        }
+    }
+
+    pub(crate) fn basic(col: &mut Collection) -> Self {
+        Self::new(col, "basic")
+    }
+
+    pub(crate) fn fields(mut self, fields: &[&str]) -> Self {
+        *self.note.fields_mut() = fields.iter().map(ToString::to_string).collect();
+        self
+    }
+
+    pub(crate) fn deck(mut self, deck: DeckId) -> Self {
+        self.deck = deck;
+        self
+    }
+
+    pub(crate) fn add(mut self, col: &mut Collection) -> Note {
+        col.add_note(&mut self.note, self.deck).unwrap();
+        self.note
+    }
+}

--- a/ts/import-csv/DeckDupeCheckSwitch.svelte
+++ b/ts/import-csv/DeckDupeCheckSwitch.svelte
@@ -1,0 +1,22 @@
+<!--
+Copyright: Ankitects Pty Ltd and contributors
+License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
+-->
+<script lang="ts">
+    import * as tr from "@tslib/ftl";
+
+    import Col from "../components/Col.svelte";
+    import Row from "../components/Row.svelte";
+    import Switch from "../components/Switch.svelte";
+
+    export let value: boolean;
+</script>
+
+<Row --cols={2}>
+    <Col --col-size={1}>
+        {tr.importingLimitDupeCheckToDeck()}
+    </Col>
+    <Col --col-size={1} --col-justify="flex-end">
+        <Switch id={undefined} bind:value />
+    </Col>
+</Row>

--- a/ts/import-csv/DeckDupeCheckSwitch.svelte
+++ b/ts/import-csv/DeckDupeCheckSwitch.svelte
@@ -4,19 +4,38 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 -->
 <script lang="ts">
     import * as tr from "@tslib/ftl";
+    import { ImportExport } from "@tslib/proto";
 
     import Col from "../components/Col.svelte";
     import Row from "../components/Row.svelte";
-    import Switch from "../components/Switch.svelte";
+    import Select from "../components/Select.svelte";
+    import SelectOption from "../components/SelectOption.svelte";
 
-    export let value: boolean;
+    export let matchScope: ImportExport.CsvMetadata.MatchScope;
+
+    const matchScopes = [
+        {
+            value: ImportExport.CsvMetadata.MatchScope.NOTETYPE,
+            label: tr.notetypesNotetype(),
+        },
+        {
+            value: ImportExport.CsvMetadata.MatchScope.NOTETYPE_AND_DECK,
+            label: tr.importingNotetypeAndDeck(),
+        },
+    ];
+
+    $: label = matchScopes.find((r) => r.value === matchScope)?.label;
 </script>
 
 <Row --cols={2}>
     <Col --col-size={1}>
-        {tr.importingLimitDupeCheckToDeck()}
+        {tr.importingMatchScope()}
     </Col>
-    <Col --col-size={1} --col-justify="flex-end">
-        <Switch id={undefined} bind:value />
+    <Col --col-size={1}>
+        <Select bind:value={matchScope} {label}>
+            {#each matchScopes as { label, value }}
+                <SelectOption {value}>{label}</SelectOption>
+            {/each}
+        </Select>
     </Col>
 </Row>

--- a/ts/import-csv/DupeResolutionSelector.svelte
+++ b/ts/import-csv/DupeResolutionSelector.svelte
@@ -19,11 +19,11 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
             label: tr.importingUpdate(),
         },
         {
-            value: ImportExport.CsvMetadata.DupeResolution.ADD,
+            value: ImportExport.CsvMetadata.DupeResolution.DUPLICATE,
             label: tr.importingDuplicate(),
         },
         {
-            value: ImportExport.CsvMetadata.DupeResolution.IGNORE,
+            value: ImportExport.CsvMetadata.DupeResolution.PRESERVE,
             label: tr.importingPreserve(),
         },
     ];

--- a/ts/import-csv/ImportCsvPage.svelte
+++ b/ts/import-csv/ImportCsvPage.svelte
@@ -28,7 +28,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     export let notetypeNameIds: Notetypes.NotetypeNameId[];
     export let deckNameIds: Decks.DeckNameId[];
     export let dupeResolution: ImportExport.CsvMetadata.DupeResolution;
-    export let limitDupeCheckToDeck: boolean;
+    export let matchScope: ImportExport.CsvMetadata.MatchScope;
 
     export let delimiter: ImportExport.CsvMetadata.Delimiter;
     export let forceDelimiter: boolean;
@@ -75,7 +75,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
                 path,
                 metadata: ImportExport.CsvMetadata.create({
                     dupeResolution,
-                    limitDupeCheckToDeck,
+                    matchScope,
                     delimiter,
                     forceDelimiter,
                     isHtml,
@@ -122,7 +122,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
                     <DeckSelector {deckNameIds} bind:deckId />
                 {/if}
                 <DupeResolutionSelector bind:dupeResolution />
-                <DeckDupeCheckSwitch bind:value={limitDupeCheckToDeck} />
+                <DeckDupeCheckSwitch bind:matchScope />
                 <Tags bind:globalTags bind:updatedTags />
             </Container>
         </Col>

--- a/ts/import-csv/ImportCsvPage.svelte
+++ b/ts/import-csv/ImportCsvPage.svelte
@@ -11,6 +11,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     import Container from "../components/Container.svelte";
     import Row from "../components/Row.svelte";
     import Spacer from "../components/Spacer.svelte";
+    import DeckDupeCheckSwitch from "./DeckDupeCheckSwitch.svelte";
     import DeckSelector from "./DeckSelector.svelte";
     import DelimiterSelector from "./DelimiterSelector.svelte";
     import DupeResolutionSelector from "./DupeResolutionSelector.svelte";
@@ -27,6 +28,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     export let notetypeNameIds: Notetypes.NotetypeNameId[];
     export let deckNameIds: Decks.DeckNameId[];
     export let dupeResolution: ImportExport.CsvMetadata.DupeResolution;
+    export let limitDupeCheckToDeck: boolean;
 
     export let delimiter: ImportExport.CsvMetadata.Delimiter;
     export let forceDelimiter: boolean;
@@ -73,6 +75,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
                 path,
                 metadata: ImportExport.CsvMetadata.create({
                     dupeResolution,
+                    limitDupeCheckToDeck,
                     delimiter,
                     forceDelimiter,
                     isHtml,
@@ -119,6 +122,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
                     <DeckSelector {deckNameIds} bind:deckId />
                 {/if}
                 <DupeResolutionSelector bind:dupeResolution />
+                <DeckDupeCheckSwitch bind:value={limitDupeCheckToDeck} />
                 <Tags bind:globalTags bind:updatedTags />
             </Container>
         </Col>

--- a/ts/import-csv/index.ts
+++ b/ts/import-csv/index.ts
@@ -48,6 +48,7 @@ export async function setupImportCsvPage(path: string): Promise<ImportCsvPage> {
             deckNameIds: decks.entries,
             notetypeNameIds: notetypes.entries,
             dupeResolution: metadata.dupeResolution,
+            limitDupeCheckToDeck: metadata.limitDupeCheckToDeck,
             delimiter: metadata.delimiter,
             forceDelimiter: metadata.forceDelimiter,
             isHtml: metadata.isHtml,

--- a/ts/import-csv/index.ts
+++ b/ts/import-csv/index.ts
@@ -48,7 +48,7 @@ export async function setupImportCsvPage(path: string): Promise<ImportCsvPage> {
             deckNameIds: decks.entries,
             notetypeNameIds: notetypes.entries,
             dupeResolution: metadata.dupeResolution,
-            limitDupeCheckToDeck: metadata.limitDupeCheckToDeck,
+            matchScope: metadata.matchScope,
             delimiter: metadata.delimiter,
             forceDelimiter: metadata.forceDelimiter,
             isHtml: metadata.isHtml,


### PR DESCRIPTION
This allows to restrict the duplicates check when importing a CSV file to the deck a note is imported into.

By the way, as we've recently talked about configuring the dupe resolution setting from inside a CSV file, it's already part of CsvMetadata. Consquently I've also added this new setting to CsvMetadata. This makes it easy us to support CSV headers for these settings, too. Should I do that?