### PR TITLE
Fix HTML editor hiding when selected as default

### DIFF
--- a/ts/editor/NoteEditor.svelte
+++ b/ts/editor/NoteEditor.svelte
@@ -151,7 +151,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
             plainTextDefaults = states.plainTextDefaults;
         } else {
             plainTextDefaults = defaultPlainTexts;
-            richTextsHidden = defaultPlainTexts;
+            richTextsHidden = [...defaultPlainTexts];
             plainTextsHidden = Array.from(defaultPlainTexts, (v) => !v);
         }
     }


### PR DESCRIPTION
Fixes a bug introduced in d2fa50dd9.

Since `plainTextDefaults` and `richTextsHidden` referenced the same array, toggling the visual editor on a field that uses the HTML editor by default would also change whether the HTML editor is the default editor for that field. 

This caused the badge that toggles the visual editor to turn into a badge that toggles the HTML editor when clicking it for the first time.