### PR TITLE
Partially fix slow editor startup

### DIFF
--- a/ts/components/Collapsible.svelte
+++ b/ts/components/Collapsible.svelte
@@ -18,7 +18,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     }
     $: duration = dynamicDuration(contentHeight);
 
-    const size = tweened<number>(undefined);
+    const size = tweened<number>(0);
 
     async function transition(collapse: boolean): Promise<void> {
         if (collapse) {


### PR DESCRIPTION
Partially fixes #2344

### Cause of #2344
Regardless of whether the option **"Use HTML editor by default"** is enabled or not, an instance of CodeMirror is created in all fields at editor startup. 

<details><summary>Relevant parts of the code</summary>

https://github.com/ankitects/anki/blob/f02aac5818136b6c1ac9fb710b785593188024a3/ts/editor/NoteEditor.svelte#L567-L570
https://github.com/ankitects/anki/blob/f02aac5818136b6c1ac9fb710b785593188024a3/ts/components/Collapsible.svelte#L21
https://github.com/ankitects/anki/blob/f02aac5818136b6c1ac9fb710b785593188024a3/ts/components/Collapsible.svelte#L53
https://github.com/ankitects/anki/blob/f02aac5818136b6c1ac9fb710b785593188024a3/ts/editor/plain-text-input/PlainTextInput.svelte#L152-L155
https://github.com/ankitects/anki/blob/f02aac5818136b6c1ac9fb710b785593188024a3/ts/editor/CodeMirror.svelte#L87-L95
https://github.com/ankitects/anki/blob/f02aac5818136b6c1ac9fb710b785593188024a3/ts/editor/code-mirror.ts#L86-L87

</details>

With this PR, instances of CodeMirror are created only when needed, as in versions 2.1.54 and earlier. You can check if instances of CodeMirror has been created by entering `document.querySelectorAll('.CodeMirror')` in the inspector's console.

### Why "partially"?
- The PR only solves cases where there is no field with the option enabled. However, if the user is using a fast PC, I don't think enabling the option in just a few fields will slow it down enough to notice. In fact, most users who report the issue on the forum seem to be using a notetype with a very large number of fields.

- The PR doesn't solve cases where there are dozens of fields with the option enabled at all. The editor remains remarkably slow to start up, just as in the current version. (This was not an issue in version 2.1.54, since there was no option to display the HTML editor by default in the first place.)