### PR TITLE
Set deck to current deck when clicked on table row

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -111,6 +111,7 @@ Stefan Kangas <stefankangas@gmail.com>
 Fabricio Duarte <fabricio.duarte.jr@gmail.com>
 Mani <github.com/krmanik>
 Kaben Nanlohy <kaben.nanlohy@gmail.com>
+Tobias Predel <tobias.predel@gmail.com>
 
 ********************
 

--- a/qt/aqt/deckbrowser.py
+++ b/qt/aqt/deckbrowser.py
@@ -118,6 +118,10 @@ class DeckBrowser:
             self._confirm_upgrade()
         elif cmd == "v2upgradeinfo":
             openLink("https://faqs.ankiweb.net/the-anki-2.1-scheduler.html")
+        elif cmd == "select":
+            set_current_deck(
+                parent=self.mw, deck_id=DeckId(int(arg))
+            ).run_in_background()
         return False
 
     def set_current_deck(self, deck_id: DeckId) -> None:
@@ -210,7 +214,14 @@ class DeckBrowser:
         else:
             klass = "deck"
 
-        buf = "<tr class='%s' id='%d'>" % (klass, node.deck_id)
+        buf = (
+            "<tr class='%s' id='%d' onclick='if(event.shiftKey) return pycmd(\"select:%d\")'>"
+            % (
+                klass,
+                node.deck_id,
+                node.deck_id,
+            )
+        )
         # deck link
         if node.children:
             collapse = (
@@ -346,7 +357,9 @@ class DeckBrowser:
         openLink(f"{aqt.appShared}decks/")
 
     def _on_create(self) -> None:
-        if op := add_deck_dialog(parent=self.mw):
+        if op := add_deck_dialog(
+            parent=self.mw, default_text=self.mw.col.decks.current()["name"]
+        ):
             op.run_in_background()
 
     ######################################################################


### PR DESCRIPTION
When a user clicks on the table row in the deck list (neither click on the deck link nor on the options menu), then set the deck in that table row as the current deck.

This gives the user some quick feedback and enables the user to easily create subdecks (as it automatically fills the add deck dialog with the deck name of the selected deck) and to create notes belonging to the selected deck.