### PR TITLE
Fix deck options selector not updating the current entry

### DIFF
--- a/ts/deck-options/ConfigSelector.svelte
+++ b/ts/deck-options/ConfigSelector.svelte
@@ -22,7 +22,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     const dispatch = createEventDispatcher();
     const dispatchPresetChange = () => dispatch("presetchange");
 
-    let value = $configList.findIndex((entry) => entry.current);
+    $: value = $configList.findIndex((entry) => entry.current);
     $: label = configLabel($configList[value]);
 
     function configLabel(entry: ConfigListEntry): string {


### PR DESCRIPTION
Fixes a regression in 766d1fdb5.

The current entry wasn't being visually updated in the selector when adding/cloning/renaming a preset.