### PR TITLE
Button hover effect: swap impressed shadow for border color

### DIFF
--- a/sass/_button-mixins.scss
+++ b/sass/_button-mixins.scss
@@ -42,7 +42,7 @@
                     var(--button-gradient-end) 100%
                 );
                 /* Makes distinguishing hover state in light theme easier */
-                @include impressed-shadow(0.2);
+                border: 1px solid var(--shadow);
             }
         }
     }


### PR DESCRIPTION
Like @tatsumoto-ren once mentioned, the current button hover effect (introduced with #2267) is too drastic and makes buttons seem clicked when they're only hovered. This changes the visual indication to a border-color change. Also makes the toolbar feel more snappy again.

## Before
![image](https://user-images.githubusercontent.com/62722460/220672547-6ad38c1a-5c1f-4d49-827d-0339c643bc52.png)


## After
![image](https://user-images.githubusercontent.com/62722460/220671955-5af5465c-7ab0-4a55-a5ca-4011e1adda0c.png)
