### PR TITLE
Add option to show new cards regardless of the review limit

### DIFF
--- a/ftl/core/deck-config.ftl
+++ b/ftl/core/deck-config.ftl
@@ -39,6 +39,11 @@ deck-config-tab-description =
     - `Preset`: The limit is shared with all decks using this preset.
     - `This deck`: The limit is specific to this deck.
     - `Today only`: Make a temporary change to this deck's limit.
+deck-config-new-cards-ignore-review-limit = New cards ignore review limit
+deck-config-new-cards-ignore-review-limit-tooltip =
+    By default, the review limit also applies to new cards and no new cards will be
+    shown when the review limit has been reached. If this option is enabled, new cards
+    will be shown regardless of the review limit.
 
 ## Daily limit tabs: please try to keep these as short as the English version,
 ## as longer text will not fit on small screens.

--- a/proto/anki/deckconfig.proto
+++ b/proto/anki/deckconfig.proto
@@ -91,9 +91,7 @@ message DeckConfig {
 
     uint32 new_per_day = 9;
     uint32 reviews_per_day = 10;
-
-    // not currently used
-    uint32 new_per_day_minimum = 35;
+    bool new_ignore_review_limit = 35;
 
     float initial_ease = 11;
     float easy_multiplier = 12;

--- a/rslib/src/deckconfig/mod.rs
+++ b/rslib/src/deckconfig/mod.rs
@@ -41,7 +41,7 @@ const DEFAULT_DECK_CONFIG_INNER: DeckConfigInner = DeckConfigInner {
     relearn_steps: Vec::new(),
     new_per_day: 20,
     reviews_per_day: 200,
-    new_per_day_minimum: 0,
+    new_ignore_review_limit: false,
     initial_ease: 2.5,
     easy_multiplier: 1.3,
     hard_multiplier: 1.2,
@@ -194,12 +194,6 @@ impl DeckConfigInner {
         let default = DEFAULT_DECK_CONFIG_INNER;
         ensure_u32_valid(&mut self.new_per_day, default.new_per_day, 0, 9999);
         ensure_u32_valid(&mut self.reviews_per_day, default.reviews_per_day, 0, 9999);
-        ensure_u32_valid(
-            &mut self.new_per_day_minimum,
-            default.new_per_day_minimum,
-            0,
-            9999,
-        );
         ensure_f32_valid(&mut self.initial_ease, default.initial_ease, 1.31, 5.0);
         ensure_f32_valid(&mut self.easy_multiplier, default.easy_multiplier, 1.0, 5.0);
         ensure_f32_valid(&mut self.hard_multiplier, default.hard_multiplier, 0.5, 1.3);

--- a/rslib/src/deckconfig/schema11.rs
+++ b/rslib/src/deckconfig/schema11.rs
@@ -51,6 +51,7 @@ pub struct DeckConfSchema11 {
     // NOTE: if adding new ones, make sure to update clear_other_duplicates()
     #[serde(default)]
     new_mix: i32,
+    /// This has been repurposed as a boolean: `new_ignore_review_limit`
     #[serde(default)]
     new_per_day_minimum: u32,
     #[serde(default)]
@@ -293,7 +294,7 @@ impl From<DeckConfSchema11> for DeckConfig {
                 relearn_steps: c.lapse.delays,
                 new_per_day: c.new.per_day,
                 reviews_per_day: c.rev.per_day,
-                new_per_day_minimum: c.new_per_day_minimum,
+                new_ignore_review_limit: c.new_per_day_minimum > 0,
                 initial_ease: (c.new.initial_factor as f32) / 1000.0,
                 easy_multiplier: c.rev.ease4,
                 hard_multiplier: c.rev.hard_factor,
@@ -403,7 +404,7 @@ impl From<DeckConfig> for DeckConfSchema11 {
             },
             other: top_other,
             new_mix: i.new_mix,
-            new_per_day_minimum: i.new_per_day_minimum,
+            new_per_day_minimum: i.new_ignore_review_limit as u32,
             interday_learning_mix: i.interday_learning_mix,
             review_order: i.review_order,
             new_sort_order: i.new_card_sort_order,

--- a/rslib/src/decks/limits.rs
+++ b/rslib/src/decks/limits.rs
@@ -16,6 +16,12 @@ use crate::deckconfig::DeckConfigId;
 use crate::pb::decks::deck::normal::DayLimit;
 use crate::prelude::*;
 
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum LimitKind {
+    Review,
+    New,
+}
+
 impl NormalDeck {
     /// The deck's review limit for today, or its regular one, if any is
     /// configured.
@@ -50,8 +56,9 @@ impl DayLimit {
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) struct RemainingLimits {
-    pub review: u32,
-    pub new: u32,
+    pub(crate) review: u32,
+    pub(crate) new: u32,
+    pub(crate) cap_new_to_review: bool,
 }
 
 impl RemainingLimits {
@@ -71,26 +78,57 @@ impl RemainingLimits {
         normal: &NormalDeck,
         config: &DeckConfig,
     ) -> RemainingLimits {
-        let (review_limit, new_limit) = if v3 {
-            let review_limit = normal
-                .current_review_limit(today)
-                .unwrap_or(config.inner.reviews_per_day);
-            let new_limit = normal
-                .current_new_limit(today)
-                .unwrap_or(config.inner.new_per_day);
-            (review_limit, new_limit)
-        } else {
-            (config.inner.reviews_per_day, config.inner.new_per_day)
-        };
-        let (new_today, mut rev_today) = deck.new_rev_counts(today);
         if v3 {
-            // any reviewed new cards contribute to the review limit
-            rev_today += new_today;
+            Self::new_for_normal_deck_v3(deck, today, normal, config)
+        } else {
+            Self::new_for_normal_deck_v2(deck, today, config)
+        }
+    }
+
+    fn new_for_normal_deck_v2(deck: &Deck, today: u32, config: &DeckConfig) -> RemainingLimits {
+        let review_limit = config.inner.reviews_per_day;
+        let new_limit = config.inner.new_per_day;
+        let (new_today_count, review_today_count) = deck.new_rev_counts(today);
+
+        Self {
+            review: (review_limit as i32 - review_today_count).max(0) as u32,
+            new: (new_limit as i32 - new_today_count).max(0) as u32,
+            cap_new_to_review: false,
+        }
+    }
+
+    fn new_for_normal_deck_v3(
+        deck: &Deck,
+        today: u32,
+        normal: &NormalDeck,
+        config: &DeckConfig,
+    ) -> RemainingLimits {
+        let mut review_limit = normal
+            .current_review_limit(today)
+            .unwrap_or(config.inner.reviews_per_day) as i32;
+        let mut new_limit = normal
+            .current_new_limit(today)
+            .unwrap_or(config.inner.new_per_day) as i32;
+        let (new_today_count, review_today_count) = deck.new_rev_counts(today);
+
+        review_limit -= review_today_count;
+        new_limit -= new_today_count;
+        if !config.inner.new_ignore_review_limit {
+            review_limit -= new_today_count;
+            new_limit = new_limit.min(review_limit);
         }
 
         Self {
-            review: (review_limit as i32 - rev_today).max(0) as u32,
-            new: (new_limit as i32 - new_today).max(0) as u32,
+            review: review_limit.max(0) as u32,
+            new: new_limit.max(0) as u32,
+            cap_new_to_review: !config.inner.new_ignore_review_limit,
+        }
+    }
+
+    pub(crate) fn get(&self, kind: LimitKind) -> u32 {
+        match kind {
+            LimitKind::Review => self.review,
+            LimitKind::New => self.new,
         }
     }
 
@@ -98,6 +136,23 @@ impl RemainingLimits {
         self.review = self.review.min(limits.review);
         self.new = self.new.min(limits.new);
     }
+
+    /// True if some limit was decremented to 0.
+    fn decremented_to_zero(&mut self, kind: LimitKind) -> bool {
+        match kind {
+            LimitKind::Review if self.cap_new_to_review => {
+                decremented_to_zero(&mut self.review) | decremented_to_zero(&mut self.new)
+            }
+            LimitKind::Review => decremented_to_zero(&mut self.review),
+            LimitKind::New => decremented_to_zero(&mut self.new),
+        }
+    }
+}
+
+fn decremented_to_zero(num: &mut u32) -> bool {
+    let to_zero = *num == 1;
+    *num = num.saturating_sub(1);
+    to_zero
 }
 
 impl Default for RemainingLimits {
@@ -105,6 +160,7 @@ impl Default for RemainingLimits {
         RemainingLimits {
             review: 9999,
             new: 9999,
+            cap_new_to_review: false,
         }
     }
 }
@@ -162,8 +218,7 @@ pub(crate) struct LimitTreeMap {
     // and (3) have more than 1 tree, it's safe to unwrap on Tree::get() and
     // Tree::root_node_id(), even if we clone Nodes.
     tree: Tree<NodeLimits>,
-    /// A map to access the tree node of a deck. Only decks with a remaining
-    /// limit above zero are included.
+    /// A map to access the tree node of a deck.
     map: HashMap<DeckId, NodeId>,
 }
 
@@ -182,9 +237,7 @@ impl LimitTreeMap {
             .unwrap();
 
         let mut map = HashMap::new();
-        if root_limits.limits.review > 0 {
-            map.insert(root_deck.id, root_id.clone());
-        }
+        map.insert(root_deck.id, root_id.clone());
 
         let mut limits = Self { tree, map };
         let mut remaining_decks = child_decks.into_iter().peekable();
@@ -247,8 +300,7 @@ impl LimitTreeMap {
         let mut child_limits = NodeLimits::new(child_deck, config, today);
         child_limits
             .limits
-            .cap_to(self.tree.get(&parent_node_id).unwrap().data().limits);
-
+            .cap_to(self.get_node_limits(&parent_node_id));
         let child_node_id = self
             .tree
             .insert(
@@ -256,16 +308,34 @@ impl LimitTreeMap {
                 InsertBehavior::UnderNode(&parent_node_id),
             )
             .unwrap();
-        if child_limits.limits.review > 0 {
-            self.map.insert(child_deck.id, child_node_id);
-        }
-    }
-    pub(crate) fn root_limit_reached(&self) -> bool {
-        self.map.is_empty()
+        self.map.insert(child_deck.id, child_node_id);
     }
 
-    pub(crate) fn limit_reached(&self, deck_id: DeckId) -> bool {
-        self.map.get(&deck_id).is_none()
+    fn get_node_id(&self, deck_id: DeckId) -> Result<&NodeId> {
+        self.map
+            .get(&deck_id)
+            .or_invalid("deck not found in limits map")
+    }
+
+    fn get_node_limits(&self, node_id: &NodeId) -> RemainingLimits {
+        self.tree.get(node_id).unwrap().data().limits
+    }
+
+    fn get_deck_limits(&self, deck_id: DeckId) -> Result<RemainingLimits> {
+        self.get_node_id(deck_id)
+            .map(|node_id| self.get_node_limits(node_id))
+    }
+
+    fn get_root_limits(&self) -> RemainingLimits {
+        self.get_node_limits(self.tree.root_node_id().unwrap())
+    }
+
+    pub(crate) fn root_limit_reached(&self, kind: LimitKind) -> bool {
+        self.get_root_limits().get(kind) == 0
+    }
+
+    pub(crate) fn limit_reached(&self, deck_id: DeckId, kind: LimitKind) -> Result<bool> {
+        Ok(self.get_deck_limits(deck_id)?.get(kind) == 0)
     }
 
     pub(crate) fn active_decks(&self) -> Vec<DeckId> {
@@ -276,59 +346,36 @@ impl LimitTreeMap {
             .collect()
     }
 
-    pub(crate) fn remaining_node_id(&self, deck_id: DeckId) -> Option<NodeId> {
-        self.map.get(&deck_id).map(Clone::clone)
+    pub(crate) fn decrement_deck_and_parent_limits(
+        &mut self,
+        deck_id: DeckId,
+        kind: LimitKind,
+    ) -> Result<()> {
+        let node_id = self.get_node_id(deck_id)?.clone();
+        self.decrement_node_and_parent_limits(&node_id, kind);
+        Ok(())
     }
 
-    pub(crate) fn decrement_node_and_parent_limits(&mut self, node_id: &NodeId, new: bool) {
+    fn decrement_node_and_parent_limits(&mut self, node_id: &NodeId, kind: LimitKind) {
         let node = self.tree.get_mut(node_id).unwrap();
         let parent = node.parent().cloned();
 
-        let limit = &mut node.data_mut().limits;
-        if if new {
-            limit.new = limit.new.saturating_sub(1);
-            limit.new
-        } else {
-            limit.review = limit.review.saturating_sub(1);
-            limit.review
-        } == 0
-        {
-            self.remove_node_and_descendants_from_map(node_id);
+        let limits = &mut node.data_mut().limits;
+        if limits.decremented_to_zero(kind) {
+            let limits = *limits;
+            self.cap_node_and_descendants(node_id, limits);
         };
 
         if let Some(parent_id) = parent {
-            self.decrement_node_and_parent_limits(&parent_id, new)
+            self.decrement_node_and_parent_limits(&parent_id, kind)
         }
     }
 
-    pub(crate) fn remove_node_and_descendants_from_map(&mut self, node_id: &NodeId) {
-        let node = self.tree.get(node_id).unwrap();
-        self.map.remove(&node.data().deck_id);
-
-        for child_id in node.children().clone() {
-            self.remove_node_and_descendants_from_map(&child_id);
-        }
-    }
-
-    pub(crate) fn cap_new_to_review(&mut self) {
-        self.cap_new_to_review_rec(&self.tree.root_node_id().unwrap().clone(), 9999);
-    }
-
-    fn cap_new_to_review_rec(&mut self, node_id: &NodeId, parent_limit: u32) {
+    fn cap_node_and_descendants(&mut self, node_id: &NodeId, limits: RemainingLimits) {
         let node = self.tree.get_mut(node_id).unwrap();
-        let mut limits = &mut node.data_mut().limits;
-        limits.new = limits.new.min(limits.review).min(parent_limit);
-
-        // clone because of borrowing rules
-        let node_limit = limits.new;
-        let children = node.children().clone();
-
-        if node_limit == 0 {
-            self.remove_node_and_descendants_from_map(node_id);
-        }
-
-        for child_id in children {
-            self.cap_new_to_review_rec(&child_id, node_limit);
+        node.data_mut().limits.cap_to(limits);
+        for child_id in node.children().clone() {
+            self.cap_node_and_descendants(&child_id, limits);
         }
     }
 }

--- a/rslib/src/decks/tree.rs
+++ b/rslib/src/decks/tree.rs
@@ -178,12 +178,15 @@ impl NodeCountsV3 {
         let mut remaining_reviews = remaining.review.saturating_sub(capped.interday_learning);
         // any remaining review limit is applied to reviews
         capped.review = capped.review.min(remaining_reviews);
-        remaining_reviews = remaining_reviews.saturating_sub(capped.review);
-        // new cards last, capped to new and remaining review limits
-        capped.new = capped.new.min(remaining_reviews).min(remaining.new);
+        capped.new = capped.new.min(remaining.new);
+        if remaining.cap_new_to_review {
+            remaining_reviews = remaining_reviews.saturating_sub(capped.review);
+            capped.new = capped.new.min(remaining_reviews);
+        }
         capped
     }
 }
+
 impl AddAssign for NodeCountsV3 {
     fn add_assign(&mut self, rhs: Self) {
         self.new += rhs.new;

--- a/rslib/src/storage/card/mod.rs
+++ b/rslib/src/storage/card/mod.rs
@@ -254,7 +254,7 @@ impl super::SqliteStorage {
         mut func: F,
     ) -> Result<()>
     where
-        F: FnMut(DueCard) -> bool,
+        F: FnMut(DueCard) -> Result<bool>,
     {
         let order_clause = review_order_sql(order, day_cutoff);
         let mut stmt = self.db.prepare_cached(&format!(
@@ -276,7 +276,7 @@ impl super::SqliteStorage {
                 current_deck_id: row.get(5)?,
                 original_deck_id: row.get(6)?,
                 kind,
-            }) {
+            })? {
                 break;
             }
         }
@@ -288,7 +288,7 @@ impl super::SqliteStorage {
     /// returns or no more cards found.
     pub(crate) fn for_each_new_card_in_deck<F>(&self, deck: DeckId, mut func: F) -> Result<()>
     where
-        F: FnMut(NewCard) -> bool,
+        F: FnMut(NewCard) -> Result<bool>,
     {
         let mut stmt = self.db.prepare_cached(&format!(
             "{} ORDER BY due, ord ASC",
@@ -296,7 +296,7 @@ impl super::SqliteStorage {
         ))?;
         let mut rows = stmt.query(params![deck])?;
         while let Some(row) = rows.next()? {
-            if !func(row_to_new_card(row)?) {
+            if !func(row_to_new_card(row)?)? {
                 break;
             }
         }
@@ -312,7 +312,7 @@ impl super::SqliteStorage {
         mut func: F,
     ) -> Result<()>
     where
-        F: FnMut(NewCard) -> bool,
+        F: FnMut(NewCard) -> Result<bool>,
     {
         let mut stmt = self.db.prepare_cached(&format!(
             "{} ORDER BY {}",
@@ -321,7 +321,7 @@ impl super::SqliteStorage {
         ))?;
         let mut rows = stmt.query(params![])?;
         while let Some(row) = rows.next()? {
-            if !func(row_to_new_card(row)?) {
+            if !func(row_to_new_card(row)?)? {
                 break;
             }
         }

--- a/ts/deck-options/DailyLimits.svelte
+++ b/ts/deck-options/DailyLimits.svelte
@@ -15,6 +15,7 @@
     import { ValueTab } from "./lib";
     import SettingTitle from "./SettingTitle.svelte";
     import SpinBoxRow from "./SpinBoxRow.svelte";
+    import SwitchRow from "./SwitchRow.svelte";
     import TabbedValue from "./TabbedValue.svelte";
     import type { DeckOption } from "./types";
     import Warning from "./Warning.svelte";
@@ -140,6 +141,11 @@
             help: tr.deckConfigReviewLimitTooltip() + v3Extra,
             url: "https://docs.ankiweb.net/deck-options.html#maximum-reviewsday",
         },
+        newIgnoreReviewLimit: {
+            title: tr.deckConfigNewCardsIgnoreReviewLimit(),
+            help: tr.deckConfigNewCardsIgnoreReviewLimitTooltip(),
+            url: "https://docs.ankiweb.net/deck-options.html#new-cardsday",
+        },
     };
     const helpSections = Object.values(settings) as DeckOption[];
 
@@ -192,5 +198,21 @@
         <Item>
             <Warning warning={reviewsTooLow} />
         </Item>
+
+        {#if state.v3Scheduler}
+            <Item>
+                <SwitchRow
+                    bind:value={$config.newIgnoreReviewLimit}
+                    defaultValue={defaults.newIgnoreReviewLimit}
+                >
+                    <SettingTitle
+                        on:click={() =>
+                            openHelpModal(
+                                Object.keys(settings).indexOf("newIgnoreReviewLimit"),
+                            )}>{settings.newIgnoreReviewLimit.title}</SettingTitle
+                    >
+                </SwitchRow>
+            </Item>
+        {/if}
     </DynamicallySlottable>
 </TitledContainer>


### PR DESCRIPTION
Closes #1834.

I must admit, this was harder than I would have thought. The code was tightly coupled to the previous behaviour.
I took the opportunity to simplify the limits code a bit (or so I hope). In a nutshell, the most important change is that the previous code enforced the review limit on new cards by capping the new limit after the review gathering, whereas the new code decrements the two limits in lockstep _during_ the review gathering.