### PR TITLE
Expose the scroll_even_if_visible parameter to outside callers

### DIFF
--- a/qt/aqt/browser/table/table.py
+++ b/qt/aqt/browser/table/table.py
@@ -132,12 +132,14 @@ class Table:
             | QItemSelectionModel.SelectionFlag.Rows,
         )
 
-    def select_single_card(self, card_id: CardId) -> None:
+    def select_single_card(
+        self, card_id: CardId, scroll_even_if_visible: bool = True
+    ) -> None:
         """Try to set the selection to the item corresponding to the given card."""
         self._reset_selection()
         if (row := self._model.get_card_row(card_id)) is not None:
             self._view.selectRow(row)
-            self._scroll_to_row(row, scroll_even_if_visible=True)
+            self._scroll_to_row(row, scroll_even_if_visible)
         else:
             self.browser.on_all_or_selected_rows_changed()
             self.browser.on_current_row_changed()


### PR DESCRIPTION
Recently there was an [issue](https://github.com/Ajatt-Tools/mergenotes/issues/10) in Merge Notes where a user complained about deleted cards still being selected after merging. When a deleted card is selected, pressing ⬇️ or ⬆️  (depending on the ordering) on the keyboard leads to the selection getting reset to the first card in the list.

I [fixed](https://github.com/Ajatt-Tools/mergenotes/commit/35fc374cfc4842cc2f7e8bb0a240671c962da5c6#diff-fac5d0c517d024a40d3f53162fa3813ff1f908763bea8a3182ff75ca9aa73421R154) the issue by re-selecting the remaining card after merging. I had to copy-paste the `select_single_card` function with the `scroll_even_if_visible` parameter changed to False.

This PR makes it possible to manipulate the parameter to remove the need to copy-paste the entire function. 