### PR TITLE
Add a button in the preferences to reset window sizes

### DIFF
--- a/ftl/core/preferences.ftl
+++ b/ftl/core/preferences.ftl
@@ -68,6 +68,7 @@ preferences-scheduler = Scheduler
 preferences-user-interface = User Interface
 preferences-import-export = Import/Export
 preferences-network-timeout = Network timeout
+preferences-reset-window-sizes = Reset Window Sizes
 
 ## NO NEED TO TRANSLATE. This text is no longer used by Anki, and will be removed in the future.
 

--- a/qt/aqt/forms/preferences.ui
+++ b/qt/aqt/forms/preferences.ui
@@ -85,13 +85,6 @@
           <string>preferences_user_interface</string>
          </property>
          <layout class="QGridLayout" name="gridLayout_2">
-          <item row="1" column="1">
-           <widget class="QComboBox" name="styleComboBox">
-            <property name="currentText">
-             <string/>
-            </property>
-           </widget>
-          </item>
           <item row="0" column="1">
            <widget class="QComboBox" name="theme"/>
           </item>
@@ -111,10 +104,10 @@
             </property>
            </widget>
           </item>
-          <item row="2" column="0">
-           <widget class="QLabel" name="uiSizeLabel">
-            <property name="text">
-             <string>preferences_user_interface_size</string>
+          <item row="1" column="1">
+           <widget class="QComboBox" name="styleComboBox">
+            <property name="currentText">
+             <string/>
             </property>
            </widget>
           </item>
@@ -129,6 +122,20 @@
            <widget class="QLabel" name="themeLabel">
             <property name="text">
              <string>preferences_theme</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QLabel" name="uiSizeLabel">
+            <property name="text">
+             <string>preferences_user_interface_size</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0" colspan="2">
+           <widget class="QPushButton" name="resetWindowSizes">
+            <property name="text">
+             <string>preferences_reset_window_sizes</string>
             </property>
            </widget>
           </item>

--- a/qt/aqt/preferences.py
+++ b/qt/aqt/preferences.py
@@ -276,6 +276,7 @@ class Preferences(QDialog):
         self.form.styleLabel.setVisible(not is_win)
         self.form.styleComboBox.setVisible(not is_win)
         self.form.legacy_import_export.setChecked(self.mw.pm.legacy_import_export())
+        qconnect(self.form.resetWindowSizes.clicked, self.on_reset_window_sizes)
 
         self.setup_language()
         self.setup_video_driver()
@@ -301,6 +302,12 @@ class Preferences(QDialog):
 
     def on_theme_changed(self, index: int) -> None:
         self.mw.set_theme(Theme(index))
+
+    def on_reset_window_sizes(self) -> None:
+        suffixes = ["Geom", "State", "Splitter"]
+        for key in list(self.prof.keys()):
+            if any(key.endswith(suffix) for suffix in suffixes):
+                del self.prof[key]
 
     # legacy - one of Henrik's add-ons is currently wrapping them
 


### PR DESCRIPTION
Closes #2403

This also resets windows and splitters state to be safe.

![image](https://user-images.githubusercontent.com/41397710/221690426-7ac78936-9d12-4f98-9301-c361480aeffc.png)
