### PR TITLE
Fix double scrollbars in deck options

### DIFF
--- a/sass/base.scss
+++ b/sass/base.scss
@@ -40,11 +40,11 @@ body {
 }
 
 html {
-    overflow-x: hidden;
     overscroll-behavior: none;
 }
 
 body {
+    overflow-x: hidden !important;
     &:not(.isMac),
     &:not(.isMac) * {
         @include scrollbar.custom;

--- a/sass/base.scss
+++ b/sass/base.scss
@@ -44,7 +44,7 @@ html {
 }
 
 body {
-    overflow-x: hidden !important;
+    overflow-x: hidden;
     &:not(.isMac),
     &:not(.isMac) * {
         @include scrollbar.custom;

--- a/ts/import-csv/import-csv-base.scss
+++ b/ts/import-csv/import-csv-base.scss
@@ -14,7 +14,8 @@
 }
 
 body {
-    height: 100vh;
+    min-height: 100vh;
+    height: auto;
     width: min(100vw, 70em);
     margin: 0 auto;
     padding: 0 1em 1em 1em;


### PR DESCRIPTION
Closes #2401.

This change also prevents the sticky element from hiding and the page from shifting to the left while a modal is open.