### PR TITLE
Ensure fields were created before saving them

### DIFF
--- a/ts/editor/NoteEditor.svelte
+++ b/ts/editor/NoteEditor.svelte
@@ -81,7 +81,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
     const sessionOptions: SessionOptions = {};
     export function saveSession(): void {
-        if (notetypeId) {
+        if (notetypeId && fieldsData.length > 0) {
             sessionOptions[notetypeId] = {
                 fieldsCollapsed,
                 fieldStates: {


### PR DESCRIPTION
This PR fixes an issue introduced in bf5bcd3f5.

Since now `fieldsCollapsed`, `richTextsHidden`, `plainTextsHidden` and `plainTextDefaults` are only set after `tick()` is resolved, but`notetypeId` is still set immediately, the editor would sometimes save empty values and restore them, messing the fields. This happened frequently when opening the browser by clicking a date on the stats page's calendar.

Checking `fieldsData` should ensure there's actually fields to save.