### PR TITLE
Fix panic with invalid sync server URL with port

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -112,6 +112,7 @@ Fabricio Duarte <fabricio.duarte.jr@gmail.com>
 Mani <github.com/krmanik>
 Kaben Nanlohy <kaben.nanlohy@gmail.com>
 Tobias Predel <tobias.predel@gmail.com>
+Daniel Tang <danielzgtg.opensource@gmail.com>
 
 ********************
 

--- a/rslib/src/backend/sync/mod.rs
+++ b/rslib/src/backend/sync/mod.rs
@@ -86,6 +86,11 @@ impl TryFrom<pb::sync::SyncAuth> for SyncAuth {
                 .endpoint
                 .map(|v| {
                     Url::try_from(v.as_str())
+                        // Without the next line, incomplete URLs like computer.local without the http://
+                        // are detected but URLs like computer.local:8000 are not.
+                        // By calling join() now, these URLs are detected too and later code that
+                        // uses and unwraps the result of join() doesn't panic
+                        .and_then(|x| x.join("/"))
                         .or_invalid("Invalid sync server specified. Please check the preferences.")
                 })
                 .transpose()?,


### PR DESCRIPTION
This fixes a Rust panic. It affects users adding a self-hosted sync server URL for the first time. Before this PR, Anki caught a Rust panic and displayed a message to exit.

I set up my sync server at `daniel-tablet1.local:8000` and typed that into "Preferences > Syncing > Self-hosted sync server". I learned after the crash that I was supposed to put `http://daniel-tablet1.local:8000`, but not before Anki had to exit. Thankfully I didn't study anything this run of the program so nothing was lost. I think that during the original development only IPs without ports were tested, because it correctly rejects `daniel-tablet1.local` but crashed when I included the port.

# Before

Anki displayed a dialog with a backtrace and showed a button to exit it. Below is the console output:

```
thread '<unnamed>' panicked at 'called `Result::unwrap()` on an `Err` value: RelativeUrlWithCannotBeABaseBase', rslib/src/sync/collection/protocol.rs:56:28
stack backtrace:
   0: rust_begin_unwind
             at /rustc/90743e7298aca107ddaa0c202a4d3604e29bfeb6/library/std/src/panicking.rs:575:5
   1: core::panicking::panic_fmt
             at /rustc/90743e7298aca107ddaa0c202a4d3604e29bfeb6/library/core/src/panicking.rs:65:14
   2: core::result::unwrap_failed
             at /rustc/90743e7298aca107ddaa0c202a4d3604e29bfeb6/library/core/src/result.rs:1791:5
   3: core::result::Result<T,E>::unwrap
   4: <anki::sync::collection::protocol::SyncMethod as anki::sync::collection::protocol::AsSyncEndpoint>::as_sync_endpoint
   5: anki::sync::http_client::HttpSyncClient::request_ext::{{closure}}
   6: <core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll
   7: anki::sync::http_client::HttpSyncClient::request::{{closure}}
   8: <core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll
   9: anki::sync::http_client::protocol::<impl anki::sync::collection::protocol::SyncProtocol for anki::sync::http_client::HttpSyncClient>::host_key::{{closure}}
  10: <core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll
  11: <core::pin::Pin<P> as core::future::future::Future>::poll
  12: anki::sync::login::sync_login::{{closure}}
  13: <core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll
  14: <futures_util::abortable::Abortable<Fut> as core::future::future::Future>::poll::{{closure}}
  15: futures_util::abortable::Abortable<T>::try_poll
  16: <futures_util::abortable::Abortable<Fut> as core::future::future::Future>::poll
  17: tokio::runtime::park::CachedParkThread::block_on::{{closure}}
  18: tokio::runtime::park::CachedParkThread::block_on
  19: tokio::runtime::context::BlockingRegionGuard::block_on
  20: tokio::runtime::handle::Handle::block_on
  21: anki::backend::sync::<impl anki::backend::Backend>::sync_login_inner
  22: anki::backend::sync::<impl anki::pb::sync::sync_service::Service for anki::backend::Backend>::sync_login
  23: anki::pb::sync::sync_service::Service::run_method
  24: anki::backend::Backend::run_method::{{closure}}
  25: core::result::Result<T,E>::and_then
  26: anki::backend::Backend::run_method
  27: rsbridge::Backend::command::{{closure}}
  28: pyo3::marker::Python::allow_threads
  29: rsbridge::Backend::command
  30: rsbridge::_::<impl rsbridge::Backend>::__pymethod_command__
  31: pyo3::impl_::trampoline::cfunction_with_keywords::{{closure}}
  32: pyo3::impl_::trampoline::trampoline_inner::{{closure}}
  33: std::panicking::try::do_call
  34: __rust_try
  35: std::panicking::try
  36: std::panic::catch_unwind
  37: pyo3::impl_::trampoline::trampoline_inner
  38: pyo3::impl_::trampoline::cfunction_with_keywords
  39: rsbridge::_::<impl pyo3::impl_::pyclass::PyMethods<rsbridge::Backend> for pyo3::impl_::pyclass::PyClassImplCollector<rsbridge::Backend>>::py_methods::ITEMS::trampoline
  40: method_vectorcall_VARARGS_KEYWORDS
             at /build/Python-3.9.15/Objects/descrobject.c:348:14
  41: _PyEval_EvalFrameDefault
             at /build/Python-3.9.15/./Include/cpython/abstract.h:118:11
  42: _PyFunction_Vectorcall
             at /build/Python-3.9.15/./Include/internal/pycore_ceval.h:40:12
  43: _PyEval_EvalFrameDefault
             at /build/Python-3.9.15/./Include/cpython/abstract.h:118:11
  44: _PyFunction_Vectorcall
             at /build/Python-3.9.15/./Include/internal/pycore_ceval.h:40:12
  45: _PyEval_EvalFrameDefault
             at /build/Python-3.9.15/./Include/cpython/abstract.h:118:11
  46: _PyFunction_Vectorcall
             at /build/Python-3.9.15/./Include/internal/pycore_ceval.h:40:12
  47: method_vectorcall
             at /build/Python-3.9.15/./Include/cpython/abstract.h:118:11
  48: _PyEval_EvalFrameDefault
             at /build/Python-3.9.15/./Include/cpython/abstract.h:118:11
  49: _PyFunction_Vectorcall
             at /build/Python-3.9.15/./Include/internal/pycore_ceval.h:40:12
  50: _PyEval_EvalFrameDefault
  51: _PyFunction_Vectorcall
             at /build/Python-3.9.15/./Include/internal/pycore_ceval.h:40:12
  52: _PyEval_EvalFrameDefault
             at /build/Python-3.9.15/./Include/cpython/abstract.h:118:11
  53: _PyFunction_Vectorcall
             at /build/Python-3.9.15/./Include/internal/pycore_ceval.h:40:12
  54: _PyEval_EvalFrameDefault
  55: _PyFunction_Vectorcall
             at /build/Python-3.9.15/./Include/internal/pycore_ceval.h:40:12
  56: _PyEval_EvalFrameDefault
             at /build/Python-3.9.15/./Include/cpython/abstract.h:118:11
  57: _PyFunction_Vectorcall
             at /build/Python-3.9.15/./Include/internal/pycore_ceval.h:40:12
  58: _PyEval_EvalFrameDefault
             at /build/Python-3.9.15/./Include/cpython/abstract.h:118:11
  59: _PyFunction_Vectorcall
             at /build/Python-3.9.15/./Include/internal/pycore_ceval.h:40:12
  60: method_vectorcall
             at /build/Python-3.9.15/./Include/cpython/abstract.h:118:11
  61: t_bootstrap
             at /build/Python-3.9.15/./Modules/_threadmodule.c:1040:11
  62: pythread_wrapper
             at /build/Python-3.9.15/Python/thread_pthread.h:245:5
  63: <unknown>
  64: <unknown>
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
Caught exception:
Traceback (most recent call last):
  File "/home/home/PycharmProjects/anki/qt/aqt/taskman.py", line 122, in _on_closures_pending
    closure()
  File "/home/home/PycharmProjects/anki/qt/aqt/taskman.py", line 71, in <lambda>
    lambda future: self.run_on_main(lambda: on_done(future))
  File "/home/home/PycharmProjects/anki/qt/aqt/taskman.py", line 90, in wrapped_done
    on_done(fut)
  File "/home/home/PycharmProjects/anki/qt/aqt/sync.py", line 269, in on_future_done
    auth = fut.result()
  File "/home/home/PycharmProjects/anki/out/extracted/python/lib/python3.9/concurrent/futures/_base.py", line 439, in result
    return self.__get_result()
  File "/home/home/PycharmProjects/anki/out/extracted/python/lib/python3.9/concurrent/futures/_base.py", line 391, in __get_result
    raise self._exception
  File "/home/home/PycharmProjects/anki/out/extracted/python/lib/python3.9/concurrent/futures/thread.py", line 58, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/home/home/PycharmProjects/anki/qt/aqt/sync.py", line 287, in <lambda>
    lambda: mw.col.sync_login(
  File "/home/home/PycharmProjects/anki/pylib/anki/collection.py", line 1197, in sync_login
    return self._backend.sync_login(
  File "/home/home/PycharmProjects/anki/out/pylib/anki/_backend_generated.py", line 762, in sync_login
    raw_bytes = self._run_command(3, 2, message.SerializeToString())
  File "/home/home/PycharmProjects/anki/pylib/anki/_backend.py", line 150, in _run_command
    return self._backend.command(service, method, input)
pyo3_runtime.PanicException: called `Result::unwrap()` on an `Err` value: RelativeUrlWithCannotBeABaseBase
```

# After

Anki correctly displays "Invalid sync server specified. Please check the preferences." for all the invalid URLs I tested and no longer crashes.