### PR TITLE
Fix confusion of reduce_motion with minimalist_mode

### DIFF
--- a/qt/aqt/webview.py
+++ b/qt/aqt/webview.py
@@ -784,7 +784,7 @@ html {{ {font} }}
             f"""document.body.classList.toggle("fancy", {json.dumps(not mw.pm.minimalist_mode())}); """
         )
         self.eval(
-            f"""document.body.classList.toggle("reduce-motion", {json.dumps(mw.pm.minimalist_mode())}); """
+            f"""document.body.classList.toggle("reduce-motion", {json.dumps(mw.pm.reduce_motion())}); """
         )
 
     @deprecated(info="use theme_manager.qcolor() instead")


### PR DESCRIPTION
This fixes a copy-and-paste error from https://github.com/ankitects/anki/pull/2289/files#diff-8ec42fbd3b64573bc5a5da25fa29dff5a1f1592398bf3a139953d0e477ef722aR740-R745 .

I haven't noticed anything user-facing, but I fixed this line of code because it looked suspicious. It's not likely that two CSS classes would be defined to be the opposite of each other when one of them is named after the other feature in that PR. If it's supposed to be like this, there should have been a comment above. I don't know how to test this function, but I think that the fix in this PR will restore the intended behavior that @kleinerpirat meant.