### PR TITLE
Fix black on grey minimalist buttons in KDE

### DIFF
--- a/sass/buttons.scss
+++ b/sass/buttons.scss
@@ -35,8 +35,8 @@ button {
     padding: 8px 10px;
     margin: 0 4px;
 
+    @include button.base;
     .fancy & {
-        @include button.base;
         border-radius: var(--border-radius-large);
         @include elevation(1, $opacity-boost: -0.08);
         &:hover {


### PR DESCRIPTION
This PR fixes an color contrast accessibility problem where the overview screen button text is illegible on KDE. Minimalist mode seems to be an effort to restore the theme before the redesign. The button text color was working fine both in the redesigned theme and the version before it, but not in this "minimalist mode"'s attempt to bring it back. This PR restores the button color properly like it was before.

This does not affect and is not reproducible by `./run` as that is using a bundled version of Qt instead of KDE's Qt. I reproduced and confirmed the fix using `tools/build` and installing to a venv created by `python3 -m venv venv --system-site-packages`. I am on Linux KDE 5.27.0 with the Breeze Dark theme. Anki is set to the Dark Theme and the Anki Style.

This is achieved by always doing `@include button.base` whether in minimalist mode or not, as the name ".base" suggests by convention. The unintended side effect, which I think turned out nicely, was that the mouse pressed styles are also added back.

# Before

![image](https://user-images.githubusercontent.com/25646384/222729072-665f53d8-8536-494a-9c9d-3901a8b6d8df.png)

# After

![image](https://user-images.githubusercontent.com/25646384/222729088-f64d3415-9dc5-49ee-8437-88fd9f29e972.png)
