### PR TITLE
Fix black on grey deck options on KDE

### DIFF
--- a/ts/deck-options/deck-options-base.scss
+++ b/ts/deck-options/deck-options-base.scss
@@ -19,5 +19,9 @@ input[type="text"] {
     background: var(--canvas-inset);
 }
 
+input {
+    color: var(--fg);
+}
+
 // Setting 100% height causes the sticky element to hide as you scroll down on Safari.
 html { height: initial; }


### PR DESCRIPTION
This PR fixes another color contrast accessibility problem. The deck options input fields were illegible on KDE.

This time it's not specific to minimalist mode. See #2414 for the runtime OS environment used.

# Before

![image](https://user-images.githubusercontent.com/25646384/222736295-56117ec5-6518-40f6-9b11-0e4cca9a7cbb.png)

# After

![image](https://user-images.githubusercontent.com/25646384/222736004-ebfed792-e3c2-4d30-ac9a-b462dff9a54e.png)
