### PR TITLE
Workaround for CodeMirror starting too big when the browser is opened

### DIFF
--- a/ts/editor/plain-text-input/PlainTextInput.svelte
+++ b/ts/editor/plain-text-input/PlainTextInput.svelte
@@ -168,6 +168,13 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
             padding-inline: 4px;
         }
 
+        :global(.CodeMirror-sizer) {
+            // Workaround for CodeMirror starting with a height bigger than it should  
+            // when the browser is opened on a notetype that has fields with the HTML
+            // editor selected by default
+            min-height: 0 !important;
+        }
+
         :global(.CodeMirror-lines) {
             padding: 8px 0;
         }

--- a/ts/editor/plain-text-input/PlainTextInput.svelte
+++ b/ts/editor/plain-text-input/PlainTextInput.svelte
@@ -169,7 +169,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         }
 
         :global(.CodeMirror-sizer) {
-            // Workaround for CodeMirror starting with a height bigger than it should  
+            // Workaround for CodeMirror starting with a height bigger than it should
             // when the browser is opened on a notetype that has fields with the HTML
             // editor selected by default
             min-height: 0 !important;


### PR DESCRIPTION
Since f3b2dbd31, when a field has the HTML editor shown by default, CodeMirror sometimes starts with the `min-height` attribute set to a value way higher it should be. It returns back to normal when the field is edited or focused.

![Peek 2023-03-03 20-31](https://user-images.githubusercontent.com/25729641/222861635-08a9b6d9-c05c-4b6d-bf7b-5ec41d2c654b.gif)

CodeMirror's docs recommend calling `cm.refresh()` after hiding/unhiding it to ensure it still looks as intended, but PlainTextInput's code already calls it when the Collapsible shows/collapses.
> If your code does something to change the size of the editor element (window resizes are already listened for), or unhides it, you should probably follow up by calling this method to ensure CodeMirror is still looking as intended. See also the autorefresh addon.

I've tried calling it in other places too, but when it works, a new problem appears. These problems are usually: (1) the height is adjusted but the width becomes smaller than the PlainTextInput and (2) the height is adjusted but you can see some frames with CodeMirror bigger than it should be before that.

The only way I found to solve this without causing more problems was changing `PlainTextInput.svelte`'s style. However, this is just a workaround and it's not fixing the root cause. CodeMirror still starts taller than it should be, which didn't happen before.

Does anyone know if there's a better way to solve this?