### PR TITLE
Fix packaged audio tools path on Windows

### DIFF
--- a/qt/aqt/sound.py
+++ b/qt/aqt/sound.py
@@ -246,7 +246,7 @@ def _packagedCmd(cmd: list[str]) -> tuple[Any, dict[str, str]]:
         del env["LD_LIBRARY_PATH"]
 
     if is_win:
-        packaged_path = Path(sys.prefix) / "audio" / (cmd[0] + ".exe")
+        packaged_path = Path(sys.prefix) / (cmd[0] + ".exe")
     elif is_mac:
         packaged_path = Path(sys.prefix) / ".." / "Resources" / cmd[0]
     else:


### PR DESCRIPTION
There is no audio subfolder as of 2.1.55+. The wrong path was not causing any issues in Anki as far as I can tell. I just found about it while investigating an issue in an add-on that uses _packagedCmd.