### PR TITLE
Ensure state mutator runs after card is rendered

### DIFF
--- a/proto/anki/scheduler.proto
+++ b/proto/anki/scheduler.proto
@@ -108,6 +108,7 @@ message QueuedCards {
     cards.Card card = 1;
     Queue queue = 2;
     SchedulingStates states = 3;
+    SchedulingContext context = 4;
   }
 
   repeated QueuedCard cards = 1;
@@ -284,7 +285,12 @@ message CustomStudyRequest {
 
 message SchedulingContext {
   string deck_name = 1;
-  string seed = 2;
+  uint64 seed = 2;
+}
+
+message SchedulingStatesWithContext {
+  SchedulingStates states = 1;
+  SchedulingContext context = 2;
 }
 
 message CustomStudyDefaultsRequest {

--- a/proto/anki/scheduler.proto
+++ b/proto/anki/scheduler.proto
@@ -282,6 +282,11 @@ message CustomStudyRequest {
   }
 }
 
+message SchedulingContext {
+  string deck_name = 1;
+  string seed = 2;
+}
+
 message CustomStudyDefaultsRequest {
   int64 deck_id = 1;
 }

--- a/pylib/anki/cards.py
+++ b/pylib/anki/cards.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import pprint
 import time
 
@@ -83,7 +84,7 @@ class Card(DeprecatedNamesMixin):
         self.due = card.due
         self.ivl = card.interval
         self.factor = card.ease_factor
-        self.reps = card.reps
+        self.reps: int = card.reps
         self.lapses = card.lapses
         self.left = card.remaining_steps
         self.odue = card.original_due
@@ -215,6 +216,15 @@ class Card(DeprecatedNamesMixin):
         if not 0 <= flag <= 7:
             raise Exception("invalid flag")
         self.flags = (self.flags & ~0b111) | flag
+
+    def review_hash(self) -> str:
+        """Sha1 of this card's id and repetition count."""
+        hash = hashlib.sha1()
+        # CardId is an i64 in Rust
+        hash.update(self.id.to_bytes(8, "little", signed=True))
+        # reps are a u32 in Rust
+        hash.update(self.reps.to_bytes(4, "little"))
+        return hash.hexdigest()
 
     @deprecated(info="use card.render_output() directly")
     def css(self) -> str:

--- a/pylib/anki/cards.py
+++ b/pylib/anki/cards.py
@@ -3,7 +3,6 @@
 
 from __future__ import annotations
 
-import hashlib
 import pprint
 import time
 
@@ -84,7 +83,7 @@ class Card(DeprecatedNamesMixin):
         self.due = card.due
         self.ivl = card.interval
         self.factor = card.ease_factor
-        self.reps: int = card.reps
+        self.reps = card.reps
         self.lapses = card.lapses
         self.left = card.remaining_steps
         self.odue = card.original_due
@@ -216,15 +215,6 @@ class Card(DeprecatedNamesMixin):
         if not 0 <= flag <= 7:
             raise Exception("invalid flag")
         self.flags = (self.flags & ~0b111) | flag
-
-    def review_hash(self) -> str:
-        """Sha1 of this card's id and repetition count."""
-        hash = hashlib.sha1()
-        # CardId is an i64 in Rust
-        hash.update(self.id.to_bytes(8, "little", signed=True))
-        # reps are a u32 in Rust
-        hash.update(self.reps.to_bytes(4, "little"))
-        return hash.hexdigest()
 
     @deprecated(info="use card.render_output() directly")
     def css(self) -> str:

--- a/pylib/anki/scheduler/v3.py
+++ b/pylib/anki/scheduler/v3.py
@@ -31,6 +31,7 @@ QueuedCards = scheduler_pb2.QueuedCards
 SchedulingState = scheduler_pb2.SchedulingState
 SchedulingStates = scheduler_pb2.SchedulingStates
 SchedulingContext = scheduler_pb2.SchedulingContext
+SchedulingStatesWithContext = scheduler_pb2.SchedulingStatesWithContext
 CardAnswer = scheduler_pb2.CardAnswer
 
 

--- a/pylib/anki/scheduler/v3.py
+++ b/pylib/anki/scheduler/v3.py
@@ -30,6 +30,7 @@ from anki.utils import int_time
 QueuedCards = scheduler_pb2.QueuedCards
 SchedulingState = scheduler_pb2.SchedulingState
 SchedulingStates = scheduler_pb2.SchedulingStates
+SchedulingContext = scheduler_pb2.SchedulingContext
 CardAnswer = scheduler_pb2.CardAnswer
 
 

--- a/qt/aqt/mediasrv.py
+++ b/qt/aqt/mediasrv.py
@@ -423,6 +423,12 @@ def set_scheduling_states() -> bytes:
     return b""
 
 
+def get_scheduling_context() -> bytes:
+    if ctx := aqt.mw.reviewer.get_scheduling_context():
+        return ctx.SerializeToString()
+    return b""
+
+
 def change_notetype() -> bytes:
     data = request.data
 
@@ -453,6 +459,7 @@ post_handler_list = [
     update_deck_configs,
     get_scheduling_states,
     set_scheduling_states,
+    get_scheduling_context,
     change_notetype,
     import_csv,
 ]

--- a/qt/aqt/mediasrv.py
+++ b/qt/aqt/mediasrv.py
@@ -27,6 +27,7 @@ import aqt.operations
 from anki import hooks
 from anki.collection import OpChanges
 from anki.decks import UpdateDeckConfigs
+from anki.scheduler.v3 import SchedulingStatesWithContext
 from anki.scheduler_pb2 import SchedulingStates
 from anki.utils import dev_mode
 from aqt.changenotetype import ChangeNotetypeDialog
@@ -408,11 +409,11 @@ def update_deck_configs() -> bytes:
     return b""
 
 
-def get_scheduling_states() -> bytes:
-    if states := aqt.mw.reviewer.get_scheduling_states():
-        return states.SerializeToString()
-    else:
-        return b""
+def get_scheduling_states_with_context() -> bytes:
+    return SchedulingStatesWithContext(
+        states=aqt.mw.reviewer.get_scheduling_states(),
+        context=aqt.mw.reviewer.get_scheduling_context(),
+    ).SerializeToString()
 
 
 def set_scheduling_states() -> bytes:
@@ -420,12 +421,6 @@ def set_scheduling_states() -> bytes:
     states = SchedulingStates()
     states.ParseFromString(request.data)
     aqt.mw.reviewer.set_scheduling_states(key, states)
-    return b""
-
-
-def get_scheduling_context() -> bytes:
-    if ctx := aqt.mw.reviewer.get_scheduling_context():
-        return ctx.SerializeToString()
     return b""
 
 
@@ -457,9 +452,8 @@ post_handler_list = [
     congrats_info,
     get_deck_configs_for_update,
     update_deck_configs,
-    get_scheduling_states,
+    get_scheduling_states_with_context,
     set_scheduling_states,
-    get_scheduling_context,
     change_notetype,
     import_csv,
 ]

--- a/qt/aqt/reviewer.py
+++ b/qt/aqt/reviewer.py
@@ -83,6 +83,7 @@ class V3CardInfo:
 
     queued_cards: QueuedCards
     states: SchedulingStates
+    context: SchedulingContext
 
     @staticmethod
     def from_queue(queued_cards: QueuedCards) -> V3CardInfo:
@@ -90,8 +91,7 @@ class V3CardInfo:
         states = top_card.states
         states.current.custom_data = top_card.card.custom_data
         return V3CardInfo(
-            queued_cards=queued_cards,
-            states=states,
+            queued_cards=queued_cards, states=states, context=top_card.context
         )
 
     def top_card(self) -> QueuedCards.QueuedCard:
@@ -268,16 +268,12 @@ class Reviewer:
     def get_scheduling_states(self) -> SchedulingStates | None:
         if v3 := self._v3:
             return v3.states
-        else:
-            return None
+        return None
 
     def get_scheduling_context(self) -> SchedulingContext | None:
-        if not self.card:
-            return None
-        return SchedulingContext(
-            deck_name=self.mw.col.decks.name(self.card.current_deck_id()),
-            seed=self.card.review_hash(),
-        )
+        if v3 := self._v3:
+            return v3.context
+        return None
 
     def set_scheduling_states(self, key: str, states: SchedulingStates) -> None:
         if key != self._state_mutation_key:

--- a/qt/aqt/reviewer.py
+++ b/qt/aqt/reviewer.py
@@ -19,7 +19,7 @@ from anki.collection import Config, OpChanges, OpChangesWithCount
 from anki.scheduler.base import ScheduleCardsAsNew
 from anki.scheduler.v3 import CardAnswer, QueuedCards
 from anki.scheduler.v3 import Scheduler as V3Scheduler
-from anki.scheduler.v3 import SchedulingStates
+from anki.scheduler.v3 import SchedulingContext, SchedulingStates
 from anki.tags import MARKED_TAG
 from anki.types import assert_exhaustive
 from aqt import AnkiQt, gui_hooks
@@ -315,6 +315,14 @@ class Reviewer:
             return v3.states
         else:
             return None
+
+    def get_scheduling_context(self) -> SchedulingContext | None:
+        if not self.card:
+            return None
+        return SchedulingContext(
+            deck_name=self.mw.col.decks.name(self.card.current_deck_id()),
+            seed=self.card.review_hash(),
+        )
 
     def set_scheduling_states(self, key: str, states: SchedulingStates) -> None:
         if key != self._state_mutation_key:

--- a/qt/aqt/reviewer.py
+++ b/qt/aqt/reviewer.py
@@ -125,12 +125,6 @@ class V3CardInfo:
             return CardAnswer.EASY
 
 
-class State(Enum):
-    WAITING = 0
-    READY = 1
-    DELAYED = 2
-
-
 class Reviewer:
     def __init__(self, mw: AnkiQt) -> None:
         self.mw = mw

--- a/qt/aqt/reviewer.py
+++ b/qt/aqt/reviewer.py
@@ -1064,6 +1064,6 @@ time = %(time)d;
 
 
 RUN_STATE_MUTATION = """
-anki.mutateNextCardStates('{key}', (states, customData, ctx) => {{ {js} }})
+anki.mutateNextCardStates('{key}', async (states, customData, ctx) => {{ {js} }})
     .finally(() => bridgeCommand('statesMutated'));
 """

--- a/qt/aqt/reviewer.py
+++ b/qt/aqt/reviewer.py
@@ -280,7 +280,7 @@ class Reviewer:
     def _run_state_mutation_hook(self) -> None:
         if self._v3 and (js := self._state_mutation_js):
             self.web.eval(
-                f"anki.mutateNextCardStates('{self._state_mutation_key}', (states, customData) => {{ {js} }})"
+                RUN_STATE_MUTATION.format(key=self._state_mutation_key, js=js)
             )
 
     # Audio
@@ -360,7 +360,6 @@ class Reviewer:
         # render & update bottom
         q = self._mungeQA(q)
         q = gui_hooks.card_will_show(q, c, "reviewQuestion")
-        self._run_state_mutation_hook()
 
         bodyclass = theme_manager.body_classes_for_card_ord(c.ord)
         a = self.mw.col.media.escape_media_filenames(c.answer())
@@ -370,6 +369,7 @@ class Reviewer:
         )
         self._update_flag_icon()
         self._update_mark_icon()
+        self._run_state_mutation_hook()
         self._showAnswerButton()
         self.mw.web.setFocus()
         # user hook
@@ -1034,3 +1034,10 @@ time = %(time)d;
     onDelete = delete_current_note
     onMark = toggle_mark_on_current_note
     setFlag = set_flag_on_current_card
+
+
+RUN_STATE_MUTATION = """
+_queueAction(() => {{
+    anki.mutateNextCardStates('{key}', (states, customData) => {{ {js} }})
+}})
+"""

--- a/qt/aqt/reviewer.py
+++ b/qt/aqt/reviewer.py
@@ -416,6 +416,7 @@ class Reviewer:
         # render & update bottom
         q = self._mungeQA(q)
         q = gui_hooks.card_will_show(q, c, "reviewQuestion")
+        self._run_state_mutation_hook()
 
         bodyclass = theme_manager.body_classes_for_card_ord(c.ord)
         a = self.mw.col.media.escape_media_filenames(c.answer())
@@ -425,7 +426,6 @@ class Reviewer:
         )
         self._update_flag_icon()
         self._update_mark_icon()
-        self._run_state_mutation_hook()
         self._showAnswerButton()
         self.mw.web.setFocus()
         # user hook
@@ -1093,7 +1093,5 @@ time = %(time)d;
 
 
 RUN_STATE_MUTATION = """
-_queueAction(() => {{
-    anki.mutateNextCardStates('{key}', (states, customData) => {{ {js} }})
-}})
+anki.mutateNextCardStates('{key}', (states, customData, ctx) => {{ {js} }});
 """

--- a/rslib/src/backend/scheduler/answering.rs
+++ b/rslib/src/backend/scheduler/answering.rs
@@ -42,6 +42,7 @@ impl From<QueuedCard> for pb::scheduler::queued_cards::QueuedCard {
         Self {
             card: Some(queued_card.card.into()),
             states: Some(queued_card.states.into()),
+            context: Some(queued_card.context),
             queue: match queued_card.kind {
                 crate::scheduler::queue::QueueEntryKind::New => {
                     pb::scheduler::queued_cards::Queue::New

--- a/rslib/src/card/mod.rs
+++ b/rslib/src/card/mod.rs
@@ -184,6 +184,13 @@ impl Card {
             .max(1) as u32;
         (remaining != new_remaining).then_some(new_remaining)
     }
+
+    /// Supposedly unique across all reviews in the collection.
+    pub fn review_seed(&self) -> u64 {
+        (self.id.0 as u64)
+            .rotate_left(8)
+            .wrapping_add(self.reps as u64)
+    }
 }
 
 impl Collection {

--- a/ts/reviewer/answering.ts
+++ b/ts/reviewer/answering.ts
@@ -17,6 +17,12 @@ async function getSchedulingStates(): Promise<Scheduler.SchedulingStates> {
     );
 }
 
+async function getSchedulingContext(): Promise<Scheduler.SchedulingContext> {
+    return Scheduler.SchedulingContext.decode(
+        await postRequest("/_anki/getSchedulingContext", ""),
+    );
+}
+
 async function setSchedulingStates(
     key: string,
     states: Scheduler.SchedulingStates,
@@ -53,11 +59,18 @@ function packCustomData(
 
 export async function mutateNextCardStates(
     key: string,
-    mutator: (states: Scheduler.SchedulingStates, customData: CustomDataStates) => void,
+    mutator: (
+        states: Scheduler.SchedulingStates,
+        customData: CustomDataStates,
+        ctx: Scheduler.SchedulingContext,
+    ) => void,
 ): Promise<void> {
-    const states = await getSchedulingStates();
+    const [states, ctx] = await Promise.all([
+        getSchedulingStates(),
+        getSchedulingContext(),
+    ]);
     const customData = unpackCustomData(states);
-    mutator(states, customData);
+    mutator(states, customData, ctx);
     packCustomData(states, customData);
     await setSchedulingStates(key, states);
 }

--- a/ts/reviewer/answering.ts
+++ b/ts/reviewer/answering.ts
@@ -63,14 +63,14 @@ export async function mutateNextCardStates(
         states: Scheduler.SchedulingStates,
         customData: CustomDataStates,
         ctx: Scheduler.SchedulingContext,
-    ) => void,
+    ) => Promise<void>,
 ): Promise<void> {
     const [states, ctx] = await Promise.all([
         getSchedulingStates(),
         getSchedulingContext(),
     ]);
     const customData = unpackCustomData(states);
-    mutator(states, customData, ctx);
+    await mutator(states, customData, ctx);
     packCustomData(states, customData);
     await setSchedulingStates(key, states);
 }

--- a/ts/reviewer/answering.ts
+++ b/ts/reviewer/answering.ts
@@ -11,15 +11,9 @@ interface CustomDataStates {
     easy: Record<string, unknown>;
 }
 
-async function getSchedulingStates(): Promise<Scheduler.SchedulingStates> {
-    return Scheduler.SchedulingStates.decode(
-        await postRequest("/_anki/getSchedulingStates", ""),
-    );
-}
-
-async function getSchedulingContext(): Promise<Scheduler.SchedulingContext> {
-    return Scheduler.SchedulingContext.decode(
-        await postRequest("/_anki/getSchedulingContext", ""),
+async function getSchedulingStatesWithContext(): Promise<Scheduler.SchedulingStatesWithContext> {
+    return Scheduler.SchedulingStatesWithContext.decode(
+        await postRequest("/_anki/getSchedulingStatesWithContext", ""),
     );
 }
 
@@ -65,12 +59,10 @@ export async function mutateNextCardStates(
         ctx: Scheduler.SchedulingContext,
     ) => Promise<void>,
 ): Promise<void> {
-    const [states, ctx] = await Promise.all([
-        getSchedulingStates(),
-        getSchedulingContext(),
-    ]);
+    const statesWithContext = await getSchedulingStatesWithContext();
+    const states = statesWithContext.states!;
     const customData = unpackCustomData(states);
-    await mutator(states, customData, ctx);
+    await mutator(states, customData, statesWithContext.context!);
     packCustomData(states, customData);
     await setSchedulingStates(key, states);
 }


### PR DESCRIPTION
Closes #2409.

I wonder if there was a reason `_run_state_mutation_hook()` was called so early before. But then again, it usually ended up running after the rest anyway, so it should be fine.

I tested with a card template containing `<div id="deck">{{Deck}}</div>`, custom scheduling `console.log("The deck is " + document.getElementById("deck").innerHTML);` and the following patch:
```diff
diff --git a/ts/reviewer/index.ts b/ts/reviewer/index.ts
index c382f5182..3116a5239 100644
--- a/ts/reviewer/index.ts
+++ b/ts/reviewer/index.ts
@@ -121,6 +121,7 @@ export async function _updateQA(
     onupdate: Callback,
     onshown: Callback,
 ): Promise<void> {
+    await new Promise((resolve) => setTimeout(resolve, 1000));
     onUpdateHook.length = 0;
     onUpdateHook.push(onupdate);
```

This works now.

Heads-up, @L-M-Sherlock.