### PR TITLE
Fix silent file save failures and bad default save path in Flatpak

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -113,6 +113,7 @@ Mani <github.com/krmanik>
 Kaben Nanlohy <kaben.nanlohy@gmail.com>
 Tobias Predel <tobias.predel@gmail.com>
 Daniel Tang <danielzgtg.opensource@gmail.com>
+Jack Pearson <github.com/jrpear>
 
 ********************
 

--- a/qt/aqt/utils.py
+++ b/qt/aqt/utils.py
@@ -638,7 +638,7 @@ def getFile(
     return ret[0] if ret else None
 
 
-def checkNeedPortalSupport():
+def running_in_sandbox():
     """Check whether running in Flatpak or Snap. When in such a sandbox, Qt
     will not report the true location of user-chosen files, but instead a
     temporary location from which the sandboxing software will copy the file to
@@ -679,7 +679,7 @@ def getSaveFile(
         f"{key} (*{ext})",
         options=QFileDialog.Option.DontConfirmOverwrite,
     )[0]
-    if file and not checkNeedPortalSupport():
+    if file and not running_in_sandbox():
         # add extension
         if not file.lower().endswith(ext):
             file += ext

--- a/qt/aqt/utils.py
+++ b/qt/aqt/utils.py
@@ -638,6 +638,23 @@ def getFile(
     return ret[0] if ret else None
 
 
+def checkNeedPortalSupport():
+    """Check whether running in Flatpak or Snap. When in such a sandbox, Qt
+    will not report the true location of user-chosen files, but instead a
+    temporary location from which the sandboxing software will copy the file to
+    the user-chosen destination. Thus file renames are impossible and caching
+    the reported file location is unhelpful."""
+    in_flatpak = (
+        QStandardPaths.locate(
+            QStandardPaths.StandardLocation.RuntimeLocation,
+            "flatpak-info",
+        )
+        != ""
+    )
+    in_snap = os.environ.get("SNAP") != ""
+    return in_flatpak or in_snap
+
+
 def getSaveFile(
     parent: QDialog,
     title: str,
@@ -662,7 +679,7 @@ def getSaveFile(
         f"{key} (*{ext})",
         options=QFileDialog.Option.DontConfirmOverwrite,
     )[0]
-    if file:
+    if file and not checkNeedPortalSupport():
         # add extension
         if not file.lower().endswith(ext):
             file += ext


### PR DESCRIPTION
Fix the issue I reported on the forum [here](https://forums.ankiweb.net/t/bug-desktop-export-fails-in-flatpak-when-file-extension-is-not-provided-by-user/27115).

I've tested that this fixes the failure to save and the weird default save path in Flatpak.

My patch checks for Snap too because that's what I saw Qt does, but I haven't tested that this issue exists or is fixed in snap. I don't even know if there's an Anki snap.

I appreciated how easy it was to build and lint Anki. Makes me want to keep working with it.

Let me know if there're any changes I should make!