### PR TITLE
Make search in stats page trigger onChange

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -114,6 +114,7 @@ Kaben Nanlohy <kaben.nanlohy@gmail.com>
 Tobias Predel <tobias.predel@gmail.com>
 Daniel Tang <danielzgtg.opensource@gmail.com>
 Jack Pearson <github.com/jrpear>
+yellowjello <github.com/yellowjello>
 
 ********************
 

--- a/ts/graphs/RangeBox.svelte
+++ b/ts/graphs/RangeBox.svelte
@@ -55,11 +55,8 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         }
     }
 
-    function searchKeyUp(event: KeyboardEvent): void {
-        // fetch data on enter
-        if (event.code === "Enter") {
-            $search = displayedSearch;
-        }
+    function updateSearch(): void {
+        $search = displayedSearch;
     }
 
     const year = tr.statisticsRange_1YearHistory();
@@ -89,7 +86,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         <input
             type="text"
             bind:value={displayedSearch}
-            on:keyup={searchKeyUp}
+            on:change={updateSearch}
             on:focus={() => {
                 searchRange = SearchRange.Custom;
             }}


### PR DESCRIPTION
### Context/Issue:
AnkiDroid uses Anki's stats/graph page when the new backend is enabled, but the "on enter key up" trigger for search does not work on software keyboards on Android, so search essentially does not work unless a hardware keyboard is connected.

The reason is because many software keyboards on Android do not send out key codes by design.

### Approach:
This PR addresses this issue by triggering the search update with the onchange event. The onchange event fires if enter key is pressed or if the field loses focus. Pressing the enter key on Android appears to trigger this event as well.