### PR TITLE
Fallback to Wayland if X11 is not available

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -115,6 +115,7 @@ Tobias Predel <tobias.predel@gmail.com>
 Daniel Tang <danielzgtg.opensource@gmail.com>
 Jack Pearson <github.com/jrpear>
 yellowjello <github.com/yellowjello>
+Ingemar Berg <github.com/ingemarberg>
 
 ********************
 

--- a/qt/aqt/__init__.py
+++ b/qt/aqt/__init__.py
@@ -532,15 +532,16 @@ def _run(argv: Optional[list[str]] = None, exec: bool = True) -> Optional[AnkiAp
         and (os.getenv("QT_QPA_PLATFORM") == "wayland" or os.getenv("WAYLAND_DISPLAY"))
         and not os.getenv("ANKI_WAYLAND")
     ):
-        # users need to opt in to wayland support, given the issues it has
-        print("Wayland support is disabled by default due to bugs:")
-        print("https://github.com/ankitects/anki/issues/1767")
-        print("You can force it on with an env var: ANKI_WAYLAND=1")
         if not os.getenv("DISPLAY"):
             print(
-                "Trying to use X11, but it is not available. Falling back to Wayland."
+                "Trying to use X11, but it is not available. Falling back to Wayland, which has some bugs:"
             )
+            print("https://github.com/ankitects/anki/issues/1767")
         else:
+            # users need to opt in to wayland support, given the issues it has
+            print("Wayland support is disabled by default due to bugs:")
+            print("https://github.com/ankitects/anki/issues/1767")
+            print("You can force it on with an env var: ANKI_WAYLAND=1")
             os.environ["QT_QPA_PLATFORM"] = "xcb"
 
     # profile manager

--- a/qt/aqt/__init__.py
+++ b/qt/aqt/__init__.py
@@ -536,7 +536,12 @@ def _run(argv: Optional[list[str]] = None, exec: bool = True) -> Optional[AnkiAp
         print("Wayland support is disabled by default due to bugs:")
         print("https://github.com/ankitects/anki/issues/1767")
         print("You can force it on with an env var: ANKI_WAYLAND=1")
-        os.environ["QT_QPA_PLATFORM"] = "xcb"
+        if not os.getenv("DISPLAY"):
+            print(
+                "Trying to use X11, but it is not available. Falling back to Wayland."
+            )
+        else:
+            os.environ["QT_QPA_PLATFORM"] = "xcb"
 
     # profile manager
     i18n_setup = False


### PR DESCRIPTION
When Anki is running in a Wayland-only session and `ANKI_WAYLAND` is not set, Anki will crash on startup. It may be more helpful to print a warning and then fallback to Wayland instead. This might not be a very common case, but it can occur when Anki is running in a Flatpak sandbox. In this case `WAYLAND_DISPLAY` would be set, while `DISPLAY` is not. This pull request should fix that issue.

I had to temporarily change `getattr(sys, "frozen", False)` to `getattr(sys, "frozen", True)` in order to test this, but I assume that is to be expected when running a non-packaged version of Anki.

Please let me know if there is a better way to do this!