### PR TITLE
Fix current tag text not committed when changing note via shortcut key

### DIFF
--- a/ts/editor/NoteEditor.svelte
+++ b/ts/editor/NoteEditor.svelte
@@ -48,6 +48,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     import Absolute from "../components/Absolute.svelte";
     import Badge from "../components/Badge.svelte";
     import { TagEditor } from "../tag-editor";
+    import { commitTagEdits } from "../tag-editor/TagInput.svelte";
     import { ChangeTimer } from "./change-timer";
     import { clearableArray } from "./destroyable";
     import DuplicateLink from "./DuplicateLink.svelte";
@@ -280,9 +281,14 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         );
     }
 
-    export function saveFieldNow(): void {
+    function saveFieldNow(): void {
         /* this will always be a key save */
         fieldSave.fireImmediately();
+    }
+
+    function saveNow(): void {
+        commitTagEdits();
+        saveFieldNow();
     }
 
     export function saveOnPageHide() {
@@ -352,7 +358,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
             setTagsCollapsed,
             setBackgrounds,
             setClozeHint,
-            saveNow: saveFieldNow,
+            saveNow,
             focusIfField,
             getNoteId,
             setNoteId,

--- a/ts/tag-editor/TagInput.svelte
+++ b/ts/tag-editor/TagInput.svelte
@@ -2,12 +2,21 @@
 Copyright: Ankitects Pty Ltd and contributors
 License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 -->
-<script lang="ts">
-    import { createEventDispatcher, getContext, onMount, tick } from "svelte";
+<script context="module" lang="ts">
+    let current: HTMLInputElement | null = null;
 
+    export function commitTagEdits(): void {
+        current?.blur();
+    }
+</script>
+
+<script lang="ts">
     import { tagActionsShortcutsKey } from "@tslib/context-keys";
     import { isArrowLeft, isArrowRight } from "@tslib/keys";
     import { registerShortcut } from "@tslib/shortcuts";
+    import { createEventDispatcher, getContext, onMount, tick } from "svelte";
+    import type { ActionReturn } from "svelte/action";
+
     import {
         delimChar,
         normalizeTagname,
@@ -242,6 +251,17 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         registerShortcut(onSelectAll, selectAllShortcut, { target: input });
         input.focus();
     });
+
+    function updateCurrent(input: HTMLInputElement): ActionReturn {
+        current = input;
+        return {
+            destroy(): void {
+                if (current === input) {
+                    current = null;
+                }
+            },
+        };
+    }
 </script>
 
 <input
@@ -261,6 +281,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     on:input={() => dispatch("taginput")}
     on:copy|preventDefault={onCopy}
     on:paste|preventDefault={onPaste}
+    use:updateCurrent
 />
 
 <style lang="scss">


### PR DESCRIPTION
Fixes #1924

The issue also happens when closing editor with <kbd>Esc</kbd>.