### PR TITLE
Fix tags popover becoming separated from the tags field

### DIFF
--- a/ts/tag-editor/WithAutocomplete.svelte
+++ b/ts/tag-editor/WithAutocomplete.svelte
@@ -127,7 +127,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 <WithFloating
     keepOnKeyup
     show={$show}
-    preferredPlacement="top-start"
+    preferredPlacement="top"
     portalTarget={document.body}
     let:asReference
     on:close={() => show.set(false)}


### PR DESCRIPTION
This fixes the issue in https://forums.ankiweb.net/t/anki-2-1-61-beta/28361/2.

`"top-start"` doesn't seem to be a valid placement anymore.