### PR TITLE
Don't download nodejs if NODE_BINARY is set, add YARN_BINARY

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -117,6 +117,7 @@ Jack Pearson <github.com/jrpear>
 yellowjello <github.com/yellowjello>
 Ingemar Berg <github.com/ingemarberg>
 Ben Kerman <ben@kermanic.org>
+Euan Kemp <euank@euank.com>
 
 ********************
 

--- a/build/ninja_gen/src/node.rs
+++ b/build/ninja_gen/src/node.rs
@@ -129,7 +129,18 @@ pub fn setup_node(
     let node_binary = build.expand_inputs(node_binary);
     build.variable("node_binary", &node_binary[0]);
 
-    build.add("yarn", YarnSetup {})?;
+    match std::env::var("YARN_BINARY") {
+        Ok(path) => {
+            assert!(
+                Utf8Path::new(&path).is_absolute(),
+                "YARN_BINARY must be absolute"
+            );
+            build.add_resolved_files_to_group("yarn:bin", &vec![path]);
+        }
+        Err(_) => {
+            build.add("yarn", YarnSetup {})?;
+        }
+    };
 
     for binary in binary_exports {
         data_exports.insert(

--- a/build/ninja_gen/src/node.rs
+++ b/build/ninja_gen/src/node.rs
@@ -105,16 +105,6 @@ pub fn setup_node(
     binary_exports: &[&'static str],
     mut data_exports: HashMap<&str, Vec<Cow<str>>>,
 ) -> Result<()> {
-    download_and_extract(
-        build,
-        "node",
-        archive,
-        hashmap! {
-            "bin" => vec![if cfg!(windows) { "node.exe" } else { "bin/node" }],
-            "npm" => vec![if cfg!(windows) { "npm.cmd " } else { "bin/npm" }]
-        },
-    )?;
-
     let node_binary = match std::env::var("NODE_BINARY") {
         Ok(path) => {
             assert!(
@@ -124,6 +114,15 @@ pub fn setup_node(
             path.into()
         }
         Err(_) => {
+            download_and_extract(
+                build,
+                "node",
+                archive,
+                hashmap! {
+                    "bin" => vec![if cfg!(windows) { "node.exe" } else { "bin/node" }],
+                    "npm" => vec![if cfg!(windows) { "npm.cmd " } else { "bin/npm" }]
+                },
+            )?;
             inputs![":extract:node:bin"]
         }
     };


### PR DESCRIPTION
Some build environments, such as nixpkgs, restrict network access and
thus would prefer to not download anything at all. Setting PROTOC_BINARY
and friends makes the build system not download stuff, but the same was not true for nodejs.
This PR updates it so nodejs behaves similarly in that regard.

While I was at it, I also added YARN_BINARY which does what you'd expect.

For a little more context, these patches are what let this build system work over here: https://github.com/NixOS/nixpkgs/pull/221229

I, unfortunately, can't actually verify everything works without the \*_BINARY env vars set as easily because the binaries it downloads don't run on nixos, so the build of course fails.

<sup>(thanks for the excellent project btw <3)</sup>