### PR TITLE
fix stats calendar incorrect due to daylight savings time

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -118,6 +118,7 @@ yellowjello <github.com/yellowjello>
 Ingemar Berg <github.com/ingemarberg>
 Ben Kerman <ben@kermanic.org>
 Euan Kemp <euank@euank.com>
+Kieran Black <kieranlblack@gmail.com>
 
 ********************
 

--- a/proto/anki/stats.proto
+++ b/proto/anki/stats.proto
@@ -141,6 +141,7 @@ message GraphsResponse {
   FutureDue future_due = 7;
   Added added = 8;
   ReviewCountsAndTimes reviews = 9;
+  uint32 rollover_hour = 10;
 }
 
 message GraphPreferences {

--- a/qt/aqt/about.py
+++ b/qt/aqt/about.py
@@ -230,6 +230,7 @@ def show(mw: aqt.AnkiQt) -> QDialog:
             "hafatsat anki",
             "Carlos Duarte",
             "Edgar Benavent Català",
+            "Kieran Black",
         )
     )
 

--- a/rslib/src/stats/graphs/mod.rs
+++ b/rslib/src/stats/graphs/mod.rs
@@ -71,6 +71,7 @@ impl Collection {
             hours: Some(ctx.hours()),
             buttons: Some(ctx.buttons()),
             card_counts: Some(ctx.card_counts()),
+            rollover_hour: self.rollover_for_current_scheduler()? as u32,
         };
         Ok(resp)
     }

--- a/ts/graphs/calendar.ts
+++ b/ts/graphs/calendar.ts
@@ -85,7 +85,7 @@ export function renderCalendar(
     const dayMap: Map<number, DayDatum> = new Map();
     let maxCount = 0;
     for (const [day, count] of sourceData.reviewCount.entries()) {
-        const date = new Date(now.getTime() + day * 86400 * 1000);
+        const date = timeDay.offset(now, day);
         if (count > maxCount) {
             maxCount = count;
         }
@@ -110,7 +110,7 @@ export function renderCalendar(
     const oneYearAgoFromNow = new Date(now);
     oneYearAgoFromNow.setFullYear(now.getFullYear() - 1);
     for (let i = 0; i < 365; i++) {
-        const date = new Date(startDate.getTime() + i * 86400 * 1000);
+        const date = timeDay.offset(startDate, i);
         if (date > now) {
             // don't fill out future dates
             continue;


### PR DESCRIPTION
Previously, when computing counts for the calendar in the stats menu, it was assumed that days had 86,400 seconds. However, this assumption does not hold true on the day when daylight savings occurs. As such, there is an hour period where all reviews occurring after daylight savings are computed as belonging to the wrong day.

This screenshot was taken between 00:00 - 1:00 on Saturday. At that time no reviews had been completed for Saturday yet the shift by one day is visible in the graph with March 12th (DST went into effect) being recorded as having no reviews.
<img width="499" alt="image" src="https://user-images.githubusercontent.com/48463323/227741680-f383f6c9-0fb7-4294-add4-c59ade03adef.png">

The issue on the frontend is simpler to fix since the included library, `D3`, has a built-in time library which can account for DST. It  is trickier on the backend half of things.

I am currently working on fixing this issue.

Fixes #1025 