### PR TITLE
bump walkdir from 2.3.2 to 2.3.3

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -118,7 +118,7 @@ yellowjello <github.com/yellowjello>
 Ingemar Berg <github.com/ingemarberg>
 Ben Kerman <ben@kermanic.org>
 Euan Kemp <euank@euank.com>
-Kieran Black <kieranlblack@gmail.com
+Kieran Black <kieranlblack@gmail.com>
 
 ********************
 

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -118,7 +118,7 @@ yellowjello <github.com/yellowjello>
 Ingemar Berg <github.com/ingemarberg>
 Ben Kerman <ben@kermanic.org>
 Euan Kemp <euank@euank.com>
-Kieran Black <kieranlblack@gmail.com>
+Kieran Black <kieranlblack@gmail.com
 
 ********************
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4405,12 +4405,11 @@ checksum = "9d5b2c62b4012a3e1eca5a7e077d13b3bf498c4073e33ccd58626607748ceeca"
 
 [[package]]
 name = "walkdir"
-version = "2.3.2"
+version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
+checksum = "36df944cda56c7d8d8b7496af378e6b16de9284591917d307c9b4d313c44e698"
 dependencies = [
  "same-file",
- "winapi",
  "winapi-util",
 ]
 

--- a/build/ninja_gen/Cargo.toml
+++ b/build/ninja_gen/Cargo.toml
@@ -15,6 +15,6 @@ itertools = "0.10.5"
 lazy_static = "1.4.0"
 maplit = "1.0.2"
 num_cpus = "1.15.0"
-walkdir = "2.3.2"
+walkdir = "2.3.3"
 which = "4.3.0"
 workspace-hack = { version = "0.1", path = "../../tools/workspace-hack" }

--- a/qt/bundle/mac/Cargo.toml
+++ b/qt/bundle/mac/Cargo.toml
@@ -19,5 +19,5 @@ plist = "1.4.0"
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1.0.91"
 simple-file-manifest = "0.11.0"
-walkdir = "2.3.2"
+walkdir = "2.3.3"
 workspace-hack = { version = "0.1", path = "../../../tools/workspace-hack" }

--- a/qt/bundle/win/Cargo.toml
+++ b/qt/bundle/win/Cargo.toml
@@ -14,5 +14,5 @@ camino = "1.1.2"
 clap = { version = "4.1.1", features = ["derive"] }
 glob = "0.3.1"
 tugger-windows-codesign = "0.10.0"
-walkdir = "2.3.2"
+walkdir = "2.3.3"
 workspace-hack = { version = "0.1", path = "../../../tools/workspace-hack" }


### PR DESCRIPTION
Build was failing on windows due to `walkdir` matching `.` as any folder starting with `.` instead of as the cwd and so when generating cached files for the build process, only folders and files starting with a `.` were available. Could still build but had to bootstrap with a linux environment first.

It seems that `walkdir` inadvertently fixed this in the latest version.