### PR TITLE
Add a deck selector to Stats

### DIFF
--- a/qt/aqt/forms/stats.ui
+++ b/qt/aqt/forms/stats.ui
@@ -44,30 +44,17 @@
       <number>8</number>
      </property>
      <property name="leftMargin">
-      <number>6</number>
+      <number>16</number>
      </property>
      <property name="topMargin">
       <number>6</number>
      </property>
      <property name="rightMargin">
-      <number>6</number>
+      <number>16</number>
      </property>
      <property name="bottomMargin">
       <number>6</number>
      </property>
-     <item>
-      <spacer name="horizontalSpacer">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
      <item>
       <widget class="QGroupBox" name="groupBox_2">
        <property name="title">
@@ -128,6 +115,19 @@
       </widget>
      </item>
      <item>
+      <layout class="QHBoxLayout" name="horizontalLayout_4">
+       <property name="topMargin">
+        <number>4</number>
+       </property>
+       <property name="bottomMargin">
+        <number>0</number>
+       </property>
+       <item alignment="Qt::AlignLeft">
+        <widget class="QWidget" name="deckArea" native="true"/>
+       </item>
+      </layout>
+     </item>
+     <item alignment="Qt::AlignRight">
       <widget class="QDialogButtonBox" name="buttonBox">
        <property name="orientation">
         <enum>Qt::Horizontal</enum>
@@ -139,19 +139,6 @@
         <bool>true</bool>
        </property>
       </widget>
-     </item>
-     <item>
-      <spacer name="horizontalSpacer_2">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
      </item>
     </layout>
    </item>

--- a/qt/aqt/stats.py
+++ b/qt/aqt/stats.py
@@ -8,7 +8,9 @@ from typing import Any
 import aqt
 import aqt.forms
 import aqt.main
+from anki.decks import DeckId
 from aqt import gui_hooks
+from aqt.operations.deck import set_current_deck
 from aqt.qt import *
 from aqt.theme import theme_manager
 from aqt.utils import (
@@ -43,6 +45,15 @@ class NewDeckStats(QDialog):
         f.groupBox.setVisible(False)
         f.groupBox_2.setVisible(False)
         restoreGeom(self, self.name, default_size=(800, 800))
+
+        from aqt.deckchooser import DeckChooser
+
+        DeckChooser(
+            self.mw,
+            f.deckArea,
+            on_deck_changed=self.on_deck_changed,
+        )
+
         b = f.buttonBox.addButton(
             tr.statistics_save_pdf(), QDialogButtonBox.ButtonRole.ActionRole
         )
@@ -68,6 +79,11 @@ class NewDeckStats(QDialog):
     def closeWithCallback(self, callback: Callable[[], None]) -> None:
         self.reject()
         callback()
+
+    def on_deck_changed(self, deck_id: int) -> None:
+        set_current_deck(parent=self.mw, deck_id=DeckId(deck_id)).success(
+            lambda _: self.refresh()
+        ).run_in_background(initiator=self)
 
     def _imagePath(self) -> str:
         name = time.strftime("-%Y-%m-%d@%H-%M-%S.pdf", time.localtime(time.time()))

--- a/qt/aqt/stats.py
+++ b/qt/aqt/stats.py
@@ -44,6 +44,8 @@ class NewDeckStats(QDialog):
         f.setupUi(self)
         f.groupBox.setVisible(False)
         f.groupBox_2.setVisible(False)
+        if not is_mac:
+            f.horizontalLayout_4.setContentsMargins(0, 0, 0, 0)
         restoreGeom(self, self.name, default_size=(800, 800))
 
         from aqt.deckchooser import DeckChooser

--- a/qt/aqt/stats.py
+++ b/qt/aqt/stats.py
@@ -61,6 +61,8 @@ class NewDeckStats(QDialog):
         )
         qconnect(b.clicked, self.saveImage)
         b.setAutoDefault(False)
+        b = f.buttonBox.button(QDialogButtonBox.StandardButton.Close)
+        b.setAutoDefault(False)
         maybeHideClose(self.form.buttonBox)
         addCloseShortcut(self)
         gui_hooks.stats_dialog_will_show(self)

--- a/qt/aqt/stats.py
+++ b/qt/aqt/stats.py
@@ -85,9 +85,9 @@ class NewDeckStats(QDialog):
         callback()
 
     def on_deck_changed(self, deck_id: int) -> None:
-        set_current_deck(parent=self.mw, deck_id=DeckId(deck_id)).success(
+        set_current_deck(parent=self, deck_id=DeckId(deck_id)).success(
             lambda _: self.refresh()
-        ).run_in_background(initiator=self)
+        ).run_in_background()
 
     def _imagePath(self) -> str:
         name = time.strftime("-%Y-%m-%d@%H-%M-%S.pdf", time.localtime(time.time()))


### PR DESCRIPTION
### What this PR does
Add a deck selector to the UI of the stats screen to make it easier to switch between decks.

Closes #2434

### Approach
- Reuse existing DeckChooser and put in in the bottom bar of the (new) stats screen
- Change current deck on deck selection and reload stats page
- Left align the deck chooser and right align the save pdf/close buttons

### Questions
1. Currently, the size of the deck chooser corresponds to the length of the deck name. Should we add a constraint to the size like min/max/fixed size?
<img width="699" alt="Screenshot 2023-03-28 at 1 55 37 PM" src="https://user-images.githubusercontent.com/5134058/228371394-cae2801c-f074-47ba-b7d1-1edde5f8b998.png">
<img width="699" alt="Screenshot 2023-03-28 at 1 56 00 PM" src="https://user-images.githubusercontent.com/5134058/228371438-5758fa0c-b131-4d68-bd35-051d53d59cda.png">

2. Removing the spacers and right-aligning button box made it so that the elements are also left/right aligned instead of centered in the legacy stats screen. Is this fine?
<img width="699" alt="Screenshot 2023-03-28 at 1 57 31 PM" src="https://user-images.githubusercontent.com/5134058/228372777-72512a9a-7884-42f4-b0b3-dacc95160d0c.png">