### PR TITLE
Fix MathJax editor sometimes not properly sized / getting cut off

### DIFF
--- a/ts/components/Popover.svelte
+++ b/ts/components/Popover.svelte
@@ -86,7 +86,6 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         }
 
         &.hidden {
-            width: 0;
             visibility: hidden;
         }
 

--- a/ts/editor/mathjax-overlay/MathjaxEditor.svelte
+++ b/ts/editor/mathjax-overlay/MathjaxEditor.svelte
@@ -114,7 +114,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         overflow: hidden;
 
         :global(.CodeMirror) {
-            max-width: 28rem;
+            max-width: 100ch;
             min-width: 14rem;
             margin-bottom: 0.25rem;
         }

--- a/ts/editor/mathjax-overlay/MathjaxOverlay.svelte
+++ b/ts/editor/mathjax-overlay/MathjaxOverlay.svelte
@@ -210,6 +210,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
                 reference={activeImage}
                 offset={20}
                 keepOnKeyup
+                portalTarget={document.body}
                 let:position={positionFloating}
                 on:close={resetHandle}
             >


### PR DESCRIPTION
Includes fixes for a few issues with the MathJax editor and a style change.

### Issues
- Fixes #2463
    - Appears to have regressed in #2224
    - I confirmed that 9a38815 does not re-introduce the weird animation issue mentioned in #2224.
- When 'Reduce motion' is enabled, a popover appears momentarily out of position and then shifts to the correct position.

    https://user-images.githubusercontent.com/47855854/230796898-0e434722-6726-40b3-922e-cb0c859aa7fd.mp4

- MathJax editor sometimes getting cut off

    ![mathjax-editor-cut-off](https://user-images.githubusercontent.com/47855854/230797067-ce9f1910-af88-45d0-bd46-4da2f5fe2b99.png)

### Style change
While creating this PR, I felt that the maximum width of the Mathjax editor was too narrow, so I made it wide enough to display approximately 100 characters per line.