### PR TITLE
Refactor plain/rich text input toggling code; fix focus loss

### DIFF
--- a/ts/editor/helpers.ts
+++ b/ts/editor/helpers.ts
@@ -21,7 +21,7 @@ export function withFontColor(
 }
 
 export class Flag {
-    flag: boolean;
+    private flag: boolean;
 
     constructor() {
         this.flag = false;
@@ -31,7 +31,8 @@ export class Flag {
         this.flag = on;
     }
 
-    check(): boolean {
+    /** Resets the flag to false and returns the previous value. */
+    checkAndReset(): boolean {
         const val = this.flag;
         this.flag = false;
         return val;

--- a/ts/editor/helpers.ts
+++ b/ts/editor/helpers.ts
@@ -1,9 +1,6 @@
 // Copyright: Ankitects Pty Ltd and contributors
 // License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
-import type { PlainTextInputAPI } from "./plain-text-input";
-import type { RichTextInputAPI } from "./rich-text-input";
-
 function isFontElement(element: Element): element is HTMLFontElement {
     return element.tagName === "FONT";
 }
@@ -23,14 +20,20 @@ export function withFontColor(
     return false;
 }
 
-/***
- * Required for field inputs wrapped in Collapsible
- */
-export async function refocusInput(
-    api: RichTextInputAPI | PlainTextInputAPI,
-): Promise<void> {
-    do {
-        await new Promise(window.requestAnimationFrame);
-    } while (!api.focusable);
-    api.refocus();
+export class Flag {
+    flag: boolean;
+
+    constructor() {
+        this.flag = false;
+    }
+
+    setFlag(on: boolean): void {
+        this.flag = on;
+    }
+
+    check(): boolean {
+        const val = this.flag;
+        this.flag = false;
+        return val;
+    }
 }

--- a/ts/editor/plain-text-input/PlainTextInput.svelte
+++ b/ts/editor/plain-text-input/PlainTextInput.svelte
@@ -37,11 +37,13 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     import { baseOptions, gutterOptions, htmlanki } from "../code-mirror";
     import CodeMirror from "../CodeMirror.svelte";
     import { context as editingAreaContext } from "../EditingArea.svelte";
+    import { Flag } from "../helpers";
     import { context as noteEditorContext } from "../NoteEditor.svelte";
     import removeProhibitedTags from "./remove-prohibited";
     import { storedToUndecorated, undecoratedToStored } from "./transform";
 
     export let hidden = false;
+    export const focusFlag = new Flag();
 
     $: configuration = {
         mode: htmlanki,
@@ -115,7 +117,12 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
     $: {
         pushUpdate(!hidden);
-        tick().then(refresh);
+        tick().then(() => {
+            refresh();
+            if (focusFlag.check()) {
+                refocus();
+            }
+        });
     }
 
     function onChange({ detail: html }: CustomEvent<string>): void {

--- a/ts/editor/plain-text-input/PlainTextInput.svelte
+++ b/ts/editor/plain-text-input/PlainTextInput.svelte
@@ -119,7 +119,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         pushUpdate(!hidden);
         tick().then(() => {
             refresh();
-            if (focusFlag.check()) {
+            if (focusFlag.checkAndReset()) {
                 refocus();
             }
         });

--- a/ts/editor/rich-text-input/RichTextInput.svelte
+++ b/ts/editor/rich-text-input/RichTextInput.svelte
@@ -196,7 +196,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
     $: {
         pushUpdate(!hidden);
-        if (focusFlag.check()) {
+        if (focusFlag.checkAndReset()) {
             tick().then(refocus);
         }
     }

--- a/ts/editor/rich-text-input/RichTextInput.svelte
+++ b/ts/editor/rich-text-input/RichTextInput.svelte
@@ -64,7 +64,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     import { directionKey, fontFamilyKey, fontSizeKey } from "@tslib/context-keys";
     import { promiseWithResolver } from "@tslib/promise";
     import { singleCallback } from "@tslib/typing";
-    import { getAllContexts, getContext, onMount } from "svelte";
+    import { getAllContexts, getContext, onMount, tick } from "svelte";
     import type { Readable } from "svelte/store";
 
     import { placeCaretAfterContent } from "../../domlib/place-caret";
@@ -73,6 +73,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     import useInputHandler from "../../sveltelib/input-handler";
     import { pageTheme } from "../../sveltelib/theme";
     import { context as editingAreaContext } from "../EditingArea.svelte";
+    import { Flag } from "../helpers";
     import { context as noteEditorContext } from "../NoteEditor.svelte";
     import getNormalizingNodeStore from "./normalizing-node-store";
     import useRichTextResolve from "./rich-text-resolve";
@@ -80,6 +81,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     import { fragmentToStored, storedToFragment } from "./transform";
 
     export let hidden = false;
+    export const focusFlag = new Flag();
 
     const { focusedInput } = noteEditorContext.get();
     const { content, editingInputs } = editingAreaContext.get();
@@ -192,7 +194,12 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         $apiStore = null;
     }
 
-    $: pushUpdate(!hidden);
+    $: {
+        pushUpdate(!hidden);
+        if (focusFlag.check()) {
+            tick().then(refocus);
+        }
+    }
 
     onMount(() => {
         $editingInputs.push(api);


### PR DESCRIPTION
Fixes #2476

The main purpose of this refactoring is to move the focus processing inside the reactive statements so that polling using `requestAnimationFrame` is no longer necessary.