### PR TITLE
Add a hook that allows to edit a note before it is added.

### DIFF
--- a/pylib/anki/collection.py
+++ b/pylib/anki/collection.py
@@ -562,6 +562,7 @@ class Collection(DeprecatedNamesMixin):
         return Note(self, notetype)
 
     def add_note(self, note: Note, deck_id: DeckId) -> OpChanges:
+        hooks.note_will_be_added(self, note, deck_id)
         out = self._backend.add_note(note=note._to_backend_note(), deck_id=deck_id)
         note.id = NoteId(out.note_id)
         return out.changes

--- a/pylib/tools/genhooks.py
+++ b/pylib/tools/genhooks.py
@@ -38,7 +38,12 @@ hooks = [
             "note: anki.notes.Note",
             "deck_id: anki.decks.DeckId",
         ],
-        doc="Can modify the note before it is added to the collection.",
+        doc="""Allows modifying a note before it's added to the collection.
+
+        This hook may be called both when users use the Add screen, and when
+        add-ons like AnkiConnect add notes. It is not called when importing. If
+        you wish to alter the Add screen, use gui_hooks.add_cards_will_add_note
+        instead.""",
     ),
     Hook(
         name="media_files_did_export",

--- a/pylib/tools/genhooks.py
+++ b/pylib/tools/genhooks.py
@@ -33,7 +33,7 @@ hooks = [
     ),
     Hook(
         name="note_will_be_added",
-        args=["col: anki.collection.Collection", "note: Note", "deck_id: DeckId"],
+        args=["col: anki.collection.Collection", "note: anki.notes.Note", "deck_id: anki.decks.DeckId"],
         doc="Can modify the note before it is added to the collection.",
     ),
     Hook(

--- a/pylib/tools/genhooks.py
+++ b/pylib/tools/genhooks.py
@@ -33,7 +33,11 @@ hooks = [
     ),
     Hook(
         name="note_will_be_added",
-        args=["col: anki.collection.Collection", "note: anki.notes.Note", "deck_id: anki.decks.DeckId"],
+        args=[
+            "col: anki.collection.Collection",
+            "note: anki.notes.Note",
+            "deck_id: anki.decks.DeckId",
+        ],
         doc="Can modify the note before it is added to the collection.",
     ),
     Hook(

--- a/pylib/tools/genhooks.py
+++ b/pylib/tools/genhooks.py
@@ -32,6 +32,11 @@ hooks = [
         legacy_hook="remNotes",
     ),
     Hook(
+        name="note_will_be_added",
+        args=["col: anki.collection.Collection", "note: Note", "deck_id: DeckId"],
+        doc="Can modify the note before it is added to the collection.",
+    ),
+    Hook(
         name="media_files_did_export",
         args=["count: int"],
         doc="Only used by legacy .apkg exporter. Will be deprecated in the future.",


### PR DESCRIPTION
This hook lets us change a note before it is added to the collection. 

It can be used for intercepting notes that AnkiConnect adds and adding new information to them.