### PR TITLE
Fix sync client ignoring directories

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -119,6 +119,7 @@ Ingemar Berg <github.com/ingemarberg>
 Ben Kerman <ben@kermanic.org>
 Euan Kemp <euank@euank.com>
 Kieran Black <kieranlblack@gmail.com>
+XeR <github.com/XeR>
 
 ********************
 

--- a/rslib/src/backend/sync/mod.rs
+++ b/rslib/src/backend/sync/mod.rs
@@ -90,7 +90,7 @@ impl TryFrom<pb::sync::SyncAuth> for SyncAuth {
                         // are detected but URLs like computer.local:8000 are not.
                         // By calling join() now, these URLs are detected too and later code that
                         // uses and unwraps the result of join() doesn't panic
-                        .and_then(|x| x.join("/"))
+                        .and_then(|x| x.join("./"))
                         .or_invalid("Invalid sync server specified. Please check the preferences.")
                 })
                 .transpose()?,


### PR DESCRIPTION
Current implementation of the sync client does not properly send requests to a self-hosted sync server if the URL has directories.

If the self-hosted sync URL is `https://example.org/foo/bar/`, Anki is expected to send requests to `https://example.org/foo/bar/sync/hostKey`. Instead, it will discard the directories and wrongly send requests to `https://example.org/sync/hostKey`.

Fixes: e5d5d1d ("Fix panic with invalid sync server URL with port")