### PR TITLE
Fix custom font preloading sometimes not working

### DIFF
--- a/ts/reviewer/preload.ts
+++ b/ts/reviewer/preload.ts
@@ -94,9 +94,9 @@ function preloadFonts(fragment: DocumentFragment): Promise<void>[] {
 export async function preloadResources(html: string): Promise<void> {
     template.innerHTML = html;
     const fragment = template.content;
-    const styleSheets = preloadStyleSheets(fragment);
-    const images = preloadImages(fragment);
-    const fonts = preloadFonts(fragment);
+    const styleSheets = preloadStyleSheets(fragment.cloneNode(true) as DocumentFragment);
+    const images = preloadImages(fragment.cloneNode(true) as DocumentFragment);
+    const fonts = preloadFonts(fragment.cloneNode(true) as DocumentFragment);
 
     let timeout: number;
     if (fonts.length) {


### PR DESCRIPTION
This fixes an issue with my previous PR #2356 where custom font preloading would not work if both a reference to an external style sheet and a description of a custom font are present in a style element.