### PR TITLE
Add pycmd to play all card audio in sequence

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -120,6 +120,7 @@ Ben Kerman <ben@kermanic.org>
 Euan Kemp <euank@euank.com>
 Kieran Black <kieranlblack@gmail.com>
 XeR <github.com/XeR>
+BtbN <btbn@btbn.de>
 
 ********************
 

--- a/qt/aqt/sound.py
+++ b/qt/aqt/sound.py
@@ -824,14 +824,21 @@ def av_refs_to_play_icons(text: str) -> str:
 
 
 def play_clicked_audio(pycmd: str, card: Card) -> None:
-    """eg. if pycmd is 'play:q:0', play the first audio on the question side."""
+    """eg. if pycmd is 'play:q:0', play the first audio on the question side.
+    Likewise, if it is 'play:a:all', play all card audio in sequence."""
     play, context, str_idx = pycmd.split(":")
-    idx = int(str_idx)
+    try:
+        idx = int(str_idx)
+    except ValueError:
+        idx = 0
     if context == "q":
         tags = card.question_av_tags()
     else:
         tags = card.answer_av_tags()
-    av_player.play_tags([tags[idx]])
+    if str_idx == "all":
+        av_player.play_tags(tags)
+    else:
+        av_player.play_tags([tags[idx]])
 
 
 # Init defaults


### PR DESCRIPTION
This adds a pycmd for playing all card audio in sequence.
The primary use for this is to add a "Play"-Button to Card templates, which just replays all the audio on the card.
As opposed to just one single clip.

It also allows for more complex Card-Side JavaScript, which can base the decision on whether to play or not to play the audio on more complex factors, like the entered answer or a bit of data from the corresponding Note.