### PR TITLE
Allow the user to configure answer keys

### DIFF
--- a/ftl/core/preferences.ftl
+++ b/ftl/core/preferences.ftl
@@ -72,6 +72,7 @@ preferences-import-export = Import/Export
 preferences-network-timeout = Network timeout
 preferences-reset-window-sizes = Reset Window Sizes
 preferences-reset-window-sizes-complete = Window sizes and locations have been reset.
+preferences-shortcut-placeholder = Enter an unused shortcut key, or leave empty to disable.
 
 ## NO NEED TO TRANSLATE. This text is no longer used by Anki, and will be removed in the future.
 

--- a/ftl/core/preferences.ftl
+++ b/ftl/core/preferences.ftl
@@ -58,6 +58,7 @@ preferences-appearance = Appearance
 preferences-general = General
 preferences-style = Style
 preferences-review = Review
+preferences-answer-keys = Answer keys
 preferences-distractions = Distractions
 preferences-minimalist-mode = Minimalist mode
 preferences-editing = Editing

--- a/qt/aqt/forms/preferences.ui
+++ b/qt/aqt/forms/preferences.ui
@@ -245,7 +245,7 @@
       <attribute name="title">
        <string>preferences_review</string>
       </attribute>
-      <layout class="QVBoxLayout" name="verticalLayout_6">
+      <layout class="QVBoxLayout" name="review_options_layout">
        <item>
         <widget class="QGroupBox" name="schedulerGroup">
          <property name="title">

--- a/qt/aqt/preferences.py
+++ b/qt/aqt/preferences.py
@@ -61,7 +61,7 @@ class Preferences(QDialog):
             (3, tr.studying_good()),
             (4, tr.studying_easy()),
         )
-        self.form.verticalLayout_6.addWidget(
+        self.form.review_options_layout.addWidget(
             group := QGroupBox(tr.preferences_answer_keys())
         )
         group.setLayout(layout := QFormLayout())

--- a/qt/aqt/preferences.py
+++ b/qt/aqt/preferences.py
@@ -79,10 +79,7 @@ class Preferences(QDialog):
                     QRegularExpression(r"^[a-z0-9\]\[=,./;\'\\-]$")
                 )
             )
-            line_edit.setPlaceholderText("Key letter")
-            line_edit.setToolTip(
-                "Leave empty to disable.\nIf a key is taken by something else, behavior is undefined."
-            )
+            line_edit.setPlaceholderText(tr.preferences_shortcut_placeholder())
 
     def accept(self) -> None:
         # avoid exception if main window is already closed

--- a/qt/aqt/profiles.py
+++ b/qt/aqt/profiles.py
@@ -10,7 +10,7 @@ import shutil
 import traceback
 from enum import Enum
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Optional
 
 import anki.lang
 import aqt.forms

--- a/qt/aqt/profiles.py
+++ b/qt/aqt/profiles.py
@@ -116,6 +116,8 @@ class LoadMetaResult:
 
 
 class ProfileManager:
+    default_answer_keys = {ease_num: str(ease_num) for ease_num in range(1, 5)}
+
     def __init__(self, base: Path) -> None:  #
         "base should be retrieved via ProfileMangager.get_created_base_folder"
         ## Settings which should be forgotten each Anki restart
@@ -536,6 +538,12 @@ create table if not exists profiles
 
     def set_spacebar_rates_card(self, on: bool) -> None:
         self.meta["spacebar_rates_card"] = on
+
+    def get_answer_key(self, ease: int) -> Optional[str]:
+        return self.meta.setdefault("answer_keys", self.default_answer_keys).get(ease)
+
+    def set_answer_key(self, ease: int, key: str):
+        self.meta.setdefault("answer_keys", self.default_answer_keys)[ease] = key
 
     def hide_top_bar(self) -> bool:
         return self.meta.get("hide_top_bar", False)

--- a/qt/aqt/reviewer.py
+++ b/qt/aqt/reviewer.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import functools
 import json
 import random
 import re
@@ -507,14 +508,11 @@ class Reviewer:
             ("o", self.onOptions),
             ("i", self.on_card_info),
             ("Ctrl+Alt+i", self.on_previous_card_info),
-            ("1", lambda: self._answerCard(1)),
-            ("2", lambda: self._answerCard(2)),
-            ("3", lambda: self._answerCard(3)),
-            ("4", lambda: self._answerCard(4)),
-            ("h", lambda: self._answerCard(1)),
-            ("j", lambda: self._answerCard(2)),
-            ("k", lambda: self._answerCard(3)),
-            ("l", lambda: self._answerCard(4)),
+            *(
+                (key, functools.partial(self._answerCard, ease))
+                for ease in aqt.mw.pm.default_answer_keys
+                if (key := aqt.mw.pm.get_answer_key(ease))
+            ),
             ("u", self.mw.undo),
             ("5", self.on_pause_audio),
             ("6", self.on_seek_backward),


### PR DESCRIPTION
This PR adds a group box in Preferences > Review which lets the user change answer keys. By default answer keys are set to numbers: [1,2,3,4].

![screenshot-2023-05-16-09-08-38](https://github.com/ankitects/anki/assets/69171671/fc5d93bf-0033-4b2f-b82c-a5175ef3e608)

Some translations are currently not implemented. 