### PR TITLE
Add zoom out and zoom in shortcuts

### DIFF
--- a/qt/aqt/forms/main.ui
+++ b/qt/aqt/forms/main.ui
@@ -258,10 +258,16 @@
    <property name="text">
     <string>qt_accel_zoom_in</string>
    </property>
+   <property name="shortcut">
+    <string notr="true">Ctrl+=</string>
+   </property>
   </action>
   <action name="actionZoomOut">
    <property name="text">
     <string>qt_accel_zoom_out</string>
+   </property>
+   <property name="shortcut">
+    <string notr="true">Ctrl+-</string>
    </property>
   </action>
   <action name="actionResetZoom">


### PR DESCRIPTION
Added missing keyboard shortcuts for zooming in and out, which can be handy while reviewing cards.