### PR TITLE
Ensure there's no duplicate shortcuts after running state_shortcuts_will_change

### DIFF
--- a/qt/aqt/main.py
+++ b/qt/aqt/main.py
@@ -1126,6 +1126,9 @@ title="{}" {}>{}</button>""".format(
         gui_hooks.state_shortcuts_will_change(self.state, shortcuts)
         # legacy hook
         runHook(f"{self.state}StateShortcuts", shortcuts)
+        # remove duplicate shortcuts (possibly added by add-ons)
+        # by filtering them through a dictionary.
+        shortcuts = list(dict(shortcuts).items())
         self.stateShortcuts = self.applyShortcuts(shortcuts)
 
     def clearStateShortcuts(self) -> None:

--- a/qt/aqt/main.py
+++ b/qt/aqt/main.py
@@ -1112,16 +1112,20 @@ title="{}" {}>{}</button>""".format(
         self.applyShortcuts(globalShortcuts)
         self.stateShortcuts: list[QShortcut] = []
 
+    def _normalize_shortcuts(
+        self, shortcuts: Sequence[tuple[str, Callable]]
+    ) -> Sequence[tuple[QKeySequence, Callable]]:
+        """
+        Remove duplicate shortcuts (possibly added by add-ons)
+        by normalizing them and filtering through a dictionary.
+        """
+        return tuple({QKeySequence(key): fn for key, fn in shortcuts}.items())
+
     def applyShortcuts(
         self, shortcuts: Sequence[tuple[str, Callable]]
     ) -> list[QShortcut]:
-        # remove duplicate shortcuts (possibly added by add-ons)
-        # by normalizing them and filtering through a dictionary.
-        shortcuts: dict[QKeySequence, Callable] = {
-            QKeySequence(key): fn for key, fn in shortcuts
-        }
         qshortcuts = []
-        for key, fn in shortcuts.items():
+        for key, fn in self._normalize_shortcuts(shortcuts):
             scut = QShortcut(key, self, activated=fn)  # type: ignore
             scut.setAutoRepeat(False)
             qshortcuts.append(scut)

--- a/qt/aqt/main.py
+++ b/qt/aqt/main.py
@@ -1118,6 +1118,8 @@ title="{}" {}>{}</button>""".format(
         """
         Remove duplicate shortcuts (possibly added by add-ons)
         by normalizing them and filtering through a dictionary.
+        The last duplicate shortcut wins, so add-ons will override
+        standard shortcuts if they append to the shortcut list.
         """
         return tuple({QKeySequence(key): fn for key, fn in shortcuts}.items())
 

--- a/qt/aqt/main.py
+++ b/qt/aqt/main.py
@@ -1115,8 +1115,13 @@ title="{}" {}>{}</button>""".format(
     def applyShortcuts(
         self, shortcuts: Sequence[tuple[str, Callable]]
     ) -> list[QShortcut]:
+        # remove duplicate shortcuts (possibly added by add-ons)
+        # by normalizing them and filtering through a dictionary.
+        shortcuts: dict[QKeySequence, Callable] = {
+            QKeySequence(key): fn for key, fn in shortcuts
+        }
         qshortcuts = []
-        for key, fn in shortcuts:
+        for key, fn in shortcuts.items():
             scut = QShortcut(QKeySequence(key), self, activated=fn)  # type: ignore
             scut.setAutoRepeat(False)
             qshortcuts.append(scut)
@@ -1126,9 +1131,6 @@ title="{}" {}>{}</button>""".format(
         gui_hooks.state_shortcuts_will_change(self.state, shortcuts)
         # legacy hook
         runHook(f"{self.state}StateShortcuts", shortcuts)
-        # remove duplicate shortcuts (possibly added by add-ons)
-        # by filtering them through a dictionary.
-        shortcuts = list(dict(shortcuts).items())
         self.stateShortcuts = self.applyShortcuts(shortcuts)
 
     def clearStateShortcuts(self) -> None:

--- a/qt/aqt/main.py
+++ b/qt/aqt/main.py
@@ -1122,7 +1122,7 @@ title="{}" {}>{}</button>""".format(
         }
         qshortcuts = []
         for key, fn in shortcuts.items():
-            scut = QShortcut(QKeySequence(key), self, activated=fn)  # type: ignore
+            scut = QShortcut(key, self, activated=fn)  # type: ignore
             scut.setAutoRepeat(False)
             qshortcuts.append(scut)
         return qshortcuts


### PR DESCRIPTION
There are add-ons that `extend` the list of shortcuts but forget to check if the new keys are already occupied. Such add-ons will break every time Anki changes its default shortcuts. 

Some affected add-ons: 

* https://ankiweb.net/shared/info/850294128
* https://ankiweb.net/shared/info/1844908621 ([code](https://github.com/glutanimate/hint-hotkeys/blob/41054cdd509ec91acf95260e8a24ba7dab1702e7/src/hint_hotkeys/_addon.py#L74))

Instead of forcing the authors to release fixes, we can filter the list of shortcrust for them, after they modify it. If this PR is merged, any default shortcuts should always be overridden by add-ons. And Anki will be able to freely modify any of its shortcuts in the future without worrying about add-ons.