### PR TITLE
Make Anki's MathJax typesetting awaitable

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -124,6 +124,7 @@ mgrottenthaler <github.com/mgrottenthaler>
 Austin Siew <github.com/Aquafina-water-bottle>
 Joel Koen <mail@joelkoen.com>
 Christopher Woggon <christopher.woggon@gmail.com>
+Nil Admirari <https://github.com/nihil-admirari>
 
 ********************
 

--- a/ts/reviewer/index.ts
+++ b/ts/reviewer/index.ts
@@ -147,14 +147,14 @@ export async function _updateQA(
     bridgeCommand("updateToolbar");
 
     // wait for mathjax to ready
-    await MathJax.startup.promise
+    await (MathJax.startup.promise = MathJax.startup.promise
         .then(() => {
             // clear MathJax buffers from previous typesets
             MathJax.typesetClear();
 
             return MathJax.typesetPromise([qa]);
         })
-        .catch(renderError("MathJax"));
+        .catch(renderError("MathJax")));
 
     qa.style.opacity = "1";
 


### PR DESCRIPTION
`MathJax.startup.promise` must be reassigned to make downstream code await not only MathJax's initial typesetting, but Anki's typesetting as well. See e.g. the following block in [MathJax's documentation](https://docs.mathjax.org/en/latest/web/typeset.html)

```js
function typeset(code) {
  MathJax.startup.promise = MathJax.startup.promise
    .then(() => MathJax.typesetPromise(code()))
    .catch((err) => console.log('Typeset failed: ' + err.message));
  return MathJax.startup.promise;
}
```