### PR TITLE
Fix some add-on installation errors not being reported

### DIFF
--- a/qt/aqt/addons.py
+++ b/qt/aqt/addons.py
@@ -1184,6 +1184,7 @@ class DownloaderInstaller(QObject):
 
     def _download_done(self, future: Future) -> None:
         self.mgr.mw.progress.finish()
+        future.result()
         # qt gets confused if on_done() opens new windows while the progress
         # modal is still cleaning up
         self.mgr.mw.progress.single_shot(50, lambda: self.on_done(self.log))


### PR DESCRIPTION
A missing future.result() call was masking add-on install/update errors. You can reproduce the issue by installing my add-on [InContext](https://ankiweb.net/shared/info/385420176), then manually decreasing meta.json's `mod` value and checking for add-on updates to trigger an update. You should see that the download progress dialog closes silently with Anki showing the "No updates available." tooltip. Anki then will prompt to update the same add-on every time.

In the case of InContext, a PermissionError was being masked, which is caused by the add-on holding a DB connection to a file in the user_files folder indefinitely, preventing Anki from backing up the folder (only a problem on Windows AFAIK).

I guess the issue in my add-on can be solved by either (1) refactoring the add-on to hold a DB connection only when absolutely needed, (2) patching some methods or (3) making use of hooks to close the connection when the add-on is being deleted/updated. I prefer (3) but the `addons_dialog_will_delete_addons` hook for example is not called when updating. Will you accept a PR that adds a call to it in the update routine, or maybe adds a new hook?