### PR TITLE
 Add add-on installation hooks 

### DIFF
--- a/qt/aqt/addons.py
+++ b/qt/aqt/addons.py
@@ -426,7 +426,9 @@ class AddonManager:
             conflicts = manifest.get("conflicts", [])
             found_conflicts = self._disableConflicting(package, conflicts)
             meta = self.addonMeta(package)
+            gui_hooks.addon_manager_will_install_addon(self, package)
             self._install(package, zfile)
+            gui_hooks.addon_manager_did_install_addon(self, package)
 
         schema = self._manifest_schema["properties"]
         manifest_meta = {

--- a/qt/tools/genhooks_gui.py
+++ b/qt/tools/genhooks_gui.py
@@ -1214,12 +1214,18 @@ gui_hooks.webview_did_inject_style_into_page.append(mytest)
     Hook(
         name="addon_manager_will_install_addon",
         args=["manager: aqt.addons.AddonManager", "module: str"],
-        doc="""Called before installing or updating an addon.""",
+        doc="""Called before installing or updating an addon.
+        
+        Can be used to release DB connections or open files that
+        would prevent an update from succeeding.""",
     ),
     Hook(
         name="addon_manager_did_install_addon",
         args=["manager: aqt.addons.AddonManager", "module: str"],
-        doc="""Called after installing or updating an addon.""",
+        doc="""Called after installing or updating an addon.
+        
+        Can be used to restore DB connections or open files after
+        an add-on has been updated.""",
     ),
     # Model
     ###################

--- a/qt/tools/genhooks_gui.py
+++ b/qt/tools/genhooks_gui.py
@@ -1211,6 +1211,16 @@ gui_hooks.webview_did_inject_style_into_page.append(mytest)
         args=["dialog: aqt.addons.AddonsDialog", "ids: list[str]"],
         doc="""Allows doing an action before an add-on is deleted.""",
     ),
+    Hook(
+        name="addon_manager_will_install_addon",
+        args=["manager: aqt.addons.AddonManager", "module: str"],
+        doc="""Called before installing or updating an addon.""",
+    ),
+    Hook(
+        name="addon_manager_did_install_addon",
+        args=["manager: aqt.addons.AddonManager", "module: str"],
+        doc="""Called after installing or updating an addon.""",
+    ),
     # Model
     ###################
     Hook(


### PR DESCRIPTION
A follow-up to #2518

This adds the `addons_manager_will_install_addon` and `addons_manager_did_install_addon` hooks. My main use case is to prevent update errors caused by the add-on holding a DB connection to some file in the add-on folder.  Example usage:
```python
def on_addon_manager_will_install_addon(manager, module):
    if module == manager.addonFromModule(__name__):
        db.close()


def on_addon_manager_did_install_addon(manager, module):
    if module == manager.addonFromModule(__name__):
        db.init()


gui_hooks.addon_manager_will_install_addon.append(
    on_addon_manager_will_install_addon
)

gui_hooks.addon_manager_did_install_addon.append(
    on_addon_manager_did_install_addon
)
```

Another common source of installation errors are open .pyd files coming from bundled dependencies. The AnkiHub add-on for example patches `AddonManager.deleteAddon` twice to work around similar errors. (I probably have a bunch of more add-ons suffering from this issue too).

dc066bb fixes a crash in .deleteAddon() when run from the update routine and OSError is thrown there.