### PR TITLE
change window name when reviewing or deck screen

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -124,6 +124,7 @@ mgrottenthaler <github.com/mgrottenthaler>
 Austin Siew <github.com/Aquafina-water-bottle>
 Joel Koen <mail@joelkoen.com>
 Christopher Woggon <christopher.woggon@gmail.com>
+Sudomain <sudomain1@gmail.com>
 
 ********************
 

--- a/qt/aqt/main.py
+++ b/qt/aqt/main.py
@@ -732,6 +732,8 @@ class AnkiQt(QMainWindow):
     def _reviewState(self, oldState: MainWindowState) -> None:
         self.reviewer.show()
 
+        self.setWindowTitle("Study - Anki")
+
         if self.pm.hide_top_bar():
             self.toolbarWeb.hide_timer.setInterval(500)
             self.toolbarWeb.hide_timer.start()
@@ -748,6 +750,7 @@ class AnkiQt(QMainWindow):
             self.toolbarWeb.elevate()
             self.toolbarWeb.show()
             self.bottomWeb.show()
+            self.setWindowTitle(f"{self.pm.name} - Anki")
 
     # Resetting state
     ##########################################################################


### PR DESCRIPTION
Caused by my [forum post](https://forums.ankiweb.net/t/feature-request-when-studying-a-deck-change-window-title-to-studying-deck-name/30736), I need Anki to have a different window title when studying a deck than when the deck overview screen is shown. Currently the title is "USERNAME - Anki" for both.

Possible further aesthetic enhancements would be:
1. having the deck name that's being studied in the title
2. number of cards and/or ETA left to study in the title
3. Having a different window title than "USERNAME - Anki" on the study/deck overview screen (not sure what the name is for this, but it's the screen that shows after selecting a deck but before pressing "study now")

I didn't attempt these things in case they were changes are too large (or too computationally expensive). I only needed a different window title to target Anki using an xdotool script.