### PR TITLE
Automate schema 11 other duplicates clearing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,6 +97,7 @@ dependencies = [
  "csv",
  "difflib",
  "env_logger",
+ "field_names_derive",
  "flate2",
  "fluent",
  "fluent-bundle",
@@ -1172,6 +1173,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
 dependencies = [
  "instant",
+]
+
+[[package]]
+name = "field_names_derive"
+version = "0.0.0"
+dependencies = [
+ "quote",
+ "syn 2.0.12",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
   "rslib/i18n",
   "rslib/i18n_helpers",
   "rslib/linkchecker",
+  "rslib/field_names_derive",
   "pylib/rsbridge",
   "build/configure",
   "build/ninja_gen",

--- a/rslib/Cargo.toml
+++ b/rslib/Cargo.toml
@@ -42,6 +42,7 @@ features = ["json", "socks", "stream", "multipart"]
 
 [dependencies]
 anki_i18n = { path = "i18n" }
+field_names_derive = { path = "field_names_derive" }
 
 csv = { git = "https://github.com/ankitects/rust-csv.git", rev = "1c9d3aab6f79a7d815c69f925a46a4590c115f90" }
 percent-encoding-iri = { git = "https://github.com/ankitects/rust-url.git", rev = "bb930b8d089f4d30d7d19c12e54e66191de47b88" }

--- a/rslib/field_names_derive/Cargo.toml
+++ b/rslib/field_names_derive/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "field_names_derive"
+publish = false
+description = "Derive macro for the FieldNames trait defined in the anki crate"
+
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+rust-version.workspace = true
+
+[lib]
+proc-macro = true
+
+[dependencies]
+quote = "1.0"
+syn = "2.0"

--- a/rslib/field_names_derive/src/lib.rs
+++ b/rslib/field_names_derive/src/lib.rs
@@ -1,0 +1,31 @@
+// Copyright: Ankitects Pty Ltd and contributors
+// License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
+
+//! Derive macro for the trait [anki::serde::FieldNames].
+
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::parse_macro_input;
+use syn::ItemStruct;
+
+/// Derive macro for the trait [anki::serde::FieldNames].
+#[proc_macro_derive(FieldNames)]
+pub fn derive_field_names(input: TokenStream) -> TokenStream {
+    let item = parse_macro_input!(input as ItemStruct);
+    let name = &item.ident;
+    let field_names = item
+        .fields
+        .iter()
+        .filter_map(|f| f.ident.as_ref())
+        .map(ToString::to_string);
+
+    quote! {
+        impl crate::serde::FieldNames for #name {
+            /// The named fields of this struct as strings.
+            fn field_names() -> &'static [&'static str] {
+                &[#(#field_names),*]
+            }
+        }
+    }
+    .into()
+}

--- a/rslib/src/serde.rs
+++ b/rslib/src/serde.rs
@@ -9,6 +9,10 @@ use serde_json::Value;
 
 use crate::timestamp::TimestampSecs;
 
+pub(crate) trait FieldNames {
+    fn field_names() -> &'static [&'static str];
+}
+
 /// Note: if you wish to cover the case where a field is missing, make sure you
 /// also use the `serde(default)` flag.
 pub(crate) fn default_on_invalid<'de, T, D>(deserializer: D) -> Result<T, D::Error>

--- a/rslib/src/text.rs
+++ b/rslib/src/text.rs
@@ -538,6 +538,23 @@ where
     })
 }
 
+pub(crate) fn snake_to_camel_case(snake: impl AsRef<str>) -> String {
+    let mut camel = String::with_capacity(snake.as_ref().len());
+    let mut capitalize = false;
+    for mut ch in snake.as_ref().chars() {
+        if ch == '_' {
+            capitalize = true;
+        } else {
+            if capitalize {
+                ch = ch.to_ascii_uppercase();
+            }
+            camel.push(ch);
+            capitalize = false;
+        }
+    }
+    camel
+}
+
 #[cfg(test)]
 mod test {
     use std::borrow::Cow;
@@ -643,5 +660,12 @@ mod test {
                 &format!("<img src=\"{output}\">")
             );
         }
+    }
+
+    #[test]
+    fn case_conversion() {
+        assert_eq!(snake_to_camel_case("snamel"), "snamel");
+        assert_eq!(snake_to_camel_case("snaky_snake"), "snakySnake");
+        assert_eq!(snake_to_camel_case("snaky_snake_2"), "snakySnake2");
     }
 }

--- a/tools/minilints/src/main.rs
+++ b/tools/minilints/src/main.rs
@@ -36,6 +36,7 @@ const IGNORED_FOLDERS: &[&str] = &[
     "./qt/aqt/forms",
     "./tools/workspace-hack",
     "./qt/bundle/PyOxidizer",
+    "./target",
 ];
 
 fn main() -> Result<()> {


### PR DESCRIPTION
While working on the discussed notetype import improvements, I noticed an issue with the duplicate clearing and decided to try to get rid of it for good with a proc macro. What do you think?
I could also add it to the remaining schema 11 structs, so that if they get extended, too, in the future, there's no risk of forgetting that.