### PR TITLE
Refactor progress handling

### DIFF
--- a/qt/aqt/mediacheck.py
+++ b/qt/aqt/mediacheck.py
@@ -59,6 +59,7 @@ class MediaChecker:
 
     def _set_progress_enabled(self, enabled: bool) -> None:
         if self._progress_timer:
+            self._progress_timer.stop()
             self._progress_timer.deleteLater()
             self._progress_timer = None
         if enabled:

--- a/qt/aqt/mediasync.py
+++ b/qt/aqt/mediasync.py
@@ -78,6 +78,7 @@ class MediaSyncer:
     def _on_finished(self, future: Future) -> None:
         self._syncing = False
         if self._progress_timer:
+            self._progress_timer.stop()
             self._progress_timer.deleteLater()
             self._progress_timer = None
         gui_hooks.media_sync_did_start_or_stop(False)

--- a/qt/aqt/progress.py
+++ b/qt/aqt/progress.py
@@ -236,6 +236,7 @@ class ProgressManager:
                 self._show_timer.stop()
                 self._show_timer = None
         if self._backend_timer:
+            self._backend_timer.stop()
             self._backend_timer.deleteLater()
             self._backend_timer = None
 

--- a/rslib/src/collection/mod.rs
+++ b/rslib/src/collection/mod.rs
@@ -11,6 +11,7 @@ use std::fmt::Debug;
 use std::fmt::Formatter;
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::sync::Mutex;
 
 use anki_i18n::I18n;
 use anki_io::create_dir_all;
@@ -21,6 +22,7 @@ use crate::decks::DeckId;
 use crate::error::Result;
 use crate::notetype::Notetype;
 use crate::notetype::NotetypeId;
+use crate::progress::ProgressState;
 use crate::scheduler::queue::CardQueues;
 use crate::scheduler::SchedulerInfo;
 use crate::storage::SchemaVersion;
@@ -39,6 +41,7 @@ pub struct CollectionBuilder {
     check_integrity: bool,
     // temporary option for AnkiDroid
     force_schema11: Option<bool>,
+    progress_handler: Option<Arc<Mutex<ProgressState>>>,
 }
 
 impl CollectionBuilder {
@@ -50,7 +53,7 @@ impl CollectionBuilder {
         builder
     }
 
-    pub fn build(&self) -> Result<Collection> {
+    pub fn build(&mut self) -> Result<Collection> {
         let col_path = self
             .collection_path
             .clone()
@@ -74,7 +77,10 @@ impl CollectionBuilder {
             media_db,
             tr,
             server,
-            state: CollectionState::default(),
+            state: CollectionState {
+                progress: self.progress_handler.clone().unwrap_or_default(),
+                ..Default::default()
+            },
         };
 
         Ok(col)
@@ -121,6 +127,13 @@ impl CollectionBuilder {
         self.check_integrity = check_integrity;
         self
     }
+
+    /// If provided, progress info will be written to the provided mutex, and
+    /// can be tracked on a separate thread.
+    pub fn set_shared_progress_state(&mut self, state: Arc<Mutex<ProgressState>>) -> &mut Self {
+        self.progress_handler = Some(state);
+        self
+    }
 }
 
 #[derive(Debug, Default)]
@@ -137,11 +150,11 @@ pub struct CollectionState {
     /// The modification time at the last backup, so we don't create multiple
     /// identical backups.
     pub(crate) last_backup_modified: Option<TimestampMillis>,
+    pub(crate) progress: Arc<Mutex<ProgressState>>,
 }
 
 pub struct Collection {
     pub storage: SqliteStorage,
-    #[allow(dead_code)]
     pub(crate) col_path: PathBuf,
     pub(crate) media_folder: PathBuf,
     pub(crate) media_db: PathBuf,

--- a/rslib/src/import_export/gather.rs
+++ b/rslib/src/import_export/gather.rs
@@ -8,10 +8,10 @@ use anki_io::filename_is_safe;
 use itertools::Itertools;
 
 use super::ExportProgress;
-use super::IncrementableProgress;
 use crate::decks::immediate_parent_name;
 use crate::latex::extract_latex;
 use crate::prelude::*;
+use crate::progress::ThrottlingProgressHandler;
 use crate::revlog::RevlogEntry;
 use crate::search::CardTableGuard;
 use crate::search::NoteTableGuard;
@@ -61,7 +61,7 @@ impl ExchangeData {
 
     pub(super) fn gather_media_names(
         &mut self,
-        progress: &mut IncrementableProgress<ExportProgress>,
+        progress: &mut ThrottlingProgressHandler<ExportProgress>,
     ) -> Result<()> {
         let mut inserter = |name: String| {
             if filename_is_safe(&name) {

--- a/rslib/src/import_export/mod.rs
+++ b/rslib/src/import_export/mod.rs
@@ -6,8 +6,6 @@ mod insert;
 pub mod package;
 pub mod text;
 
-use std::marker::PhantomData;
-
 pub use anki_proto::import_export::import_response::Log as NoteLog;
 pub use anki_proto::import_export::import_response::Note as LogNote;
 use snafu::Snafu;
@@ -18,97 +16,25 @@ use crate::text::strip_html_preserving_media_filenames;
 use crate::text::truncate_to_char_boundary;
 use crate::text::CowMapping;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum ImportProgress {
-    File,
+    #[default]
     Extracting,
+    File,
     Gathering,
     Media(usize),
     MediaCheck(usize),
     Notes(usize),
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum ExportProgress {
+    #[default]
     File,
     Gathering,
     Notes(usize),
     Cards(usize),
     Media(usize),
-}
-
-/// Wrapper around a progress function, usually passed by the
-/// [crate::backend::Backend], to make repeated calls more ergonomic.
-pub(crate) struct IncrementableProgress<P>(Box<dyn FnMut(P, bool) -> bool>);
-
-impl<P> IncrementableProgress<P> {
-    /// `progress_fn: (progress, throttle) -> should_continue`
-    pub(crate) fn new(progress_fn: impl 'static + FnMut(P, bool) -> bool) -> Self {
-        Self(Box::new(progress_fn))
-    }
-
-    /// Returns an [Incrementor] with an `increment()` function for use in
-    /// loops.
-    pub(crate) fn incrementor<'inc, 'progress: 'inc, 'map: 'inc>(
-        &'progress mut self,
-        mut count_map: impl 'map + FnMut(usize) -> P,
-    ) -> Incrementor<'inc, impl FnMut(usize) -> Result<()> + 'inc> {
-        Incrementor::new(move |u| self.update(count_map(u), true))
-    }
-
-    /// Manually triggers an update.
-    /// Returns [AnkiError::Interrupted] if the operation should be cancelled.
-    pub(crate) fn call(&mut self, progress: P) -> Result<()> {
-        self.update(progress, false)
-    }
-
-    fn update(&mut self, progress: P, throttle: bool) -> Result<()> {
-        if (self.0)(progress, throttle) {
-            Ok(())
-        } else {
-            Err(AnkiError::Interrupted)
-        }
-    }
-
-    /// Stopgap for returning a progress fn compliant with the media code.
-    pub(crate) fn media_db_fn(
-        &mut self,
-        count_map: impl 'static + Fn(usize) -> P,
-    ) -> Result<impl FnMut(usize) -> bool + '_> {
-        Ok(move |count| (self.0)(count_map(count), true))
-    }
-}
-
-pub(crate) struct Incrementor<'f, F: 'f + FnMut(usize) -> Result<()>> {
-    update_fn: F,
-    count: usize,
-    update_interval: usize,
-    _phantom: PhantomData<&'f ()>,
-}
-
-impl<'f, F: 'f + FnMut(usize) -> Result<()>> Incrementor<'f, F> {
-    fn new(update_fn: F) -> Self {
-        Self {
-            update_fn,
-            count: 0,
-            update_interval: 17,
-            _phantom: PhantomData,
-        }
-    }
-
-    /// Increments the progress counter, periodically triggering an update.
-    /// Returns [AnkiError::Interrupted] if the operation should be cancelled.
-    pub(crate) fn increment(&mut self) -> Result<()> {
-        self.count += 1;
-        if self.count % self.update_interval != 0 {
-            return Ok(());
-        }
-        (self.update_fn)(self.count)
-    }
-
-    pub(crate) fn count(&self) -> usize {
-        self.count
-    }
 }
 
 impl Note {

--- a/rslib/src/import_export/package/apkg/import/media.rs
+++ b/rslib/src/import_export/package/apkg/import/media.rs
@@ -15,10 +15,10 @@ use crate::import_export::package::media::extract_media_entries;
 use crate::import_export::package::media::MediaCopier;
 use crate::import_export::package::media::SafeMediaEntry;
 use crate::import_export::ImportProgress;
-use crate::import_export::IncrementableProgress;
 use crate::media::files::add_hash_suffix_to_file_stem;
 use crate::media::files::sha1_of_reader;
 use crate::prelude::*;
+use crate::progress::ThrottlingProgressHandler;
 
 /// Map of source media files, that do not already exist in the target.
 #[derive(Default)]
@@ -76,7 +76,7 @@ fn prepare_media(
     media_entries: Vec<SafeMediaEntry>,
     archive: &mut ZipArchive<File>,
     existing_sha1s: &HashMap<String, Sha1Hash>,
-    progress: &mut IncrementableProgress<ImportProgress>,
+    progress: &mut ThrottlingProgressHandler<ImportProgress>,
 ) -> Result<MediaUseMap> {
     let mut media_map = MediaUseMap::default();
     let mut incrementor = progress.incrementor(ImportProgress::MediaCheck);

--- a/rslib/src/import_export/package/apkg/tests.rs
+++ b/rslib/src/import_export/package/apkg/tests.rs
@@ -48,10 +48,9 @@ fn roundtrip_inner(legacy: bool) {
             true,
             legacy,
             None,
-            |_, _| true,
         )
         .unwrap();
-    target_col.import_apkg(&apkg_path, |_, _| true).unwrap();
+    target_col.import_apkg(&apkg_path).unwrap();
 
     target_col.assert_decks();
     target_col.assert_notetype(&notetype);

--- a/rslib/src/import_export/package/colpkg/tests.rs
+++ b/rslib/src/import_export/package/colpkg/tests.rs
@@ -40,7 +40,8 @@ fn roundtrip() -> Result<()> {
         // export to a file
         let col = collection_with_media(dir, name)?;
         let colpkg_name = dir.join(format!("{name}.colpkg"));
-        col.export_colpkg(&colpkg_name, true, legacy, |_, _| true)?;
+        let progress = col.new_progress_handler();
+        col.export_colpkg(&colpkg_name, true, legacy)?;
 
         // import into a new collection
         let anki2_name = dir
@@ -56,7 +57,7 @@ fn roundtrip() -> Result<()> {
             &anki2_name,
             &import_media_dir,
             &import_media_db,
-            |_, _| true,
+            progress,
         )?;
 
         // confirm collection imported
@@ -89,8 +90,7 @@ fn normalization_check_on_export() -> Result<()> {
     // manually write a file in the wrong encoding.
     write_file(col.media_folder.join("ぱぱ.jpg"), "nfd encoding")?;
     assert_eq!(
-        col.export_colpkg(&colpkg_name, true, false, |_, _| true,)
-            .unwrap_err(),
+        col.export_colpkg(&colpkg_name, true, false,).unwrap_err(),
         AnkiError::MediaCheckRequired
     );
     // file should have been cleaned up

--- a/rslib/src/import_export/text/csv/export.rs
+++ b/rslib/src/import_export/text/csv/export.rs
@@ -15,7 +15,6 @@ use regex::Regex;
 use super::metadata::Delimiter;
 use crate::import_export::text::csv::metadata::DelimeterExt;
 use crate::import_export::ExportProgress;
-use crate::import_export::IncrementableProgress;
 use crate::notetype::RenderCardOutput;
 use crate::prelude::*;
 use crate::search::SearchNode;
@@ -32,10 +31,8 @@ impl Collection {
         path: &str,
         search: impl TryIntoSearch,
         with_html: bool,
-        progress_fn: impl 'static + FnMut(ExportProgress, bool) -> bool,
     ) -> Result<usize> {
-        let mut progress = IncrementableProgress::new(progress_fn);
-        progress.call(ExportProgress::File)?;
+        let mut progress = self.new_progress_handler::<ExportProgress>();
         let mut incrementor = progress.incrementor(ExportProgress::Cards);
 
         let mut writer = file_writer_with_header(path, with_html)?;
@@ -52,13 +49,8 @@ impl Collection {
         Ok(cards.len())
     }
 
-    pub fn export_note_csv(
-        &mut self,
-        mut request: ExportNoteCsvRequest,
-        progress_fn: impl 'static + FnMut(ExportProgress, bool) -> bool,
-    ) -> Result<usize> {
-        let mut progress = IncrementableProgress::new(progress_fn);
-        progress.call(ExportProgress::File)?;
+    pub fn export_note_csv(&mut self, mut request: ExportNoteCsvRequest) -> Result<usize> {
+        let mut progress = self.new_progress_handler::<ExportProgress>();
         let mut incrementor = progress.incrementor(ExportProgress::Notes);
 
         let guard = self.search_notes_into_table(Into::<SearchNode>::into(&mut request))?;

--- a/rslib/src/import_export/text/csv/import.rs
+++ b/rslib/src/import_export/text/csv/import.rs
@@ -18,24 +18,19 @@ use crate::import_export::text::csv::metadata::Delimiter;
 use crate::import_export::text::ForeignData;
 use crate::import_export::text::ForeignNote;
 use crate::import_export::text::NameOrId;
-use crate::import_export::ImportProgress;
 use crate::import_export::NoteLog;
 use crate::prelude::*;
 use crate::text::strip_utf8_bom;
 
 impl Collection {
-    pub fn import_csv(
-        &mut self,
-        path: &str,
-        metadata: CsvMetadata,
-        progress_fn: impl 'static + FnMut(ImportProgress, bool) -> bool,
-    ) -> Result<OpOutput<NoteLog>> {
+    pub fn import_csv(&mut self, path: &str, metadata: CsvMetadata) -> Result<OpOutput<NoteLog>> {
+        let progress = self.new_progress_handler();
         let file = open_file(path)?;
         let mut ctx = ColumnContext::new(&metadata)?;
         let notes = ctx.deserialize_csv(file, metadata.delimiter())?;
         let mut data = ForeignData::from(metadata);
         data.notes = notes;
-        data.import(self, progress_fn)
+        data.import(self, progress)
     }
 }
 

--- a/rslib/src/import_export/text/json.rs
+++ b/rslib/src/import_export/text/json.rs
@@ -4,29 +4,20 @@
 use anki_io::read_file;
 
 use crate::import_export::text::ForeignData;
-use crate::import_export::ImportProgress;
 use crate::import_export::NoteLog;
 use crate::prelude::*;
 
 impl Collection {
-    pub fn import_json_file(
-        &mut self,
-        path: &str,
-        mut progress_fn: impl 'static + FnMut(ImportProgress, bool) -> bool,
-    ) -> Result<OpOutput<NoteLog>> {
-        progress_fn(ImportProgress::Gathering, false);
+    pub fn import_json_file(&mut self, path: &str) -> Result<OpOutput<NoteLog>> {
+        let progress = self.new_progress_handler();
         let slice = read_file(path)?;
         let data: ForeignData = serde_json::from_slice(&slice)?;
-        data.import(self, progress_fn)
+        data.import(self, progress)
     }
 
-    pub fn import_json_string(
-        &mut self,
-        json: &str,
-        mut progress_fn: impl 'static + FnMut(ImportProgress, bool) -> bool,
-    ) -> Result<OpOutput<NoteLog>> {
-        progress_fn(ImportProgress::Gathering, false);
+    pub fn import_json_string(&mut self, json: &str) -> Result<OpOutput<NoteLog>> {
+        let progress = self.new_progress_handler();
         let data: ForeignData = serde_json::from_str(json)?;
-        data.import(self, progress_fn)
+        data.import(self, progress)
     }
 }

--- a/rslib/src/lib.rs
+++ b/rslib/src/lib.rs
@@ -28,6 +28,7 @@ pub mod notetype;
 pub mod ops;
 mod preferences;
 pub mod prelude;
+mod progress;
 pub mod revlog;
 pub mod scheduler;
 pub mod search;

--- a/rslib/src/media/mod.rs
+++ b/rslib/src/media/mod.rs
@@ -16,6 +16,7 @@ use crate::media::files::mtime_as_i64;
 use crate::media::files::remove_files;
 use crate::media::files::sha1_of_data;
 use crate::prelude::*;
+use crate::progress::ThrottlingProgressHandler;
 use crate::sync::http_client::HttpSyncClient;
 use crate::sync::login::SyncAuth;
 use crate::sync::media::database::client::changetracker::ChangeTracker;
@@ -139,10 +140,11 @@ impl MediaManager {
     }
 
     /// Sync media.
-    pub async fn sync_media<F>(self, progress: F, auth: SyncAuth) -> Result<()>
-    where
-        F: FnMut(MediaSyncProgress) -> bool,
-    {
+    pub async fn sync_media(
+        self,
+        progress: ThrottlingProgressHandler<MediaSyncProgress>,
+        auth: SyncAuth,
+    ) -> Result<()> {
         let client = HttpSyncClient::new(auth);
         let mut syncer = MediaSyncer::new(self, progress, client)?;
         syncer.sync().await

--- a/rslib/src/sync/collection/finish.rs
+++ b/rslib/src/sync/collection/finish.rs
@@ -3,15 +3,11 @@
 
 use crate::prelude::*;
 use crate::sync::collection::normal::ClientSyncState;
-use crate::sync::collection::normal::NormalSyncProgress;
 use crate::sync::collection::normal::NormalSyncer;
 use crate::sync::collection::protocol::EmptyInput;
 use crate::sync::collection::protocol::SyncProtocol;
 
-impl<F> NormalSyncer<'_, F>
-where
-    F: FnMut(NormalSyncProgress, bool),
-{
+impl NormalSyncer<'_> {
     pub(in crate::sync) async fn finalize(&mut self, state: &ClientSyncState) -> Result<()> {
         let new_server_mtime = self.server.finish(EmptyInput::request()).await?.json()?;
         self.col.finalize_sync(state, new_server_mtime)

--- a/rslib/src/sync/collection/progress.rs
+++ b/rslib/src/sync/collection/progress.rs
@@ -27,5 +27,3 @@ pub async fn sync_abort(auth: SyncAuth) -> error::Result<()> {
         .await?
         .json()
 }
-
-pub type FullSyncProgressFn = Box<dyn FnMut(FullSyncProgress, bool) + Send + Sync + 'static>;

--- a/rslib/src/sync/collection/sanity.rs
+++ b/rslib/src/sync/collection/sanity.rs
@@ -10,7 +10,6 @@ use tracing::info;
 use crate::error::SyncErrorKind;
 use crate::prelude::*;
 use crate::serde::default_on_invalid;
-use crate::sync::collection::normal::NormalSyncProgress;
 use crate::sync::collection::normal::NormalSyncer;
 use crate::sync::collection::protocol::SyncProtocol;
 use crate::sync::request::IntoSyncRequest;
@@ -51,10 +50,7 @@ pub struct SanityCheckDueCounts {
     pub review: u32,
 }
 
-impl<F> NormalSyncer<'_, F>
-where
-    F: FnMut(NormalSyncProgress, bool),
-{
+impl NormalSyncer<'_> {
     /// Caller should force full sync after rolling back.
     pub(in crate::sync) async fn sanity_check(&mut self) -> Result<()> {
         let local_counts = self.col.storage.sanity_check_info()?;

--- a/rslib/src/sync/http_client/full_sync.rs
+++ b/rslib/src/sync/http_client/full_sync.rs
@@ -7,8 +7,8 @@ use std::time::Duration;
 use tokio::select;
 use tokio::time::interval;
 
+use crate::progress::ThrottlingProgressHandler;
 use crate::sync::collection::progress::FullSyncProgress;
-use crate::sync::collection::progress::FullSyncProgressFn;
 use crate::sync::collection::protocol::EmptyInput;
 use crate::sync::collection::protocol::SyncMethod;
 use crate::sync::collection::upload::UploadResponse;
@@ -19,49 +19,47 @@ use crate::sync::request::SyncRequest;
 use crate::sync::response::SyncResponse;
 
 impl HttpSyncClient {
-    pub fn set_full_sync_progress_fn(&mut self, func: Option<FullSyncProgressFn>) {
-        *self.full_sync_progress_fn.lock().unwrap() = func;
-    }
-
-    fn full_sync_progress_monitor(&self, sending: bool) -> (IoMonitor, impl Future<Output = ()>) {
-        let mut progress = FullSyncProgress {
-            transferred_bytes: 0,
-            total_bytes: 0,
-        };
-        let mut progress_fn = self
-            .full_sync_progress_fn
-            .lock()
-            .unwrap()
-            .take()
-            .expect("progress func was not set");
+    fn full_sync_progress_monitor(
+        &self,
+        sending: bool,
+        mut progress: ThrottlingProgressHandler<FullSyncProgress>,
+    ) -> (IoMonitor, impl Future<Output = ()>) {
         let io_monitor = IoMonitor::new();
         let io_monitor2 = io_monitor.clone();
         let update_progress = async move {
             let mut interval = interval(Duration::from_millis(100));
             loop {
                 interval.tick().await;
-                let guard = io_monitor2.0.lock().unwrap();
-                progress.total_bytes = if sending {
-                    guard.total_bytes_to_send
-                } else {
-                    guard.total_bytes_to_receive
-                } as usize;
-                progress.transferred_bytes = if sending {
-                    guard.bytes_sent
-                } else {
-                    guard.bytes_received
-                } as usize;
-                progress_fn(progress, true)
+                let (total_bytes, transferred_bytes) = {
+                    let guard = io_monitor2.0.lock().unwrap();
+                    (
+                        if sending {
+                            guard.total_bytes_to_send
+                        } else {
+                            guard.total_bytes_to_receive
+                        },
+                        if sending {
+                            guard.bytes_sent
+                        } else {
+                            guard.bytes_received
+                        },
+                    )
+                };
+                _ = progress.update(false, |p| {
+                    p.total_bytes = total_bytes as usize;
+                    p.transferred_bytes = transferred_bytes as usize;
+                })
             }
         };
         (io_monitor, update_progress)
     }
 
-    pub(super) async fn download_inner(
+    pub(in super::super) async fn download_with_progress(
         &self,
         req: SyncRequest<EmptyInput>,
+        progress: ThrottlingProgressHandler<FullSyncProgress>,
     ) -> HttpResult<SyncResponse<Vec<u8>>> {
-        let (io_monitor, progress_fut) = self.full_sync_progress_monitor(false);
+        let (io_monitor, progress_fut) = self.full_sync_progress_monitor(false, progress);
         let output = self.request_ext(SyncMethod::Download, req, io_monitor);
         select! {
             _ = progress_fut => unreachable!(),
@@ -69,11 +67,12 @@ impl HttpSyncClient {
         }
     }
 
-    pub(super) async fn upload_inner(
+    pub(in super::super) async fn upload_with_progress(
         &self,
         req: SyncRequest<Vec<u8>>,
+        progress: ThrottlingProgressHandler<FullSyncProgress>,
     ) -> HttpResult<SyncResponse<UploadResponse>> {
-        let (io_monitor, progress_fut) = self.full_sync_progress_monitor(true);
+        let (io_monitor, progress_fut) = self.full_sync_progress_monitor(true, progress);
         let output = self.request_ext(SyncMethod::Upload, req, io_monitor);
         select! {
             _ = progress_fut => unreachable!(),

--- a/rslib/src/sync/http_client/mod.rs
+++ b/rslib/src/sync/http_client/mod.rs
@@ -5,7 +5,6 @@ pub(crate) mod full_sync;
 pub(crate) mod io_monitor;
 mod protocol;
 
-use std::sync::Mutex;
 use std::time::Duration;
 
 use reqwest::Client;
@@ -14,7 +13,6 @@ use reqwest::StatusCode;
 use reqwest::Url;
 
 use crate::notes;
-use crate::sync::collection::progress::FullSyncProgressFn;
 use crate::sync::collection::protocol::AsSyncEndpoint;
 use crate::sync::error::HttpError;
 use crate::sync::error::HttpResult;
@@ -25,6 +23,7 @@ use crate::sync::request::header_and_stream::SYNC_HEADER_NAME;
 use crate::sync::request::SyncRequest;
 use crate::sync::response::SyncResponse;
 
+#[derive(Clone)]
 pub struct HttpSyncClient {
     /// Set to the empty string for initial login
     pub sync_key: String,
@@ -32,7 +31,6 @@ pub struct HttpSyncClient {
     client: Client,
     pub endpoint: Url,
     pub io_timeout: Duration,
-    full_sync_progress_fn: Mutex<Option<FullSyncProgressFn>>,
 }
 
 impl HttpSyncClient {
@@ -46,19 +44,6 @@ impl HttpSyncClient {
                 .endpoint
                 .unwrap_or_else(|| Url::try_from("https://sync.ankiweb.net/").unwrap()),
             io_timeout,
-            full_sync_progress_fn: Mutex::new(None),
-        }
-    }
-
-    #[cfg(test)]
-    pub fn partial_clone(&self) -> Self {
-        Self {
-            sync_key: self.sync_key.clone(),
-            session_key: self.session_key.clone(),
-            client: self.client.clone(),
-            endpoint: self.endpoint.clone(),
-            full_sync_progress_fn: Mutex::new(None),
-            io_timeout: self.io_timeout,
         }
     }
 

--- a/rslib/src/sync/http_client/protocol.rs
+++ b/rslib/src/sync/http_client/protocol.rs
@@ -4,6 +4,7 @@
 use async_trait::async_trait;
 
 use crate::prelude::TimestampMillis;
+use crate::progress::ThrottlingProgressHandler;
 use crate::sync::collection::changes::ApplyChangesRequest;
 use crate::sync::collection::changes::UnchunkedChanges;
 use crate::sync::collection::chunks::ApplyChunkRequest;
@@ -97,11 +98,13 @@ impl SyncProtocol for HttpSyncClient {
     }
 
     async fn upload(&self, req: SyncRequest<Vec<u8>>) -> HttpResult<SyncResponse<UploadResponse>> {
-        self.upload_inner(req).await
+        self.upload_with_progress(req, ThrottlingProgressHandler::default())
+            .await
     }
 
     async fn download(&self, req: SyncRequest<EmptyInput>) -> HttpResult<SyncResponse<Vec<u8>>> {
-        self.download_inner(req).await
+        self.download_with_progress(req, ThrottlingProgressHandler::default())
+            .await
     }
 }
 

--- a/rslib/src/sync/media/progress.rs
+++ b/rslib/src/sync/media/progress.rs
@@ -9,3 +9,9 @@ pub struct MediaSyncProgress {
     pub uploaded_files: usize,
     pub uploaded_deletions: usize,
 }
+
+#[derive(Debug, Default, Clone, Copy)]
+#[repr(transparent)]
+pub struct MediaCheckProgress {
+    pub checked: usize,
+}


### PR DESCRIPTION
Previously it was Backend's responsibility to store the last progress, and when calling routines in Collection, one had to construct and pass in a Fn, which wasn't the most ergonomic. This PR adds the last progress state to the collection, so that the routines no longer need a separate progress arg, and makes some other tweaks to improve ergonomics.

ThrottlingProgressHandler has been tweaked so that it now stores the current state, so that callers don't need to store it separately. When a long-running routine starts, it calls col.new_progress_handler(), which automatically initializes the data to defaults, and updates the shared UI state, so we no longer need to manually update the state at the start of an operation.

The backend shares the Arc<Mutex<>> with the collection, so it can get at the current state, and so we can update the state when importing a backup.

Other tweaks:

- The current Incrementor was awkward to use in the media check, which uses a single incrementing value across multiple method calls, so I've added a simpler alternative for such cases. The old incrementor method has been kept, but implemented directly on ThrottlingProgressHandler.
- The full sync code was passing the progress handler in a complicated way that may once have been required, but no longer is.
- On the Qt side, timers are now stopped before deletion, or they keep running for a few seconds.
- I left the ChangeTracker using a closure, as it's used for both importing and syncing.