### PR TITLE
Fix two issues with MathJax editor

### DIFF
--- a/ts/editor/NoteEditor.svelte
+++ b/ts/editor/NoteEditor.svelte
@@ -60,6 +60,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     import ImageOverlay from "./image-overlay";
     import { shrinkImagesByDefault } from "./image-overlay/ImageOverlay.svelte";
     import MathjaxOverlay from "./mathjax-overlay";
+    import { closeMathjaxEditor } from "./mathjax-overlay/MathjaxEditor.svelte";
     import Notification from "./Notification.svelte";
     import PlainTextInput from "./plain-text-input";
     import { closeHTMLTags } from "./plain-text-input/PlainTextInput.svelte";
@@ -292,6 +293,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     }
 
     function saveNow(): void {
+        closeMathjaxEditor?.();
         $commitTagEdits();
         saveFieldNow();
     }

--- a/ts/editor/mathjax-overlay/MathjaxEditor.svelte
+++ b/ts/editor/mathjax-overlay/MathjaxEditor.svelte
@@ -2,6 +2,17 @@
 Copyright: Ankitects Pty Ltd and contributors
 License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 -->
+<script context="module" lang="ts">
+    import { writable } from "svelte/store";
+
+    export let closeMathjaxEditor: (() => void) | null = null;
+
+    const closeSignalStore = writable<symbol>(Symbol(), (set) => {
+        closeMathjaxEditor = () => set(Symbol());
+        return () => (closeMathjaxEditor = null);
+    });
+</script>
+
 <script lang="ts">
     import * as tr from "@tslib/ftl";
     import { noop } from "@tslib/functional";
@@ -94,6 +105,8 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
             }
         });
     });
+
+    $: $closeSignalStore, dispatch("close");
 </script>
 
 <div class="mathjax-editor" class:light-theme={!$pageTheme.isDark}>

--- a/ts/editor/mathjax-overlay/MathjaxOverlay.svelte
+++ b/ts/editor/mathjax-overlay/MathjaxOverlay.svelte
@@ -229,10 +229,6 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
                             placeHandle(true);
                             resetHandle();
                         }}
-                        on:blur={async () => {
-                            await tick();
-                            await resetHandle();
-                        }}
                         on:close={resetHandle}
                         let:editor={mathjaxEditor}
                     >


### PR DESCRIPTION
Fixes #1947

Also fixes an issue where the MathJax editor would not close when changing notes via shortcut (Ctrl+N/Ctrl+P).