### PR TITLE
Add did-add-field-hook analogous to did-delete-field

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -127,6 +127,7 @@ Christopher Woggon <christopher.woggon@gmail.com>
 Kavel Rao <github.com/kavelrao>
 Ben Yip <github.com/bennyyip>
 mmjang <752515918@qq.com>
+3ter <github.com/3ter>
 
 ********************
 

--- a/qt/aqt/fields.py
+++ b/qt/aqt/fields.py
@@ -186,6 +186,8 @@ class FieldDialog(QDialog):
         self.saveField()
         f = self.mm.new_field(name)
         self.mm.add_field(self.model, f)
+        gui_hooks.fields_did_add_field(self, f)
+
         self.fillFields()
         self.form.fieldList.setCurrentRow(len(self.model["flds"]) - 1)
 

--- a/qt/tools/genhooks_gui.py
+++ b/qt/tools/genhooks_gui.py
@@ -1245,6 +1245,10 @@ gui_hooks.webview_did_inject_style_into_page.append(mytest)
     # Fields
     ###################
     Hook(
+        name="fields_did_add_field",
+        args=["dialog: aqt.fields.FieldDialog", "field: anki.models.FieldDict"],
+    ),
+    Hook(
         name="fields_did_rename_field",
         args=[
             "dialog: aqt.fields.FieldDialog",


### PR DESCRIPTION
For the addon https://github.com/zjosua/anki-mc I wanted to modify a card template if certain fields were added or deleted. I then found that in https://github.com/ankitects/anki/pull/790 the hook for adding a field was omitted.

PS I wanted to run the tests locally but couldn't due to the error
```
failed: check:minilints
```
when running `ninja check`. Without `check` building works fine. I liked the [instructions](https://github.com/ankitects/anki/blob/main/docs/development.md) by the way.