### PR TITLE
Fix addon update dialog showing twice

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ target
 node_modules
 .n2_db
 .ninja_log
+.ninja_deps

--- a/qt/aqt/main.py
+++ b/qt/aqt/main.py
@@ -498,6 +498,8 @@ class AnkiQt(QMainWindow):
             self._refresh_after_sync()
             if onsuccess:
                 onsuccess()
+            if not self.safeMode:
+                self.maybe_check_for_addon_updates(self.setupAutoUpdate)
 
         self.maybe_auto_sync_on_open_close(_onsuccess)
 
@@ -1033,16 +1035,10 @@ title="{}" {}>{}</button>""".format(
 
     def maybe_auto_sync_on_open_close(self, after_sync: Callable[[], None]) -> None:
         "If disabled, after_sync() is called immediately."
-
-        def after_sync_and_call_addon_update() -> None:
-            after_sync()
-            if not self.safeMode:
-                self.maybe_check_for_addon_updates(self.setupAutoUpdate)
-
         if self.can_auto_sync():
-            self._sync_collection_and_media(after_sync_and_call_addon_update)
+            self._sync_collection_and_media(after_sync)
         else:
-            after_sync_and_call_addon_update()
+            after_sync()
 
     def maybe_auto_sync_media(self) -> None:
         if self.can_auto_sync():

--- a/qt/aqt/main.py
+++ b/qt/aqt/main.py
@@ -962,6 +962,7 @@ title="{}" {}>{}</button>""".format(
                 requested_by_user=False,
             )
             self.pm.set_last_addon_update_check(int_time())
+            self.pm.set_last_run_version()
         elif on_done:
             on_done()
 
@@ -1150,7 +1151,6 @@ title="{}" {}>{}</button>""".format(
     ##########################################################################
 
     def closeEvent(self, event: QCloseEvent) -> None:
-        self.pm.set_last_run_version()
         if self.state == "profileManager":
             # if profile manager active, this event may fire via OS X menu bar's
             # quit option

--- a/qt/aqt/main.py
+++ b/qt/aqt/main.py
@@ -954,7 +954,7 @@ title="{}" {}>{}</button>""".format(
             if on_done:
                 on_done()
 
-        if elap > 86_400 or self.pm.last_run_version() != point_version():
+        if elap > 86_400 or self.pm.last_run_version != point_version():
             check_and_prompt_for_updates(
                 self,
                 self.addonManager,
@@ -962,7 +962,6 @@ title="{}" {}>{}</button>""".format(
                 requested_by_user=False,
             )
             self.pm.set_last_addon_update_check(int_time())
-            self.pm.set_last_run_version()
         elif on_done:
             on_done()
 

--- a/qt/aqt/profiles.py
+++ b/qt/aqt/profiles.py
@@ -117,6 +117,7 @@ class LoadMetaResult:
 
 class ProfileManager:
     default_answer_keys = {ease_num: str(ease_num) for ease_num in range(1, 5)}
+    last_run_version: int = 0
 
     def __init__(self, base: Path) -> None:  #
         "base should be retrieved via ProfileMangager.get_created_base_folder"
@@ -132,6 +133,8 @@ class ProfileManager:
         # load metadata
         res = self._loadMeta()
         self.firstRun = res.firstTime
+        self.last_run_version = self.meta.get("last_run_version", self.last_run_version)
+        self.meta["last_run_version"] = point_version()
         return res
 
     # -p profile provided on command line.
@@ -505,12 +508,6 @@ create table if not exists profiles
 
     # Shared options
     ######################################################################
-
-    def last_run_version(self) -> int:
-        return self.meta.get("last_run_version", 0)
-
-    def set_last_run_version(self) -> None:
-        self.meta["last_run_version"] = point_version()
 
     def uiScale(self) -> float:
         scale = self.meta.get("uiScale", 1.0)


### PR DESCRIPTION
723a3aaa5b889e64c4bcfef11a2335acaab8a91b is actually redundant with 122a6f860f8382c31804211ca38e0149287713d0, but I guess it's still more correct this way.