### PR TITLE
Address a11y warning for TabbedValue

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -129,7 +129,7 @@ Ben Yip <github.com/bennyyip>
 mmjang <752515918@qq.com>
 shunlog <github.com/shunlog>
 3ter <github.com/3ter>
-Derek Dang <https://github.com/derekdang/>
+Derek Dang <github.com/derekdang/>
 
 ********************
 

--- a/ts/deck-options/SettingTitle.svelte
+++ b/ts/deck-options/SettingTitle.svelte
@@ -2,6 +2,8 @@
     Copyright: Ankitects Pty Ltd and contributors
     License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 -->
+<!-- svelte-ignore a11y-no-static-element-interactions -->
+<!-- svelte-ignore a11y-click-events-have-key-events -->
 <div class="setting-title" on:click>
     <slot />
 </div>

--- a/ts/deck-options/TabbedValue.svelte
+++ b/ts/deck-options/TabbedValue.svelte
@@ -45,7 +45,7 @@
 <ul>
     {#each tabs as tab, idx}
         <li class:active={activeTab === idx}>
-            <span on:click={handleClick(idx)}>{tab.title}</span>
+            <button on:click={handleClick(idx)}>{tab.title}</button>
         </li>
     {/each}
 </ul>
@@ -61,19 +61,21 @@
         list-style: none;
     }
 
-    span {
+    button {
         display: block;
         white-space: nowrap;
         cursor: pointer;
         color: var(--fg-subtle);
+        border: none;
+        background-color: transparent;
     }
 
-    li.active > span {
+    li.active > button {
         color: var(--fg);
         border-bottom: 4px solid var(--border-focus);
         margin-bottom: -2px;
     }
-    span:hover {
+    button:hover {
         color: var(--fg);
     }
 </style>


### PR DESCRIPTION
Resolves the warnings for `TabbedValue.svelte` & `SettingTitle.svelte` as part of #2564.

Tabs for Daily Limits section in Deck Options are now `Button`s instead of `Span`s.
To verify, enable V3 Scheduler in Preferences and go to Deck Options for any Deck.

Also added explicit ignore for a11y warnings in SettingTitle. Clicking the Setting Title opens the contextual Help Content directly as a convenience. In the discussion in #2578, the user will be able to navigate to the HelpModal without a mouse. 