### PR TITLE
Add keyboard shortcut for legacy stats

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -130,6 +130,7 @@ mmjang <752515918@qq.com>
 shunlog <github.com/shunlog>
 3ter <github.com/3ter>
 Derek Dang <github.com/derekdang/>
+Luc Mcgrady <github.com/Luc-mcgrady>
 
 ********************
 

--- a/qt/aqt/main.py
+++ b/qt/aqt/main.py
@@ -1102,6 +1102,7 @@ title="{}" {}>{}</button>""".format(
             ("a", self.onAddCard),
             ("b", self.onBrowse),
             ("t", self.onStats),
+            ("shift+t", self.onStats),
             ("y", self.on_sync_button_clicked),
         ]
         self.applyShortcuts(globalShortcuts)

--- a/qt/aqt/main.py
+++ b/qt/aqt/main.py
@@ -1102,7 +1102,7 @@ title="{}" {}>{}</button>""".format(
             ("a", self.onAddCard),
             ("b", self.onBrowse),
             ("t", self.onStats),
-            ("shift+t", self.onStats),
+            ("Shift+t", self.onStats),
             ("y", self.on_sync_button_clicked),
         ]
         self.applyShortcuts(globalShortcuts)


### PR DESCRIPTION
Currently, shift clicking the stats button is the only way to open the legacy stats menu.
This adds pressing shift-t as an option to do the same thing.