### PR TITLE
Fix a11y error in CardsCount Component

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -130,6 +130,7 @@ mmjang <752515918@qq.com>
 shunlog <github.com/shunlog>
 3ter <github.com/3ter>
 Derek Dang <github.com/derekdang/>
+Kehinde Adeleke <adelekekehinde06@gmail.com>
 
 ********************
 

--- a/ts/graphs/CardCounts.svelte
+++ b/ts/graphs/CardCounts.svelte
@@ -64,7 +64,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
                         <td>
                             <span style="color: {d.colour};">■&nbsp;</span>
                             {#if $prefs.browserLinksSupported}
-                                <span class="search-link" on:click={() => dispatch('search', { query: d.query })}>{d.label}</span>
+                                <button class="search-link" on:click={() => dispatch('search', { query: d.query })}>{d.label}</button>
                             {:else}
                                 <span>{d.label}</span>
                             {/if}
@@ -124,8 +124,15 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         }
     }
 
-    .search-link:hover {
+    .search-link {
+        border: none;
+        background: transparent;
         cursor: pointer;
+        box-shadow: none;
+        padding: 4px;
+    }
+
+    .search-link:hover {
         color: var(--fg-link);
         text-decoration: underline;
     }

--- a/ts/graphs/CardCounts.svelte
+++ b/ts/graphs/CardCounts.svelte
@@ -129,7 +129,8 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         background: transparent;
         cursor: pointer;
         box-shadow: none;
-        padding: 4px;
+        padding: 1px 3px;
+        margin-bottom: 0px;
     }
 
     .search-link:hover {


### PR DESCRIPTION
This PR aims replaces the `span` element with a semantically appropriate `button` element.
This would ensure that:

1. The button can be tabbed.
2. There is proper focus indicator.
3. The a11y warning don't show up.

One question I have is:
To fix this error, I had to uncomment each of this line:
```
  build.add_variable(
            "compiler_warnings",
            [
                "a11y-click-events-have-key-events", //here
                "a11y-no-noninteractive-tabindex", //here
                "a11y-no-static-element-interactions", //and here
            ]
            .iter()
            .map(|warning| format!("{}$:ignore", warning))
            .collect::<Vec<_>>()
            .join(","),
        );
```
Is that the best practice of fixing the errors?
Or is there a cleaner way?
