### PR TITLE
Improve namespacing for debug console

### DIFF
--- a/qt/aqt/debug_console.py
+++ b/qt/aqt/debug_console.py
@@ -282,14 +282,16 @@ class DebugConsole(QDialog):
         import traceback
 
         text = self._text.toPlainText()
-        card = self._debugCard
-        bcard = self._debugBrowserCard
-        mw = aqt.mw
-        pp = pprint.pprint
+        vars = {
+            "card": self._debugCard,
+            "bcard": self._debugBrowserCard,
+            "mw": aqt.mw,
+            "pp": pprint.pprint,
+        }
         self._captureOutput(True)
         try:
             # pylint: disable=exec-used
-            exec(text)
+            exec(text, vars)
         except:
             self._output += traceback.format_exc()
         self._captureOutput(False)


### PR DESCRIPTION
https://forums.ankiweb.net/t/debug-console-throws-errors-on-correct-code/32382


If we don't pass dicts for globals and locals to `exec()`, the ones from the surrounding code are used. But functions and list comprehensions have their own locals dict, and thus can't access other names declared in the REPL or locals like `mw`.
This patch fixes that by passing in a dict that is used both for globals and locals.