### PR TITLE
Introduce new Reviewer zoom mode for images

### DIFF
--- a/qt/aqt/main.py
+++ b/qt/aqt/main.py
@@ -1342,15 +1342,9 @@ title="{}" {}>{}</button>""".format(
         qconnect(m.actionPreferences.triggered, self.onPrefs)
 
         # View
-        qconnect(
-            m.actionZoomIn.triggered,
-            lambda: self.web.setZoomFactor(self.web.zoomFactor() + 0.1),
-        )
-        qconnect(
-            m.actionZoomOut.triggered,
-            lambda: self.web.setZoomFactor(self.web.zoomFactor() - 0.1),
-        )
-        qconnect(m.actionResetZoom.triggered, lambda: self.web.setZoomFactor(1))
+        qconnect(m.actionZoomIn.triggered, self.zoom_in)
+        qconnect(m.actionZoomOut.triggered, self.zoom_out)
+        qconnect(m.actionResetZoom.triggered, self.reset_zoom)
         # app-wide shortcut
         qconnect(m.actionFullScreen.triggered, self.on_toggle_full_screen)
         m.actionFullScreen.setShortcut(
@@ -1396,6 +1390,24 @@ title="{}" {}>{}</button>""".format(
     def show_menubar(self) -> None:
         self.form.menubar.setMaximumSize(QWIDGETSIZE_MAX, QWIDGETSIZE_MAX)
         self.form.menubar.setMinimumSize(0, 0)
+
+    def zoom_in(self) -> None:
+        if self.state != "review":
+            self.web.setZoomFactor(self.web.zoomFactor() + 0.1)
+        else:
+            self.reviewer.zoom_in()
+
+    def zoom_out(self) -> None:
+        if self.state != "review":
+            self.web.setZoomFactor(self.web.zoomFactor() - 0.1)
+        else:
+            self.reviewer.zoom_out()
+
+    def reset_zoom(self) -> None:
+        if self.state != "review":
+            self.web.setZoomFactor(1)
+        else:
+            self.reviewer.reset_zoom()
 
     # Auto update
     ##########################################################################

--- a/qt/aqt/main.py
+++ b/qt/aqt/main.py
@@ -1391,23 +1391,29 @@ title="{}" {}>{}</button>""".format(
         self.form.menubar.setMaximumSize(QWIDGETSIZE_MAX, QWIDGETSIZE_MAX)
         self.form.menubar.setMinimumSize(0, 0)
 
+    # Triggering a zoom action with Shift held down changes the zoom level without
+    # affecting layout sizing, thus allowing users to zoom into images
+
     def zoom_in(self) -> None:
-        if self.state != "review":
-            self.web.setZoomFactor(self.web.zoomFactor() + 0.1)
-        else:
+        if self.state == "review" and bool(
+            self.app.queryKeyboardModifiers() & Qt.KeyboardModifier.ShiftModifier
+        ):
             self.reviewer.zoom_in()
+        else:
+            self.web.setZoomFactor(self.web.zoomFactor() + 0.1)
 
     def zoom_out(self) -> None:
-        if self.state != "review":
-            self.web.setZoomFactor(self.web.zoomFactor() - 0.1)
-        else:
+        if self.state == "review" and bool(
+            self.app.queryKeyboardModifiers() & Qt.KeyboardModifier.ShiftModifier
+        ):
             self.reviewer.zoom_out()
+        else:
+            self.web.setZoomFactor(self.web.zoomFactor() - 0.1)
 
     def reset_zoom(self) -> None:
-        if self.state != "review":
-            self.web.setZoomFactor(1)
-        else:
+        if self.state == "review":
             self.reviewer.reset_zoom()
+        self.web.setZoomFactor(1)
 
     # Auto update
     ##########################################################################

--- a/qt/aqt/reviewer.py
+++ b/qt/aqt/reviewer.py
@@ -1083,13 +1083,13 @@ time = %(time)d;
     # Zoom handling
 
     def zoom_in(self):
-        self.web.eval(f"anki.triggerZoomStep(1)")
+        self.web.eval("anki.triggerZoomStep(1)")
 
     def zoom_out(self):
-        self.web.eval(f"anki.triggerZoomStep(-1)")
+        self.web.eval("anki.triggerZoomStep(-1)")
 
     def reset_zoom(self):
-        self.web.eval(f"anki.resetZoom()")
+        self.web.eval("anki.resetZoom()")
 
     def set_zoom_step(self, step: int, interactive: bool = True):
         """Set predefined reviewer zoom step, cf. zoom.ts for indices

--- a/qt/aqt/reviewer.py
+++ b/qt/aqt/reviewer.py
@@ -1098,7 +1098,9 @@ time = %(time)d;
             step: zoom step corresponding to predefined zoom factor index
             interactive: controls zoom info box and zoom step persistence
         """
-        self.web.eval(f"anki.setZoomStep({json.dumps(step)})")
+        self.web.eval(
+            f"anki.setZoomStep({json.dumps(step)}, {json.dumps(interactive)})"
+        )
 
     def store_zoom_step(self, step: int):
         self.mw.pm.profile["lastReviewerZoomStep"] = step

--- a/qt/aqt/reviewer.py
+++ b/qt/aqt/reviewer.py
@@ -587,8 +587,8 @@ class Reviewer:
             play_clicked_audio(url, self.card)
         elif url.startswith("updateToolbar"):
             self.mw.toolbarWeb.update_background_image()
-        elif url.startswith("scale"):
-            self.store_scale_factor(float(url.split(":")[1]))
+        elif url.startswith("zoom"):
+            self.store_zoom_step(int(url.split(":")[1]))
         elif url == "statesMutated":
             self._states_mutated = True
         else:
@@ -1083,23 +1083,29 @@ time = %(time)d;
     # Zoom handling
 
     def zoom_in(self):
-        self.web.eval(f"anki.triggerScaleStep(1)")
+        self.web.eval(f"anki.triggerZoomStep(1)")
 
     def zoom_out(self):
-        self.web.eval(f"anki.triggerScaleStep(-1)")
+        self.web.eval(f"anki.triggerZoomStep(-1)")
 
     def reset_zoom(self):
-        self.web.eval(f"anki.setScaleFactor(1)")
+        self.web.eval(f"anki.resetZoom()")
 
-    def set_scale_factor(self, scale_factor: float, store: bool = True):
-        self.web.eval(f"anki.setScaleFactor({json.dumps(scale_factor)})")
+    def set_zoom_step(self, step: int, interactive: bool = True):
+        """Set predefined reviewer zoom step, cf. zoom.ts for indices
 
-    def store_scale_factor(self, scale_factor: float):
-        self.mw.pm.profile["lastReviewerScaleFactor"] = scale_factor
+        Args:
+            step: zoom step corresponding to predefined zoom factor index
+            interactive: controls zoom info box and zoom step persistence
+        """
+        self.web.eval(f"anki.setZoomStep({json.dumps(step)})")
+
+    def store_zoom_step(self, step: int):
+        self.mw.pm.profile["lastReviewerZoomStep"] = step
 
     def maybe_restore_scale_factor(self):
-        if scale_factor := self.mw.pm.profile.get("lastReviewerScaleFactor", None):
-            self.set_scale_factor(scale_factor, store=False)
+        if scale_factor := self.mw.pm.profile.get("lastReviewerZoomStep", None):
+            self.set_zoom_step(scale_factor, interactive=False)
 
     # legacy
 

--- a/qt/aqt/reviewer.py
+++ b/qt/aqt/reviewer.py
@@ -389,6 +389,7 @@ class Reviewer:
         self._update_mark_icon()
         self._showAnswerButton()
         self.mw.web.setFocus()
+        self.maybe_restore_scale_factor()
         # user hook
         gui_hooks.reviewer_did_show_question(c)
 
@@ -586,6 +587,8 @@ class Reviewer:
             play_clicked_audio(url, self.card)
         elif url.startswith("updateToolbar"):
             self.mw.toolbarWeb.update_background_image()
+        elif url.startswith("scale"):
+            self.store_scale_factor(float(url.split(":")[1]))
         elif url == "statesMutated":
             self._states_mutated = True
         else:
@@ -1076,6 +1079,27 @@ time = %(time)d;
             tooltip(tr.studying_you_havent_recorded_your_voice_yet())
             return
         av_player.play_file(self._recordedAudio)
+
+    # Zoom handling
+
+    def zoom_in(self):
+        self.web.eval(f"anki.triggerScaleStep(1)")
+
+    def zoom_out(self):
+        self.web.eval(f"anki.triggerScaleStep(-1)")
+
+    def reset_zoom(self):
+        self.web.eval(f"anki.setScaleFactor(1)")
+
+    def set_scale_factor(self, scale_factor: float, store: bool = True):
+        self.web.eval(f"anki.setScaleFactor({json.dumps(scale_factor)})")
+
+    def store_scale_factor(self, scale_factor: float):
+        self.mw.pm.profile["lastReviewerScaleFactor"] = scale_factor
+
+    def maybe_restore_scale_factor(self):
+        if scale_factor := self.mw.pm.profile.get("lastReviewerScaleFactor", None):
+            self.set_scale_factor(scale_factor, store=False)
 
     # legacy
 

--- a/ts/reviewer/index.ts
+++ b/ts/reviewer/index.ts
@@ -11,10 +11,14 @@ export { default as $, default as jQuery } from "jquery/dist/jquery";
 
 import { setupImageCloze } from "../image-occlusion/review";
 import { mutateNextCardStates } from "./answering";
+import { resetScaleFactor, setScaleFactor, setupWheelZoom, triggerScaleStep } from "./zoom";
 
 globalThis.anki = globalThis.anki || {};
 globalThis.anki.mutateNextCardStates = mutateNextCardStates;
 globalThis.anki.setupImageCloze = setupImageCloze;
+globalThis.anki.setScaleFactor = setScaleFactor
+globalThis.anki.triggerScaleStep = triggerScaleStep
+globalThis.anki.resetScaleFactor = resetScaleFactor
 
 import { bridgeCommand } from "@tslib/bridgecommand";
 import { registerPackage } from "@tslib/runtime-require";
@@ -167,13 +171,13 @@ export function _showQuestion(q: string, a: string, bodyclass: string): void {
         _updateQA(
             q,
             null,
-            function() {
+            function () {
                 // return to top of window
                 window.scrollTo(0, 0);
 
                 document.body.className = bodyclass;
             },
-            function() {
+            function () {
                 // focus typing area if visible
                 typeans = document.getElementById("typeans") as HTMLInputElement;
                 if (typeans) {
@@ -195,7 +199,7 @@ export function _showAnswer(a: string, bodyclass: string): void {
         _updateQA(
             a,
             null,
-            function() {
+            function () {
                 if (bodyclass) {
                     //  when previewing
                     document.body.className = bodyclass;
@@ -204,7 +208,7 @@ export function _showAnswer(a: string, bodyclass: string): void {
                 // avoid scrolling to the answer until images load
                 allImagesLoaded().then(scrollToAnswer);
             },
-            function() {
+            function () {
                 /* noop */
             },
         )
@@ -262,6 +266,8 @@ document.addEventListener("focusout", (event) => {
         document.body.removeChild(dummyButton);
     }
 });
+
+setupWheelZoom()
 
 registerPackage("anki/reviewer", {
     // If you append a function to this each time the question or answer

--- a/ts/reviewer/index.ts
+++ b/ts/reviewer/index.ts
@@ -11,14 +11,14 @@ export { default as $, default as jQuery } from "jquery/dist/jquery";
 
 import { setupImageCloze } from "../image-occlusion/review";
 import { mutateNextCardStates } from "./answering";
-import { resetScaleFactor, setScaleFactor, setupWheelZoom, triggerScaleStep } from "./zoom";
+import { resetZoom, setupWheelZoom, setZoomStep, triggerZoomStep } from "./zoom";
 
 globalThis.anki = globalThis.anki || {};
 globalThis.anki.mutateNextCardStates = mutateNextCardStates;
 globalThis.anki.setupImageCloze = setupImageCloze;
-globalThis.anki.setScaleFactor = setScaleFactor
-globalThis.anki.triggerScaleStep = triggerScaleStep
-globalThis.anki.resetScaleFactor = resetScaleFactor
+globalThis.anki.setZoomStep = setZoomStep
+globalThis.anki.triggerZoomStep = triggerZoomStep
+globalThis.anki.resetZoom = resetZoom
 
 import { bridgeCommand } from "@tslib/bridgecommand";
 import { registerPackage } from "@tslib/runtime-require";

--- a/ts/reviewer/index.ts
+++ b/ts/reviewer/index.ts
@@ -16,9 +16,9 @@ import { resetZoom, setupWheelZoom, setZoomStep, triggerZoomStep } from "./zoom"
 globalThis.anki = globalThis.anki || {};
 globalThis.anki.mutateNextCardStates = mutateNextCardStates;
 globalThis.anki.setupImageCloze = setupImageCloze;
-globalThis.anki.setZoomStep = setZoomStep
-globalThis.anki.triggerZoomStep = triggerZoomStep
-globalThis.anki.resetZoom = resetZoom
+globalThis.anki.setZoomStep = setZoomStep;
+globalThis.anki.triggerZoomStep = triggerZoomStep;
+globalThis.anki.resetZoom = resetZoom;
 
 import { bridgeCommand } from "@tslib/bridgecommand";
 import { registerPackage } from "@tslib/runtime-require";
@@ -171,13 +171,13 @@ export function _showQuestion(q: string, a: string, bodyclass: string): void {
         _updateQA(
             q,
             null,
-            function () {
+            function() {
                 // return to top of window
                 window.scrollTo(0, 0);
 
                 document.body.className = bodyclass;
             },
-            function () {
+            function() {
                 // focus typing area if visible
                 typeans = document.getElementById("typeans") as HTMLInputElement;
                 if (typeans) {
@@ -199,7 +199,7 @@ export function _showAnswer(a: string, bodyclass: string): void {
         _updateQA(
             a,
             null,
-            function () {
+            function() {
                 if (bodyclass) {
                     //  when previewing
                     document.body.className = bodyclass;
@@ -208,7 +208,7 @@ export function _showAnswer(a: string, bodyclass: string): void {
                 // avoid scrolling to the answer until images load
                 allImagesLoaded().then(scrollToAnswer);
             },
-            function () {
+            function() {
                 /* noop */
             },
         )
@@ -267,7 +267,7 @@ document.addEventListener("focusout", (event) => {
     }
 });
 
-setupWheelZoom()
+setupWheelZoom();
 
 registerPackage("anki/reviewer", {
     // If you append a function to this each time the question or answer

--- a/ts/reviewer/reviewer.scss
+++ b/ts/reviewer/reviewer.scss
@@ -74,7 +74,7 @@ pre {
     -webkit-text-stroke-color: black;
 }
 
-#_scaleinfo {
+#_zoominfo {
     position: fixed;
     display: none;
 

--- a/ts/reviewer/reviewer.scss
+++ b/ts/reviewer/reviewer.scss
@@ -74,6 +74,18 @@ pre {
     -webkit-text-stroke-color: black;
 }
 
+#_scaleinfo {
+    position: fixed;
+    display: none;
+
+
+    right: 10px;
+    top: 0;
+    font-size: 20px;
+    color: var(--fg-subtle);
+    background: var(--canvas-overlay);
+}
+
 #typeans {
     width: 100%;
     // https://anki.tenderapp.com/discussions/beta-testing/1854-using-margin-auto-causes-horizontal-scrollbar-on-typesomething

--- a/ts/reviewer/reviewer.scss
+++ b/ts/reviewer/reviewer.scss
@@ -11,6 +11,7 @@ hr {
 body {
     margin: 20px;
     overflow-wrap: break-word;
+    transform-origin: top;
     // default background setting to fit with toolbar
     background-size: cover;
     background-repeat: no-repeat;
@@ -40,12 +41,15 @@ pre {
 
 #_flag {
     position: fixed;
+
     [dir="ltr"] & {
         right: 10px;
     }
+
     [dir="rtl"] & {
         left: 10px;
     }
+
     top: 0;
     font-size: 30px;
     -webkit-text-stroke-width: 1px;
@@ -54,12 +58,15 @@ pre {
 
 #_mark {
     position: fixed;
+
     [dir="ltr"] & {
         left: 10px;
     }
+
     [dir="rtl"] & {
         right: 10px;
     }
+
     top: 0;
     font-size: 30px;
     color: yellow;
@@ -126,6 +133,7 @@ button {
 .drawing {
     zoom: 50%;
 }
+
 .nightMode img.drawing {
     filter: unquote("invert(1) hue-rotate(180deg)");
 }

--- a/ts/reviewer/reviewer.scss
+++ b/ts/reviewer/reviewer.scss
@@ -78,7 +78,6 @@ pre {
     position: fixed;
     display: none;
 
-
     right: 10px;
     top: 0;
     font-size: 20px;

--- a/ts/reviewer/zoom.ts
+++ b/ts/reviewer/zoom.ts
@@ -1,0 +1,60 @@
+// Copyright: Ankitects Pty Ltd and contributors
+// License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
+
+/* eslint
+@typescript-eslint/no-explicit-any: "off",
+ */
+
+import { bridgeCommand } from "@tslib/bridgecommand";
+
+const ZOOM_STEP = 0.1;
+const DEFAULT_SCALE_FACTOR = 1;
+const MAXIMUM_SCALE_FACTOR = 5;  // Chromium defaults
+const MINIMUM_SCALE_FACTOR = 0.25;
+
+let scaleFactor = 1.0;
+let scaleTimer: null | number = null;
+
+export function triggerScaleStep(sign: number) {
+    scaleFactor = Math.min(
+        Math.max(scaleFactor * (1 + sign * ZOOM_STEP), MINIMUM_SCALE_FACTOR),
+        MAXIMUM_SCALE_FACTOR
+    );
+    setScaleFactor(scaleFactor);
+}
+
+export function setScaleFactor(newScaleFactor: number, store = true) {
+    const scaledContainer = document.body;
+    scaledContainer.style.transform = `scale(${newScaleFactor})`;
+    scaleFactor = newScaleFactor;
+    if (scaleTimer) {
+        clearTimeout(scaleTimer);
+    }
+    if (store) {
+        scaleTimer = setTimeout(() => {
+            storeScaleFactor(newScaleFactor);
+        }, 100);
+    }
+}
+
+export function resetScaleFactor() {
+    setScaleFactor(DEFAULT_SCALE_FACTOR);
+}
+
+export function setupWheelZoom() {
+    document.addEventListener(
+        "wheel",
+        (event) => {
+            if (!event.ctrlKey) {
+                return;
+            }
+            event.preventDefault();
+            triggerScaleStep(-Math.sign(event.deltaY));
+        },
+        { passive: false }
+    );
+}
+
+function storeScaleFactor(scale: number) {
+    bridgeCommand(`scale:${scale}`);
+}

--- a/ts/reviewer/zoom.ts
+++ b/ts/reviewer/zoom.ts
@@ -92,7 +92,7 @@ export function setupWheelZoom(): void {
     document.addEventListener(
         "wheel",
         (event) => {
-            if (!event.ctrlKey) {
+            if (!event.ctrlKey || !event.shiftKey) {
                 return;
             }
             event.preventDefault();

--- a/ts/reviewer/zoom.ts
+++ b/ts/reviewer/zoom.ts
@@ -34,7 +34,7 @@ let zoomSaveTimer: number | null = null;
 
 export function triggerZoomStep(sign: number): void {
     const step = zoomStep + sign
-    if (step < 0 || step > PRESET_ZOOM_FACTORS.length) {
+    if (step < 0 || step > (PRESET_ZOOM_FACTORS.length - 1)) {
         return
     }
 
@@ -92,7 +92,7 @@ export function setupWheelZoom(): void {
     document.addEventListener(
         "wheel",
         (event) => {
-            if (!event.ctrlKey || !event.shiftKey) {
+            if (!(event.ctrlKey && event.shiftKey)) {
                 return;
             }
             event.preventDefault();

--- a/ts/reviewer/zoom.ts
+++ b/ts/reviewer/zoom.ts
@@ -23,14 +23,15 @@ export function triggerScaleStep(sign: number) {
     setScaleFactor(scaleFactor);
 }
 
-export function setScaleFactor(newScaleFactor: number, store = true) {
+export function setScaleFactor(newScaleFactor: number, interactive = true) {
     const scaledContainer = document.body;
     scaledContainer.style.transform = `scale(${newScaleFactor})`;
     scaleFactor = newScaleFactor;
     if (scaleTimer) {
         clearTimeout(scaleTimer);
     }
-    if (store) {
+    if (interactive) {
+        displayScaleInfo(newScaleFactor)
         scaleTimer = setTimeout(() => {
             storeScaleFactor(newScaleFactor);
         }, 100);
@@ -43,6 +44,21 @@ export function resetScaleFactor() {
 
 function storeScaleFactor(scale: number) {
     bridgeCommand(`scale:${scale}`);
+}
+
+const scaleInfoId = "_scaleinfo"
+
+function displayScaleInfo(scaleFactor: number) {
+    console.log("displayscaleinfo")
+    let scaleInfoBox = document.getElementById(scaleInfoId)
+    if (!scaleInfoBox) {
+        scaleInfoBox = document.createElement("div")
+        document.documentElement.appendChild(scaleInfoBox)
+        scaleInfoBox.id = scaleInfoId
+    }
+    scaleInfoBox.innerHTML = `${Math.round(scaleFactor * 100)}%`
+    scaleInfoBox.style.display = "block";
+    setTimeout(() => { scaleInfoBox!.style.display = "none"; }, 1000)
 }
 
 export function setupWheelZoom() {

--- a/ts/reviewer/zoom.ts
+++ b/ts/reviewer/zoom.ts
@@ -12,7 +12,7 @@ const DEFAULT_SCALE_FACTOR = 1;
 const MAXIMUM_SCALE_FACTOR = 5;  // Chromium defaults
 const MINIMUM_SCALE_FACTOR = 0.25;
 
-let scaleFactor = 1.0;
+let scaleFactor = DEFAULT_SCALE_FACTOR;
 let scaleTimer: null | number = null;
 
 export function triggerScaleStep(sign: number) {
@@ -41,6 +41,10 @@ export function resetScaleFactor() {
     setScaleFactor(DEFAULT_SCALE_FACTOR);
 }
 
+function storeScaleFactor(scale: number) {
+    bridgeCommand(`scale:${scale}`);
+}
+
 export function setupWheelZoom() {
     document.addEventListener(
         "wheel",
@@ -53,8 +57,4 @@ export function setupWheelZoom() {
         },
         { passive: false }
     );
-}
-
-function storeScaleFactor(scale: number) {
-    bridgeCommand(`scale:${scale}`);
 }

--- a/ts/reviewer/zoom.ts
+++ b/ts/reviewer/zoom.ts
@@ -33,9 +33,9 @@ let zoomStep = DEFAULT_ZOOM_STEP;
 let zoomSaveTimer: number | null = null;
 
 export function triggerZoomStep(sign: number): void {
-    const step = zoomStep + sign
+    const step = zoomStep + sign;
     if (step < 0 || step > (PRESET_ZOOM_FACTORS.length - 1)) {
-        return
+        return;
     }
 
     setZoomStep(step);
@@ -43,12 +43,12 @@ export function triggerZoomStep(sign: number): void {
 
 export function setZoomStep(step: number, interactive = true): void {
     const zoomedContainer = document.body;
-    const zoomFactor = PRESET_ZOOM_FACTORS[step]
+    const zoomFactor = PRESET_ZOOM_FACTORS[step];
     if (zoomFactor === undefined) {
-        return
+        return;
     }
     zoomedContainer.style.transform = `scale(${zoomFactor})`;
-    zoomStep = step
+    zoomStep = step;
     if (zoomSaveTimer) {
         clearTimeout(zoomSaveTimer);
     }
@@ -61,7 +61,7 @@ export function setZoomStep(step: number, interactive = true): void {
 }
 
 export function resetZoom(): void {
-    setZoomStep(DEFAULT_ZOOM_STEP)
+    setZoomStep(DEFAULT_ZOOM_STEP);
 }
 
 function storeZoomStep(step: number) {
@@ -79,7 +79,7 @@ function displayZoomInfo(zoomFactor: number) {
         zoomInfoBox.id = zoomInfoId;
     }
     if (zoomInfoTimer) {
-        clearTimeout(zoomInfoTimer)
+        clearTimeout(zoomInfoTimer);
     }
     zoomInfoBox.innerHTML = `${Math.round(zoomFactor * 100)}%`;
     zoomInfoBox.style.display = "block";
@@ -98,6 +98,6 @@ export function setupWheelZoom(): void {
             event.preventDefault();
             triggerZoomStep(-Math.sign(event.deltaY));
         },
-        { passive: false }
+        { passive: false },
     );
 }


### PR DESCRIPTION
Inspired by https://github.com/ankitects/anki/issues/2588, but hoping to address image zoom in a more general capacity as I think  this has been a long-standing issue for quite a few users (even predating native zoom, see e.g. the reviews on [zoom add-ons](https://ankiweb.net/shared/info/1956318463) from as far back as 2.0).

In its current iteration, this PR introduces a **new JS-based zoom system** that works in parallel to the Qt-native system. When the Reviewer is active, any user-triggered zoom actions can be switched over to this alternate mode by holding down <kbd>Shift</kbd>. In alternate mode, zooming is performed by scale-transforming `document.body`, preserving the layout sizing and thus allowing users to freely zoom into images. Quick comparison between the mode (native first, JS second):

https://github.com/ankitects/anki/assets/5459332/452dad48-3968-4f31-9eca-6e10c833b98a

The **downside** to this approach, and why I ended up implementing it as an optional mode, is that text does not reflow when the layout sizing is preserved, so long-ish paragraphs will end up extending past the viewport. This makes the mode ill-suited for use cases where users will want to adjust the zoom level in order to boost text readability – which I assume are quite common, e.g. when using Anki at larger screen distances.

I played around with this a lot, going back-and-forth between different approaches, and wasn't able to find a full-page zoom mode that works well for both scenarios – thus the two modes, even if not particularly ideal from a discoverability standpoint.

On the upside, this PR also introduces a couple of zoom **features** in the alternate mode which I think are quite neat to have:

- the zoom level is now communicated via a small info box in the top right
- zoom levels in alternate mode are persisted across Anki sessions – not sure if this is 100% desirable for everyone, could switch it back to just being persistent within a session

**Some thoughts on alternatives**

If we are happy to handle this on a less generic level, then I think it could be interesting to take [@krmanik's approach](https://github.com/ankitects/anki/issues/2588#issuecomment-1648289462) and extend it to all images, i.e. see if we can't equip all `img`s with a ctrl+scroll handler that would allow users to zoom into individual images. The problem I would see here is that we don't have full control over user-created note types, or at least not as much as we do with a default note type like IO, and so we could run into scenarios where card layout or styling interferes with image zooming or creates unexpected behavior of some sort. 