### PR TITLE
[Development] Specify `extra` directory as a designated ignored folder

### DIFF
--- a/.dprint.json
+++ b/.dprint.json
@@ -29,7 +29,6 @@
         "qt/bundle/PyOxidizer",
         "target",
         ".mypy_cache",
-        ".pytest_cache",
         "extra"
     ],
     "plugins": [

--- a/.dprint.json
+++ b/.dprint.json
@@ -27,7 +27,10 @@
         "licenses.json",
         ".dmypy.json",
         "qt/bundle/PyOxidizer",
-        "target"
+        "target",
+        ".mypy_cache",
+        ".pytest_cache",
+        "extra"
     ],
     "plugins": [
         "https://plugins.dprint.dev/typescript-0.85.1.wasm",

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -50,7 +50,7 @@ module.exports = {
         },
     ],
     env: { browser: true },
-    ignorePatterns: ["backend_proto.d.ts", "*.svelte.d.ts", "vendor"],
+    ignorePatterns: ["backend_proto.d.ts", "*.svelte.d.ts", "vendor", "extra/*"],
     globals: {
         globalThis: false,
         NodeListOf: false,

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ node_modules
 .n2_db
 .ninja_log
 .ninja_deps
+/extra

--- a/docs/development.md
+++ b/docs/development.md
@@ -95,6 +95,10 @@ When formatting issues are reported, they can be fixed with
 cargo clippy --fix
 ```
 
+## Excluding your own untracked files from formatting and checks
+
+If you want to add files or folders to the project tree that should be excluded from version tracking and not be matched by formatters and checks, place them in an `extra` folder and they will automatically be ignored.
+
 ## Optimized builds
 
 The `./run` command will create a non-optimized build by default. This is faster

--- a/tools/minilints/src/main.rs
+++ b/tools/minilints/src/main.rs
@@ -41,7 +41,6 @@ const IGNORED_FOLDERS: &[&str] = &[
     "./qt/bundle/PyOxidizer",
     "./target",
     ".mypy_cache",
-    ".pytest_cache",
     "./extra",
 ];
 

--- a/tools/minilints/src/main.rs
+++ b/tools/minilints/src/main.rs
@@ -40,6 +40,9 @@ const IGNORED_FOLDERS: &[&str] = &[
     "./tools/workspace-hack",
     "./qt/bundle/PyOxidizer",
     "./target",
+    ".mypy_cache",
+    ".pytest_cache",
+    "./extra",
 ];
 
 fn main() -> Result<()> {


### PR DESCRIPTION
Excludes `extra/` from version tracking, file formatters, and file checks, which should allow contributors to add their own files to the project tree without interfering with checks (e.g. in my case MWE code samples for PRs, etc.)

Also adds mypy caches to the exclusion rules, allowing contributors to use the VS Code mypy integration.

(follow-up to a [fairly old discussion](https://github.com/ankitects/anki/pull/2202#issuecomment-1328159393), picking it up now as I have been running into a lot of woes with dprint checks recently)