### PR TITLE
Pass AddCards instance to notetype change hook

### DIFF
--- a/qt/aqt/addcards.py
+++ b/qt/aqt/addcards.py
@@ -188,8 +188,8 @@ class AddCards(QMainWindow):
         self.editor.loadNote(
             focusTo=min(self.editor.last_field_index or 0, len(new_note.fields) - 1)
         )
-        gui_hooks.add_cards_did_change_note_type(
-            old_note.note_type(), new_note.note_type()
+        gui_hooks.addcards_did_change_note_type(
+            self, old_note.note_type(), new_note.note_type()
         )
 
     def _load_new_note(self, sticky_fields_from: Optional[Note] = None) -> None:

--- a/qt/tools/genhooks_gui.py
+++ b/qt/tools/genhooks_gui.py
@@ -1013,6 +1013,19 @@ gui_hooks.webview_did_inject_style_into_page.append(mytest)
     Hook(
         name="add_cards_did_change_note_type",
         args=["old: anki.models.NoteType", "new: anki.models.NoteType"],
+        doc="""Deprecated. Use addcards_did_change_note_type instead.
+        Executed after the user selects a new note type when adding
+        cards.""",
+    ),
+    Hook(
+        name="addcards_did_change_note_type",
+        args=[
+            "addcards: aqt.addcards.AddCards",
+            "old: anki.models.NoteType",
+            "new: anki.models.NoteType",
+        ],
+        replaces="add_cards_did_change_note_type",
+        replaced_hook_args=["old: anki.models.NoteType", "new: anki.models.NoteType"],
         doc="""Executed after the user selects a new note type when adding
         cards.""",
     ),


### PR DESCRIPTION
Allows add-ons that modify `AddCards` to more easily react to notetype changes without needing to keep `AddCards` instances as state or accessing them through other roundabout ways.

Deprecates `add_cards_did_change_note_type` in favor of `addcards_did_change_note_type`.

----

On a general note, this is a common issue with a lot of the hooks we have, where subscribers are provided with an event and some data attached to it, but not the Anki object they are most likely to interact with in order to react to the event (e.g. in this case updating an add-on managed UI in the AddCards window). As a result, add-ons commonly have to fall back to using more fragile access patterns to Anki objects, e.g. via the dialog manager, or by being more stateful, e.g. by  observing the current AddCards instance with `add_cards_did_init` and keeping a reference to it (while assuming that it's a singleton) – the latter is what two out of three add-ons that use `add_cards_did_change_note_type` currently seem to do.

This works, but is not particularly pretty and seems prone to common errors like not dereferencing objects when windows are destroyed and thus impeding garbage collection or leading to other errors. The approach also breaks down as soon as you throw an add-on like [Opening the same window multiple time](https://ankiweb.net/shared/info/354407385) into the mix.

Unfortunately it's difficult to change things now, so I'm approaching this more iteratively when I see that an existing hook that I want to use in an add-on might encourage fragile add-on patterns, but – in general – for newly added hooks I think it would be good for us to keep an eye on whether it makes sense to pass in more context.