### PR TITLE
Perform occlusion mode reset directly after adding notes

### DIFF
--- a/ts/editor/NoteEditor.svelte
+++ b/ts/editor/NoteEditor.svelte
@@ -426,6 +426,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         if (page) {
             page.remove();
         }
+        imageOcclusionMode = undefined;
     }
     globalThis.resetIOImageLoaded = resetIOImageLoaded;
 
@@ -550,7 +551,6 @@ the AddCards dialog) should be implemented in the user of this component.
                 --border-right-radius="5px"
                 class="io-select-image-btn"
                 on:click={() => {
-                    imageOcclusionMode = undefined;
                     bridgeCommand("addImageForOcclusion");
                 }}
             >


### PR DESCRIPTION
Seems to fix the additional scenarios discussed in the #2596 comments

Does this look OK to you? Don't fully grok the implications of resetting the mode here, but if it works on image selection button click, I'd imagine that this is safe, too.

One caveat: `resetIOImageLoaded()` is called from Python and thus only pertinent on desktop. If #2596 also occurs on mobile we might have to solve this differently (though I wasn't able to reproduce this and would imagine that it's impossible as each mask editing session happens in a new web view context, right?)