### PR TITLE
follow-up pr for io button in note editor

### DIFF
--- a/qt/aqt/addcards.py
+++ b/qt/aqt/addcards.py
@@ -115,8 +115,8 @@ class AddCards(QMainWindow):
         self.addButton.setToolTip(shortcut(tr.adding_add_shortcut_ctrlandenter()))
 
         # add io button
-        self.io_add_button = bb.addButton(f"{tr.actions_add()} {downArrow()}", ar)
-        qconnect(self.io_add_button.clicked, self.onAddIo)
+        self.io_add_button = bb.addButton(f"{tr.actions_add()}", ar)
+        qconnect(self.io_add_button.clicked, self.add_io_note)
         self.io_add_button.setShortcut(QKeySequence("Ctrl+Shift+I"))
 
         # close
@@ -372,21 +372,8 @@ class AddCards(QMainWindow):
 
         self.ifCanClose(doClose)
 
-    def onAddIo(self) -> None:
-        m = QMenu(self)
-        a = m.addAction(tr.notetypes_hide_all_guess_one())
-        qconnect(a.triggered, self.add_io_hide_all_note)
-        a = m.addAction(tr.notetypes_hide_one_guess_one())
-        qconnect(a.triggered, self.add_io_hide_one_note)
-        m.popup(QCursor.pos())
-
-    def add_io_hide_all_note(self) -> None:
-        self.editor.web.eval("setOcclusionField(true)")
-        self.add_current_note()
-        self.editor.web.eval("resetIOImageLoaded()")
-
-    def add_io_hide_one_note(self) -> None:
-        self.editor.web.eval("setOcclusionField(false)")
+    def add_io_note(self) -> None:
+        self.editor.web.eval("setOcclusionFieldInner()")
         self.add_current_note()
         self.editor.web.eval("resetIOImageLoaded()")
 

--- a/qt/aqt/editor.py
+++ b/qt/aqt/editor.py
@@ -562,8 +562,8 @@ require("anki/ui").loaded.then(() => require("anki/NoteEditor").instances[0].too
             self.editorMode != EditorMode.ADD_CARDS
             and self.current_notetype_is_image_occlusion()
         ):
-            options = {"kind": "edit", "noteId": self.note.id}
-            options = {"mode": options}
+            mode = {"kind": "edit", "noteId": self.note.id}
+            options = {"mode": mode}
             js += " setupMaskEditor(%s);" % json.dumps(options)
 
         js = gui_hooks.editor_will_load_note(js, self.note, self)
@@ -1202,10 +1202,16 @@ require("anki/ui").loaded.then(() => require("anki/NoteEditor").instances[0].too
         def accept(file: str) -> None:
             try:
                 html = self._addMedia(file)
-                mode = {"kind": "add", "imagePath": file, "notetypeId": 0}
-                # pass both html and options
-                options = {"html": html, "mode": mode}
-                self.web.eval(f"setupMaskEditor({json.dumps(options)})")
+                if self.editorMode == EditorMode.ADD_CARDS:
+                    mode = {"kind": "add", "imagePath": file, "notetypeId": 0}
+                    options = {"html": html, "mode": mode}
+                    self.web.eval(f"setupMaskEditor({json.dumps(options)})")
+                else:
+                    mode = {"kind": "edit", "notetypeId": self.note.id}
+                    options = {"html": html, "mode": mode}
+                    self.web.eval(f"resetIOImage({json.dumps(file)})")
+                    self.web.eval(f"setImageField({json.dumps(html)})")
+                    self.web.eval(f"setupMaskEditor({json.dumps(options)})")
             except Exception as e:
                 showWarning(str(e))
                 return

--- a/ts/editor/NoteEditor.svelte
+++ b/ts/editor/NoteEditor.svelte
@@ -412,17 +412,6 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         }
 
         isIOImageLoaded = true;
-
-        // event for updating canvas on edit mode
-        setTimeout(() => {
-            const canvas = globalThis.canvas;
-            canvas.on("object:modified", () => {
-                updateIONoteInEditMode();
-            });
-            canvas.on("object:removed", () => {
-                updateIONoteInEditMode();
-            });
-        }, 500);
     }
 
     function setImageField(html) {
@@ -573,7 +562,10 @@ the AddCards dialog) should be implemented in the user of this component.
 
     {#if imageOcclusionMode}
         <div style="display: {$ioMaskEditorVisible ? 'block' : 'none'}">
-            <ImageOcclusionPage mode={imageOcclusionMode} />
+            <ImageOcclusionPage
+                mode={imageOcclusionMode}
+                on:change={updateIONoteInEditMode}
+            />
         </div>
     {/if}
 

--- a/ts/editor/NoteEditor.svelte
+++ b/ts/editor/NoteEditor.svelte
@@ -298,10 +298,10 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     }
 
     function saveNow(): void {
-        updateIONoteInEditMode();
         closeMathjaxEditor?.();
         $commitTagEdits();
         saveFieldNow();
+        imageOcclusionMode = undefined;
     }
 
     export function saveOnPageHide() {
@@ -390,7 +390,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     import ImageOcclusionPage from "image-occlusion/ImageOcclusionPage.svelte";
     import type { IOMode } from "image-occlusion/lib";
     import { exportShapesToClozeDeletions } from "image-occlusion/shapes/to-cloze";
-    import { ioMaskEditorVisible } from "image-occlusion/store";
+    import { hideAllGuessOne, ioMaskEditorVisible } from "image-occlusion/store";
 
     import { mathjaxConfig } from "../editable/mathjax-element";
     import CollapseLabel from "./CollapseLabel.svelte";
@@ -402,9 +402,33 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         imageOcclusionMode = options.mode;
         if (options.mode.kind === "add") {
             fieldStores[1].set(options.html);
+        } else {
+            const clozeNote = get(fieldStores[0]);
+            if (clozeNote.includes("oi=1")) {
+                $hideAllGuessOne = true;
+            } else {
+                $hideAllGuessOne = false;
+            }
         }
+
         isIOImageLoaded = true;
+
+        // event for updating canvas on edit mode
+        setTimeout(() => {
+            const canvas = globalThis.canvas;
+            canvas.on("object:modified", () => {
+                updateIONoteInEditMode();
+            });
+            canvas.on("object:removed", () => {
+                updateIONoteInEditMode();
+            });
+        }, 500);
     }
+
+    function setImageField(html) {
+        fieldStores[1].set(html);
+    }
+    globalThis.setImageField = setImageField;
 
     // update cloze deletions and set occlusion fields, it call in saveNow to update cloze deletions
     function updateIONoteInEditMode() {
@@ -417,6 +441,15 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
             }
         }
     }
+
+    function setOcclusionFieldInner() {
+        if (isImageOcclusion) {
+            const occlusionsData = exportShapesToClozeDeletions($hideAllGuessOne);
+            fieldStores[0].set(occlusionsData.clozes);
+        }
+    }
+    // global for calling this method in desktop note editor
+    globalThis.setOcclusionFieldInner = setOcclusionFieldInner;
 
     // reset for new occlusion in add mode
     function resetIOImageLoaded() {
@@ -484,6 +517,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
             setIsEditMode,
             setupMaskEditor,
             setOcclusionField,
+            setOcclusionFieldInner,
             ...oldEditorAdapter,
         });
 

--- a/ts/image-occlusion/ImageOcclusionPage.svelte
+++ b/ts/image-occlusion/ImageOcclusionPage.svelte
@@ -42,7 +42,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     </div>
 
     <div hidden={activeTabValue != 1}>
-        <MasksEditor {mode} />
+        <MasksEditor {mode} on:change />
     </div>
 
     <div hidden={activeTabValue != 2}>

--- a/ts/image-occlusion/ImageOcclusionPage.svelte
+++ b/ts/image-occlusion/ImageOcclusionPage.svelte
@@ -11,15 +11,12 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     import MasksEditor from "./MaskEditor.svelte";
     import Notes from "./Notes.svelte";
     import StickyFooter from "./StickyFooter.svelte";
+    import { hideAllGuessOne } from "./store";
 
     export let mode: IOMode;
 
-    async function hideAllGuessOne(): Promise<void> {
-        addOrUpdateNote(mode, true);
-    }
-
-    async function hideOneGuessOne(): Promise<void> {
-        addOrUpdateNote(mode, false);
+    async function addNote(): Promise<void> {
+        addOrUpdateNote(mode, $hideAllGuessOne);
     }
 
     const items = [
@@ -52,7 +49,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         <Notes />
     </div>
 
-    <StickyFooter {hideAllGuessOne} {hideOneGuessOne} />
+    <StickyFooter {addNote} />
 </Container>
 
 <style lang="scss">

--- a/ts/image-occlusion/MaskEditor.svelte
+++ b/ts/image-occlusion/MaskEditor.svelte
@@ -5,6 +5,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 <script lang="ts">
     import type { PanZoom } from "panzoom";
     import panzoom from "panzoom";
+    import { createEventDispatcher } from "svelte";
 
     import type { IOMode } from "./lib";
     import { setupMaskEditor, setupMaskEditorForEdit } from "./mask-editor";
@@ -17,6 +18,12 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     const startingTool = mode.kind === "add" ? "draw-rectangle" : "cursor";
     $: canvas = null;
 
+    const dispatch = createEventDispatcher();
+
+    function onChange() {
+        dispatch("change", { canvas });
+    }
+
     function init(node) {
         instance = panzoom(node, {
             bounds: true,
@@ -28,11 +35,11 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         instance.pause();
 
         if (mode.kind == "add") {
-            setupMaskEditor(mode.imagePath, instance).then((canvas1) => {
+            setupMaskEditor(mode.imagePath, instance, onChange).then((canvas1) => {
                 canvas = canvas1;
             });
         } else {
-            setupMaskEditorForEdit(mode.noteId, instance).then((canvas1) => {
+            setupMaskEditorForEdit(mode.noteId, instance, onChange).then((canvas1) => {
                 canvas = canvas1;
             });
         }

--- a/ts/image-occlusion/StickyFooter.svelte
+++ b/ts/image-occlusion/StickyFooter.svelte
@@ -8,8 +8,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     import ButtonGroup from "../components/ButtonGroup.svelte";
     import LabelButton from "../components/LabelButton.svelte";
 
-    export let hideAllGuessOne: () => void;
-    export let hideOneGuessOne: () => void;
+    export let addNote: () => void;
 </script>
 
 <div style:flex-grow="1" />
@@ -18,18 +17,10 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         <LabelButton
             --border-left-radius="5px"
             --border-right-radius="5px"
-            on:click={hideAllGuessOne}
+            on:click={addNote}
             class=" bottom-btn"
         >
-            {tr.notetypesHideAllGuessOne()}
-        </LabelButton>
-        <LabelButton
-            --border-left-radius="5px"
-            --border-right-radius="5px"
-            on:click={hideOneGuessOne}
-            class=" bottom-btn"
-        >
-            {tr.notetypesHideOneGuessOne()}
+            {tr.actionsAdd()}
         </LabelButton>
     </ButtonGroup>
 </div>

--- a/ts/image-occlusion/icons.ts
+++ b/ts/image-occlusion/icons.ts
@@ -9,6 +9,7 @@ export { default as mdiAlignHorizontalRight } from "@mdi/svg/svg/align-horizonta
 export { default as mdiAlignVerticalBottom } from "@mdi/svg/svg/align-vertical-bottom.svg";
 export { default as mdiAlignVerticalCenter } from "@mdi/svg/svg/align-vertical-center.svg";
 export { default as mdiAlignVerticalTop } from "@mdi/svg/svg/align-vertical-top.svg";
+export { default as mdiChevronDown } from "@mdi/svg/svg/chevron-down.svg";
 export { default as mdiClose } from "@mdi/svg/svg/close.svg";
 export { default as mdiCodeTags } from "@mdi/svg/svg/code-tags.svg";
 export { default as mdiCopy } from "@mdi/svg/svg/content-copy.svg";
@@ -27,7 +28,10 @@ export { default as mdiZoomIn } from "@mdi/svg/svg/magnify-plus-outline.svg";
 export { default as mdiMagnifyScan } from "@mdi/svg/svg/magnify-scan.svg";
 export { default as mdiRectangleOutline } from "@mdi/svg/svg/rectangle-outline.svg";
 export { default as mdiRedo } from "@mdi/svg/svg/redo.svg";
+export { default as mdiRefresh } from "@mdi/svg/svg/refresh.svg";
+export { default as mdiSquare } from "@mdi/svg/svg/square.svg";
 export { default as mdiUndo } from "@mdi/svg/svg/undo.svg";
 export { default as mdiUnfoldMoreHorizontal } from "@mdi/svg/svg/unfold-more-horizontal.svg";
 export { default as mdiUngroup } from "@mdi/svg/svg/ungroup.svg";
 export { default as mdiVectorPolygonVariant } from "@mdi/svg/svg/vector-polygon-variant.svg";
+export { default as mdiViewDashboard } from "@mdi/svg/svg/view-dashboard.svg";

--- a/ts/image-occlusion/store.ts
+++ b/ts/image-occlusion/store.ts
@@ -11,3 +11,5 @@ export const zoomResetValue = writable(1);
 export const tagsWritable = writable([""]);
 // it stores the visibility of mask editor
 export const ioMaskEditorVisible = writable(true);
+// it store hide all or hide one mode
+export const hideAllGuessOne = writable(true);


### PR DESCRIPTION
In this PR the reset image and io mode (hide all & hide one) implemented. The button for mobile client for two mode moved to toolbar. The option to change mode in toolbar is helpful in add, edit and browse mode.
The reset image feature need help, I have tried to implement but the option is only available to desktop client and didn't find better solution for both mobile and desktop. In browse mode changing the note does not update mask editor so there is fix in this PR.