### PR TITLE
Fixed MIME handling for non-standard umask(1) values

### DIFF
--- a/qt/bundle/lin/install.sh
+++ b/qt/bundle/lin/install.sh
@@ -31,6 +31,10 @@ xdg-mime default anki.desktop application/x-colpkg
 xdg-mime default anki.desktop application/x-apkg
 xdg-mime default anki.desktop application/x-ankiaddon
 
+if [ $(id -u) -eq 0 ]; then
+  chmod -R o+r /usr/share/mime
+fi
+
 rm install.sh
 
 echo "Install complete. Type 'anki' to run."


### PR DESCRIPTION
I set `umask` to 027, which apparently causes the `xdg-mime` commands to create unreadable entries in _/usr/share/mime_ when run as root. This has bricked my DE on at least one occasion so I think it would be reasonable to ensure that the contents of this directory remain readable