### PR TITLE
Fix crash caused by uninitialized self._reps in class Reviewer

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -132,6 +132,7 @@ shunlog <github.com/shunlog>
 Derek Dang <github.com/derekdang/>
 Luc Mcgrady <github.com/Luc-Mcgrady>
 Kehinde Adeleke <adelekekehinde06@gmail.com>
+Marko Juhanne <github.com/mjuhanne>
 
 ********************
 

--- a/qt/aqt/reviewer.py
+++ b/qt/aqt/reviewer.py
@@ -161,7 +161,7 @@ class Reviewer:
         self.web.set_bridge_command(self._linkHandler, self)
         self.bottom.web.set_bridge_command(self._linkHandler, ReviewerBottomBar(self))
         self._state_mutation_js = self.mw.col.get_config("cardStateCustomizer")
-        self._reps: int = None
+        self._reps = None
         self._refresh_needed = RefreshNeeded.QUEUES
         self.refresh_if_needed()
 

--- a/qt/aqt/reviewer.py
+++ b/qt/aqt/reviewer.py
@@ -149,6 +149,7 @@ class Reviewer:
         self._card_info = ReviewerCardInfo(self.mw)
         self._previous_card_info = PreviousReviewerCardInfo(self.mw)
         self._states_mutated = True
+        self._reps: int = None
         hooks.card_did_leech.append(self.onLeech)
 
     def show(self) -> None:


### PR DESCRIPTION
Reviewer: Fixes the crash when call to refresh_if_needed() is invoked and self._reps is referenced before it is initialised in  show()

Note that the trace below is from earlier version but the crash can be reproduced with the newest version as well.

```
Error
An error occurred. Please start Anki while holding down the shift key, which will temporarily disable the add-ons you have installed.
If the issue only occurs when add-ons are enabled, please use the Tools > Add-ons menu item to disable some add-ons and restart Anki, repeating until you discover the add-on that is causing the problem.
When you've discovered the add-on that is causing the problem, please report the issue to the add-on author.
Debug info:
Anki 2.1.65 (aa9a734f) Python 3.9.2 Qt 6.5.1 PyQt 6.5.1
Platform: macOS-11.1-arm64-arm-64bit
Flags: frz=False ao=True sv=2
Add-ons, last update check: 2023-07-29 09:41:34
Add-ons possibly involved: ⁨Migaku Kanji GOD⁩

Caught exception:
Traceback (most recent call last):
  File "/opt/homebrew/lib/python3.9/site-packages/aqt/webview.py", line 46, in cmd
    return json.dumps(self.onCmd(str))
  File "/opt/homebrew/lib/python3.9/site-packages/aqt/webview.py", line 153, in _onCmd
    return self._onBridgeCmd(str)
  File "/opt/homebrew/lib/python3.9/site-packages/aqt/webview.py", line 662, in _onBridgeCmd
    return self.onBridgeCmd(cmd)
  File "/opt/homebrew/lib/python3.9/site-packages/aqt/overview.py", line 92, in _linkHandler
    self.mw.moveToState("review")
  File "/opt/homebrew/lib/python3.9/site-packages/aqt/main.py", line 711, in moveToState
    gui_hooks.state_will_change(state, oldState)
  File "/opt/homebrew/lib/python3.9/site-packages/_aqt/hooks.py", line 4757, in __call__
    hook(new_state, old_state)
  File "/Users/markojuhanne/Library/Application Support/Anki2/addons21/1872210448/reviewer.py", line 59, in learn_ahead_refresh_on_review_start
    aqt.mw.migaku_kanji_db.refresh_learn_ahead()
  File "/Users/markojuhanne/Library/Application Support/Anki2/addons21/1872210448/kanji.py", line 423, in refresh_learn_ahead
    self.make_cards_from_characters(ct, new, None)
  File "/Users/markojuhanne/Library/Application Support/Anki2/addons21/1872210448/kanji.py", line 608, in make_cards_from_characters
    aqt.mw.requireReset()
  File "/opt/homebrew/lib/python3.9/site-packages/aqt/main.py", line 837, in requireReset
    self.reset()
  File "/opt/homebrew/lib/python3.9/site-packages/aqt/main.py", line 822, in reset
    self._synthesize_op_did_execute_from_reset()
  File "/opt/homebrew/lib/python3.9/site-packages/aqt/main.py", line 774, in _synthesize_op_did_execute_from_reset
    gui_hooks.operation_did_execute(op, None)
  File "/opt/homebrew/lib/python3.9/site-packages/_aqt/hooks.py", line 3620, in __call__
    hook(changes, handler)
  File "/opt/homebrew/lib/python3.9/site-packages/aqt/main.py", line 782, in on_operation_did_execute
    dirty = self.reviewer.op_executed(changes, handler, focused)
  File "/opt/homebrew/lib/python3.9/site-packages/aqt/reviewer.py", line 209, in op_executed
    self.refresh_if_needed()
  File "/opt/homebrew/lib/python3.9/site-packages/aqt/reviewer.py", line 181, in refresh_if_needed
    self.nextCard()
  File "/opt/homebrew/lib/python3.9/site-packages/aqt/reviewer.py", line 240, in nextCard
    if self._reps is None:
AttributeError: 'Reviewer' object has no attribute '_reps'
```