### PR TITLE
Shift output suppression into n2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3362,6 +3362,7 @@ name = "runner"
 version = "0.0.0"
 dependencies = [
  "anki_io",
+ "anki_process",
  "anyhow",
  "camino",
  "clap",

--- a/build/configure/src/python.rs
+++ b/build/configure/src/python.rs
@@ -110,6 +110,10 @@ impl BuildAction for GenPythonProto {
         build.add_inputs("protoc-gen-mypy", inputs![":pyenv:protoc-gen-mypy"]);
         build.add_outputs("", python_outputs);
     }
+
+    fn hide_last_line(&self) -> bool {
+        true
+    }
 }
 
 pub struct BuildWheel {

--- a/build/ninja_gen/src/action.rs
+++ b/build/ninja_gen/src/action.rs
@@ -40,6 +40,14 @@ pub trait BuildAction {
         false
     }
 
+    fn hide_success(&self) -> bool {
+        true
+    }
+
+    fn hide_last_line(&self) -> bool {
+        false
+    }
+
     fn name(&self) -> &'static str {
         std::any::type_name::<Self>().split("::").last().unwrap()
     }

--- a/build/ninja_gen/src/build.rs
+++ b/build/ninja_gen/src/build.rs
@@ -262,6 +262,14 @@ impl BuildStatement<'_> {
         if let Some(pool) = action.concurrency_pool() {
             stmt.rule_variables.push(("pool".into(), pool.into()));
         }
+        stmt.rule_variables.push((
+            "hide_success".into(),
+            (action.hide_success() as u8).to_string(),
+        ));
+        stmt.rule_variables.push((
+            "hide_last_line".into(),
+            (action.hide_last_line() as u8).to_string(),
+        ));
 
         stmt
     }

--- a/build/ninja_gen/src/node.rs
+++ b/build/ninja_gen/src/node.rs
@@ -239,6 +239,10 @@ impl BuildAction for SvelteCheck {
         let hash = simple_hash(&self.tsconfig);
         build.add_output_stamp(format!("tests/svelte-check.{hash}"));
     }
+
+    fn hide_last_line(&self) -> bool {
+        true
+    }
 }
 
 pub struct TypescriptCheck {
@@ -306,6 +310,10 @@ impl BuildAction for JestTest<'_> {
         build.add_variable("folder", self.folder);
         let hash = simple_hash(self.folder);
         build.add_output_stamp(format!("tests/jest.{hash}"));
+    }
+
+    fn hide_last_line(&self) -> bool {
+        true
     }
 }
 

--- a/build/ninja_gen/src/python.rs
+++ b/build/ninja_gen/src/python.rs
@@ -137,6 +137,10 @@ impl BuildAction for PythonTypecheck {
         let hash = simple_hash(self.folders);
         build.add_output_stamp(format!("tests/python_typecheck.{hash}"));
     }
+
+    fn hide_last_line(&self) -> bool {
+        true
+    }
 }
 
 struct PythonFormat<'a> {
@@ -245,5 +249,9 @@ impl BuildAction for PythonTest {
         build.add_env_var("ANKI_TEST_MODE", "1");
         let hash = simple_hash(self.folder);
         build.add_output_stamp(format!("tests/python_pytest.{hash}"));
+    }
+
+    fn hide_last_line(&self) -> bool {
+        true
     }
 }

--- a/build/runner/Cargo.toml
+++ b/build/runner/Cargo.toml
@@ -9,6 +9,7 @@ rust-version.workspace = true
 
 [dependencies]
 anki_io.workspace = true
+anki_process.workspace = true
 anyhow.workspace = true
 camino.workspace = true
 clap.workspace = true

--- a/build/runner/src/bundle/artifacts.rs
+++ b/build/runner/src/bundle/artifacts.rs
@@ -8,7 +8,7 @@ use std::process::Command;
 use camino::Utf8PathBuf;
 use clap::Args;
 
-use crate::run::run_silent;
+use crate::run::run_command;
 
 #[derive(Args, Debug)]
 pub struct BuildArtifactsArgs {
@@ -29,7 +29,7 @@ pub fn build_artifacts(args: BuildArtifactsArgs) {
         fs::remove_dir_all(&build_folder).unwrap();
     }
 
-    run_silent(
+    run_command(
         Command::new(&args.pyoxidizer_bin)
             .args([
                 "--system-rust",

--- a/build/runner/src/bundle/binary.rs
+++ b/build/runner/src/bundle/binary.rs
@@ -6,7 +6,7 @@ use std::process::Command;
 use camino::Utf8Path;
 
 use super::artifacts::macos_deployment_target;
-use crate::run::run_silent;
+use crate::run::run_command;
 
 pub fn build_bundle_binary() {
     let mut features = String::from("build-mode-prebuilt-artifacts");
@@ -37,5 +37,5 @@ pub fn build_bundle_binary() {
         )
         .env("MACOSX_DEPLOYMENT_TARGET", macos_deployment_target())
         .env("CARGO_BUILD_TARGET", env!("TARGET"));
-    run_silent(&mut command);
+    run_command(&mut command);
 }

--- a/build/runner/src/bundle/folder.rs
+++ b/build/runner/src/bundle/folder.rs
@@ -12,7 +12,7 @@ use clap::ValueEnum;
 
 use crate::paths::absolute_msys_path;
 use crate::paths::unix_path;
-use crate::run::run_silent;
+use crate::run::run_command;
 
 #[derive(Clone, Copy, ValueEnum, Debug)]
 enum DistKind {
@@ -58,7 +58,7 @@ fn copy_qt_from_venv(kind: DistKind, folder_root: &Utf8Path) {
     let lib_path = folder_root.join("lib");
     fs::create_dir_all(&lib_path).unwrap();
     let dst_path = with_slash(absolute_msys_path(&lib_path));
-    run_silent(Command::new("rsync").args([
+    run_command(Command::new("rsync").args([
         "-a",
         "--delete",
         "--exclude-from",
@@ -70,7 +70,7 @@ fn copy_qt_from_venv(kind: DistKind, folder_root: &Utf8Path) {
 
 fn copy_linux_extras(kind: DistKind, folder_root: &Utf8Path) {
     // add README, installer, etc
-    run_silent(Command::new("rsync").args(["-a", "qt/bundle/lin/", &with_slash(folder_root)]));
+    run_command(Command::new("rsync").args(["-a", "qt/bundle/lin/", &with_slash(folder_root)]));
 
     // add extra IME plugins from download
     let lib_path = folder_root.join("lib");
@@ -84,11 +84,11 @@ fn copy_linux_extras(kind: DistKind, folder_root: &Utf8Path) {
         DistKind::Standard => "PyQt6/Qt6/plugins",
         DistKind::Alternate => "PyQt5/Qt5/plugins",
     });
-    run_silent(Command::new("rsync").args(["-a", &with_slash(src_path), &with_slash(dst_path)]));
+    run_command(Command::new("rsync").args(["-a", &with_slash(src_path), &with_slash(dst_path)]));
 }
 
 fn copy_windows_extras(folder_root: &Utf8Path) {
-    run_silent(Command::new("rsync").args([
+    run_command(Command::new("rsync").args([
         "-a",
         "out/extracted/win_amd64_audio/",
         &with_slash(folder_root),
@@ -131,7 +131,7 @@ fn copy_binary_and_pylibs(folder_root: &Utf8Path) {
         .join("../build")
         .join(env!("TARGET"))
         .join("release/resources/extra_files");
-    run_silent(Command::new("rsync").args([
+    run_command(Command::new("rsync").args([
         "-a",
         "--exclude",
         "PyQt6",

--- a/build/runner/src/pyenv.rs
+++ b/build/runner/src/pyenv.rs
@@ -6,7 +6,7 @@ use std::process::Command;
 use camino::Utf8Path;
 use clap::Args;
 
-use crate::run::run_silent;
+use crate::run::run_command;
 
 #[derive(Args)]
 pub struct PyenvArgs {
@@ -28,7 +28,7 @@ pub fn setup_pyenv(args: PyenvArgs) {
     let pip_sync = pyenv_bin_folder.join("pip-sync");
 
     if !pyenv_python.exists() {
-        run_silent(
+        run_command(
             Command::new(&args.python_bin)
                 .args(["-m", "venv"])
                 .args(args.venv_args)
@@ -44,7 +44,7 @@ pub fn setup_pyenv(args: PyenvArgs) {
                 .unwrap();
         }
 
-        run_silent(Command::new(pyenv_python).args([
+        run_command(Command::new(pyenv_python).args([
             "-m",
             "pip",
             "install",
@@ -53,5 +53,5 @@ pub fn setup_pyenv(args: PyenvArgs) {
         ]));
     }
 
-    run_silent(Command::new(pip_sync).args(&args.reqs));
+    run_command(Command::new(pip_sync).args(&args.reqs));
 }

--- a/build/runner/src/rsync.rs
+++ b/build/runner/src/rsync.rs
@@ -7,7 +7,7 @@ use camino::Utf8Path;
 use clap::Args;
 
 use crate::paths::absolute_msys_path;
-use crate::run::run_silent;
+use crate::run::run_command;
 
 #[derive(Args)]
 pub struct RsyncArgs {
@@ -23,7 +23,7 @@ pub struct RsyncArgs {
 
 pub fn rsync_files(args: RsyncArgs) {
     let output_dir = absolute_msys_path(Utf8Path::new(&args.output_dir));
-    run_silent(
+    run_command(
         Command::new("rsync")
             .current_dir(&args.prefix)
             .arg("--relative")

--- a/build/runner/src/run.rs
+++ b/build/runner/src/run.rs
@@ -3,10 +3,10 @@
 
 use std::io::ErrorKind;
 use std::process::Command;
-use std::process::Output;
 
 use anki_io::create_dir_all;
 use anki_io::write_file;
+use anki_process::CommandExt;
 use anyhow::Result;
 use clap::Args;
 
@@ -32,7 +32,7 @@ pub fn run_commands(args: RunArgs) -> Result<()> {
         create_dir_all(&dir)?;
     }
     for command in commands {
-        run_silent(&mut build_command(command, &args.env, &args.cwd));
+        run_command(&mut build_command(command, &args.env, &args.cwd));
     }
     if let Some(stamp_file) = args.stamp {
         write_file(stamp_file, b"")?;
@@ -82,26 +82,6 @@ fn split_args(args: Vec<String>) -> Vec<Vec<String>> {
     commands
 }
 
-/// Log stdout/stderr and exit if command failed; return output on success.
-/// If OUTPUT_SUCCESS=1 is defined, output will be shown on success.
-pub fn run_silent(command: &mut Command) -> Output {
-    let output = command
-        .output()
-        .unwrap_or_else(|e| panic!("failed to run command: {:?}: {e}", command));
-    if !output.status.success() {
-        println!(
-            "Command failed: \n{}\n{}",
-            String::from_utf8_lossy(&output.stdout),
-            String::from_utf8_lossy(&output.stderr),
-        );
-        std::process::exit(output.status.code().unwrap_or(1));
-    }
-    if std::env::var("OUTPUT_SUCCESS").is_ok() {
-        println!(
-            "{}{}",
-            String::from_utf8_lossy(&output.stdout),
-            String::from_utf8_lossy(&output.stderr)
-        );
-    }
-    output
+pub fn run_command(command: &mut Command) {
+    command.ensure_success().unwrap();
 }

--- a/build/runner/src/yarn.rs
+++ b/build/runner/src/yarn.rs
@@ -6,7 +6,7 @@ use std::process::Command;
 
 use clap::Args;
 
-use crate::run::run_silent;
+use crate::run::run_command;
 
 #[derive(Args)]
 pub struct YarnArgs {
@@ -17,7 +17,7 @@ pub struct YarnArgs {
 pub fn setup_yarn(args: YarnArgs) {
     link_node_modules();
 
-    run_silent(Command::new(&args.yarn_bin).arg("install"));
+    run_command(Command::new(&args.yarn_bin).arg("install"));
 
     std::fs::write(args.stamp, b"").unwrap();
 }

--- a/tools/install-n2
+++ b/tools/install-n2
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-cargo install --git https://github.com/evmar/n2.git --rev 715feedd746d622862601cc7c197fcb18c6b5ae8
+cargo install --git https://github.com/ankitects/n2.git --rev 56202604d4c541524b82381162eafae4290fdd22


### PR DESCRIPTION
After updating with tools/install-n2, you should now be able to see
the last line of long-running commands like cargo invocations.