### PR TITLE
Support AVIF

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -135,6 +135,7 @@ Kehinde Adeleke <adelekekehinde06@gmail.com>
 Marko Juhanne <github.com/mjuhanne>
 Gabriel Heinatz <anorot@gmail.com>
 Monty Evans <montyevans@gmail.com>
+Nil Admirari <https://github.com/nihil-admirari>
 
 ********************
 

--- a/pylib/anki/media.py
+++ b/pylib/anki/media.py
@@ -116,6 +116,7 @@ class MediaManager(DeprecatedNamesMixin):
                 "image/png": ".png",
                 "image/svg+xml": ".svg",
                 "image/webp": ".webp",
+                "image/avif": ".avif",
             }
             if content_type in type_map:
                 fname += type_map[content_type]

--- a/qt/aqt/editor.py
+++ b/qt/aqt/editor.py
@@ -58,7 +58,7 @@ from aqt.utils import (
 )
 from aqt.webview import AnkiWebView, AnkiWebViewKind
 
-pics = ("jpg", "jpeg", "png", "tif", "tiff", "gif", "svg", "webp", "ico")
+pics = ("jpg", "jpeg", "png", "tif", "tiff", "gif", "svg", "webp", "ico", "avif")
 audio = (
     "3gp",
     "aac",

--- a/rslib/src/image_occlusion/imagedata.rs
+++ b/rslib/src/image_occlusion/imagedata.rs
@@ -142,7 +142,7 @@ impl Collection {
     fn is_image_file(&mut self, path: &PathBuf) -> Result<bool> {
         let file_path = Path::new(&path);
         let supported_extensions = [
-            "jpg", "jpeg", "png", "tif", "tiff", "gif", "svg", "webp", "ico",
+            "jpg", "jpeg", "png", "tif", "tiff", "gif", "svg", "webp", "ico", "avif",
         ];
 
         if file_path.exists() {

--- a/rslib/src/media/check.rs
+++ b/rslib/src/media/check.rs
@@ -453,7 +453,7 @@ impl MediaChecker<'_> {
 
     fn maybe_extract_inline_image<'a>(&mut self, fname_decoded: &'a str) -> Result<Cow<'a, str>> {
         static BASE64_IMG: Lazy<Regex> = Lazy::new(|| {
-            Regex::new("(?i)^data:image/(jpg|jpeg|png|gif|webp);base64,(.+)$").unwrap()
+            Regex::new("(?i)^data:image/(jpg|jpeg|png|gif|webp|avif);base64,(.+)$").unwrap()
         });
 
         let Some(caps) = BASE64_IMG.captures(fname_decoded) else {


### PR DESCRIPTION
New image format, supported everywhere: https://caniuse.com/avif.

Currently, pictures can be manually copied to media folder, but attach file dialog does not support AVIF.