### PR TITLE
Add ability to tab to DuplicateLink

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -136,6 +136,7 @@ Marko Juhanne <github.com/mjuhanne>
 Gabriel Heinatz <anorot@gmail.com>
 Monty Evans <montyevans@gmail.com>
 Nil Admirari <https://github.com/nihil-admirari>
+Michael Winkworth <github.com/SteelColossus>
 
 ********************
 

--- a/ts/editor/DuplicateLink.svelte
+++ b/ts/editor/DuplicateLink.svelte
@@ -8,11 +8,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 </script>
 
 <span class="duplicate-link-container">
-    <a
-        class="duplicate-link"
-        href="/#"
-        on:click={() => bridgeCommand("dupes")}
-    >
+    <a class="duplicate-link" href="/#" on:click={() => bridgeCommand("dupes")}>
         {tr.editingShowDuplicates()}
     </a>
 </span>

--- a/ts/editor/DuplicateLink.svelte
+++ b/ts/editor/DuplicateLink.svelte
@@ -7,19 +7,23 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     import * as tr from "@tslib/ftl";
 </script>
 
-<a
-    class="duplicate-link"
-    href="/#"
-    tabindex="-1"
-    on:click={() => bridgeCommand("dupes")}
->
-    {tr.editingShowDuplicates()}
-</a>
+<span class="duplicate-link-container">
+    <a
+        class="duplicate-link"
+        href="/#"
+        on:click={() => bridgeCommand("dupes")}
+    >
+        {tr.editingShowDuplicates()}
+    </a>
+</span>
 
 <style lang="scss">
-    .duplicate-link {
-        color: var(--highlight-color);
+    .duplicate-link-container {
         text-align: center;
         flex-grow: 1;
+    }
+
+    .duplicate-link {
+        color: var(--highlight-color);
     }
 </style>


### PR DESCRIPTION
The change that allows the DuplicateLink to be tabbed to is the removal of the `tabindex`. The other changes are to make the link only as wide as the text, otherwise the tab outline appears around the whole `<span>`, which would make it look weird.

Here is a screenshot of what the link looks like when it's been tabbed to after the change:

![image](https://github.com/ankitects/anki/assets/4004806/fbe01438-e27d-4041-8759-beadd303bbf3)

This issue was mentioned previously in https://github.com/ankitects/anki/issues/2564#issuecomment-1672324190.