### PR TITLE
Refactor media sync handling

### DIFF
--- a/proto/anki/collection.proto
+++ b/proto/anki/collection.proto
@@ -8,6 +8,7 @@ option java_multiple_files = true;
 package anki.collection;
 
 import "anki/generic.proto";
+import "anki/sync.proto";
 
 service CollectionService {
   rpc CheckDatabase(generic.Empty) returns (CheckDatabaseResponse);
@@ -100,12 +101,6 @@ message OpChangesAfterUndo {
 }
 
 message Progress {
-  message MediaSync {
-    string checked = 1;
-    string added = 2;
-    string removed = 3;
-  }
-
   message FullSync {
     uint32 transferred = 1;
     uint32 total = 2;
@@ -136,7 +131,7 @@ message Progress {
 
   oneof value {
     generic.Empty none = 1;
-    MediaSync media_sync = 2;
+    sync.MediaSyncProgress media_sync = 2;
     string media_check = 3;
     FullSync full_sync = 4;
     NormalSync normal_sync = 5;

--- a/proto/anki/sync.proto
+++ b/proto/anki/sync.proto
@@ -9,17 +9,19 @@ package anki.sync;
 
 import "anki/generic.proto";
 
-/// Syncing methods are only available with a Backend handle.
+// Syncing methods are only available with a Backend handle.
 service SyncService {}
 
 service BackendSyncService {
   rpc SyncMedia(SyncAuth) returns (generic.Empty);
   rpc AbortMediaSync(generic.Empty) returns (generic.Empty);
+  // Can be used by the frontend to detect an active sync. If the sync aborted
+  // with an error, the next call to this method will return the error.
+  rpc MediaSyncStatus(generic.Empty) returns (MediaSyncStatusResponse);
   rpc SyncLogin(SyncLoginRequest) returns (SyncAuth);
   rpc SyncStatus(SyncAuth) returns (SyncStatusResponse);
-  rpc SyncCollection(SyncAuth) returns (SyncCollectionResponse);
-  rpc FullUpload(SyncAuth) returns (generic.Empty);
-  rpc FullDownload(SyncAuth) returns (generic.Empty);
+  rpc SyncCollection(SyncCollectionRequest) returns (SyncCollectionResponse);
+  rpc FullUploadOrDownload(FullUploadOrDownloadRequest) returns (generic.Empty);
   rpc AbortSync(generic.Empty) returns (generic.Empty);
 }
 
@@ -45,6 +47,11 @@ message SyncStatusResponse {
   optional string new_endpoint = 4;
 }
 
+message SyncCollectionRequest {
+  SyncAuth auth = 1;
+  bool sync_media = 2;
+}
+
 message SyncCollectionResponse {
   enum ChangesRequired {
     NO_CHANGES = 0;
@@ -60,4 +67,23 @@ message SyncCollectionResponse {
   string server_message = 2;
   ChangesRequired required = 3;
   optional string new_endpoint = 4;
+  int32 server_media_usn = 5;
+}
+
+message MediaSyncStatusResponse {
+  bool active = 1;
+  MediaSyncProgress progress = 2;
+}
+
+message MediaSyncProgress {
+  string checked = 1;
+  string added = 2;
+  string removed = 3;
+}
+
+message FullUploadOrDownloadRequest {
+  SyncAuth auth = 1;
+  bool upload = 2;
+  // if not provided, media syncing will be skipped
+  optional int32 server_usn = 3;
 }

--- a/qt/aqt/forms/synclog.ui
+++ b/qt/aqt/forms/synclog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>557</width>
-    <height>295</height>
+    <width>482</width>
+    <height>90</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -15,12 +15,15 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <widget class="QPlainTextEdit" name="plainTextEdit">
-     <property name="readOnly">
-      <bool>true</bool>
+    <widget class="QLabel" name="log_label">
+     <property name="text">
+      <string notr="true">TextLabel</string>
      </property>
-     <property name="plainText">
-      <string notr="true"/>
+     <property name="textFormat">
+      <enum>Qt::PlainText</enum>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
      </property>
     </widget>
    </item>

--- a/qt/aqt/main.py
+++ b/qt/aqt/main.py
@@ -1019,9 +1019,6 @@ title="{}" {}>{}</button>""".format(
 
     def _sync_collection_and_media(self, after_sync: Callable[[], None]) -> None:
         "Caller should ensure auth available."
-        # start media sync if not already running
-        if not self.media_syncer.is_syncing():
-            self.media_syncer.start()
 
         def on_collection_sync_finished() -> None:
             self.col.clear_python_undo()

--- a/qt/aqt/mediasync.py
+++ b/qt/aqt/mediasync.py
@@ -5,110 +5,94 @@ from __future__ import annotations
 
 import time
 from concurrent.futures import Future
-from dataclasses import dataclass
-from typing import Any, Callable, Union
+from datetime import datetime
+from typing import Any, Callable
 
 import aqt
 import aqt.forms
 import aqt.main
-from anki.collection import Progress
+from anki.collection import Collection
 from anki.errors import Interrupted
-from anki.types import assert_exhaustive
 from anki.utils import int_time
 from aqt import gui_hooks
-from aqt.qt import QDialog, QDialogButtonBox, QPushButton, QTextCursor, QTimer, qconnect
-from aqt.utils import disable_help_button, tr
-
-LogEntry = Union[Progress.MediaSync, str]
-
-
-@dataclass
-class LogEntryWithTime:
-    time: int
-    entry: LogEntry
+from aqt.operations import QueryOp
+from aqt.qt import QDialog, QDialogButtonBox, QPushButton, Qt, QTimer, qconnect
+from aqt.utils import disable_help_button, show_info, tr
 
 
 class MediaSyncer:
     def __init__(self, mw: aqt.main.AnkiQt) -> None:
         self.mw = mw
         self._syncing: bool = False
-        self._log: list[LogEntryWithTime] = []
-        self._progress_timer: QTimer | None = None
+        self.last_progress = ""
+        self._last_progress_at = 0
         gui_hooks.media_sync_did_start_or_stop.append(self._on_start_stop)
-
-    def _on_progress(self) -> None:
-        progress = self.mw.col.latest_progress()
-        if not progress.HasField("media_sync"):
-            return
-        sync_progress = progress.media_sync
-        self._log_and_notify(sync_progress)
 
     def start(self) -> None:
         "Start media syncing in the background, if it's not already running."
+        if not self.mw.pm.media_syncing_enabled() or not (
+            auth := self.mw.pm.sync_auth()
+        ):
+            return
+
+        def run(col: Collection) -> None:
+            col.sync_media(auth)
+
+        # this will exit after the thread is spawned, but may block if there's an existing
+        # backend lock
+        QueryOp(parent=aqt.mw, op=run, success=lambda _: 1).run_in_background()
+
+        self.start_monitoring()
+
+    def start_monitoring(self) -> None:
         if self._syncing:
             return
-
-        if not self.mw.pm.media_syncing_enabled():
-            self._log_and_notify(tr.sync_media_disabled())
-            return
-
-        auth = self.mw.pm.sync_auth()
-        if auth is None:
-            return
-
-        self._log_and_notify(tr.sync_media_starting())
         self._syncing = True
-        self._progress_timer = self.mw.progress.timer(
-            1000, self._on_progress, True, True, parent=self.mw
-        )
         gui_hooks.media_sync_did_start_or_stop(True)
+        self._update_progress(tr.sync_media_starting())
 
-        def run() -> None:
-            self.mw.col.sync_media(auth)
+        def monitor() -> None:
+            while True:
+                resp = self.mw.col.media_sync_status()
+                if not resp.active:
+                    return
+                if p := resp.progress:
+                    self._update_progress(f"{p.added}, {p.removed}, {p.checked}")
 
-        self.mw.taskman.run_in_background(run, self._on_finished)
+                time.sleep(0.25)
 
-    def _log_and_notify(self, entry: LogEntry) -> None:
-        entry_with_time = LogEntryWithTime(time=int_time(), entry=entry)
-        self._log.append(entry_with_time)
-        self.mw.taskman.run_on_main(
-            lambda: gui_hooks.media_sync_did_progress(entry_with_time)
-        )
+        print("start monitoring")
+        self.mw.taskman.run_in_background(monitor, self._on_finished)
+
+    def _update_progress(self, progress: str) -> None:
+        self.last_progress = progress
+        self.mw.taskman.run_on_main(lambda: gui_hooks.media_sync_did_progress(progress))
 
     def _on_finished(self, future: Future) -> None:
         self._syncing = False
-        if self._progress_timer:
-            self._progress_timer.stop()
-            self._progress_timer.deleteLater()
-            self._progress_timer = None
+        self._last_progress_at = int_time()
         gui_hooks.media_sync_did_start_or_stop(False)
 
         exc = future.exception()
         if exc is not None:
             self._handle_sync_error(exc)
         else:
-            self._log_and_notify(tr.sync_media_complete())
+            self._update_progress(tr.sync_media_complete())
 
     def _handle_sync_error(self, exc: BaseException) -> None:
         if isinstance(exc, Interrupted):
-            self._log_and_notify(tr.sync_media_aborted())
+            self._update_progress(tr.sync_media_aborted())
             return
         else:
-            # Avoid popups for errors; they can cause a deadlock if
-            # a modal window happens to be active, or a duplicate auth
-            # failed message if the password is changed.
-            self._log_and_notify(str(exc))
+            show_info(str(exc), modality=Qt.WindowModality.NonModal)
             return
-
-    def entries(self) -> list[LogEntryWithTime]:
-        return self._log
 
     def abort(self) -> None:
         if not self.is_syncing():
             return
-        self._log_and_notify(tr.sync_media_aborting())
         self.mw.col.set_wants_abort()
         self.mw.col.abort_media_sync()
+        self._update_progress(tr.sync_media_aborting())
 
     def is_syncing(self) -> bool:
         return self._syncing
@@ -140,11 +124,7 @@ class MediaSyncer:
         if self.is_syncing():
             return 0
 
-        if self._log:
-            last = self._log[-1].time
-        else:
-            last = 0
-        return int_time() - last
+        return int_time() - self._last_progress_at
 
 
 class MediaSyncDialog(QDialog):
@@ -172,10 +152,7 @@ class MediaSyncDialog(QDialog):
         gui_hooks.media_sync_did_progress.append(self._on_log_entry)
         gui_hooks.media_sync_did_start_or_stop.append(self._on_start_stop)
 
-        self.form.plainTextEdit.setPlainText(
-            "\n".join(self._entry_to_text(x) for x in syncer.entries())
-        )
-        self.form.plainTextEdit.moveCursor(QTextCursor.MoveOperation.End)
+        self._on_log_entry(syncer.last_progress)
         self.show()
 
     def reject(self) -> None:
@@ -197,24 +174,11 @@ class MediaSyncDialog(QDialog):
         self._syncer.abort()
         self.abort_button.setHidden(True)
 
-    def _time_and_text(self, stamp: int, text: str) -> str:
-        asctime = time.asctime(time.localtime(stamp))
-        return f"{asctime}: {text}"
-
-    def _entry_to_text(self, entry: LogEntryWithTime) -> str:
-        if isinstance(entry.entry, str):
-            txt = entry.entry
-        elif isinstance(entry.entry, Progress.MediaSync):
-            txt = self._logentry_to_text(entry.entry)
-        else:
-            assert_exhaustive(entry.entry)
-        return self._time_and_text(entry.time, txt)
-
-    def _logentry_to_text(self, e: Progress.MediaSync) -> str:
-        return f"{e.added}, {e.removed}, {e.checked}"
-
-    def _on_log_entry(self, entry: LogEntryWithTime) -> None:
-        self.form.plainTextEdit.appendPlainText(self._entry_to_text(entry))
+    def _on_log_entry(self, entry: str) -> None:
+        dt = datetime.fromtimestamp(int_time())
+        time = dt.strftime("%H:%M:%S")
+        text = f"{time}: {entry}"
+        self.form.log_label.setText(text)
         if not self._syncer.is_syncing():
             self.abort_button.setHidden(True)
 

--- a/qt/aqt/mediasync.py
+++ b/qt/aqt/mediasync.py
@@ -61,7 +61,6 @@ class MediaSyncer:
 
                 time.sleep(0.25)
 
-        print("start monitoring")
         self.mw.taskman.run_in_background(monitor, self._on_finished)
 
     def _update_progress(self, progress: str) -> None:

--- a/qt/aqt/utils.py
+++ b/qt/aqt/utils.py
@@ -141,12 +141,13 @@ class MessageBox(QMessageBox):
         buttons: Sequence[str | QMessageBox.StandardButton] | None = None,
         default_button: int = 0,
         textFormat: Qt.TextFormat = Qt.TextFormat.PlainText,
+        modality: Qt.WindowModality = Qt.WindowModality.WindowModal,
     ) -> None:
         parent = parent or aqt.mw.app.activeWindow() or aqt.mw
         super().__init__(parent)
         self.setText(text)
         self.setWindowTitle(title)
-        self.setWindowModality(Qt.WindowModality.WindowModal)
+        self.setWindowModality(modality)
         self.setIcon(icon)
         if icon == QMessageBox.Icon.Question and theme_manager.night_mode:
             img = self.iconPixmap().toImage()

--- a/qt/tools/genhooks_gui.py
+++ b/qt/tools/genhooks_gui.py
@@ -881,7 +881,7 @@ gui_hooks.webview_did_inject_style_into_page.append(mytest)
     ),
     Hook(
         name="media_sync_did_progress",
-        args=["entry: aqt.mediasync.LogEntryWithTime"],
+        args=["entry: str"],
     ),
     Hook(name="media_sync_did_start_or_stop", args=["running: bool"]),
     Hook(

--- a/rslib/process/src/lib.rs
+++ b/rslib/process/src/lib.rs
@@ -17,7 +17,7 @@ pub enum Error {
         cmdline: String,
         source: std::io::Error,
     },
-    #[snafu(display("Fail with code {code:?}: {cmdline}"))]
+    #[snafu(display("Failed with code {code:?}: {cmdline}"))]
     ReturnedError { cmdline: String, code: Option<i32> },
     #[snafu(display("Couldn't decode stdout/stderr as utf8"))]
     InvalidUtf8 {

--- a/rslib/src/backend/mod.rs
+++ b/rslib/src/backend/mod.rs
@@ -55,6 +55,7 @@ pub struct BackendInner {
     runtime: OnceCell<Runtime>,
     state: Mutex<BackendState>,
     backup_task: Mutex<Option<JoinHandle<Result<()>>>>,
+    media_sync_task: Mutex<Option<JoinHandle<Result<()>>>>,
     web_client: OnceCell<Client>,
 }
 
@@ -89,6 +90,7 @@ impl Backend {
             runtime: OnceCell::new(),
             state: Mutex::new(BackendState::default()),
             backup_task: Mutex::new(None),
+            media_sync_task: Mutex::new(None),
             web_client: OnceCell::new(),
         }))
     }

--- a/rslib/src/media/mod.rs
+++ b/rslib/src/media/mod.rs
@@ -147,10 +147,11 @@ impl MediaManager {
         progress: ThrottlingProgressHandler<MediaSyncProgress>,
         auth: SyncAuth,
         client: Client,
+        server_usn: Option<Usn>,
     ) -> Result<()> {
         let client = HttpSyncClient::new(auth, client);
         let mut syncer = MediaSyncer::new(self, progress, client)?;
-        syncer.sync().await
+        syncer.sync(server_usn).await
     }
 
     pub fn all_checksums_after_checking(

--- a/rslib/src/progress.rs
+++ b/rslib/src/progress.rs
@@ -240,11 +240,8 @@ pub(crate) fn progress_to_proto(
     }
 }
 
-fn media_sync_progress(
-    p: MediaSyncProgress,
-    tr: &I18n,
-) -> anki_proto::collection::progress::MediaSync {
-    anki_proto::collection::progress::MediaSync {
+fn media_sync_progress(p: MediaSyncProgress, tr: &I18n) -> anki_proto::sync::MediaSyncProgress {
+    anki_proto::sync::MediaSyncProgress {
         checked: tr.sync_media_checked_count(p.checked).into(),
         added: tr
             .sync_media_added_count(p.uploaded_files, p.downloaded_files)

--- a/rslib/src/sync/collection/meta.rs
+++ b/rslib/src/sync/collection/meta.rs
@@ -42,6 +42,9 @@ pub struct SyncMeta {
     pub host_number: u32,
     #[serde(default)]
     pub empty: bool,
+    /// This field is not set by col.sync_meta(), and must be filled in
+    /// separately.
+    pub media_usn: Usn,
     #[serde(skip)]
     pub v2_scheduler_or_later: bool,
     #[serde(skip)]
@@ -77,6 +80,7 @@ impl SyncMeta {
             server_message: remote.server_message,
             host_number: remote.host_number,
             new_endpoint,
+            server_media_usn: remote.media_usn,
         }
     }
 }
@@ -132,6 +136,8 @@ impl Collection {
             empty: !self.storage.have_at_least_one_card()?,
             v2_scheduler_or_later: self.scheduler_version() == SchedulerVersion::V2,
             v2_timezone: self.get_creation_utc_offset().is_some(),
+            // must be filled in by calling code
+            media_usn: Usn(0),
         })
     }
 }

--- a/rslib/src/sync/collection/normal.rs
+++ b/rslib/src/sync/collection/normal.rs
@@ -53,6 +53,7 @@ pub struct ClientSyncState {
     pub(in crate::sync) server_usn: Usn,
     // -1 in client case; used to locate pending entries
     pub(in crate::sync) pending_usn: Usn,
+    pub(in crate::sync) server_media_usn: Usn,
 }
 
 impl NormalSyncer<'_> {
@@ -139,6 +140,8 @@ pub struct SyncOutput {
     pub server_message: String,
     pub host_number: u32,
     pub new_endpoint: Option<String>,
+    #[allow(unused)]
+    pub(crate) server_media_usn: Usn,
 }
 
 impl From<ClientSyncState> for SyncOutput {
@@ -148,6 +151,7 @@ impl From<ClientSyncState> for SyncOutput {
             server_message: s.server_message,
             host_number: s.host_number,
             new_endpoint: s.new_endpoint,
+            server_media_usn: s.server_media_usn,
         }
     }
 }

--- a/rslib/src/sync/http_server/handlers.rs
+++ b/rslib/src/sync/http_server/handlers.rs
@@ -61,7 +61,9 @@ impl SyncProtocol for Arc<SimpleServer> {
     async fn meta(&self, req: SyncRequest<MetaRequest>) -> HttpResult<SyncResponse<SyncMeta>> {
         self.with_authenticated_user(req, |user, req| {
             let req = req.json()?;
-            user.with_col(|col| server_meta(req, col))
+            let mut meta = user.with_col(|col| server_meta(req, col))?;
+            meta.media_usn = user.media.last_usn()?;
+            Ok(meta)
         })
         .await
         .and_then(SyncResponse::try_from_obj)

--- a/rslib/src/sync/media/tests.rs
+++ b/rslib/src/sync/media/tests.rs
@@ -151,13 +151,13 @@ impl SyncTestContext {
     async fn sync_media1(&self) -> Result<()> {
         let mut syncer =
             MediaSyncer::new(self.media1(), ignore_progress(), self.client.clone()).unwrap();
-        syncer.sync().await
+        syncer.sync(None).await
     }
 
     async fn sync_media2(&self) -> Result<()> {
         let mut syncer =
             MediaSyncer::new(self.media2(), ignore_progress(), self.client.clone()).unwrap();
-        syncer.sync().await
+        syncer.sync(None).await
     }
 
     /// As local change detection depends on a millisecond timestamp,


### PR DESCRIPTION
- The media USN is now returned in sync/meta, which avoids an extra round-trip.
- Media syncing is now automatically started by the syncing code at the end of a normal or full sync, which avoids it competing for bandwidth and resources, and avoids duplicate invalid login messages when the auth token is invalid.
- Added a new media_sync_progress() method to both check if media is syncing, and get access to the latest progress.
- Updated the sync log screen to only show the latest line, like AnkiMobile.
- Show media sync errors in a pop-up, so they don't get missed. Use a non-modal pop-up to avoid potential conflicts with other modals.