### PR TITLE
Fix some issues with undo/redo in mask editor

### DIFF
--- a/ts/image-occlusion/MaskEditor.svelte
+++ b/ts/image-occlusion/MaskEditor.svelte
@@ -2,6 +2,16 @@
 Copyright: Ankitects Pty Ltd and contributors
 License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 -->
+<script context="module" lang="ts">
+    import { writable } from "svelte/store";
+
+    const changeSignal = writable(Symbol());
+
+    export function emitChangeSignal() {
+        changeSignal.set(Symbol());
+    }
+</script>
+
 <script lang="ts">
     import type { PanZoom } from "panzoom";
     import panzoom from "panzoom";
@@ -27,6 +37,8 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     function onChange() {
         dispatch("change", { canvas });
     }
+
+    $: $changeSignal, onChange();
 
     function init(node) {
         instance = panzoom(node, {

--- a/ts/image-occlusion/Toolbar.svelte
+++ b/ts/image-occlusion/Toolbar.svelte
@@ -29,7 +29,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         zoomTools,
     } from "./tools/more-tools";
     import { tools } from "./tools/tool-buttons";
-    import { undoRedoTools } from "./tools/tool-undo-redo";
+    import { undoRedoTools, undoStack } from "./tools/tool-undo-redo";
 
     export let canvas;
     export let instance;
@@ -172,9 +172,10 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
                     ? 'left-border-radius'
                     : 'right-border-radius'}"
                 {iconSize}
-                on:click={() => {
-                    tool.action(canvas);
-                }}
+                on:click={tool.action}
+                disabled={tool.name === "undo"
+                    ? !$undoStack.undoable
+                    : !$undoStack.redoable}
             >
                 {@html tool.icon}
             </IconButton>

--- a/ts/image-occlusion/mask-editor.ts
+++ b/ts/image-occlusion/mask-editor.ts
@@ -13,7 +13,7 @@ import { notesDataStore, tagsWritable, zoomResetValue } from "./store";
 import Toast from "./Toast.svelte";
 import { addShapesToCanvasFromCloze } from "./tools/add-from-cloze";
 import { enableSelectable, moveShapeToCanvasBoundaries } from "./tools/lib";
-import { undoRedoInit } from "./tools/tool-undo-redo";
+import { undoStack } from "./tools/tool-undo-redo";
 import type { Size } from "./types";
 
 export const setupMaskEditor = async (
@@ -34,6 +34,7 @@ export const setupMaskEditor = async (
         image.height = size.height;
         image.width = size.width;
         setCanvasZoomRatio(canvas, instance);
+        undoStack.reset();
     };
 
     return canvas;
@@ -75,6 +76,7 @@ export const setupMaskEditorForEdit = async (
         addShapesToCanvasFromCloze(canvas, clozeNote.occlusions);
         enableSelectable(canvas, true);
         addClozeNotesToTextEditor(clozeNote.header, clozeNote.backExtra, clozeNote.tags);
+        undoStack.reset();
         window.requestAnimationFrame(() => {
             image.style.visibility = "visible";
         });
@@ -87,11 +89,11 @@ function initCanvas(onChange: () => void): fabric.Canvas {
     const canvas = new fabric.Canvas("canvas");
     tagsWritable.set([]);
     globalThis.canvas = canvas;
+    undoStack.setCanvas(canvas);
     // enables uniform scaling by default without the need for the Shift key
     canvas.uniformScaling = false;
     canvas.uniScaleKey = "none";
     moveShapeToCanvasBoundaries(canvas);
-    undoRedoInit(canvas);
     canvas.on("object:modified", onChange);
     canvas.on("object:removed", onChange);
     return canvas;

--- a/ts/image-occlusion/tools/tool-ellipse.ts
+++ b/ts/image-occlusion/tools/tool-ellipse.ts
@@ -4,9 +4,7 @@
 import { fabric } from "fabric";
 
 import { BORDER_COLOR, disableRotation, SHAPE_MASK_COLOR, stopDraw } from "./lib";
-import { objectAdded } from "./tool-undo-redo";
-
-const addedEllipseIds: string[] = [];
+import { undoStack } from "./tool-undo-redo";
 
 export const drawEllipse = (canvas: fabric.Canvas): void => {
     canvas.selectionColor = "rgba(0, 0, 0, 0)";
@@ -117,6 +115,6 @@ export const drawEllipse = (canvas: fabric.Canvas): void => {
         }
 
         ellipse.setCoords();
-        objectAdded(canvas, addedEllipseIds, ellipse.id);
+        undoStack.onObjectAdded(ellipse.id);
     });
 };

--- a/ts/image-occlusion/tools/tool-polygon.ts
+++ b/ts/image-occlusion/tools/tool-polygon.ts
@@ -5,7 +5,7 @@ import { fabric } from "fabric";
 import type { PanZoom } from "panzoom";
 
 import { BORDER_COLOR, disableRotation, SHAPE_MASK_COLOR } from "./lib";
-import { objectAdded, saveCanvasState } from "./tool-undo-redo";
+import { undoStack } from "./tool-undo-redo";
 
 let activeLine;
 let activeShape;
@@ -13,7 +13,6 @@ let linesList: fabric.Line = [];
 let pointsList: fabric.Circle = [];
 let drawMode = false;
 let zoomValue = 1;
-const addedPolygonIds: string[] = [];
 
 export const drawPolygon = (canvas: fabric.Canvas, panzoom: PanZoom): void => {
     canvas.selectionColor = "rgba(0, 0, 0, 0)";
@@ -190,12 +189,12 @@ const generatePolygon = (canvas: fabric.Canvas, pointsList): void => {
         disableRotation(polygon);
         canvas.add(polygon);
         // view undo redo tools
-        objectAdded(canvas, addedPolygonIds, polygon.id);
+        undoStack.onObjectAdded(polygon.id);
     }
 
     polygon.on("modified", () => {
         modifiedPolygon(canvas, polygon);
-        saveCanvasState(canvas);
+        undoStack.onObjectModified();
     });
 
     toggleDrawPolygon(canvas);
@@ -223,7 +222,7 @@ const modifiedPolygon = (canvas: fabric.Canvas, polygon: fabric.Polygon): void =
 
     polygon1.on("modified", () => {
         modifiedPolygon(canvas, polygon1);
-        saveCanvasState(canvas);
+        undoStack.onObjectModified();
     });
 
     canvas.remove(polygon);

--- a/ts/image-occlusion/tools/tool-rect.ts
+++ b/ts/image-occlusion/tools/tool-rect.ts
@@ -4,9 +4,7 @@
 import { fabric } from "fabric";
 
 import { BORDER_COLOR, disableRotation, SHAPE_MASK_COLOR, stopDraw } from "./lib";
-import { objectAdded } from "./tool-undo-redo";
-
-const addedRectangleIds: string[] = [];
+import { undoStack } from "./tool-undo-redo";
 
 export const drawRectangle = (canvas: fabric.Canvas): void => {
     canvas.selectionColor = "rgba(0, 0, 0, 0)";
@@ -111,6 +109,6 @@ export const drawRectangle = (canvas: fabric.Canvas): void => {
         }
 
         rect.setCoords();
-        objectAdded(canvas, addedRectangleIds, rect.id);
+        undoStack.onObjectAdded(rect.id);
     });
 };


### PR DESCRIPTION
Fixes some issues with undo/redo in the IO mask editor. See the commit message for details. 

Also adds a small UI improvement:
The undo/redo buttons are now disabled when there is no action to undo/redo.