### PR TITLE
fix single_card_revlog_to_items

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -137,6 +137,7 @@ Gabriel Heinatz <anorot@gmail.com>
 Monty Evans <montyevans@gmail.com>
 Nil Admirari <https://github.com/nihil-admirari>
 Michael Winkworth <github.com/SteelColossus>
+Jarrett Ye <jarrett.ye@outlook.com>
 
 ********************
 

--- a/qt/aqt/about.py
+++ b/qt/aqt/about.py
@@ -231,6 +231,7 @@ def show(mw: aqt.AnkiQt) -> QDialog:
             "Carlos Duarte",
             "Edgar Benavent Català",
             "Kieran Black",
+            "Jarrett Ye",
         )
     )
 

--- a/rslib/src/scheduler/fsrs/weights.rs
+++ b/rslib/src/scheduler/fsrs/weights.rs
@@ -358,7 +358,6 @@ mod tests {
         );
     }
 
-
     #[test]
     fn single_learning_step_skipped_when_training() {
         assert_eq!(

--- a/rslib/src/scheduler/fsrs/weights.rs
+++ b/rslib/src/scheduler/fsrs/weights.rs
@@ -139,7 +139,7 @@ fn single_card_revlog_to_items(
     for (index, entry) in entries.iter().enumerate().rev() {
         if entry.review_kind == RevlogReviewKind::Learning {
             last_learn_entry = Some(index);
-        } else if last_learn_entry != None {
+        } else if last_learn_entry.is_some() {
             break;
         }
     }

--- a/rslib/src/scheduler/fsrs/weights.rs
+++ b/rslib/src/scheduler/fsrs/weights.rs
@@ -165,12 +165,8 @@ fn single_card_revlog_to_items(
         if manually_rescheduled || cram {
             return false;
         }
-        if entry.review_kind == RevlogReviewKind::Review {
-            // Keep only the first review when multiple reviews done on one day
-            unique_dates.insert(entry.days_elapsed(next_day_at))
-        } else {
-            true
-        }
+        // Keep only the first review when multiple reviews done on one day
+        unique_dates.insert(entry.days_elapsed(next_day_at))
     });
 
     // Old versions of Anki did not record Manual entries in the review log when


### PR DESCRIPTION
```rust
fn keep_first_revlog_same_date(
    entries: Vec<RevlogEntry>,
    next_day_starts_at: i64,
    timezone: Tz,
) -> Vec<RevlogEntry> {
    let mut entries = entries.clone();
    let mut unique_dates = std::collections::HashSet::new();
    entries.retain(|entry| {
        let date = convert_to_date(entry.id, next_day_starts_at, timezone);
        unique_dates.insert(date)
    });
    entries
}
```
https://github.com/open-spaced-repetition/fsrs-rs/blob/3389062ff6ae23e4543d8872c0db354a73d1e40a/src/convertor_tests.rs#L128-L140

If there are multiple reviews (no matter the review kind) done on one day, keep only the first review.