### PR TITLE
Add a backend method to add notes in bulk

### DIFF
--- a/proto/anki/notes.proto
+++ b/proto/anki/notes.proto
@@ -64,7 +64,7 @@ message AddNoteResponse {
 }
 
 message AddNotesRequest {
-  repeated AddNoteRequest note_and_deck_id = 1;
+  repeated AddNoteRequest requests = 1;
 }
 
 message AddNotesResponse {

--- a/proto/anki/notes.proto
+++ b/proto/anki/notes.proto
@@ -14,6 +14,7 @@ import "anki/cards.proto";
 
 service NotesService {
   rpc NewNote(notetypes.NotetypeId) returns (Note);
+  rpc AddNote(AddNoteRequest) returns (AddNoteResponse);
   rpc AddNotes(AddNotesRequest) returns (AddNotesResponse);
   rpc DefaultsForAdding(DefaultsForAddingRequest) returns (DeckAndNotetype);
   rpc DefaultDeckForNotetype(notetypes.NotetypeId) returns (decks.DeckId);
@@ -52,9 +53,18 @@ message Note {
   repeated string fields = 7;
 }
 
-message AddNotesRequest {
-  repeated Note notes = 1;
+message AddNoteRequest {
+  Note note = 1;
   int64 deck_id = 2;
+}
+
+message AddNoteResponse {
+  collection.OpChanges changes = 1;
+  int64 note_id = 2;
+}
+
+message AddNotesRequest {
+  repeated AddNoteRequest note_and_deck_id = 1;
 }
 
 message AddNotesResponse {

--- a/proto/anki/notes.proto
+++ b/proto/anki/notes.proto
@@ -14,7 +14,7 @@ import "anki/cards.proto";
 
 service NotesService {
   rpc NewNote(notetypes.NotetypeId) returns (Note);
-  rpc AddNote(AddNoteRequest) returns (AddNoteResponse);
+  rpc AddNotes(AddNotesRequest) returns (AddNotesResponse);
   rpc DefaultsForAdding(DefaultsForAddingRequest) returns (DeckAndNotetype);
   rpc DefaultDeckForNotetype(notetypes.NotetypeId) returns (decks.DeckId);
   rpc UpdateNotes(UpdateNotesRequest) returns (collection.OpChanges);
@@ -52,14 +52,14 @@ message Note {
   repeated string fields = 7;
 }
 
-message AddNoteRequest {
-  Note note = 1;
+message AddNotesRequest {
+  repeated Note notes = 1;
   int64 deck_id = 2;
 }
 
-message AddNoteResponse {
+message AddNotesResponse {
   collection.OpChanges changes = 1;
-  int64 note_id = 2;
+  repeated int64 nids = 2;
 }
 
 message UpdateNotesRequest {

--- a/pylib/anki/collection.py
+++ b/pylib/anki/collection.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Generator, Literal, Sequence, Union, cast
+from typing import Any, Generator, Iterable, Literal, Sequence, Union, cast
 
 from anki import (
     ankiweb_pb2,
@@ -14,6 +14,7 @@ from anki import (
     image_occlusion_pb2,
     import_export_pb2,
     links_pb2,
+    notes_pb2,
     search_pb2,
     stats_pb2,
     sync_pb2,
@@ -125,6 +126,12 @@ class CardIdsLimit:
 
 
 ExportLimit = Union[DeckIdLimit, NoteIdsLimit, CardIdsLimit, None]
+
+
+@dataclass
+class AddNoteRequest:
+    note: Note
+    deck_id: DeckId
 
 
 class Collection(DeprecatedNamesMixin):
@@ -575,16 +582,25 @@ class Collection(DeprecatedNamesMixin):
         return Note(self, notetype)
 
     def add_note(self, note: Note, deck_id: DeckId) -> OpChanges:
-        return self.add_notes([note], deck_id)
+        hooks.note_will_be_added(self, note, deck_id)
+        out = self._backend.add_note(note=note._to_backend_note(), deck_id=deck_id)
+        note.id = NoteId(out.note_id)
+        return out.changes
 
-    def add_notes(self, notes: Sequence[Note], deck_id: DeckId) -> OpChanges:
-        for note in notes:
-            hooks.note_will_be_added(self, note, deck_id)
+    def add_notes(self, requests: Iterable[AddNoteRequest]) -> OpChanges:
+        for request in requests:
+            hooks.note_will_be_added(self, request.note, request.deck_id)
         out = self._backend.add_notes(
-            notes=[note._to_backend_note() for note in notes], deck_id=deck_id
+            note_and_deck_id=[
+                notes_pb2.AddNoteRequest(
+                    note=request.note._to_backend_note(), deck_id=request.deck_id
+                )
+                for request in requests
+            ]
         )
-        for idx, note in enumerate(notes):
-            note.id = NoteId(out.nids[idx])
+        for idx, request in enumerate(requests):
+            request.note.id = NoteId(out.nids[idx])
+
         return out.changes
 
     def remove_notes(self, note_ids: Sequence[NoteId]) -> OpChangesWithCount:

--- a/pylib/anki/collection.py
+++ b/pylib/anki/collection.py
@@ -591,7 +591,7 @@ class Collection(DeprecatedNamesMixin):
         for request in requests:
             hooks.note_will_be_added(self, request.note, request.deck_id)
         out = self._backend.add_notes(
-            note_and_deck_id=[
+            requests=[
                 notes_pb2.AddNoteRequest(
                     note=request.note._to_backend_note(), deck_id=request.deck_id
                 )

--- a/pylib/anki/collection.py
+++ b/pylib/anki/collection.py
@@ -583,8 +583,8 @@ class Collection(DeprecatedNamesMixin):
         out = self._backend.add_notes(
             notes=[note._to_backend_note() for note in notes], deck_id=deck_id
         )
-        for i, note in enumerate(notes):
-            note.id = NoteId(out.nids[i])
+        for idx, note in enumerate(notes):
+            note.id = NoteId(out.nids[idx])
         return out.changes
 
     def remove_notes(self, note_ids: Sequence[NoteId]) -> OpChangesWithCount:

--- a/pylib/anki/collection.py
+++ b/pylib/anki/collection.py
@@ -575,9 +575,16 @@ class Collection(DeprecatedNamesMixin):
         return Note(self, notetype)
 
     def add_note(self, note: Note, deck_id: DeckId) -> OpChanges:
-        hooks.note_will_be_added(self, note, deck_id)
-        out = self._backend.add_note(note=note._to_backend_note(), deck_id=deck_id)
-        note.id = NoteId(out.note_id)
+        return self.add_notes([note], deck_id)
+
+    def add_notes(self, notes: Sequence[Note], deck_id: DeckId) -> OpChanges:
+        for note in notes:
+            hooks.note_will_be_added(self, note, deck_id)
+        out = self._backend.add_notes(
+            notes=[note._to_backend_note() for note in notes], deck_id=deck_id
+        )
+        for i, note in enumerate(notes):
+            note.id = NoteId(out.nids[i])
         return out.changes
 
     def remove_notes(self, note_ids: Sequence[NoteId]) -> OpChangesWithCount:

--- a/rslib/src/image_occlusion/imagedata.rs
+++ b/rslib/src/image_occlusion/imagedata.rs
@@ -13,7 +13,6 @@ use anki_proto::image_occlusion::GetImageOcclusionNoteResponse;
 use regex::Regex;
 
 use crate::media::MediaManager;
-use crate::notetype::CardGenContext;
 use crate::prelude::*;
 
 impl Collection {
@@ -67,10 +66,8 @@ impl Collection {
             note.set_field(3, back_extra)?;
             note.tags = tags;
 
-            let last_deck = col.get_last_deck_added_to_for_notetype(note.notetype_id);
-            let ctx = CardGenContext::new(nt.as_ref(), last_deck, col.usn()?);
             let norm = col.get_config_bool(BoolKey::NormalizeNoteText);
-            col.add_note_inner(&ctx, &mut note, current_deck.id, norm)?;
+            col.add_notes_inner(&mut [note], current_deck.id, norm)?;
 
             Ok(())
         })

--- a/rslib/src/image_occlusion/imagedata.rs
+++ b/rslib/src/image_occlusion/imagedata.rs
@@ -65,9 +65,7 @@ impl Collection {
             note.set_field(2, header)?;
             note.set_field(3, back_extra)?;
             note.tags = tags;
-
-            let norm = col.get_config_bool(BoolKey::NormalizeNoteText);
-            col.add_notes_inner(&mut [note], current_deck.id, norm)?;
+            col.add_note_inner(&mut note, current_deck.id)?;
 
             Ok(())
         })

--- a/rslib/src/notes/mod.rs
+++ b/rslib/src/notes/mod.rs
@@ -371,7 +371,6 @@ impl Collection {
             note.prepare_for_update(ctx.notetype, normalize_text)?;
             note.set_modified(ctx.usn);
             self.add_note_only_undoable(note)?;
-            let ctx = contexts.get(&note.notetype_id).unwrap();
             self.generate_cards_for_new_note(ctx, note, did)?;
         }
         for notetype_id in notetypes.into_keys() {

--- a/rslib/src/notes/service.rs
+++ b/rslib/src/notes/service.rs
@@ -6,7 +6,6 @@ use crate::cloze::add_cloze_numbers_in_string;
 use crate::collection::Collection;
 use crate::decks::DeckId;
 use crate::error;
-use crate::error::OrInvalid;
 use crate::error::OrNotFound;
 use crate::notes::Note;
 use crate::notes::NoteId;
@@ -27,14 +26,14 @@ impl crate::services::NotesService for Collection {
         Ok(nt.new_note().into())
     }
 
-    fn add_note(
+    fn add_notes(
         &mut self,
-        input: anki_proto::notes::AddNoteRequest,
-    ) -> error::Result<anki_proto::notes::AddNoteResponse> {
-        let mut note: Note = input.note.or_invalid("no note provided")?.into();
-        let changes = self.add_note(&mut note, DeckId(input.deck_id))?;
-        Ok(anki_proto::notes::AddNoteResponse {
-            note_id: note.id.0,
+        input: anki_proto::notes::AddNotesRequest,
+    ) -> error::Result<anki_proto::notes::AddNotesResponse> {
+        let mut notes: Vec<Note> = input.notes.into_iter().map(|n| n.into()).collect();
+        let changes = self.add_notes(&mut notes, DeckId(input.deck_id))?;
+        Ok(anki_proto::notes::AddNotesResponse {
+            nids: notes.iter().map(|n| n.id.0).collect(),
             changes: Some(changes.into()),
         })
     }

--- a/rslib/src/notes/service.rs
+++ b/rslib/src/notes/service.rs
@@ -6,7 +6,10 @@ use crate::cloze::add_cloze_numbers_in_string;
 use crate::collection::Collection;
 use crate::decks::DeckId;
 use crate::error;
+use crate::error::AnkiError;
+use crate::error::OrInvalid;
 use crate::error::OrNotFound;
+use crate::notes::AddNoteRequest;
 use crate::notes::Note;
 use crate::notes::NoteId;
 use crate::prelude::IntoNewtypeVec;
@@ -26,14 +29,30 @@ impl crate::services::NotesService for Collection {
         Ok(nt.new_note().into())
     }
 
+    fn add_note(
+        &mut self,
+        input: anki_proto::notes::AddNoteRequest,
+    ) -> error::Result<anki_proto::notes::AddNoteResponse> {
+        let mut note: Note = input.note.or_invalid("no note provided")?.into();
+        let changes = self.add_note(&mut note, DeckId(input.deck_id))?;
+        Ok(anki_proto::notes::AddNoteResponse {
+            note_id: note.id.0,
+            changes: Some(changes.into()),
+        })
+    }
+
     fn add_notes(
         &mut self,
         input: anki_proto::notes::AddNotesRequest,
     ) -> error::Result<anki_proto::notes::AddNotesResponse> {
-        let mut notes: Vec<Note> = input.notes.into_iter().map(|n| n.into()).collect();
-        let changes = self.add_notes(&mut notes, DeckId(input.deck_id))?;
+        let mut requests = input
+            .note_and_deck_id
+            .into_iter()
+            .map(TryInto::try_into)
+            .collect::<error::Result<Vec<AddNoteRequest>, AnkiError>>()?;
+        let changes = self.add_notes(&mut requests)?;
         Ok(anki_proto::notes::AddNotesResponse {
-            nids: notes.iter().map(|n| n.id.0).collect(),
+            nids: requests.iter().map(|r| r.note.id.0).collect(),
             changes: Some(changes.into()),
         })
     }

--- a/rslib/src/notes/service.rs
+++ b/rslib/src/notes/service.rs
@@ -46,7 +46,7 @@ impl crate::services::NotesService for Collection {
         input: anki_proto::notes::AddNotesRequest,
     ) -> error::Result<anki_proto::notes::AddNotesResponse> {
         let mut requests = input
-            .note_and_deck_id
+            .requests
             .into_iter()
             .map(TryInto::try_into)
             .collect::<error::Result<Vec<AddNoteRequest>, AnkiError>>()?;


### PR DESCRIPTION
Using col.add_note() in a CollectionOp where custom undo entries are involved can easily trigger the "target undo op not found" error due to the undo queue limit. Currently, one has to resort to workarounds such as in the example in https://github.com/ankitects/anki/issues/2628#issuecomment-1703827442

This PR adds the col.add_notes() method to add a list of notes in bulk, registering a single undo entry.
