### PR TITLE
Fix unable to save field dialog if certain fields are deleted

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -139,6 +139,7 @@ Nil Admirari <https://github.com/nihil-admirari>
 Michael Winkworth <github.com/SteelColossus>
 Mateusz Wojewoda <kawa1.11@o2.pl>
 Jarrett Ye <jarrett.ye@outlook.com>
+Sam Waechter <github.com/swektr>
 
 ********************
 

--- a/rslib/src/notetype/mod.rs
+++ b/rslib/src/notetype/mod.rs
@@ -550,13 +550,22 @@ impl Notetype {
         fields: HashMap<String, Option<String>>,
         parsed: &mut [(Option<ParsedTemplate>, Option<ParsedTemplate>)],
     ) {
+        let first_remaining_field_name = &self.fields.get(0).unwrap().name;
+        let is_cloze = self.is_cloze();
         for (idx, (q_opt, a_opt)) in parsed.iter_mut().enumerate() {
             if let Some(q) = q_opt {
                 q.rename_and_remove_fields(&fields);
+                if q.all_referenced_field_names().is_empty() ||
+                   is_cloze && q.all_referenced_cloze_field_names().is_empty() {
+                    q.add_missing_field_replacement(first_remaining_field_name, is_cloze);
+                }
                 self.templates[idx].config.q_format = q.template_to_string();
             }
             if let Some(a) = a_opt {
                 a.rename_and_remove_fields(&fields);
+                if is_cloze && a.all_referenced_cloze_field_names().is_empty() {
+                    a.add_missing_field_replacement(first_remaining_field_name, is_cloze);
+                }
                 self.templates[idx].config.a_format = a.template_to_string();
             }
         }

--- a/rslib/src/notetype/mod.rs
+++ b/rslib/src/notetype/mod.rs
@@ -555,8 +555,9 @@ impl Notetype {
         for (idx, (q_opt, a_opt)) in parsed.iter_mut().enumerate() {
             if let Some(q) = q_opt {
                 q.rename_and_remove_fields(&fields);
-                if q.all_referenced_field_names().is_empty() ||
-                   is_cloze && q.all_referenced_cloze_field_names().is_empty() {
+                if q.all_referenced_field_names().is_empty()
+                    || is_cloze && q.all_referenced_cloze_field_names().is_empty()
+                {
                     q.add_missing_field_replacement(first_remaining_field_name, is_cloze);
                 }
                 self.templates[idx].config.q_format = q.template_to_string();

--- a/rslib/src/template.rs
+++ b/rslib/src/template.rs
@@ -731,6 +731,21 @@ impl ParsedTemplate {
         self.0 = rename_and_remove_fields(old_nodes, fields);
     }
 
+    pub(crate) fn contains_cloze_replacement(&self) -> bool {
+        self.0.iter().any(|node| {
+            matches!(
+                node,
+                ParsedNode::Replacement {key:_, filters} if filters.iter().any(|f| f=="cloze")
+            )
+        })
+    }
+
+    pub(crate) fn contains_field_replacement(&self) -> bool {
+        self.0
+            .iter()
+            .any(|node| matches!(node, ParsedNode::Replacement { key: _, filters: _ }))
+    }
+
     pub(crate) fn add_missing_field_replacement(&mut self, field_name: &str, is_cloze: bool) {
         let key = String::from(field_name);
         let filters = match is_cloze {

--- a/rslib/src/template.rs
+++ b/rslib/src/template.rs
@@ -730,6 +730,15 @@ impl ParsedTemplate {
         let old_nodes = std::mem::take(&mut self.0);
         self.0 = rename_and_remove_fields(old_nodes, fields);
     }
+
+    pub(crate) fn add_missing_field_replacement(&mut self, field_name: &str, is_cloze: bool) {
+        let key = String::from(field_name);
+        let filters = match is_cloze {
+            true  => vec![String::from("cloze")],
+            false => Vec::new(),
+        };
+        self.0.push(ParsedNode::Replacement {key, filters});
+    }
 }
 
 fn rename_and_remove_fields(

--- a/rslib/src/template.rs
+++ b/rslib/src/template.rs
@@ -734,10 +734,10 @@ impl ParsedTemplate {
     pub(crate) fn add_missing_field_replacement(&mut self, field_name: &str, is_cloze: bool) {
         let key = String::from(field_name);
         let filters = match is_cloze {
-            true  => vec![String::from("cloze")],
+            true => vec![String::from("cloze")],
             false => Vec::new(),
         };
-        self.0.push(ParsedNode::Replacement {key, filters});
+        self.0.push(ParsedNode::Replacement { key, filters });
     }
 }
 


### PR DESCRIPTION
Implemented solution suggested in issue #2556
I decided to use the already available `ParsedTemplate::all_referenced_field_names` and `ParsedTemplate::all_referenced_cloze_field_names` to check for field referenceless and/or clozeless sides.  However, I wonder if it might be better to define and use something like the following to avoid the overhead of allocating a new HashSet: 
```rust
// UNTESTED
impl ParsedTemplate {
    pub(crate) fn contains_cloze_replacement(&self) -> bool {
        self.0.iter().any(|node| matches!(
            node, 
            ParsedNode::Replacement {key:_, filters} if filters.iter().any(|f| f=="cloze")
        ))
    }

    pub(crate) fn contains_field_replacement(&self) -> bool {
        self.0.iter().any(|node| matches!(node, ParsedNode::Replacement {key:_,filters:_}))
    }
}
```