### PR TITLE
Add an option to stop the timer on answer

### DIFF
--- a/ftl/core/preferences.ftl
+++ b/ftl/core/preferences.ftl
@@ -73,6 +73,7 @@ preferences-network-timeout = Network timeout
 preferences-reset-window-sizes = Reset Window Sizes
 preferences-reset-window-sizes-complete = Window sizes and locations have been reset.
 preferences-shortcut-placeholder = Enter an unused shortcut key, or leave empty to disable.
+preferences-stop-timer-on-answer = Stop timer on answer
 
 ## NO NEED TO TRANSLATE. This text is no longer used by Anki, and will be removed in the future.
 

--- a/proto/anki/config.proto
+++ b/proto/anki/config.proto
@@ -53,6 +53,7 @@ message ConfigKey {
     RESET_COUNTS_REVIEWER = 22;
     RANDOM_ORDER_REPOSITION = 23;
     SHIFT_POSITION_OF_EXISTING_CARDS = 24;
+    STOP_TIMER_ON_ANSWER = 25;
   }
   enum String {
     SET_DUE_BROWSER = 0;
@@ -117,6 +118,7 @@ message Preferences {
     bool show_remaining_due_counts = 3;
     bool show_intervals_on_buttons = 4;
     uint32 time_limit_secs = 5;
+    bool stop_timer_on_answer = 6;
   }
   message Editing {
     bool adding_defaults_to_current_deck = 1;

--- a/qt/aqt/data/web/js/reviewer-bottom.ts
+++ b/qt/aqt/data/web/js/reviewer-bottom.ts
@@ -6,13 +6,16 @@
 */
 
 let time: number; // set in python code
+let timerStopped = false;
 
 let maxTime = 0;
 document.addEventListener("DOMContentLoaded", () => {
     updateTime();
     setInterval(function() {
-        time += 1;
-        updateTime();
+        if (!timerStopped) {
+            time += 1;
+            updateTime();
+        }
     }, 1000);
 });
 
@@ -41,8 +44,9 @@ function showQuestion(txt: string, maxTime_: number): void {
     maxTime = maxTime_;
 }
 
-function showAnswer(txt: string): void {
+function showAnswer(txt: string, stopTimer = false): void {
     document.getElementById("middle").innerHTML = txt;
+    timerStopped = stopTimer;
 }
 
 function selectedAnswerButton(): string {

--- a/qt/aqt/forms/preferences.ui
+++ b/qt/aqt/forms/preferences.ui
@@ -471,6 +471,19 @@
               </property>
              </widget>
             </item>
+            <item>
+              <widget class="QCheckBox" name="stop_timer_on_answer">
+                  <property name="sizePolicy">
+                    <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                    </sizepolicy>
+                  </property>
+                  <property name="text">
+                    <string>preferences_stop_timer_on_answer</string>
+                  </property>
+              </widget>
+            </item>
            </layout>
           </widget>
          </item>

--- a/qt/aqt/forms/preferences.ui
+++ b/qt/aqt/forms/preferences.ui
@@ -1164,6 +1164,7 @@
   <tabstop>showProgress</tabstop>
   <tabstop>showEstimates</tabstop>
   <tabstop>spacebar_rates_card</tabstop>
+  <tabstop>stop_timer_on_answer</tabstop>
   <tabstop>pastePNG</tabstop>
   <tabstop>paste_strips_formatting</tabstop>
   <tabstop>useCurrent</tabstop>

--- a/qt/aqt/preferences.py
+++ b/qt/aqt/preferences.py
@@ -126,6 +126,7 @@ class Preferences(QDialog):
         form.showProgress.setChecked(reviewing.show_remaining_due_counts)
         form.showPlayButtons.setChecked(not reviewing.hide_audio_play_buttons)
         form.interrupt_audio.setChecked(reviewing.interrupt_audio_when_answering)
+        form.stop_timer_on_answer.setChecked(reviewing.stop_timer_on_answer)
 
         editing = self.prefs.editing
         form.useCurrent.setCurrentIndex(
@@ -160,6 +161,7 @@ class Preferences(QDialog):
         reviewing.time_limit_secs = form.timeLimit.value() * 60
         reviewing.hide_audio_play_buttons = not self.form.showPlayButtons.isChecked()
         reviewing.interrupt_audio_when_answering = self.form.interrupt_audio.isChecked()
+        reviewing.stop_timer_on_answer = self.form.stop_timer_on_answer.isChecked()
 
         editing = self.prefs.editing
         editing.adding_defaults_to_current_deck = not form.useCurrent.currentIndex()

--- a/qt/aqt/reviewer.py
+++ b/qt/aqt/reviewer.py
@@ -709,6 +709,7 @@ class Reviewer:
 </center>
 <script>
 time = %(time)d;
+timerStopped = false;
 </script>
 """ % dict(
             edit=tr.studying_edit(),
@@ -742,7 +743,10 @@ time = %(time)d;
             self.mw.progress.single_shot(50, self._showEaseButtons)
             return
         middle = self._answerButtons()
-        self.bottom.web.eval(f"showAnswer({json.dumps(middle)});")
+        stop_timer = self.mw.col.get_config_bool(Config.Bool.STOP_TIMER_ON_ANSWER)
+        self.bottom.web.eval(
+            f"showAnswer({json.dumps(middle)}, {json.dumps(stop_timer)});"
+        )
 
     def _remaining(self) -> str:
         if not self.mw.col.conf["dueCounts"]:

--- a/rslib/src/backend/config.rs
+++ b/rslib/src/backend/config.rs
@@ -36,6 +36,7 @@ impl From<BoolKeyProto> for BoolKey {
             BoolKeyProto::ResetCountsReviewer => BoolKey::ResetCountsReviewer,
             BoolKeyProto::RandomOrderReposition => BoolKey::RandomOrderReposition,
             BoolKeyProto::ShiftPositionOfExistingCards => BoolKey::ShiftPositionOfExistingCards,
+            BoolKeyProto::StopTimerOnAnswer => BoolKey::StopTimerOnAnswer,
         }
     }
 }

--- a/rslib/src/config/bool.rs
+++ b/rslib/src/config/bool.rs
@@ -36,6 +36,7 @@ pub enum BoolKey {
     ShiftPositionOfExistingCards,
     MergeNotetypes,
     WithScheduling,
+    StopTimerOnAnswer,
 
     #[strum(to_string = "normalize_note_text")]
     NormalizeNoteText,

--- a/rslib/src/preferences.rs
+++ b/rslib/src/preferences.rs
@@ -108,6 +108,7 @@ impl Collection {
             show_intervals_on_buttons: self
                 .get_config_bool(BoolKey::ShowIntervalsAboveAnswerButtons),
             time_limit_secs: self.get_answer_time_limit_secs(),
+            stop_timer_on_answer: self.get_config_bool(BoolKey::StopTimerOnAnswer),
         })
     }
 
@@ -127,6 +128,7 @@ impl Collection {
             s.show_intervals_on_buttons,
         )?;
         self.set_answer_time_limit_secs(s.time_limit_secs)?;
+        self.set_config_bool_inner(BoolKey::StopTimerOnAnswer, s.stop_timer_on_answer)?;
         Ok(())
     }
 


### PR DESCRIPTION
This adds a preference setting to stop the displayed timer when the card is answered.

Closes #2665