### PR TITLE
Add "Anki 2.1.50+ Collection Package" to exporting.ftl

### DIFF
--- a/ftl/core/exporting.ftl
+++ b/ftl/core/exporting.ftl
@@ -1,6 +1,7 @@
 exporting-all-decks = All Decks
 exporting-anki-20-deck = Anki 2.0 Deck
 exporting-anki-collection-package = Anki Collection Package
+exporting-anki-2150-collection-package = Anki 2.1.50+ Collection Package
 exporting-anki-deck-package = Anki Deck Package
 exporting-cards-in-plain-text = Cards in Plain Text
 exporting-collection = collection


### PR DESCRIPTION
Hello,

I couldn't find this `Anki 2.1.50+ Collection Package` string on https://i18n.ankiweb.net, so I hope I have taken the correct steps to rectify this. Not a significant PR, I know.


Thank you for your hard work, as always.

HR