### PR TITLE
Match IO extensions in a case-insensitive manner

### DIFF
--- a/rslib/src/image_occlusion/imagedata.rs
+++ b/rslib/src/image_occlusion/imagedata.rs
@@ -150,7 +150,7 @@ impl Collection {
             if meta.is_file() {
                 if let Some(ext_osstr) = file_path.extension() {
                     if let Some(ext_str) = ext_osstr.to_str() {
-                        if supported_extensions.contains(&ext_str) {
+                        if supported_extensions.contains(&ext_str.to_lowercase().as_str()) {
                             return Ok(true);
                         }
                     }


### PR DESCRIPTION
I happened to test with an image with the `.JPG` extension. The image was showing when adding the note or reviewing, but not when editing.