### PR TITLE
More sensible FSRS progress indicator precision

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -140,6 +140,7 @@ Michael Winkworth <github.com/SteelColossus>
 Mateusz Wojewoda <kawa1.11@o2.pl>
 Jarrett Ye <jarrett.ye@outlook.com>
 Sam Waechter <github.com/swektr>
+Michael Eliachevitch <m.eliachevitch@posteo.de>
 
 ********************
 

--- a/ts/deck-options/FsrsOptions.svelte
+++ b/ts/deck-options/FsrsOptions.svelte
@@ -166,7 +166,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         if (!val || !val.total) {
             return "";
         }
-        let pct = ((val.current / val.total) * 100).toFixed(2);
+        let pct = ((val.current / val.total) * 100).toFixed(1);
         pct = `${pct}%`;
         if (val instanceof ComputeRetentionProgress) {
             return pct;
@@ -181,7 +181,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         if (!val || !val.total) {
             return "";
         }
-        const pct = ((val.current / val.total) * 100).toFixed(2);
+        const pct = ((val.current / val.total) * 100).toFixed(0);
         return `${pct}%`;
     }
 </script>


### PR DESCRIPTION
Its very helpful having a sub-permille precision in a progress indicator, percent-precision or at most a tenth of a percent should be sufficient for any indicator.

But in particular the compute-retention progress has 10 steps, i.e. the progress increases in 10%-intervals (10%, 20%, ...), it *cannot* have sub-decimal progress-percentages, see the [fsrs-rs `optimal_retention` function](https://github.com/open-spaced-repetition/fsrs-rs/blob/2d5b19b4941599b1fbc7a49dbbe89774f975e4ed/src/optimal_retention.rs#L365-L368). So there integer percents should be enough, everything else is misleading.

The compute-weights progress is currently (as of beta-2) not showing up at all. Maybe if the bug is fixed it can show sub-percent percentages, so for know I changed that to 0.1% precision. But I think integer percentages should be fine here as well, so upon request I can fix that.

**Before:**  
![](https://global.discourse-cdn.com/business7/uploads/anki2/original/3X/8/1/81e04b52a1a6101aada32a215138aab58907cdd5.png)
**After:**  
![image](https://github.com/ankitects/anki/assets/5121824/77003f46-0f37-4cb7-88e8-2a326afe8fec)


Also see my [comment on this issue in the beta forum thread](https://forums.ankiweb.net/t/anki-23-10-beta/34912/39).