### PR TITLE
Button to set desired FSRS retention to optimal/calculated

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -140,6 +140,7 @@ Michael Winkworth <github.com/SteelColossus>
 Mateusz Wojewoda <kawa1.11@o2.pl>
 Jarrett Ye <jarrett.ye@outlook.com>
 Sam Waechter <github.com/swektr>
+Michael Eliachevitch <m.eliachevitch@posteo.de>
 
 ********************
 

--- a/ftl/core/deck-config.ftl
+++ b/ftl/core/deck-config.ftl
@@ -334,7 +334,7 @@ deck-config-get-params = Get Params
 deck-config-fsrs-on-all-clients =
     Please ensure all of your Anki clients are Anki(Mobile) 23.10+ or AnkiDroid 2.17+. FSRS will
     not work correctly if one of your clients is older.
-deck-config-your-optimal-retention = Your optimal retention is { $num }.
+deck-config-set-optimal-retention = Set optimal retention to { $num }.
 
 ## NO NEED TO TRANSLATE. This text is no longer used by Anki, and will be removed in the future.
 

--- a/ftl/core/deck-config.ftl
+++ b/ftl/core/deck-config.ftl
@@ -334,7 +334,7 @@ deck-config-get-params = Get Params
 deck-config-fsrs-on-all-clients =
     Please ensure all of your Anki clients are Anki(Mobile) 23.10+ or AnkiDroid 2.17+. FSRS will
     not work correctly if one of your clients is older.
-deck-config-set-optimal-retention = Set desired retention to { $num }.
+deck-config-set-optimal-retention = Set desired retention to { $num }
 
 ## NO NEED TO TRANSLATE. This text is no longer used by Anki, and will be removed in the future.
 

--- a/ftl/core/deck-config.ftl
+++ b/ftl/core/deck-config.ftl
@@ -334,7 +334,7 @@ deck-config-get-params = Get Params
 deck-config-fsrs-on-all-clients =
     Please ensure all of your Anki clients are Anki(Mobile) 23.10+ or AnkiDroid 2.17+. FSRS will
     not work correctly if one of your clients is older.
-deck-config-set-optimal-retention = Set optimal retention to { $num }.
+deck-config-set-optimal-retention = Set desired retention to { $num }.
 
 ## NO NEED TO TRANSLATE. This text is no longer used by Anki, and will be removed in the future.
 

--- a/ts/deck-options/FsrsOptions.svelte
+++ b/ts/deck-options/FsrsOptions.svelte
@@ -33,7 +33,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     let computingWeights = false;
     let checkingWeights = false;
     let computingRetention = false;
-    let optimalRetention: number | undefined;  // FIXME: session-global, shared between decks
+    let optimalRetention: number | undefined; // FIXME: session-global, shared between decks
     $: computing = computingWeights || checkingWeights || computingRetention;
     $: customSearch = `preset:"${$presetName}"`;
 
@@ -182,12 +182,20 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         return `${pct}%`;
     }
 
-
-    function stringForSetOptimalRetention(retention: number) : String {
+    // this function could probably be inlined in svelte but escaping the curly braces is a hassle
+    function stringForSetOptimalRetention(retention: number): String {
         if (!retention) {
             return "";
         }
-        return tr.deckConfigSetOptimalRetention({num: retention.toFixed(2)});
+        return tr.deckConfigSetOptimalRetention({ num: retention.toFixed(2) });
+    }
+
+    // also could have been inlined but I needed boilerplate to silence the type checker
+    function setDesiredRetentionToOptimal() {
+        if (!optimalRetention) {
+            return;
+        }
+        $config.desiredRetention = optimalRetention;
     }
 </script>
 
@@ -273,13 +281,15 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         </button>
 
         {#if optimalRetention}
-        <button
-            class="btn {'btn-primary'}"
-            disabled={!optimalRetention || computingRetention || (optimalRetention ===  $config.desiredRetention)}
-            on:click={() => $config.desiredRetention = optimalRetention}
-        >
-            {stringForSetOptimalRetention(optimalRetention)}
-        </button>
+            <button
+                class="btn {'btn-primary'}"
+                disabled={!optimalRetention ||
+                    computingRetention ||
+                    optimalRetention === $config.desiredRetention}
+                on:click={() => setDesiredRetentionToOptimal()}
+            >
+                {stringForSetOptimalRetention(optimalRetention)}
+            </button>
         {/if}
         <div>{computeRetentionProgressString}</div>
     </details>

--- a/ts/deck-options/FsrsOptions.svelte
+++ b/ts/deck-options/FsrsOptions.svelte
@@ -33,7 +33,10 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     let computingWeights = false;
     let checkingWeights = false;
     let computingRetention = false;
-    let optimalRetention: number | undefined; // FIXME: session-global, shared between decks
+    let optimalRetention = 0;
+    $: if ($presetName) {
+        optimalRetention = 0;
+    }
     $: computing = computingWeights || checkingWeights || computingRetention;
     $: customSearch = `preset:"${$presetName}"`;
 
@@ -182,7 +185,6 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         return `${pct}%`;
     }
 
-    // this function could probably be inlined in svelte but escaping the curly braces is a hassle
     function stringForSetOptimalRetention(retention: number): String {
         if (!retention) {
             return "";
@@ -190,7 +192,6 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         return tr.deckConfigSetOptimalRetention({ num: retention.toFixed(2) });
     }
 
-    // also could have been inlined but I needed boilerplate to silence the type checker
     function setDesiredRetentionToOptimal() {
         if (!optimalRetention) {
             return;
@@ -284,7 +285,6 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
             <button
                 class="btn {'btn-primary'}"
                 disabled={!optimalRetention ||
-                    computingRetention ||
                     optimalRetention === $config.desiredRetention}
                 on:click={() => setDesiredRetentionToOptimal()}
             >

--- a/ts/deck-options/FsrsOptions.svelte
+++ b/ts/deck-options/FsrsOptions.svelte
@@ -33,6 +33,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     let computingWeights = false;
     let checkingWeights = false;
     let computingRetention = false;
+    let optimalRetention: number | undefined;  // FIXME: session-global, shared between decks
     $: computing = computingWeights || checkingWeights || computingRetention;
     $: customSearch = `preset:"${$presetName}"`;
 
@@ -136,11 +137,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
                     optimalRetentionRequest.weights = $config.fsrsWeights;
                     optimalRetentionRequest.search = `preset:"${state.getCurrentName()}"`;
                     const resp = await computeOptimalRetention(optimalRetentionRequest);
-                    alert(
-                        tr.deckConfigYourOptimalRetention({
-                            num: resp.optimalRetention,
-                        }),
-                    );
+                    optimalRetention = resp.optimalRetention;
                     if (computeRetentionProgress) {
                         computeRetentionProgress.current =
                             computeRetentionProgress.total;
@@ -183,6 +180,14 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         }
         const pct = ((val.current / val.total) * 100).toFixed(2);
         return `${pct}%`;
+    }
+
+
+    function stringForSetOptimalRetention(retention: number) : String {
+        if (!retention) {
+            return "";
+        }
+        return tr.deckConfigSetOptimalRetention({num: retention.toFixed(2)});
     }
 </script>
 
@@ -266,6 +271,16 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
                 {tr.deckConfigComputeButton()}
             {/if}
         </button>
+
+        {#if optimalRetention}
+        <button
+            class="btn {'btn-primary'}"
+            disabled={!optimalRetention || computingRetention || (optimalRetention ===  $config.desiredRetention)}
+            on:click={() => $config.desiredRetention = optimalRetention}
+        >
+            {stringForSetOptimalRetention(optimalRetention)}
+        </button>
+        {/if}
         <div>{computeRetentionProgressString}</div>
     </details>
 </div>


### PR DESCRIPTION
Temporarily save the calculated optimal retention and display it with a button that sets the desired retention above to this value.Don't show button until attention had been calculated. Disable button when optimal and desired attention are equal.

I find this nicer than the current alert-popup solution, as it avoids a popup and gives a choice to the user to accept the calculated retention or not, while also persisting the calculated retention on the screen for a bit.
| Before computation | After computation | After clicking once |
|--------|--------|--------|
| ![image](https://github.com/ankitects/anki/assets/5121824/135b10ab-2d5d-47a8-a9d4-b6c292b36377)  |  ![image](https://github.com/ankitects/anki/assets/5121824/78b1b7ef-a71e-44e3-bc49-7f14f8ec5f3d) | ![image](https://github.com/ankitects/anki/assets/5121824/3c7d1270-f712-4550-9098-f01b90eb3506) |

#### TODO
- [X] What's still missing is that the `optimalRetention` variable is global and persists when I change presets. When changing presets the variable should reset to `undefined`, which would also makes the button disappear. Ideally it should also disappear when changing the FSRS parameters. So probably it should be made part of some deck options state and subscribe to some events. But with that I might need some help. Also I thought whether that variable should go into the deck options schema but tbh it's not something we want to persist between sessions, users should recalculate it.