### PR TITLE
Update rust-csv

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -141,6 +141,7 @@ Mateusz Wojewoda <kawa1.11@o2.pl>
 Jarrett Ye <jarrett.ye@outlook.com> 
 Sam Waechter <github.com/swektr>
 Michael Eliachevitch <m.eliachevitch@posteo.de>
+Dominique Martinet <asmadeus@codewreck.org>
 
 ********************
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,7 +98,7 @@ dependencies = [
  "coarsetime",
  "convert_case",
  "criterion",
- "csv 1.1.6",
+ "csv",
  "data-encoding",
  "difflib",
  "dirs",
@@ -543,18 +543,6 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
-dependencies = [
- "lazy_static",
- "memchr",
- "regex-automata 0.1.10",
- "serde",
-]
-
-[[package]]
-name = "bstr"
 version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c2f7349907b712260e64b0afe2f84692af14a454be26187d9df565c7f69266a"
@@ -635,7 +623,7 @@ name = "burn-dataset"
 version = "0.10.0"
 source = "git+https://github.com/burn-rs/burn.git?rev=163e48c9699b2cc6d67fd7539cbf6821ecbf953b#163e48c9699b2cc6d67fd7539cbf6821ecbf953b"
 dependencies = [
- "csv 1.2.2",
+ "csv",
  "derive-new",
  "dirs",
  "rand 0.8.5",
@@ -1092,23 +1080,11 @@ dependencies = [
 
 [[package]]
 name = "csv"
-version = "1.1.6"
-source = "git+https://github.com/ankitects/rust-csv.git?rev=1c9d3aab6f79a7d815c69f925a46a4590c115f90#1c9d3aab6f79a7d815c69f925a46a4590c115f90"
-dependencies = [
- "bstr 0.2.17",
- "csv-core 0.1.10 (git+https://github.com/ankitects/rust-csv.git?rev=1c9d3aab6f79a7d815c69f925a46a4590c115f90)",
- "itoa",
- "ryu",
- "serde",
-]
-
-[[package]]
-name = "csv"
-version = "1.2.2"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "626ae34994d3d8d668f4269922248239db4ae42d538b14c398b74a52208e8086"
+checksum = "ac574ff4d437a7b5ad237ef331c17ccca63c46479e5b5453eb8e10bb99a759fe"
 dependencies = [
- "csv-core 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "csv-core",
  "itoa",
  "ryu",
  "serde",
@@ -1116,17 +1092,9 @@ dependencies = [
 
 [[package]]
 name = "csv-core"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b2466559f260f48ad25fe6317b3c8dac77b5bdb5763ac7d9d6103530663bc90"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "csv-core"
-version = "0.1.10"
-source = "git+https://github.com/ankitects/rust-csv.git?rev=1c9d3aab6f79a7d815c69f925a46a4590c115f90#1c9d3aab6f79a7d815c69f925a46a4590c115f90"
+checksum = "5efa2b3d7902f4b634a20cae3c9c4e6209dc4779feb6863329607560143efa70"
 dependencies = [
  "memchr",
 ]
@@ -1723,7 +1691,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "759c97c1e17c55525b57192c06a267cda0ac5210b222d6b82189a2338fa1c13d"
 dependencies = [
  "aho-corasick",
- "bstr 1.6.2",
+ "bstr",
  "fnv",
  "log",
  "regex",
@@ -2821,7 +2789,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c62dcb6174f9cb326eac248f07e955d5d559c272730b6c03e396b443b562788"
 dependencies = [
- "bstr 1.6.2",
+ "bstr",
  "normpath",
  "winapi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,10 +26,6 @@ members = [
 exclude = ["qt/bundle"]
 resolver = "2"
 
-[workspace.dependencies.csv]
-git = "https://github.com/ankitects/rust-csv.git"
-rev = "1c9d3aab6f79a7d815c69f925a46a4590c115f90"
-
 [workspace.dependencies.percent-encoding-iri]
 git = "https://github.com/ankitects/rust-url.git"
 rev = "bb930b8d089f4d30d7d19c12e54e66191de47b88"
@@ -73,6 +69,7 @@ clap = { version = "4.3.24", features = ["derive"] }
 coarsetime = "0.1.28"
 convert_case = "0.6.0"
 criterion = { version = "0.5.1" }
+csv = "1.3.0"
 data-encoding = "2.4.0"
 difflib = "0.4.0"
 flate2 = "1.0.27"

--- a/cargo/licenses.json
+++ b/cargo/licenses.json
@@ -315,15 +315,6 @@
     "description": "Buffer type for block processing of data"
   },
   {
-    "name": "bstr",
-    "version": "0.2.17",
-    "authors": "Andrew Gallant <jamslam@gmail.com>",
-    "repository": "https://github.com/BurntSushi/bstr",
-    "license": "Apache-2.0 OR MIT",
-    "license_file": null,
-    "description": "A string type that is not required to be valid UTF-8."
-  },
-  {
     "name": "bumpalo",
     "version": "3.14.0",
     "authors": "Nick Fitzgerald <fitzgen@gmail.com>",
@@ -622,16 +613,7 @@
   },
   {
     "name": "csv",
-    "version": "1.1.6",
-    "authors": "Andrew Gallant <jamslam@gmail.com>",
-    "repository": "https://github.com/BurntSushi/rust-csv",
-    "license": "MIT OR Unlicense",
-    "license_file": null,
-    "description": "Fast CSV parsing with support for serde."
-  },
-  {
-    "name": "csv",
-    "version": "1.2.2",
+    "version": "1.3.0",
     "authors": "Andrew Gallant <jamslam@gmail.com>",
     "repository": "https://github.com/BurntSushi/rust-csv",
     "license": "MIT OR Unlicense",
@@ -640,16 +622,7 @@
   },
   {
     "name": "csv-core",
-    "version": "0.1.10",
-    "authors": "Andrew Gallant <jamslam@gmail.com>",
-    "repository": "https://github.com/BurntSushi/rust-csv",
-    "license": "MIT OR Unlicense",
-    "license_file": null,
-    "description": "Bare bones CSV parsing with no_std support."
-  },
-  {
-    "name": "csv-core",
-    "version": "0.1.10",
+    "version": "0.1.11",
     "authors": "Andrew Gallant <jamslam@gmail.com>",
     "repository": "https://github.com/BurntSushi/rust-csv",
     "license": "MIT OR Unlicense",


### PR DESCRIPTION
Upstream rust-csv 1.3.0 includes our patch and can be used instead of the ankitects repo.

This fixes `cargo vendor`

EDIT: as said in other issue feel free to drop this and commit yourself if that's less work, I don't care about authorship