### PR TITLE
Refactor IO image pickers into separate component

### DIFF
--- a/ts/editor/NoteEditor.svelte
+++ b/ts/editor/NoteEditor.svelte
@@ -390,6 +390,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     import LabelButton from "components/LabelButton.svelte";
     import Shortcut from "components/Shortcut.svelte";
     import ImageOcclusionPage from "image-occlusion/ImageOcclusionPage.svelte";
+    import ImageOcclusionPicker from "image-occlusion/ImageOcclusionPicker.svelte";
     import type { IOMode } from "image-occlusion/lib";
     import { exportShapesToClozeDeletions } from "image-occlusion/shapes/to-cloze";
     import { hideAllGuessOne, ioMaskEditorVisible } from "image-occlusion/store";
@@ -401,6 +402,17 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     let isIOImageLoaded = false;
     let imageOcclusionMode: IOMode | undefined;
     let ioFields = new ImageOcclusionFieldIndexes({});
+
+    function pickIOImage() {
+        imageOcclusionMode = undefined;
+        bridgeCommand("addImageForOcclusion");
+    }
+
+    function pickIOImageFromClipboard() {
+        imageOcclusionMode = undefined;
+        bridgeCommand("addImageForOcclusionFromClipboard");
+    }
+
     async function setupMaskEditor(options: { html: string; mode: IOMode }) {
         imageOcclusionMode = undefined;
         const getIoFields = getImageOcclusionFields({
@@ -586,35 +598,10 @@ the AddCards dialog) should be implemented in the user of this component.
     {/if}
 
     {#if $ioMaskEditorVisible && isImageOcclusion && !isIOImageLoaded}
-        <div id="io-select-image-div" style="padding-top: 60px; text-align: center;">
-            <LabelButton
-                --border-left-radius="5px"
-                --border-right-radius="5px"
-                class="io-select-image-btn"
-                on:click={() => {
-                    imageOcclusionMode = undefined;
-                    bridgeCommand("addImageForOcclusion");
-                }}
-            >
-                {tr.notetypesIoSelectImage()}
-            </LabelButton>
-        </div>
-        <div
-            id="io-select-clipboard-image-div"
-            style="padding-top: 30px; text-align: center;"
-        >
-            <LabelButton
-                --border-left-radius="5px"
-                --border-right-radius="5px"
-                class="io-select-image-btn"
-                on:click={() => {
-                    imageOcclusionMode = undefined;
-                    bridgeCommand("addImageForOcclusionFromClipboard");
-                }}
-            >
-                {tr.notetypesIoPasteImageFromClipboard()}
-            </LabelButton>
-        </div>
+        <ImageOcclusionPicker
+            onPickImage={pickIOImage}
+            onPickImageFromClipboard={pickIOImageFromClipboard}
+        />
     {/if}
 
     {#if !$ioMaskEditorVisible}

--- a/ts/editor/NoteEditor.svelte
+++ b/ts/editor/NoteEditor.svelte
@@ -764,12 +764,6 @@ the AddCards dialog) should be implemented in the user of this component.
         top: unset !important;
         margin-top: 2px !important;
     }
-
-    :global(.io-select-image-btn) {
-        margin: auto;
-        padding: 0px 8px 0px 8px !important;
-    }
-
     :global(.image-occlusion .sticky-footer) {
         display: none;
     }

--- a/ts/editor/NoteEditor.svelte
+++ b/ts/editor/NoteEditor.svelte
@@ -387,7 +387,6 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     import { ImageOcclusionFieldIndexes } from "@tslib/anki/image_occlusion_pb";
     import { getImageOcclusionFields } from "@tslib/backend";
     import { wrapInternal } from "@tslib/wrap";
-    import LabelButton from "components/LabelButton.svelte";
     import Shortcut from "components/Shortcut.svelte";
     import ImageOcclusionPage from "image-occlusion/ImageOcclusionPage.svelte";
     import ImageOcclusionPicker from "image-occlusion/ImageOcclusionPicker.svelte";

--- a/ts/image-occlusion/ImageOcclusionPicker.svelte
+++ b/ts/image-occlusion/ImageOcclusionPicker.svelte
@@ -1,0 +1,39 @@
+<!--
+Copyright: Ankitects Pty Ltd and contributors
+License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
+-->
+<script lang="ts">
+    import * as tr from "@tslib/ftl";
+
+    import Container from "../components/Container.svelte";
+    import LabelButton from "components/LabelButton.svelte";
+
+    export let onPickImage: () => void;
+    export let onPickImageFromClipboard: () => void;
+</script>
+
+<Container class="image-occlusion-picker">
+    <div id="io-select-image-div" style="padding-top: 60px; text-align: center;">
+        <LabelButton
+            --border-left-radius="5px"
+            --border-right-radius="5px"
+            class="io-select-image-btn"
+            on:click={onPickImage}
+        >
+            {tr.notetypesIoSelectImage()}
+        </LabelButton>
+    </div>
+    <div
+        id="io-select-clipboard-image-div"
+        style="padding-top: 30px; text-align: center;"
+    >
+        <LabelButton
+            --border-left-radius="5px"
+            --border-right-radius="5px"
+            class="io-select-image-btn"
+            on:click={onPickImageFromClipboard}
+        >
+            {tr.notetypesIoPasteImageFromClipboard()}
+        </LabelButton>
+    </div>
+</Container>

--- a/ts/image-occlusion/ImageOcclusionPicker.svelte
+++ b/ts/image-occlusion/ImageOcclusionPicker.svelte
@@ -13,27 +13,31 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 </script>
 
 <Container class="image-occlusion-picker">
-    <div id="io-select-image-div" style="padding-top: 60px; text-align: center;">
+    <div id="io-pick-image-file" style="padding-top: 60px; text-align: center;">
         <LabelButton
             --border-left-radius="5px"
             --border-right-radius="5px"
-            class="io-select-image-btn"
+            class="io-image-picker-button"
             on:click={onPickImage}
         >
             {tr.notetypesIoSelectImage()}
         </LabelButton>
     </div>
-    <div
-        id="io-select-clipboard-image-div"
-        style="padding-top: 30px; text-align: center;"
-    >
+    <div id="io-pick-image-clipboard" style="padding-top: 30px; text-align: center;">
         <LabelButton
             --border-left-radius="5px"
             --border-right-radius="5px"
-            class="io-select-image-btn"
+            class="io-image-picker-button"
             on:click={onPickImageFromClipboard}
         >
             {tr.notetypesIoPasteImageFromClipboard()}
         </LabelButton>
     </div>
 </Container>
+
+<style lang="scss">
+    :global(.io-image-picker-button) {
+        margin: auto;
+        padding: 0px 8px 0px 8px !important;
+    }
+</style>

--- a/ts/image-occlusion/ImageOcclusionPicker.svelte
+++ b/ts/image-occlusion/ImageOcclusionPicker.svelte
@@ -6,7 +6,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     import * as tr from "@tslib/ftl";
 
     import Container from "../components/Container.svelte";
-    import LabelButton from "components/LabelButton.svelte";
+    import LabelButton from "../components/LabelButton.svelte";
 
     export let onPickImage: () => void;
     export let onPickImageFromClipboard: () => void;


### PR DESCRIPTION
Essentially just wrapping the image pickers in a container, so that I can more easily target the image selection screen with IOE. No other changes beyond tweaking the class names slightly.