### PR TITLE
Propagate editor UI state transitions to add-ons

### DIFF
--- a/qt/aqt/editor.py
+++ b/qt/aqt/editor.py
@@ -90,6 +90,18 @@ class EditorMode(Enum):
     BROWSER = 2
 
 
+class EditorState(Enum):
+    """
+    Current input state of the editing UI.
+    """
+
+    INITIAL = -1
+    FIELDS = 0
+    IO_PICKER = 1
+    IO_MASKS = 2
+    IO_FIELDS = 3
+
+
 class Editor:
     """The screen that embeds an editing widget should listen for changes via
     the `operation_did_execute` hook, and call set_note() when the editor needs
@@ -124,6 +136,7 @@ class Editor:
         self.last_field_index: int | None = None
         # current card, for card layout
         self.card: Card | None = None
+        self.state: EditorState | None = None
         self._init_links()
         self.setupOuter()
         self.add_webview()
@@ -474,6 +487,12 @@ require("anki/ui").loaded.then(() => require("anki/NoteEditor").instances[0].too
             collapsed = collapsed_string == "true"
             self.setTagsCollapsed(collapsed)
 
+        elif cmd.startswith("editorState"):
+            (_, new_state_id, old_state_id) = cmd.split(":", 2)
+            self.signal_state_change(
+                EditorState(int(new_state_id)), EditorState(int(old_state_id))
+            )
+
         elif cmd in self._links:
             return self._links[cmd](self)
 
@@ -482,6 +501,12 @@ require("anki/ui").loaded.then(() => require("anki/NoteEditor").instances[0].too
 
     def mungeHTML(self, txt: str) -> str:
         return gui_hooks.editor_will_munge_html(txt, self)
+
+    def signal_state_change(
+        self, new_state: EditorState, old_state: EditorState
+    ) -> None:
+        self.state = new_state
+        gui_hooks.editor_state_did_change(self, new_state, old_state)
 
     # Setting/unsetting the current note
     ######################################################################

--- a/qt/aqt/editor.py
+++ b/qt/aqt/editor.py
@@ -136,7 +136,7 @@ class Editor:
         self.last_field_index: int | None = None
         # current card, for card layout
         self.card: Card | None = None
-        self.state: EditorState | None = None
+        self.state: EditorState = EditorState.INITIAL
         self._init_links()
         self.setupOuter()
         self.add_webview()

--- a/qt/tools/genhooks_gui.py
+++ b/qt/tools/genhooks_gui.py
@@ -1152,6 +1152,16 @@ gui_hooks.webview_did_inject_style_into_page.append(mytest)
         or by a right-click paste.
         """,
     ),
+    Hook(
+        name="editor_state_did_change",
+        args=[
+            "editor: aqt.editor.Editor",
+            "new_state: aqt.editor.EditorState",
+            "old_state: aqt.editor.EditorState",
+        ],
+        doc="""Called when the input state of the editor changes, e.g. when
+        switching to an image occlusion note type.""",
+    ),
     # Tag
     ###################
     Hook(name="tag_editor_did_process_key", args=["tag_edit: TagEdit", "evt: QEvent"]),

--- a/ts/editor/types.ts
+++ b/ts/editor/types.ts
@@ -19,3 +19,11 @@ export type NotetypeIdAndModTime = {
     id: number;
     modTime: number;
 };
+
+export enum EditorState {
+    Initial = -1,
+    Fields = 0,
+    ImageOcclusionPicker = 1,
+    ImageOcclusionMasks = 2,
+    ImageOcclusionFields = 3,
+}


### PR DESCRIPTION
Signal changes to the editor interface state via a Python hook, allowing add-on subscribers to adjust their UI to state transitions.