### PR TITLE
Fix polygon tool not working

### DIFF
--- a/ts/image-occlusion/shapes/to-cloze.ts
+++ b/ts/image-occlusion/shapes/to-cloze.ts
@@ -3,6 +3,7 @@
 
 import type { Canvas, Object as FabricObject } from "fabric";
 import { fabric } from "fabric";
+import { cloneDeep } from "lodash-es";
 
 import { makeMaskTransparent } from "../tools/lib";
 import type { Size } from "../types";
@@ -52,15 +53,19 @@ function fabricObjectToBaseShapeOrShapes(
 ): ShapeOrShapes | null {
     let shape: Shape;
 
+    // Prevents the original fabric object from mutating when a non-primitive
+    // property of a Shape mutates.
+    const cloned = cloneDeep(object);
+
     switch (object.type) {
         case "rect":
-            shape = new Rectangle(object);
+            shape = new Rectangle(cloned);
             break;
         case "ellipse":
-            shape = new Ellipse(object);
+            shape = new Ellipse(cloned);
             break;
         case "polygon":
-            shape = new Polygon(object);
+            shape = new Polygon(cloned);
             break;
         case "group":
             return object._objects.map((child) => {

--- a/ts/image-occlusion/shapes/to-cloze.ts
+++ b/ts/image-occlusion/shapes/to-cloze.ts
@@ -96,7 +96,7 @@ function shapeOrShapesToCloze(
 ): string {
     let text = "";
     function addKeyValue(key: string, value: string) {
-        if (Number.isNaN(Number(value))) {
+        if (key !== "points" && Number.isNaN(Number(value))) {
             value = ".0000";
         }
         text += `:${key}=${value}`;

--- a/ts/image-occlusion/tools/tool-polygon.ts
+++ b/ts/image-occlusion/tools/tool-polygon.ts
@@ -4,6 +4,7 @@
 import { fabric } from "fabric";
 import type { PanZoom } from "panzoom";
 
+import { emitChangeSignal } from "../MaskEditor.svelte";
 import { BORDER_COLOR, disableRotation, SHAPE_MASK_COLOR } from "./lib";
 import { undoStack } from "./tool-undo-redo";
 
@@ -190,6 +191,7 @@ const generatePolygon = (canvas: fabric.Canvas, pointsList): void => {
         canvas.add(polygon);
         // view undo redo tools
         undoStack.onObjectAdded(polygon.id);
+        emitChangeSignal();
     }
 
     polygon.on("modified", () => {


### PR DESCRIPTION
Fixes #2679

Also,
- Fixes an issue where polygon objects were not converted correctly to cloze strings
  - Currently, the polygon tool is not working at all because the `points` property of all polygon objects is converted to `points=.0000`, not only when editing but also when adding.
- Fixes an issue where added polygons are sometimes not saved to the DB when switching notes or closing the editor