### PR TITLE
GitHub issue #2713 float right and left are reversed

### DIFF
--- a/ts/editor/image-overlay/icons.ts
+++ b/ts/editor/image-overlay/icons.ts
@@ -1,9 +1,10 @@
 // Copyright: Ankitects Pty Ltd and contributors
 // License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
-export { default as floatLeftIcon } from "@mdi/svg/svg/format-float-left.svg";
+// currently floatRightButton and floatLeftButton are swapped because they are apparently reversed in the source as well
+export { default as floatRightIcon } from "@mdi/svg/svg/format-float-left.svg";
 export { default as floatNoneIcon } from "@mdi/svg/svg/format-float-none.svg";
-export { default as floatRightIcon } from "@mdi/svg/svg/format-float-right.svg";
+export { default as floatLeftIcon } from "@mdi/svg/svg/format-float-right.svg";
 export { default as sizeClear } from "@mdi/svg/svg/image-remove.svg";
 export { default as sizeActual } from "@mdi/svg/svg/image-size-select-actual.svg";
 export { default as sizeMinimized } from "@mdi/svg/svg/image-size-select-large.svg";


### PR DESCRIPTION
Hey,
this is my first pull request ever, so please don't roast me too much!

I tried to take care of Github issue #2713 Float left/right buttons are reversed.
see
[https://github.com/ankitects/anki/issues/2713](url)

Because of (for me mystical) reasons the import of format-float-left.svg and format-float-right.svg are reversed. I checked the website and the corresponding github repository 
[https://github.com/Templarian/MaterialDesign-SVG](url)

But there, it does not seem to be reversed to me.

All tests are passing!
