### PR TITLE
Fix a11y issues with Badge component

### DIFF
--- a/ts/components/Badge.svelte
+++ b/ts/components/Badge.svelte
@@ -24,7 +24,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     });
 </script>
 
-<span
+<button
     bind:this={spanRef}
     title={tooltip}
     class="badge {className}"
@@ -35,11 +35,20 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     <IconConstrain {iconSize} {widthMultiplier} {flipX}>
         <slot />
     </IconConstrain>
-</span>
+</button>
 
 <style>
     .badge {
         color: var(--badge-color, inherit);
+        border-color: transparent;
+        background: transparent;
+    }
+
+    .badge:hover,
+    .badge:active {
+        border-color: transparent;
+        background: transparent;
+        box-shadow: none;
     }
 
     .dropdown-toggle::after {

--- a/ts/components/Badge.svelte
+++ b/ts/components/Badge.svelte
@@ -40,13 +40,14 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 <style>
     .badge {
         color: var(--badge-color, inherit);
-        border-color: transparent;
+        border: none;
         background: transparent;
+        padding: 0;
     }
 
     .badge:hover,
     .badge:active {
-        border-color: transparent;
+        border: none;
         background: transparent;
         box-shadow: none;
     }


### PR DESCRIPTION
This PR will fix the a11y issues with the badge component by replacing the `span` with a semantically accurate `button` component.