### PR TITLE
Fix ModuleNotFoundError: No module named 'distutils'

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -142,6 +142,7 @@ Jarrett Ye <jarrett.ye@outlook.com>
 Sam Waechter <github.com/swektr>
 Michael Eliachevitch <m.eliachevitch@posteo.de>
 Dominique Martinet <asmadeus@codewreck.org>
+Virinci
 
 ********************
 

--- a/qt/aqt/mpv.py
+++ b/qt/aqt/mpv.py
@@ -36,10 +36,8 @@ import sys
 import tempfile
 import threading
 import time
-from distutils.spawn import (  # pylint: disable=import-error,no-name-in-module
-    find_executable,
-)
 from queue import Empty, Full, Queue
+from shutil import which
 from typing import Optional
 
 from anki.utils import is_win
@@ -78,7 +76,7 @@ class MPVBase:
     based JSON IPC.
     """
 
-    executable = find_executable("mpv")
+    executable = which("mpv")
     popenEnv: Optional[dict[str, str]] = None
 
     default_argv = [


### PR DESCRIPTION
`distutils` was deprecated in Python 3.10 and it was removed in Python 3.12.

The module was used for finding the executable path of `mpv` using the `distutils.spawn.find_executable` function. This task can also be handled by `shutil.which`.

The error log on Anki version 2.1.15_6 (packaged by my distribution Void Linux) was:
```
$ anki
Traceback (most recent call last):
  File "/usr/bin/anki", line 6, in <module>
    import aqt
  File "/usr/share/anki/aqt/__init__.py", line 4, in <module>
    from anki import version as _version
  File "/usr/share/anki/anki/__init__.py", line 14, in <module>
    from anki.storage import Collection
  File "/usr/share/anki/anki/storage.py", line 13, in <module>
    from anki.collection import _Collection
  File "/usr/share/anki/anki/collection.py", line 26, in <module>
    from anki.sound import stripSounds
  File "/usr/share/anki/anki/sound.py", line 89, in <module>
    from anki.mpv import MPV, MPVBase
  File "/usr/share/anki/anki/mpv.py", line 39, in <module>
    from distutils.spawn import find_executable # pylint: disable=import-error,no-name-in-module
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ModuleNotFoundError: No module named 'distutils'
```