### PR TITLE
Change IO text background color to white

### DIFF
--- a/ts/image-occlusion/review.ts
+++ b/ts/image-occlusion/review.ts
@@ -10,7 +10,7 @@ import { extractShapesFromRenderedClozes } from "./shapes/from-cloze";
 import { Polygon } from "./shapes/polygon";
 import { Rectangle } from "./shapes/rectangle";
 import { Text } from "./shapes/text";
-import { TEXT_FONT_FAMILY, TEXT_PADDING } from "./tools/lib";
+import { TEXT_BACKGROUND_COLOR, TEXT_FONT_FAMILY, TEXT_PADDING } from "./tools/lib";
 import type { Size } from "./types";
 
 export function setupImageCloze(): void {
@@ -136,7 +136,7 @@ function drawShape(
         ctx.textBaseline = "top";
         ctx.scale(shape.scaleX, shape.scaleY);
         const textMetrics = ctx.measureText(shape.text);
-        ctx.fillStyle = properties.inActiveShapeColor;
+        ctx.fillStyle = TEXT_BACKGROUND_COLOR;
         ctx.fillRect(
             shape.left / shape.scaleX,
             shape.top / shape.scaleY,

--- a/ts/image-occlusion/shapes/text.ts
+++ b/ts/image-occlusion/shapes/text.ts
@@ -3,7 +3,7 @@
 
 import { fabric } from "fabric";
 
-import { SHAPE_MASK_COLOR, TEXT_FONT_FAMILY, TEXT_PADDING } from "../tools/lib";
+import { TEXT_BACKGROUND_COLOR, TEXT_FONT_FAMILY, TEXT_PADDING } from "../tools/lib";
 import type { ConstructorParams, Size } from "../types";
 import type { ShapeDataForCloze } from "./base";
 import { Shape } from "./base";
@@ -41,7 +41,7 @@ export class Text extends Shape {
         return new fabric.IText(this.text, {
             ...this,
             fontFamily: TEXT_FONT_FAMILY,
-            backgroundColor: SHAPE_MASK_COLOR,
+            backgroundColor: TEXT_BACKGROUND_COLOR,
             padding: TEXT_PADDING,
         });
     }

--- a/ts/image-occlusion/tools/lib.ts
+++ b/ts/image-occlusion/tools/lib.ts
@@ -9,6 +9,7 @@ import { zoomResetValue } from "../store";
 
 export const SHAPE_MASK_COLOR = "#ffeba2";
 export const BORDER_COLOR = "#212121";
+export const TEXT_BACKGROUND_COLOR = "#ffffff";
 export const TEXT_FONT_FAMILY = "Arial";
 export const TEXT_PADDING = 5;
 

--- a/ts/image-occlusion/tools/tool-text.ts
+++ b/ts/image-occlusion/tools/tool-text.ts
@@ -6,8 +6,8 @@ import { fabric } from "fabric";
 import {
     disableRotation,
     enableUniformScaling,
-    SHAPE_MASK_COLOR,
     stopDraw,
+    TEXT_BACKGROUND_COLOR,
     TEXT_FONT_FAMILY,
     TEXT_PADDING,
 } from "./lib";
@@ -32,7 +32,7 @@ export const drawText = (canvas: fabric.Canvas): void => {
             strokeWidth: 1,
             noScaleCache: false,
             fontFamily: TEXT_FONT_FAMILY,
-            backgroundColor: SHAPE_MASK_COLOR,
+            backgroundColor: TEXT_BACKGROUND_COLOR,
             padding: TEXT_PADDING,
         });
         disableRotation(text);


### PR DESCRIPTION
I would recommend that we use a neutral background color for labels. Using the mask color could be confusing and make occlusions more difficult to parse at a glance.