### PR TITLE
Fix previewer geometry not being restored sometimes

### DIFF
--- a/qt/aqt/browser/previewer.py
+++ b/qt/aqt/browser/previewer.py
@@ -66,6 +66,7 @@ class Previewer(QDialog):
         self._create_gui()
         self._setup_web_view()
         self.render_card()
+        restoreGeom(self, "preview")
         self.show()
 
     def _create_gui(self) -> None:
@@ -105,7 +106,6 @@ class Previewer(QDialog):
 
         self.vbox.addWidget(self.bbox)
         self.setLayout(self.vbox)
-        restoreGeom(self, "preview")
 
     def _on_finished(self, ok: int) -> None:
         saveGeom(self, "preview")


### PR DESCRIPTION
I was able to reproduce #2724 inconsistently. Maximizing/minimizing the window also fixed it for me. I found that moving the restoreGeom() call down fixes it as far as I can tell. I have no idea why this works.