### PR TITLE
Fix selected shapes shifting to canvas origin

### DIFF
--- a/ts/image-occlusion/shapes/to-cloze.ts
+++ b/ts/image-occlusion/shapes/to-cloze.ts
@@ -36,6 +36,10 @@ export function exportShapesToClozeDeletions(occludeInactive: boolean): {
  */
 function baseShapesFromFabric(occludeInactive: boolean): ShapeOrShapes[] {
     const canvas = globalThis.canvas as Canvas;
+
+    // Prevents multiple shapes in 'activeSelection' from shifting to the canvas origin
+    canvas.discardActiveObject();
+
     makeMaskTransparent(canvas, false);
     const objects = canvas.getObjects() as FabricObject[];
     return objects

--- a/ts/image-occlusion/tools/tool-ellipse.ts
+++ b/ts/image-occlusion/tools/tool-ellipse.ts
@@ -115,6 +115,7 @@ export const drawEllipse = (canvas: fabric.Canvas): void => {
         }
 
         ellipse.setCoords();
+        canvas.setActiveObject(ellipse);
         undoStack.onObjectAdded(ellipse.id);
     });
 };

--- a/ts/image-occlusion/tools/tool-polygon.ts
+++ b/ts/image-occlusion/tools/tool-polygon.ts
@@ -189,6 +189,7 @@ const generatePolygon = (canvas: fabric.Canvas, pointsList): void => {
     if (polygon.width > 5 && polygon.height > 5) {
         disableRotation(polygon);
         canvas.add(polygon);
+        canvas.setActiveObject(polygon);
         // view undo redo tools
         undoStack.onObjectAdded(polygon.id);
         emitChangeSignal();

--- a/ts/image-occlusion/tools/tool-rect.ts
+++ b/ts/image-occlusion/tools/tool-rect.ts
@@ -109,6 +109,7 @@ export const drawRectangle = (canvas: fabric.Canvas): void => {
         }
 
         rect.setCoords();
+        canvas.setActiveObject(rect);
         undoStack.onObjectAdded(rect.id);
     });
 };

--- a/ts/image-occlusion/tools/tool-text.ts
+++ b/ts/image-occlusion/tools/tool-text.ts
@@ -38,6 +38,7 @@ export const drawText = (canvas: fabric.Canvas): void => {
         disableRotation(text);
         enableUniformScaling(canvas, text);
         canvas.add(text);
+        canvas.setActiveObject(text);
         undoStack.onObjectAdded(text.id);
     });
 };


### PR DESCRIPTION
Fixes #2725

The problem in #2725 is caused by the fact that when newly added shape overlaps another, they become selected. In fact, in addition to the #2725 case, the problem of shifting to the canvas origin also occurs when the user clicks on the **Add** button with multiple non-overlapping shapes selected with the mouse.

Multiple objects in the `activeSelection` seem to have coordinates relative to the selected objects, just as objects in a `fabric.Group` have coordinates relative to the `Group`. I suppose we could recalculate the coordinates in the same way as #2682, but I took this approach because I thought it would be easier to simply deselect them before converting them to cloze text, unlike in the case of `Group`.

---

96f5befe58ac3a025f5c3fa5b8d6f8abb78358a8 is not required to fix #2725, but I believe the preferred behavior is for only the newly added shape to be in the selected state.