### PR TITLE
Reduce shaking of bottom bar

### DIFF
--- a/qt/aqt/toolbar.py
+++ b/qt/aqt/toolbar.py
@@ -202,7 +202,7 @@ class BottomWebView(ToolbarWebView):
     def animate_height(self, height: int) -> None:
         self.web_height = height
 
-        if self.mw.pm.reduce_motion():
+        if self.mw.pm.reduce_motion() or height == self.height():
             self.setFixedHeight(height)
         else:
             # Collapse/Expand animation


### PR DESCRIPTION
Closes #2668

The shaking should be mostly gone now. The animation is still not smooth, but this is probably a Qt issue.