### PR TITLE
Another approach to preventing selected shapes from shifting

### DIFF
--- a/ts/image-occlusion/shapes/to-cloze.ts
+++ b/ts/image-occlusion/shapes/to-cloze.ts
@@ -36,10 +36,6 @@ export function exportShapesToClozeDeletions(occludeInactive: boolean): {
  */
 function baseShapesFromFabric(occludeInactive: boolean): ShapeOrShapes[] {
     const canvas = globalThis.canvas as Canvas;
-
-    // Prevents multiple shapes in 'activeSelection' from shifting to the canvas origin
-    canvas.discardActiveObject();
-
     makeMaskTransparent(canvas, false);
     const objects = canvas.getObjects() as FabricObject[];
     return objects

--- a/ts/image-occlusion/shapes/to-cloze.ts
+++ b/ts/image-occlusion/shapes/to-cloze.ts
@@ -37,13 +37,24 @@ export function exportShapesToClozeDeletions(occludeInactive: boolean): {
 function baseShapesFromFabric(occludeInactive: boolean): ShapeOrShapes[] {
     const canvas = globalThis.canvas as Canvas;
     makeMaskTransparent(canvas, false);
+    const activeObject = canvas.getActiveObject();
+    const selectionContainingMultipleObjects = activeObject instanceof fabric.ActiveSelection
+            && (activeObject.size() > 1)
+        ? activeObject
+        : null;
     const objects = canvas.getObjects() as FabricObject[];
     return objects
         .map((object) => {
+            // If the object is in the active selection containing multiple objects,
+            // we need to calculate its x and y coordinates relative to the canvas.
+            const parent = selectionContainingMultipleObjects?.contains(object)
+                ? selectionContainingMultipleObjects
+                : undefined;
             return fabricObjectToBaseShapeOrShapes(
                 canvas,
                 object,
                 occludeInactive,
+                parent,
             );
         })
         .filter((o): o is ShapeOrShapes => o !== null);


### PR DESCRIPTION
Another approach to fixing #2725 .

I've found that the approach in #2729 is flawed. While it correctly converts multiple shapes that are selected to cloze text, it also causes an issue where the selection is cleared when it should not be. For example, if you select multiple shapes and release the mouse while moving them around, the selection will be cleared.

We should take the same approach as in #2682.
