### PR TITLE
Add APIs for IO card rendering

### DIFF
--- a/proto/anki/image_occlusion.proto
+++ b/proto/anki/image_occlusion.proto
@@ -64,7 +64,7 @@ message GetImageOcclusionNoteResponse {
     repeated ImageOcclusionProperty properties = 2;
   }
 
-  message ImageClozeNote {
+  message ImageOcclusionNote {
     bytes image_data = 1;
     repeated ImageOcclusion occlusions = 2;
     string header = 3;
@@ -73,7 +73,7 @@ message GetImageOcclusionNoteResponse {
   }
 
   oneof value {
-    ImageClozeNote note = 1;
+    ImageOcclusionNote note = 1;
     string error = 2;
   }
 }

--- a/rslib/src/image_occlusion/imagedata.rs
+++ b/rslib/src/image_occlusion/imagedata.rs
@@ -82,7 +82,10 @@ impl Collection {
         Ok(GetImageOcclusionNoteResponse { value: Some(value) })
     }
 
-    pub fn get_image_occlusion_note_inner(&mut self, note_id: NoteId) -> Result<ImageOcclusionNote> {
+    pub fn get_image_occlusion_note_inner(
+        &mut self,
+        note_id: NoteId,
+    ) -> Result<ImageOcclusionNote> {
         let note = self.storage.get_note(note_id)?.or_not_found(note_id)?;
         let mut cloze_note = ImageOcclusionNote::default();
 

--- a/rslib/src/image_occlusion/imagedata.rs
+++ b/rslib/src/image_occlusion/imagedata.rs
@@ -6,7 +6,7 @@ use std::path::PathBuf;
 
 use anki_io::metadata;
 use anki_io::read_file;
-use anki_proto::image_occlusion::get_image_occlusion_note_response::ImageClozeNote;
+use anki_proto::image_occlusion::get_image_occlusion_note_response::ImageOcclusionNote;
 use anki_proto::image_occlusion::get_image_occlusion_note_response::Value;
 use anki_proto::image_occlusion::AddImageOcclusionNoteRequest;
 use anki_proto::image_occlusion::GetImageForOcclusionResponse;
@@ -82,9 +82,9 @@ impl Collection {
         Ok(GetImageOcclusionNoteResponse { value: Some(value) })
     }
 
-    pub fn get_image_occlusion_note_inner(&mut self, note_id: NoteId) -> Result<ImageClozeNote> {
+    pub fn get_image_occlusion_note_inner(&mut self, note_id: NoteId) -> Result<ImageOcclusionNote> {
         let note = self.storage.get_note(note_id)?.or_not_found(note_id)?;
-        let mut cloze_note = ImageClozeNote::default();
+        let mut cloze_note = ImageOcclusionNote::default();
 
         let fields = note.fields();
 

--- a/rslib/src/image_occlusion/notetype.rs
+++ b/rslib/src/image_occlusion/notetype.rs
@@ -99,7 +99,7 @@ pub(crate) fn image_occlusion_notetype(tr: &I18n) -> Notetype {
 </div>
 <script>
 try {{
-    anki.setupImageCloze();
+    anki.imageOcclusion.setup();
 }} catch (exc) {{
     document.getElementById("err").innerHTML = `{err_loading}<br><br>${{exc}}`;
 }}

--- a/ts/image-occlusion/review.ts
+++ b/ts/image-occlusion/review.ts
@@ -4,41 +4,51 @@
 import * as tr from "@tslib/ftl";
 
 import { optimumPixelSizeForCanvas } from "./canvas-scale";
-import type { Shape } from "./shapes";
+import { Shape } from "./shapes";
 import { Ellipse, extractShapesFromRenderedClozes, Polygon, Rectangle, Text } from "./shapes";
 import { TEXT_BACKGROUND_COLOR, TEXT_FONT_FAMILY, TEXT_PADDING } from "./tools/lib";
 import type { Size } from "./types";
 
-export type ImageClozeShapes = {
+export type ImageOcclusionShapes = {
     active: Shape[];
     inactive: Shape[];
 };
 
 export type DrawShapesFilter = (
-    shapes: ImageClozeShapes,
+    shapes: ImageOcclusionShapes,
     properties: ShapeProperties,
     context: CanvasRenderingContext2D,
-) => ImageClozeShapes;
+) => ImageOcclusionShapes;
 
 export type DrawShapesCallback = (
-    shapes: ImageClozeShapes,
+    shapes: ImageOcclusionShapes,
     properties: ShapeProperties,
     context: CanvasRenderingContext2D,
 ) => void;
 
-export interface SetupImageClozeOptions {
+export interface SetupImageOcclusionOptions {
     onWillDrawShapes?: DrawShapesFilter;
     onDidDrawShapes?: DrawShapesCallback;
 }
 
-export function setupImageCloze(setupOptions?: SetupImageClozeOptions): void {
+export const imageOcclusionAPI = {
+    setup: setupImageOcclusion,
+    drawShape,
+    Ellipse,
+    Polygon,
+    Rectangle,
+    Shape,
+    Text,
+};
+
+function setupImageOcclusion(setupOptions?: SetupImageOcclusionOptions): void {
     window.addEventListener("load", () => {
-        window.addEventListener("resize", () => setupImageCloze(setupOptions));
+        window.addEventListener("resize", () => setupImageOcclusion(setupOptions));
     });
-    window.requestAnimationFrame(() => setupImageClozeInner(setupOptions));
+    window.requestAnimationFrame(() => setupImageOcclusionInner(setupOptions));
 }
 
-function setupImageClozeInner(setupOptions?: SetupImageClozeOptions): void {
+function setupImageOcclusionInner(setupOptions?: SetupImageOcclusionOptions): void {
     const canvas = document.querySelector(
         "#image-occlusion-canvas",
     ) as HTMLCanvasElement | null;

--- a/ts/image-occlusion/review.ts
+++ b/ts/image-occlusion/review.ts
@@ -105,37 +105,46 @@ function drawShapes(
     }
 
     for (const shape of activeShapes) {
-        drawShape(
+        drawShape({
             context,
             size,
             shape,
-            properties.activeShapeColor,
-            properties.activeBorder.color,
-            properties.activeBorder.width,
-        );
+            fill: properties.activeShapeColor,
+            stroke: properties.activeBorder.color,
+            strokeWidth: properties.activeBorder.width,
+        });
     }
     for (const shape of inactiveShapes.filter((s) => s.occludeInactive)) {
-        drawShape(
+        drawShape({
             context,
             size,
             shape,
-            properties.inActiveShapeColor,
-            properties.inActiveBorder.color,
-            properties.inActiveBorder.width,
-        );
+            fill: properties.inActiveShapeColor,
+            stroke: properties.inActiveBorder.color,
+            strokeWidth: properties.inActiveBorder.width,
+        });
     }
 
     onDidDrawShapes?.({ activeShapes, inactiveShapes, properties }, context);
 }
 
-function drawShape(
-    ctx: CanvasRenderingContext2D,
-    size: Size,
-    shape: Shape,
-    fill: string,
-    stroke: string,
-    strokeWidth: number,
-): void {
+interface DrawShapeParameters {
+    context: CanvasRenderingContext2D;
+    size: Size;
+    shape: Shape;
+    fill: string;
+    stroke: string;
+    strokeWidth: number;
+}
+
+function drawShape({
+    context: ctx,
+    size,
+    shape,
+    fill,
+    stroke,
+    strokeWidth,
+}: DrawShapeParameters): void {
     shape = shape.toAbsolute(size);
 
     ctx.fillStyle = fill;

--- a/ts/image-occlusion/review.ts
+++ b/ts/image-occlusion/review.ts
@@ -136,7 +136,7 @@ function drawShape(
     stroke: string,
     strokeWidth: number,
 ): void {
-    shape.makeAbsolute(size);
+    shape = shape.toAbsolute(size);
 
     ctx.fillStyle = fill;
     ctx.strokeStyle = stroke;

--- a/ts/image-occlusion/shapes/base.ts
+++ b/ts/image-occlusion/shapes/base.ts
@@ -50,18 +50,24 @@ export class Shape {
     }
 
     toFabric(size: Size): fabric.ForCloze {
-        this.makeAbsolute(size);
-        return new fabric.Object(this);
+        const absolute = this.toAbsolute(size);
+        return new fabric.Object(absolute);
     }
 
-    makeNormal(size: Size): void {
-        this.left = xToNormalized(size, this.left);
-        this.top = yToNormalized(size, this.top);
+    toNormal(size: Size): Shape {
+        return new Shape({
+            ...this,
+            left: xToNormalized(size, this.left),
+            top: yToNormalized(size, this.top),
+        });
     }
 
-    makeAbsolute(size: Size): void {
-        this.left = xFromNormalized(size, this.left);
-        this.top = yFromNormalized(size, this.top);
+    toAbsolute(size: Size): Shape {
+        return new Shape({
+            ...this,
+            left: xFromNormalized(size, this.left),
+            top: yFromNormalized(size, this.top),
+        });
     }
 }
 

--- a/ts/image-occlusion/shapes/base.ts
+++ b/ts/image-occlusion/shapes/base.ts
@@ -23,14 +23,18 @@ export class Shape {
      * question side.
      */
     occludeInactive = false;
+    /* Cloze ordinal */
+    ordinal = 0;
 
     constructor(
-        { left = 0, top = 0, fill = SHAPE_MASK_COLOR, occludeInactive = false }: ConstructorParams<Shape> = {},
+        { left = 0, top = 0, fill = SHAPE_MASK_COLOR, occludeInactive = false, ordinal = 0 }: ConstructorParams<Shape> =
+            {},
     ) {
         this.left = left;
         this.top = top;
         this.fill = fill;
         this.occludeInactive = occludeInactive;
+        this.ordinal = ordinal;
     }
 
     /** Format numbers and remove default values, for easier serialization to

--- a/ts/image-occlusion/shapes/base.ts
+++ b/ts/image-occlusion/shapes/base.ts
@@ -54,19 +54,31 @@ export class Shape {
         return new fabric.Object(absolute);
     }
 
+    normalPosition(size: Size) {
+        return {
+            left: xToNormalized(size, this.left),
+            top: yToNormalized(size, this.top),
+        };
+    }
+
     toNormal(size: Size): Shape {
         return new Shape({
             ...this,
-            left: xToNormalized(size, this.left),
-            top: yToNormalized(size, this.top),
+            ...this.normalPosition(size),
         });
+    }
+
+    absolutePosition(size: Size) {
+        return {
+            left: xFromNormalized(size, this.left),
+            top: yFromNormalized(size, this.top),
+        };
     }
 
     toAbsolute(size: Size): Shape {
         return new Shape({
             ...this,
-            left: xFromNormalized(size, this.left),
-            top: yFromNormalized(size, this.top),
+            ...this.absolutePosition(size),
         });
     }
 }

--- a/ts/image-occlusion/shapes/ellipse.ts
+++ b/ts/image-occlusion/shapes/ellipse.ts
@@ -35,20 +35,18 @@ export class Ellipse extends Shape {
     toNormal(size: Size): Ellipse {
         return new Ellipse({
             ...this,
+            ...super.normalPosition(size),
             rx: xToNormalized(size, this.rx),
             ry: yToNormalized(size, this.ry),
-            left: xToNormalized(size, this.left),
-            top: yToNormalized(size, this.top),
         });
     }
 
     toAbsolute(size: Size): Ellipse {
         return new Ellipse({
             ...this,
+            ...super.absolutePosition(size),
             rx: xFromNormalized(size, this.rx),
             ry: yFromNormalized(size, this.ry),
-            left: xFromNormalized(size, this.left),
-            top: yFromNormalized(size, this.top),
         });
     }
 }

--- a/ts/image-occlusion/shapes/ellipse.ts
+++ b/ts/image-occlusion/shapes/ellipse.ts
@@ -28,20 +28,28 @@ export class Ellipse extends Shape {
     }
 
     toFabric(size: Size): fabric.Ellipse {
-        this.makeAbsolute(size);
-        return new fabric.Ellipse(this);
+        const absolute = this.toAbsolute(size);
+        return new fabric.Ellipse(absolute);
     }
 
-    makeNormal(size: Size): void {
-        super.makeNormal(size);
-        this.rx = xToNormalized(size, this.rx);
-        this.ry = yToNormalized(size, this.ry);
+    toNormal(size: Size): Ellipse {
+        return new Ellipse({
+            ...this,
+            rx: xToNormalized(size, this.rx),
+            ry: yToNormalized(size, this.ry),
+            left: xToNormalized(size, this.left),
+            top: yToNormalized(size, this.top),
+        });
     }
 
-    makeAbsolute(size: Size): void {
-        super.makeAbsolute(size);
-        this.rx = xFromNormalized(size, this.rx);
-        this.ry = yFromNormalized(size, this.ry);
+    toAbsolute(size: Size): Ellipse {
+        return new Ellipse({
+            ...this,
+            rx: xFromNormalized(size, this.rx),
+            ry: yFromNormalized(size, this.ry),
+            left: xFromNormalized(size, this.left),
+            top: yFromNormalized(size, this.top),
+        });
     }
 }
 

--- a/ts/image-occlusion/shapes/from-cloze.ts
+++ b/ts/image-occlusion/shapes/from-cloze.ts
@@ -51,6 +51,7 @@ function extractShapeFromRenderedCloze(cloze: HTMLDivElement): Shape | null {
     }
     const props = {
         occludeInactive: cloze.dataset.occludeinactive === "1",
+        ordinal: parseInt(cloze.dataset.ordinal!),
         left: cloze.dataset.left,
         top: cloze.dataset.top,
         width: cloze.dataset.width,

--- a/ts/image-occlusion/shapes/index.ts
+++ b/ts/image-occlusion/shapes/index.ts
@@ -1,0 +1,9 @@
+// Copyright: Ankitects Pty Ltd and contributors
+// License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
+
+export { Shape } from "./base";
+export { Ellipse } from "./ellipse";
+export { extractShapesFromRenderedClozes } from "./from-cloze";
+export { Polygon } from "./polygon";
+export { Rectangle } from "./rectangle";
+export { Text } from "./text";

--- a/ts/image-occlusion/shapes/polygon.ts
+++ b/ts/image-occlusion/shapes/polygon.ts
@@ -39,9 +39,8 @@ export class Polygon extends Shape {
         });
         return new Polygon({
             ...this,
+            ...super.normalPosition(size),
             points,
-            left: xToNormalized(size, this.left),
-            top: yToNormalized(size, this.top),
         });
     }
 
@@ -55,9 +54,8 @@ export class Polygon extends Shape {
         });
         return new Polygon({
             ...this,
+            ...super.absolutePosition(size),
             points,
-            left: xFromNormalized(size, this.left),
-            top: yFromNormalized(size, this.top),
         });
     }
 }

--- a/ts/image-occlusion/shapes/polygon.ts
+++ b/ts/image-occlusion/shapes/polygon.ts
@@ -25,23 +25,39 @@ export class Polygon extends Shape {
     }
 
     toFabric(size: Size): fabric.Polygon {
-        this.makeAbsolute(size);
-        return new fabric.Polygon(this.points, this);
+        const absolute = this.toAbsolute(size);
+        return new fabric.Polygon(absolute.points, absolute);
     }
 
-    makeNormal(size: Size): void {
-        super.makeNormal(size);
+    toAbsolute(size: Size): Polygon {
+        const points: Point[] = [];
         this.points.forEach((p) => {
-            p.x = xToNormalized(size, p.x);
-            p.y = yToNormalized(size, p.y);
+            points.push({
+                x: xFromNormalized(size, p.x),
+                y: yFromNormalized(size, p.y),
+            });
+        });
+        return new Polygon({
+            ...this,
+            points,
+            left: xFromNormalized(size, this.left),
+            top: yFromNormalized(size, this.top),
         });
     }
 
-    makeAbsolute(size: Size): void {
-        super.makeAbsolute(size);
+    toNormal(size: Size): Polygon {
+        const points: Point[] = [];
         this.points.forEach((p) => {
-            p.x = xFromNormalized(size, p.x);
-            p.y = yFromNormalized(size, p.y);
+            points.push({
+                x: xToNormalized(size, p.x),
+                y: yToNormalized(size, p.y),
+            });
+        });
+        return new Polygon({
+            ...this,
+            points,
+            left: xToNormalized(size, this.left),
+            top: yToNormalized(size, this.top),
         });
     }
 }

--- a/ts/image-occlusion/shapes/polygon.ts
+++ b/ts/image-occlusion/shapes/polygon.ts
@@ -29,22 +29,6 @@ export class Polygon extends Shape {
         return new fabric.Polygon(absolute.points, absolute);
     }
 
-    toAbsolute(size: Size): Polygon {
-        const points: Point[] = [];
-        this.points.forEach((p) => {
-            points.push({
-                x: xFromNormalized(size, p.x),
-                y: yFromNormalized(size, p.y),
-            });
-        });
-        return new Polygon({
-            ...this,
-            points,
-            left: xFromNormalized(size, this.left),
-            top: yFromNormalized(size, this.top),
-        });
-    }
-
     toNormal(size: Size): Polygon {
         const points: Point[] = [];
         this.points.forEach((p) => {
@@ -58,6 +42,22 @@ export class Polygon extends Shape {
             points,
             left: xToNormalized(size, this.left),
             top: yToNormalized(size, this.top),
+        });
+    }
+
+    toAbsolute(size: Size): Polygon {
+        const points: Point[] = [];
+        this.points.forEach((p) => {
+            points.push({
+                x: xFromNormalized(size, p.x),
+                y: yFromNormalized(size, p.y),
+            });
+        });
+        return new Polygon({
+            ...this,
+            points,
+            left: xFromNormalized(size, this.left),
+            top: yFromNormalized(size, this.top),
         });
     }
 }

--- a/ts/image-occlusion/shapes/rectangle.ts
+++ b/ts/image-occlusion/shapes/rectangle.ts
@@ -35,20 +35,18 @@ export class Rectangle extends Shape {
     toNormal(size: Size): Rectangle {
         return new Rectangle({
             ...this,
+            ...super.normalPosition(size),
             width: xToNormalized(size, this.width),
             height: yToNormalized(size, this.height),
-            left: xToNormalized(size, this.left),
-            top: yToNormalized(size, this.top),
         });
     }
 
     toAbsolute(size: Size): Rectangle {
         return new Rectangle({
             ...this,
+            ...super.absolutePosition(size),
             width: xFromNormalized(size, this.width),
             height: yFromNormalized(size, this.height),
-            left: xFromNormalized(size, this.left),
-            top: yFromNormalized(size, this.top),
         });
     }
 }

--- a/ts/image-occlusion/shapes/rectangle.ts
+++ b/ts/image-occlusion/shapes/rectangle.ts
@@ -28,20 +28,28 @@ export class Rectangle extends Shape {
     }
 
     toFabric(size: Size): fabric.Rect {
-        this.makeAbsolute(size);
-        return new fabric.Rect(this);
+        const absolute = this.toAbsolute(size);
+        return new fabric.Rect(absolute);
     }
 
-    makeNormal(size: Size): void {
-        super.makeNormal(size);
-        this.width = xToNormalized(size, this.width);
-        this.height = yToNormalized(size, this.height);
+    toNormal(size: Size): Rectangle {
+        return new Rectangle({
+            ...this,
+            width: xToNormalized(size, this.width),
+            height: yToNormalized(size, this.height),
+            left: xToNormalized(size, this.left),
+            top: yToNormalized(size, this.top),
+        });
     }
 
-    makeAbsolute(size: Size): void {
-        super.makeAbsolute(size);
-        this.width = xFromNormalized(size, this.width);
-        this.height = yFromNormalized(size, this.height);
+    toAbsolute(size: Size): Rectangle {
+        return new Rectangle({
+            ...this,
+            width: xFromNormalized(size, this.width),
+            height: yFromNormalized(size, this.height),
+            left: xFromNormalized(size, this.left),
+            top: yFromNormalized(size, this.top),
+        });
     }
 }
 

--- a/ts/image-occlusion/shapes/text.ts
+++ b/ts/image-occlusion/shapes/text.ts
@@ -37,25 +37,33 @@ export class Text extends Shape {
     }
 
     toFabric(size: Size): fabric.IText {
-        this.makeAbsolute(size);
-        return new fabric.IText(this.text, {
-            ...this,
+        const absolute = this.toAbsolute(size);
+        return new fabric.IText(absolute.text, {
+            ...absolute,
             fontFamily: TEXT_FONT_FAMILY,
             backgroundColor: TEXT_BACKGROUND_COLOR,
             padding: TEXT_PADDING,
         });
     }
 
-    makeNormal(size: Size): void {
-        super.makeNormal(size);
-        this.scaleX = xToNormalized(size, this.scaleX);
-        this.scaleY = yToNormalized(size, this.scaleY);
+    toNormal(size: Size): Text {
+        return new Text({
+            ...this,
+            scaleX: xToNormalized(size, this.scaleX),
+            scaleY: yToNormalized(size, this.scaleY),
+            left: xToNormalized(size, this.left),
+            top: yToNormalized(size, this.top),
+        });
     }
 
-    makeAbsolute(size: Size): void {
-        super.makeAbsolute(size);
-        this.scaleX = xFromNormalized(size, this.scaleX);
-        this.scaleY = yFromNormalized(size, this.scaleY);
+    toAbsolute(size: Size): Text {
+        return new Text({
+            ...this,
+            scaleX: xFromNormalized(size, this.scaleX),
+            scaleY: yFromNormalized(size, this.scaleY),
+            left: xFromNormalized(size, this.left),
+            top: yFromNormalized(size, this.top),
+        });
     }
 }
 

--- a/ts/image-occlusion/shapes/text.ts
+++ b/ts/image-occlusion/shapes/text.ts
@@ -49,20 +49,18 @@ export class Text extends Shape {
     toNormal(size: Size): Text {
         return new Text({
             ...this,
+            ...super.normalPosition(size),
             scaleX: xToNormalized(size, this.scaleX),
             scaleY: yToNormalized(size, this.scaleY),
-            left: xToNormalized(size, this.left),
-            top: yToNormalized(size, this.top),
         });
     }
 
     toAbsolute(size: Size): Text {
         return new Text({
             ...this,
+            ...super.absolutePosition(size),
             scaleX: xFromNormalized(size, this.scaleX),
             scaleY: yFromNormalized(size, this.scaleY),
-            left: xFromNormalized(size, this.left),
-            top: yFromNormalized(size, this.top),
         });
     }
 }

--- a/ts/image-occlusion/shapes/to-cloze.ts
+++ b/ts/image-occlusion/shapes/to-cloze.ts
@@ -108,7 +108,7 @@ function fabricObjectToBaseShapeOrShapes(
         shape.top = newPosition.y;
     }
 
-    shape.makeNormal(size);
+    shape = shape.toNormal(size);
     return shape;
 }
 

--- a/ts/image-occlusion/shapes/to-cloze.ts
+++ b/ts/image-occlusion/shapes/to-cloze.ts
@@ -151,6 +151,7 @@ function shapeOrShapesToCloze(
     } else {
         ordinal = index + 1;
     }
+    shapeOrShapes.ordinal = ordinal;
     text = `{{c${ordinal}::image-occlusion:${type}${text}}}<br>`;
 
     return text;

--- a/ts/reviewer/index.ts
+++ b/ts/reviewer/index.ts
@@ -9,12 +9,13 @@ import "css-browser-selector/css_browser_selector.min";
 
 export { default as $, default as jQuery } from "jquery/dist/jquery";
 
-import { setupImageCloze } from "../image-occlusion/review";
+import { imageOcclusionAPI } from "../image-occlusion/review";
 import { mutateNextCardStates } from "./answering";
 
 globalThis.anki = globalThis.anki || {};
 globalThis.anki.mutateNextCardStates = mutateNextCardStates;
-globalThis.anki.setupImageCloze = setupImageCloze;
+globalThis.anki.imageOcclusion = imageOcclusionAPI;
+globalThis.anki.setupImageCloze = imageOcclusionAPI.setup; // deprecated
 
 import { bridgeCommand } from "@tslib/bridgecommand";
 import { registerPackage } from "@tslib/runtime-require";

--- a/ts/reviewer/reviewer_extras.ts
+++ b/ts/reviewer/reviewer_extras.ts
@@ -5,13 +5,14 @@
 @typescript-eslint/no-explicit-any: "off",
  */
 
-// A standalone bundle that adds mutateNextCardStates and setupImageCloze
+// A standalone bundle that adds mutateNextCardStates and the image occlusion API
 // to the anki namespace. When all clients are using reviewer.js directly, we
 // can get rid of this.
 
-import { setupImageCloze } from "../image-occlusion/review";
+import { imageOcclusionAPI } from "../image-occlusion/review";
 import { mutateNextCardStates } from "./answering";
 
 globalThis.anki = globalThis.anki || {};
 globalThis.anki.mutateNextCardStates = mutateNextCardStates;
-globalThis.anki.setupImageCloze = setupImageCloze;
+globalThis.anki.imageOcclusion = imageOcclusionAPI;
+globalThis.anki.setupImageCloze = imageOcclusionAPI.setup; // deprecated


### PR DESCRIPTION
Extends IO with a number of **JS APIs** that allow altering **IO card rendering**:

- Add `onWillDrawShapes` and `onDidDrawShapes` callback parameters to IO setup function, allowing consumers to modify rendering both before and after the occlusion masks are drawn
- Add cloze ordinal to `Shape` objects
- Allow consumers to draw their own shapes directly by exposing `drawShape` and shape classes

**Refactoring changes** as a result of these additions:

- Create a new namespace for all public IO APIs available at card render time under `globalThis.anki.imageOcclusion`
- Accordingly, change the image occlusion setup call from `anki.setupImagecloze()` to `anki.imageOcclusion.setup()` while retaining backwards  compatibility with old templates
- Update (de)normalization of shapes to be non-mutating. Mutating shapes would likely be a recipe for trouble when combined with IO API use by external consumers.
- Consistently use "image occlusion" terminology for all identifiers, compared to the previous mix of "image occlusion" and "image cloze"

-----

I was a bit unsure on the best way to add these APIs, walking through multiple different implementations and e.g. also experimenting with an extended hook system, but I eventually ended up settling on this template-centric approach with callback parameters.

(FWIW, [pushed the extended hook system here](https://github.com/ankitects/anki/compare/main...glutanimate:anki:poc-extended-reviewer-hooks), in case it could still come in handy in the future)

One point still has me a bit confused, however. We currently expose globals in the reviewer context through a number of means:

- For somewhat older private APIs used in Python → JS communication (e.g. `_drawMark`), we [`export` the corresponding symbols ](https://github.com/ankitects/anki/blob/main/ts/reviewer/index.ts#L220)in `reviewer/index.ts`
- For newer public APIs like `mutateNextCardStates` and `setupImageCloze`, we register them to a [`globalThis.anki` object](https://github.com/ankitects/anki/blob/main/ts/reviewer/index.ts#L16-L17). We do so in two places, `reviewer/index.ts` (for desktop) and [`reviewer/reviewer_extras.ts`](https://github.com/ankitects/anki/blob/main/ts/reviewer/reviewer_extras.ts) (I assume for AnkiMobile, AnkiWeb and maybe AnkiDroid?)
- Finally we have public template APIs like `onUpdateHook` that are both exposed via `export`s and [`registerPackage`](https://github.com/ankitects/anki/blob/main/ts/reviewer/index.ts#L266C32-L274), but do not seem to be exposed in `reviewer/reviewer_extras.ts`, while still being available on mobile

Which option, or combination thereof would you recommend using here? Given that we were already using the `anki` global for `setupImageCloze`, that's what I ended up going with. But I was wondering if we have started migrating more towards the `registerPackage` approach (or started and then stopped, given `mutateNextCardStates` and `setupImageCloze`?). 