### PR TITLE
Prevent media syncing from blocking collection tasks

### DIFF
--- a/qt/aqt/mediasync.py
+++ b/qt/aqt/mediasync.py
@@ -61,7 +61,9 @@ class MediaSyncer:
 
                 time.sleep(0.25)
 
-        self.mw.taskman.run_in_background(monitor, self._on_finished)
+        self.mw.taskman.run_in_background(
+            monitor, self._on_finished, uses_collection=False
+        )
 
     def _update_progress(self, progress: str) -> None:
         self.last_progress = progress


### PR DESCRIPTION
Closes #2736

> then use self.mw.backend instead of self.mw.col.

That doesn't seem to be necessary?