### PR TITLE
Drop support for checkpoints

### DIFF
--- a/pylib/anki/cards.py
+++ b/pylib/anki/cards.py
@@ -125,6 +125,7 @@ class Card(DeprecatedNamesMixin):
             desired_retention=self.desired_retention,
         )
 
+    @deprecated(info="please use col.update_card()")
     def flush(self) -> None:
         hooks.card_will_flush(self)
         if self.id != 0:

--- a/pylib/anki/dbproxy.py
+++ b/pylib/anki/dbproxy.py
@@ -25,13 +25,9 @@ class DBProxy:
 
     def __init__(self, backend: anki._backend.RustBackend) -> None:
         self._backend = backend
-        self.modified_in_python = False
 
     # Transactions
     ###############
-
-    def rollback(self) -> None:
-        self._backend.db_rollback()
 
     # Querying
     ################
@@ -43,11 +39,6 @@ class DBProxy:
         first_row_only: bool = False,
         **kwargs: ValueForDB,
     ) -> list[Row]:
-        # mark modified?
-        cananoized = sql.strip().lower()
-        for stmt in "insert", "update", "delete":
-            if cananoized.startswith(stmt):
-                self.modified_in_python = True
         sql, args2 = emulate_named_args(sql, args, kwargs)
         # fetch rows
         return self._backend.db_query(sql, args2, first_row_only)
@@ -85,7 +76,6 @@ class DBProxy:
     ################
 
     def executemany(self, sql: str, args: Iterable[Sequence[ValueForDB]]) -> None:
-        self.modified_in_python = True
         if isinstance(args, list):
             list_args = args
         else:

--- a/pylib/anki/dbproxy.py
+++ b/pylib/anki/dbproxy.py
@@ -26,17 +26,9 @@ class DBProxy:
     def __init__(self, backend: anki._backend.RustBackend) -> None:
         self._backend = backend
         self.modified_in_python = False
-        self.last_begin_at = 0
 
     # Transactions
     ###############
-
-    def begin(self) -> None:
-        self.last_begin_at = self.scalar("select mod from col")
-        self._backend.db_begin()
-
-    def commit(self) -> None:
-        self._backend.db_commit()
 
     def rollback(self) -> None:
         self._backend.db_rollback()

--- a/pylib/anki/decks.py
+++ b/pylib/anki/decks.py
@@ -424,7 +424,6 @@ class DeckManager(DeprecatedNamesMixin):
         # make sure arg is an int; legacy callers may be passing in a string
         did = DeckId(did)
         self.set_current(did)
-        self.col.reset()
 
     selected = get_current_id
 

--- a/pylib/anki/exporting.py
+++ b/pylib/anki/exporting.py
@@ -396,7 +396,6 @@ class AnkiPackageExporter(AnkiExporter):
         n = c.newNote()
         n.fields[0] = "This file requires a newer version of Anki."
         c.addNote(n)
-        c.save()
         c.close(downgrade=True)
 
         zip.write(path, "collection.anki2")

--- a/pylib/anki/importing/anki2.py
+++ b/pylib/anki/importing/anki2.py
@@ -52,7 +52,7 @@ class Anki2Importer(Importer):
         try:
             self._import()
         finally:
-            self.src.close(save=False, downgrade=False)
+            self.src.close(downgrade=False)
 
     def _prepareFiles(self) -> None:
         self.source_needs_upgrade = False

--- a/pylib/anki/media.py
+++ b/pylib/anki/media.py
@@ -179,9 +179,6 @@ class MediaManager(DeprecatedNamesMixin):
 
     def check(self) -> CheckMediaResponse:
         output = self.col._backend.check_media()
-        # files may have been renamed on disk, so an undo at this point could
-        # break file references
-        self.col.save()
         return output
 
     def render_all_latex(

--- a/pylib/anki/notes.py
+++ b/pylib/anki/notes.py
@@ -12,7 +12,7 @@ import anki.collection
 import anki.decks
 import anki.template
 from anki import hooks, notes_pb2
-from anki._legacy import DeprecatedNamesMixin
+from anki._legacy import DeprecatedNamesMixin, deprecated
 from anki.consts import MODEL_STD
 from anki.models import NotetypeDict, NotetypeId, TemplateDict
 from anki.utils import join_fields
@@ -78,6 +78,7 @@ class Note(DeprecatedNamesMixin):
             fields=self.fields,
         )
 
+    @deprecated(info="please use col.update_note()")
     def flush(self) -> None:
         """For an undo entry, use col.update_note() instead."""
         if self.id == 0:

--- a/pylib/anki/notes.py
+++ b/pylib/anki/notes.py
@@ -79,8 +79,7 @@ class Note(DeprecatedNamesMixin):
         )
 
     def flush(self) -> None:
-        """This preserves any current checkpoint.
-        For an undo entry, use col.update_note() instead."""
+        """For an undo entry, use col.update_note() instead."""
         if self.id == 0:
             raise Exception("can't flush a new note")
         self.col._backend.update_notes(

--- a/pylib/anki/scheduler/v3.py
+++ b/pylib/anki/scheduler/v3.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 from typing import Literal, Optional, Sequence
 
 from anki import frontend_pb2, scheduler_pb2
+from anki._legacy import deprecated
 from anki.cards import Card
 from anki.collection import OpChanges
 from anki.consts import *
@@ -103,6 +104,7 @@ class Scheduler(SchedulerBaseWithLegacy):
     # Fetching the next card (legacy API)
     ##########################################################################
 
+    @deprecated(info="no longer required")
     def reset(self) -> None:
         # backend automatically resets queues as operations are performed
         pass

--- a/pylib/tests/test_cards.py
+++ b/pylib/tests/test_cards.py
@@ -13,7 +13,6 @@ def test_delete():
     note["Back"] = "2"
     col.addNote(note)
     cid = note.cards()[0].id
-    col.reset()
     col.sched.answerCard(col.sched.getCard(), 2)
     col.remove_cards_and_orphaned_notes([cid])
     assert col.card_count() == 0

--- a/pylib/tests/test_decks.py
+++ b/pylib/tests/test_decks.py
@@ -22,13 +22,11 @@ def test_basic():
     assert col.decks.id("new deck") == parentId
     # we start with the default col selected
     assert col.decks.selected() == 1
-    col.reset()
     # we can select a different col
     col.decks.select(parentId)
     assert col.decks.selected() == parentId
     # let's create a child
     childId = col.decks.id("new deck::child")
-    col.sched.reset()
     # it should have been added to the active list
     assert col.decks.selected() == parentId
     # we can select the child individually too

--- a/pylib/tests/test_exporting.py
+++ b/pylib/tests/test_exporting.py
@@ -108,7 +108,6 @@ def test_export_anki_due():
     note["Front"] = "foo"
     col.addNote(note)
     col.crt -= 86400 * 10
-    col.sched.reset()
     c = col.sched.getCard()
     col.sched.answerCard(c, 3)
     col.sched.answerCard(c, 3)
@@ -130,7 +129,6 @@ def test_export_anki_due():
     imp = Anki2Importer(col2, newname)
     imp.run()
     c = col2.getCard(c.id)
-    col2.sched.reset()
     assert c.due - col2.sched.today == 1
 
 

--- a/pylib/tests/test_find.py
+++ b/pylib/tests/test_find.py
@@ -46,7 +46,6 @@ def test_find_cards():
     note["Front"] = "test"
     note["Back"] = "foo bar"
     col.addNote(note)
-    col.save()
     latestCardIds = [c.id for c in note.cards()]
     # tag searches
     assert len(col.find_cards("tag:*")) == 5
@@ -164,7 +163,6 @@ def test_find_cards():
     col.db.execute(
         "update cards set did = ? where id = ?", col.decks.id("Default::Child"), id
     )
-    col.save()
     assert len(col.find_cards("deck:default")) == 7
     assert len(col.find_cards("deck:default::child")) == 1
     assert len(col.find_cards("deck:default -deck:default::*")) == 6

--- a/pylib/tests/test_schedv3.py
+++ b/pylib/tests/test_schedv3.py
@@ -29,20 +29,17 @@ def test_clock():
 
 def test_basics():
     col = getEmptyCol()
-    col.reset()
     assert not col.sched.getCard()
 
 
 def test_new():
     col = getEmptyCol()
-    col.reset()
     assert col.sched.newCount == 0
     # add a note
     note = col.newNote()
     note["Front"] = "one"
     note["Back"] = "two"
     col.addNote(note)
-    col.reset()
     assert col.sched.newCount == 1
     # fetch it
     c = col.sched.getCard()
@@ -92,7 +89,6 @@ def test_newLimits():
     # give the child deck a different configuration
     c2 = col.decks.add_config_returning_id("new conf")
     col.decks.set_config_id_for_deck_dict(col.decks.get(deck2), c2)
-    col.reset()
     # both confs have defaulted to a limit of 20
     assert col.sched.newCount == 20
     # first card we get comes from parent
@@ -102,13 +98,11 @@ def test_newLimits():
     conf1 = col.decks.config_dict_for_deck_id(1)
     conf1["new"]["perDay"] = 10
     col.decks.save(conf1)
-    col.reset()
     assert col.sched.newCount == 10
     # if we limit child to 4, we should get 9
     conf2 = col.decks.config_dict_for_deck_id(deck2)
     conf2["new"]["perDay"] = 4
     col.decks.save(conf2)
-    col.reset()
     assert col.sched.newCount == 9
 
 
@@ -117,7 +111,6 @@ def test_newBoxes():
     note = col.newNote()
     note["Front"] = "one"
     col.addNote(note)
-    col.reset()
     c = col.sched.getCard()
     conf = col.sched._cardConf(c)
     conf["new"]["delays"] = [1, 2, 3, 4, 5]
@@ -138,7 +131,6 @@ def test_learn():
     col.addNote(note)
     # set as a new card and rebuild queues
     col.db.execute(f"update cards set queue={QUEUE_TYPE_NEW}, type={CARD_TYPE_NEW}")
-    col.reset()
     # sched.getCard should return it, since it's due in the past
     c = col.sched.getCard()
     assert c
@@ -182,7 +174,6 @@ def test_learn():
     c.type = CARD_TYPE_NEW
     c.queue = QUEUE_TYPE_LRN
     c.flush()
-    col.sched.reset()
     col.sched.answerCard(c, 4)
     assert c.type == CARD_TYPE_REV
     assert c.queue == QUEUE_TYPE_REV
@@ -203,7 +194,6 @@ def test_relearn():
     c.flush()
 
     # fail the card
-    col.reset()
     c = col.sched.getCard()
     col.sched.answerCard(c, 1)
     assert c.queue == QUEUE_TYPE_LRN
@@ -234,7 +224,6 @@ def test_relearn_no_steps():
     col.decks.save(conf)
 
     # fail the card
-    col.reset()
     c = col.sched.getCard()
     col.sched.answerCard(c, 1)
     assert c.queue == CARD_TYPE_REV and c.type == QUEUE_TYPE_REV
@@ -251,7 +240,6 @@ def test_learn_collapsed():
     col.addNote(note)
     # set as a new card and rebuild queues
     col.db.execute(f"update cards set queue={QUEUE_TYPE_NEW}, type={CARD_TYPE_NEW}")
-    col.reset()
     # should get '1' first
     c = col.sched.getCard()
     assert c.question().endswith("1")
@@ -276,7 +264,6 @@ def test_learn_day():
     note = col.newNote()
     note["Front"] = "two"
     col.addNote(note)
-    col.sched.reset()
     c = col.sched.getCard()
     conf = col.sched._cardConf(c)
     conf["new"]["delays"] = [1, 10, 1440, 2880]
@@ -300,7 +287,6 @@ def test_learn_day():
     # for testing, move it back a day
     c.due -= 1
     c.flush()
-    col.reset()
     assert col.sched.counts() == (0, 1, 0)
     c = col.sched.getCard()
     # nextIvl should work
@@ -309,13 +295,11 @@ def test_learn_day():
     col.sched.answerCard(c, 1)
     assert c.queue == QUEUE_TYPE_LRN
     col.undo()
-    col.reset()
     c = col.sched.getCard()
     col.sched.answerCard(c, 3)
     # simulate the passing of another two days
     c.due -= 2
     c.flush()
-    col.reset()
     # the last pass should graduate it into a review card
     assert ni(c, 3) == 86400
     col.sched.answerCard(c, 3)
@@ -324,7 +308,6 @@ def test_learn_day():
     # correctly
     c.due = 0
     c.flush()
-    col.reset()
     assert col.sched.counts() == (0, 0, 1)
     conf = col.sched._cardConf(c)
     conf["lapse"]["delays"] = [1440]
@@ -359,7 +342,6 @@ def test_reviews():
     ##################################################
     c = copy.copy(cardcopy)
     c.flush()
-    col.reset()
     col.sched.answerCard(c, 2)
     assert c.queue == QUEUE_TYPE_REV
     # the new interval should be (100) * 1.2 = 120
@@ -477,7 +459,6 @@ def test_button_spacing():
     c.ivl = 1
     c.start_timer()
     c.flush()
-    col.reset()
     ni = col.sched.nextIvlStr
     wo = without_unicode_isolation
     assert wo(ni(c, 2)) == "2d"
@@ -491,47 +472,12 @@ def test_button_spacing():
     assert wo(ni(c, 2)) == "1d"
 
 
-def test_overdue_lapse():
-    # disabled in commit 3069729776990980f34c25be66410e947e9d51a2
-    return
-    col = getEmptyCol()  # pylint: disable=unreachable
-    # add a note
-    note = col.newNote()
-    note["Front"] = "one"
-    col.addNote(note)
-    # simulate a review that was lapsed and is now due for its normal review
-    c = note.cards()[0]
-    c.type = CARD_TYPE_REV
-    c.queue = QUEUE_TYPE_LRN
-    c.due = -1
-    c.odue = -1
-    c.factor = STARTING_FACTOR
-    c.left = 2002
-    c.ivl = 0
-    c.flush()
-    # checkpoint
-    col.save()
-    col.sched.reset()
-    assert col.sched.counts() == (0, 2, 0)
-    c = col.sched.getCard()
-    col.sched.answerCard(c, 3)
-    # it should be due tomorrow
-    assert c.due == col.sched.today + 1
-    # revert to before
-    col.rollback()
-    # with the default settings, the overdue card should be removed from the
-    # learning queue
-    col.sched.reset()
-    assert col.sched.counts() == (0, 0, 1)
-
-
 def test_nextIvl():
     col = getEmptyCol()
     note = col.newNote()
     note["Front"] = "one"
     note["Back"] = "two"
     col.addNote(note)
-    col.reset()
     conf = col.decks.config_dict_for_deck_id(1)
     conf["new"]["delays"] = [0.5, 3, 10]
     conf["lapse"]["delays"] = [1, 5, 9]
@@ -611,7 +557,6 @@ def test_bury():
     c2.load()
     assert c2.queue == QUEUE_TYPE_SIBLING_BURIED
 
-    col.reset()
     assert not col.sched.getCard()
 
     col.sched.unbury_deck(deck_id=col.decks.get_current_id(), mode=UnburyDeck.USER_ONLY)
@@ -629,8 +574,6 @@ def test_bury():
     col.sched.bury_cards([c.id, c2.id])
     col.sched.unbury_deck(deck_id=col.decks.get_current_id())
 
-    col.reset()
-
     assert col.sched.counts() == (2, 0, 0)
 
 
@@ -641,14 +584,11 @@ def test_suspend():
     col.addNote(note)
     c = note.cards()[0]
     # suspending
-    col.reset()
     assert col.sched.getCard()
     col.sched.suspend_cards([c.id])
-    col.reset()
     assert not col.sched.getCard()
     # unsuspending
     col.sched.unsuspend_cards([c.id])
-    col.reset()
     assert col.sched.getCard()
     # should cope with rev cards being relearnt
     c.due = 0
@@ -656,7 +596,6 @@ def test_suspend():
     c.type = CARD_TYPE_REV
     c.queue = QUEUE_TYPE_REV
     c.flush()
-    col.reset()
     c = col.sched.getCard()
     col.sched.answerCard(c, 1)
     assert c.due >= time.time()
@@ -699,12 +638,10 @@ def test_filt_reviewing_early_normal():
     c.factor = STARTING_FACTOR
     c.start_timer()
     c.flush()
-    col.reset()
     assert col.sched.counts() == (0, 0, 0)
     # create a dynamic deck and refresh it
     did = col.decks.new_filtered("Cram")
     col.sched.rebuild_filtered_deck(did)
-    col.reset()
     # should appear as normal in the deck list
     assert sorted(col.sched.deck_due_tree().children)[0].review_count == 1
     # and should appear in the counts
@@ -731,7 +668,6 @@ def test_filt_reviewing_early_normal():
     c.due = col.sched.today + 75
     c.flush()
     col.sched.rebuild_filtered_deck(did)
-    col.reset()
     c = col.sched.getCard()
 
     assert col.sched.nextIvl(c, 2) == 100 * 1.2 / 2 * 86400
@@ -763,7 +699,6 @@ def test_filt_keep_lrn_state():
     # create a dynamic deck and refresh it
     did = col.decks.new_filtered("Cram")
     col.sched.rebuild_filtered_deck(did)
-    col.reset()
 
     # card should still be in learning state
     c.load()
@@ -800,7 +735,6 @@ def test_preview():
     cram["resched"] = False
     col.decks.save(cram)
     col.sched.rebuild_filtered_deck(did)
-    col.reset()
     # grab the first card
     c = col.sched.getCard()
 
@@ -860,7 +794,6 @@ def test_ordcycle():
     conf = col.decks.get_config(1)
     conf["new"]["bury"] = False
     col.decks.save(conf)
-    col.reset()
 
     # ordinals should arrive in order
     for i in range(3):
@@ -879,7 +812,6 @@ def test_counts_idx_new():
     note["Front"] = "two"
     note["Back"] = "two"
     col.addNote(note)
-    col.reset()
     assert col.sched.counts() == (2, 0, 0)
     c = col.sched.getCard()
     # getCard does not decrement counts
@@ -903,7 +835,6 @@ def test_repCounts():
     note = col.newNote()
     note["Front"] = "two"
     col.addNote(note)
-    col.reset()
     # lrnReps should be accurate on pass/fail
     assert col.sched.counts() == (2, 0, 0)
     col.sched.answerCard(col.sched.getCard(), 1)
@@ -924,7 +855,6 @@ def test_repCounts():
     note = col.newNote()
     note["Front"] = "four"
     col.addNote(note)
-    col.reset()
     # initial pass and immediate graduate should be correct too
     assert col.sched.counts() == (2, 0, 0)
     col.sched.answerCard(col.sched.getCard(), 3)
@@ -945,7 +875,6 @@ def test_repCounts():
     note = col.newNote()
     note["Front"] = "six"
     col.addNote(note)
-    col.reset()
     assert col.sched.counts() == (1, 0, 1)
     col.sched.answerCard(col.sched.getCard(), 1)
     assert col.sched.counts() == (1, 1, 0)
@@ -964,7 +893,6 @@ def test_timing():
         c.due = 0
         c.flush()
     # fail the first one
-    col.reset()
     c = col.sched.getCard()
     col.sched.answerCard(c, 1)
     # the next card should be another review
@@ -973,7 +901,6 @@ def test_timing():
     # if the failed card becomes due, it should show first
     c.due = int_time() - 1
     c.flush()
-    col.reset()
     c = col.sched.getCard()
     assert c.queue == QUEUE_TYPE_LRN
 
@@ -988,7 +915,6 @@ def test_collapse():
     note = col.newNote()
     note["Front"] = "two"
     col.addNote(note)
-    col.reset()
     # first note
     c = col.sched.getCard()
     col.sched.answerCard(c, 1)
@@ -1032,7 +958,6 @@ def test_deckDue():
     note["Front"] = "three"
     note.note_type()["did"] = col.decks.id("foo::baz")
     col.addNote(note)
-    col.reset()
     assert len(col.decks.all_names_and_ids()) == 5
     tree = col.sched.deck_due_tree().children
     assert tree[0].name == "Default"
@@ -1078,7 +1003,6 @@ def test_deckFlow():
     note["Front"] = "three"
     default1 = note.note_type()["did"] = col.decks.id("Default::1")
     col.addNote(note)
-    col.reset()
     assert col.sched.counts() == (3, 0, 0)
     # should get top level one first, then ::1, then ::2
     for i in "one", "three", "two":
@@ -1142,10 +1066,8 @@ def test_forget():
     c.ivl = 100
     c.due = 0
     c.flush()
-    col.reset()
     assert col.sched.counts() == (0, 0, 1)
     col.sched.forgetCards([c.id])
-    col.reset()
     assert col.sched.counts() == (1, 0, 0)
 
 
@@ -1183,7 +1105,6 @@ def test_norelearn():
     c.ivl = 100
     c.start_timer()
     c.flush()
-    col.reset()
     col.sched.answerCard(c, 1)
     col.sched._cardConf(c)["lapse"]["delays"] = []
     col.sched.answerCard(c, 1)
@@ -1235,7 +1156,6 @@ def test_negativeDueFilter():
     did = col.decks.new_filtered("Cram")
     col.sched.rebuild_filtered_deck(did)
     col.sched.empty_filtered_deck(did)
-    col.reset()
 
     c.load()
     assert c.due == -5
@@ -1250,7 +1170,6 @@ def test_initial_repeat():
     note["Back"] = "two"
     col.addNote(note)
 
-    col.reset()
     c = col.sched.getCard()
     col.sched.answerCard(c, 2)
     # should be due in ~ 5.5 mins

--- a/pylib/tests/test_stats.py
+++ b/pylib/tests/test_stats.py
@@ -17,7 +17,6 @@ def test_stats():
     # card stats
     card_stats = col.card_stats_data(c.id)
     assert card_stats.note_id == note.id
-    col.reset()
     c = col.sched.getCard()
     col.sched.answerCard(c, 3)
     col.sched.answerCard(c, 2)

--- a/qt/aqt/deckconf.py
+++ b/qt/aqt/deckconf.py
@@ -38,7 +38,6 @@ class DeckConf(QDialog):
         self.form = aqt.forms.dconf.Ui_Dialog()
         self.form.setupUi(self)
         gui_hooks.deck_conf_did_setup_ui_form(self)
-        self.mw.col.save()
         self.setupCombos()
         self.setupConfs()
         qconnect(

--- a/qt/aqt/deckconf.py
+++ b/qt/aqt/deckconf.py
@@ -38,7 +38,7 @@ class DeckConf(QDialog):
         self.form = aqt.forms.dconf.Ui_Dialog()
         self.form.setupUi(self)
         gui_hooks.deck_conf_did_setup_ui_form(self)
-        self.mw.checkpoint(tr.actions_options())
+        self.mw.col.save()
         self.setupCombos()
         self.setupConfs()
         qconnect(

--- a/qt/aqt/importing.py
+++ b/qt/aqt/importing.py
@@ -193,7 +193,6 @@ class ImportDialog(QDialog):
         )
         self.mw.col.models.save(self.importer.model, updateReqs=False)
         self.mw.progress.start()
-        self.mw.col.save()
 
         def on_done(future: Future) -> None:
             self.mw.progress.finish()

--- a/qt/aqt/importing.py
+++ b/qt/aqt/importing.py
@@ -193,7 +193,7 @@ class ImportDialog(QDialog):
         )
         self.mw.col.models.save(self.importer.model, updateReqs=False)
         self.mw.progress.start()
-        self.mw.checkpoint(tr.actions_import())
+        self.mw.col.save()
 
         def on_done(future: Future) -> None:
             self.mw.progress.finish()

--- a/qt/aqt/main.py
+++ b/qt/aqt/main.py
@@ -919,9 +919,7 @@ title="{}" {}>{}</button>""".format(
         signal.signal(signal.SIGTERM, self.onUnixSignal)
 
     def onUnixSignal(self, signum: Any, frame: Any) -> None:
-        # schedule a rollback & quit
         def quit() -> None:
-            self.col.db.rollback()
             self.close()
 
         self.progress.single_shot(100, quit)
@@ -1191,11 +1189,11 @@ title="{}" {}>{}</button>""".format(
 
     @deprecated(info="checkpoints are no longer supported")
     def checkpoint(self, name: str) -> None:
-        self.col.save()
+        pass
 
+    @deprecated(info="saving is automatic")
     def autosave(self) -> None:
-        self.col.save()
-        self.update_undo_actions()
+        pass
 
     onUndo = undo
 
@@ -1212,7 +1210,6 @@ title="{}" {}>{}</button>""".format(
         aqt.dialogs.open("EditCurrent", self)
 
     def onOverview(self) -> None:
-        self.col.reset()
         self.moveToState("overview")
 
     def onStats(self) -> None:

--- a/qt/aqt/operations/__init__.py
+++ b/qt/aqt/operations/__init__.py
@@ -148,7 +148,6 @@ def on_op_finished(
     mw: aqt.main.AnkiQt, result: ResultWithChanges, initiator: object | None
 ) -> None:
     mw.update_undo_actions()
-    mw.autosave()
 
     if isinstance(result, OpChanges):
         changes = result

--- a/qt/aqt/overview.py
+++ b/qt/aqt/overview.py
@@ -64,7 +64,6 @@ class Overview:
     def refresh(self) -> None:
         def success(_counts: tuple) -> None:
             self._refresh_needed = False
-            self.mw.col.reset()
             self._renderPage()
             self._renderBottom()
             self.mw.web.setFocus()

--- a/qt/aqt/profiles.py
+++ b/qt/aqt/profiles.py
@@ -325,7 +325,7 @@ class ProfileManager:
                     continue
             try:
                 c = Collection(path)
-                c.close(save=False, downgrade=True)
+                c.close(downgrade=True)
             except Exception as e:
                 print(e)
                 problem_profiles.append(name)

--- a/qt/aqt/reviewer.py
+++ b/qt/aqt/reviewer.py
@@ -178,7 +178,6 @@ class Reviewer:
 
     def refresh_if_needed(self) -> None:
         if self._refresh_needed is RefreshNeeded.QUEUES:
-            self.mw.col.reset()
             self.nextCard()
             self.mw.fade_in_webview()
             self._refresh_needed = None
@@ -444,7 +443,6 @@ class Reviewer:
     def _after_answering(self, ease: Literal[1, 2, 3, 4]) -> None:
         gui_hooks.reviewer_did_answer_card(self, self.card, ease)
         self._answeredIds.append(self.card.id)
-        self.mw.autosave()
         if not self.check_timebox():
             self.nextCard()
 

--- a/qt/aqt/sync.py
+++ b/qt/aqt/sync.py
@@ -120,7 +120,6 @@ def sync_collection(mw: aqt.main.AnkiQt, on_done: Callable[[], None]) -> None:
         else:
             full_sync(mw, out, on_done)
 
-    mw.col.save(trx=False)
     mw.taskman.with_progress(
         lambda: mw.col.sync_collection(auth, mw.pm.media_syncing_enabled()),
         on_future_done,

--- a/qt/aqt/sync.py
+++ b/qt/aqt/sync.py
@@ -98,7 +98,6 @@ def sync_collection(mw: aqt.main.AnkiQt, on_done: Callable[[], None]) -> None:
     timer.start(150)
 
     def on_future_done(fut: Future[SyncOutput]) -> None:
-        mw.col.db.begin()
         # scheduler version may have changed
         mw.col._load_scheduler()
         timer.stop()

--- a/qt/tools/genhooks_gui.py
+++ b/qt/tools/genhooks_gui.py
@@ -603,12 +603,6 @@ hooks = [
     # UI state/refreshing
     ###################
     Hook(
-        name="state_did_revert",
-        args=["action: str"],
-        legacy_hook="revertedState",
-        doc="Legacy hook, called after undoing.",
-    ),
-    Hook(
         name="state_did_undo",
         args=["changes: OpChangesAfterUndo"],
         doc="Called after backend undoes a change.",


### PR DESCRIPTION
I hope this is what you have in mind. I didn't notice any issues testing things such as syncing & backups and with some add-ons enabled (except of course some add-ons breaking because they are using removed methods), but DB stuff are tricky.

Is the `db.transact()` API you suggested intended for add-ons that access the database directly?