### PR TITLE
Rename a browser column label from "Notetype" to "Note Type"

### DIFF
--- a/rslib/src/browser_table.rs
+++ b/rslib/src/browser_table.rs
@@ -161,7 +161,7 @@ impl Column {
             Self::Lapses => tr.scheduling_lapses(),
             Self::NoteCreation => tr.browsing_created(),
             Self::NoteMod => tr.search_note_modified(),
-            Self::Notetype => tr.notetypes_notetype(),
+            Self::Notetype => tr.card_stats_note_type(),
             Self::Question => tr.browsing_question(),
             Self::Reps => tr.scheduling_reviews(),
             Self::SortField => tr.browsing_sort_field(),


### PR DESCRIPTION
This request is intended to attempt a minor fix to the change of #2751 (thanks for the work) and fix #2749 again.

The current label for note type may be a bit mismatched for the related strings.
![image](https://github.com/ankitects/anki/assets/10436072/f23a9724-c850-47eb-ad01-db22f77e3d01)

This request is trying to change the label name by reusing the existing string shown below.
![2023-10-20_16h21_37](https://github.com/ankitects/anki/assets/10436072/bd523a1c-f1f6-4f1f-816b-8f7d0010a03c)
