### PR TITLE
Make it possible to silent uninstall with WinGet

### DIFF
--- a/qt/bundle/win/anki.template.nsi
+++ b/qt/bundle/win/anki.template.nsi
@@ -216,6 +216,7 @@ Section ""
   WriteRegStr HKCU "Software\Microsoft\Windows\CurrentVersion\Uninstall\Anki" "DisplayName" "Anki"
   WriteRegStr HKCU "Software\Microsoft\Windows\CurrentVersion\Uninstall\Anki" "DisplayVersion" "@@VERSION@@"
   WriteRegStr HKCU "Software\Microsoft\Windows\CurrentVersion\Uninstall\Anki" "UninstallString" '"$INSTDIR\uninstall.exe"'
+  WriteRegStr HKCU "Software\Microsoft\Windows\CurrentVersion\Uninstall\Anki" "QuietUninstallString" '"$INSTDIR\uninstall.exe" /S'
   WriteRegDWORD HKCU "Software\Microsoft\Windows\CurrentVersion\Uninstall\Anki" "NoModify" 1
   WriteRegDWORD HKCU "Software\Microsoft\Windows\CurrentVersion\Uninstall\Anki" "NoRepair" 1
 


### PR DESCRIPTION
The related issue probably can be closed: https://github.com/ankitects/anki/issues/2541

Reference:

> https://github.com/microsoft/winget-pkgs/issues/49601#issuecomment-1054511535
> 
> Currently winget is able to silently uninstall nullsoft and inno setup application that register `QuietUninstallString` in Registry and Notepad++ here does not do that, this can either be fixed by requesting developer to add it or once when the feature at [microsoft/winget-cli#1885](https://github.com/microsoft/winget-cli/issues/1885) implemented.

https://github.com/notepad-plus-plus/notepad-plus-plus/commit/c19033c91711bc5c35bc63b804c5d31756ee58a4

> https://github.com/microsoft/winget-cli/issues/1368#issuecomment-898698659
> 
> I believe Winget simply executes the uninstaller listed in the registry. I don't think it actually remembers the installer type nor has the ability to modify the command line of the uninstaller.
> 
> Ask the Krita developers to also register the silent uninstall command:
> 
> ```
> WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${KRITA_UNINSTALL_REGKEY}" "QuietUninstallString" '"$INSTDIR\uninstall.exe" /S'
> ```

https://github.com/KDE/krita/commit/a56d6aad87f78a5a04f0dcb656f124e048a77738
