### PR TITLE
Change export notes' parent window in card browser

### DIFF
--- a/qt/aqt/browser/browser.py
+++ b/qt/aqt/browser/browser.py
@@ -916,10 +916,10 @@ class Browser(QMainWindow):
     def _on_export_notes(self) -> None:
         if not self.mw.pm.legacy_import_export():
             nids = self.selected_notes()
-            ExportDialog(self.mw, nids=nids)
+            ExportDialog(self.mw, nids=nids, parent=self)
         else:
             cids = self.selectedNotesAsCards()
-            LegacyExportDialog(self.mw, cids=list(cids))
+            LegacyExportDialog(self.mw, cids=list(cids), parent=self)
 
     # Flags & Marking
     ######################################################################

--- a/qt/aqt/exporting.py
+++ b/qt/aqt/exporting.py
@@ -7,6 +7,7 @@ import os
 import re
 import time
 from concurrent.futures import Future
+from typing import Optional
 
 import aqt
 import aqt.forms
@@ -34,8 +35,9 @@ class ExportDialog(QDialog):
         mw: aqt.main.AnkiQt,
         did: DeckId | None = None,
         cids: list[CardId] | None = None,
+        parent: Optional[QWidget] = None,
     ):
-        QDialog.__init__(self, mw, Qt.WindowType.Window)
+        QDialog.__init__(self, parent or mw, Qt.WindowType.Window)
         self.mw = mw
         self.col = mw.col.weakref()
         self.frm = aqt.forms.exporting.Ui_ExportDialog()

--- a/qt/aqt/import_export/exporting.py
+++ b/qt/aqt/import_export/exporting.py
@@ -8,7 +8,7 @@ import re
 import time
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Sequence, Type
+from typing import Optional, Sequence, Type
 
 import aqt.forms
 import aqt.main
@@ -36,8 +36,9 @@ class ExportDialog(QDialog):
         mw: aqt.main.AnkiQt,
         did: DeckId | None = None,
         nids: Sequence[NoteId] | None = None,
+        parent: Optional[QWidget] = None,
     ):
-        QDialog.__init__(self, mw, Qt.WindowType.Window)
+        QDialog.__init__(self, parent or mw, Qt.WindowType.Window)
         self.mw = mw
         self.col = mw.col.weakref()
         self.frm = aqt.forms.exporting.Ui_ExportDialog()


### PR DESCRIPTION
I'd like to suggest the following change.

## Before

![image](https://github.com/ankitects/anki/assets/16260735/f6c2b83f-fbcb-435b-9d27-e5e2e0e5f279)

![image](https://github.com/ankitects/anki/assets/16260735/11dabdeb-ce25-42a4-a45d-5fb60805cd58)

## After

![image](https://github.com/ankitects/anki/assets/16260735/6bcaf9e5-562a-4012-af45-b71933728f11)
