### PR TITLE
Fix modified polygon not being saved when editing IO note

### DIFF
--- a/ts/image-occlusion/mask-editor.ts
+++ b/ts/image-occlusion/mask-editor.ts
@@ -13,6 +13,7 @@ import { notesDataStore, tagsWritable, zoomResetValue } from "./store";
 import Toast from "./Toast.svelte";
 import { addShapesToCanvasFromCloze } from "./tools/add-from-cloze";
 import { enableSelectable, moveShapeToCanvasBoundaries } from "./tools/lib";
+import { modifiedPolygon } from "./tools/tool-polygon";
 import { undoStack } from "./tools/tool-undo-redo";
 import type { Size } from "./types";
 
@@ -94,7 +95,13 @@ function initCanvas(onChange: () => void): fabric.Canvas {
     canvas.uniformScaling = false;
     canvas.uniScaleKey = "none";
     moveShapeToCanvasBoundaries(canvas);
-    canvas.on("object:modified", onChange);
+    canvas.on("object:modified", (evt) => {
+        if (evt.target instanceof fabric.Polygon) {
+            modifiedPolygon(canvas, evt.target);
+            undoStack.onObjectModified();
+        }
+        onChange();
+    });
     canvas.on("object:removed", onChange);
     return canvas;
 }

--- a/ts/image-occlusion/tools/tool-polygon.ts
+++ b/ts/image-occlusion/tools/tool-polygon.ts
@@ -193,15 +193,11 @@ const generatePolygon = (canvas: fabric.Canvas, pointsList): void => {
         undoStack.onObjectAdded(polygon.id);
     }
 
-    polygon.on("modified", () => {
-        modifiedPolygon(canvas, polygon);
-        undoStack.onObjectModified();
-    });
-
     toggleDrawPolygon(canvas);
 };
 
-const modifiedPolygon = (canvas: fabric.Canvas, polygon: fabric.Polygon): void => {
+// https://github.com/fabricjs/fabric.js/issues/6522
+export const modifiedPolygon = (canvas: fabric.Canvas, polygon: fabric.Polygon): void => {
     const matrix = polygon.calcTransformMatrix();
     const transformedPoints = polygon.get("points")
         .map(function(p) {
@@ -219,11 +215,6 @@ const modifiedPolygon = (canvas: fabric.Canvas, polygon: fabric.Polygon): void =
         strokeWidth: 1,
         strokeUniform: true,
         noScaleCache: false,
-    });
-
-    polygon1.on("modified", () => {
-        modifiedPolygon(canvas, polygon1);
-        undoStack.onObjectModified();
     });
 
     canvas.remove(polygon);


### PR DESCRIPTION
This PR fixes an issue where modified polygons are not saved when editing an IO note.

#### Steps to reproduce
1. Add an IO note containing a polygon
1. Open the note in _edit current_ or _browse_
1. Select the polygon and transform or move it
1. Close the editor or switch to another note
1. Open the note again

#### Result
- The polygon has been saved as it was before the modification.