### PR TITLE
Allow disabling occlusion mask border

### DIFF
--- a/.dprint.json
+++ b/.dprint.json
@@ -1,6 +1,7 @@
 {
     "typescript": {
-        "indentWidth": 4
+        "indentWidth": 4,
+        "useBraces": "always"
     },
     "json": {
         "indentWidth": 4

--- a/ts/image-occlusion/review.ts
+++ b/ts/image-occlusion/review.ts
@@ -153,7 +153,9 @@ function drawShape({
     if (shape instanceof Rectangle) {
         ctx.fillRect(shape.left, shape.top, shape.width, shape.height);
         // ctx stroke methods will draw a visible stroke, even if the width is 0
-        if (strokeWidth) ctx.strokeRect(shape.left, shape.top, shape.width, shape.height);
+        if (strokeWidth) {
+            ctx.strokeRect(shape.left, shape.top, shape.width, shape.height);
+        }
     } else if (shape instanceof Ellipse) {
         const adjustedLeft = shape.left + shape.rx;
         const adjustedTop = shape.top + shape.ry;
@@ -170,7 +172,9 @@ function drawShape({
         );
         ctx.closePath();
         ctx.fill();
-        if (strokeWidth) ctx.stroke();
+        if (strokeWidth) {
+            ctx.stroke();
+        }
     } else if (shape instanceof Polygon) {
         const offset = getPolygonOffset(shape);
         ctx.save();
@@ -182,7 +186,9 @@ function drawShape({
         }
         ctx.closePath();
         ctx.fill();
-        if (strokeWidth) ctx.stroke();
+        if (strokeWidth) {
+            ctx.stroke();
+        }
         ctx.restore();
     } else if (shape instanceof Text) {
         ctx.save();

--- a/ts/image-occlusion/review.ts
+++ b/ts/image-occlusion/review.ts
@@ -152,7 +152,8 @@ function drawShape({
     ctx.lineWidth = strokeWidth;
     if (shape instanceof Rectangle) {
         ctx.fillRect(shape.left, shape.top, shape.width, shape.height);
-        ctx.strokeRect(shape.left, shape.top, shape.width, shape.height);
+        // ctx stroke methods will draw a visible stroke, even if the width is 0
+        if (strokeWidth) ctx.strokeRect(shape.left, shape.top, shape.width, shape.height);
     } else if (shape instanceof Ellipse) {
         const adjustedLeft = shape.left + shape.rx;
         const adjustedTop = shape.top + shape.ry;
@@ -169,7 +170,7 @@ function drawShape({
         );
         ctx.closePath();
         ctx.fill();
-        ctx.stroke();
+        if (strokeWidth) ctx.stroke();
     } else if (shape instanceof Polygon) {
         const offset = getPolygonOffset(shape);
         ctx.save();
@@ -181,7 +182,7 @@ function drawShape({
         }
         ctx.closePath();
         ctx.fill();
-        ctx.stroke();
+        if (strokeWidth) ctx.stroke();
         ctx.restore();
     } else if (shape instanceof Text) {
         ctx.save();
@@ -267,13 +268,13 @@ function getShapeProperties(): ShapeProperties {
                 ? inActiveShapeColor
                 : "#ffeba2",
             activeBorder: {
-                width: activeShapeBorderWidth ? activeShapeBorderWidth : 1,
+                width: !isNaN(activeShapeBorderWidth) ? activeShapeBorderWidth : 1,
                 color: activeShapeBorderColor
                     ? activeShapeBorderColor
                     : "#212121",
             },
             inActiveBorder: {
-                width: inActiveShapeBorderWidth ? inActiveShapeBorderWidth : 1,
+                width: !isNaN(inActiveShapeBorderWidth) ? inActiveShapeBorderWidth : 1,
                 color: inActiveShapeBorderColor
                     ? inActiveShapeBorderColor
                     : "#212121",


### PR DESCRIPTION
Previously, setting the border width to zero via the template CSS properties would have no effect.