### PR TITLE
Fix shape selection malfunction after creating shapes in succession

### DIFF
--- a/ts/image-occlusion/tools/lib.ts
+++ b/ts/image-occlusion/tools/lib.ts
@@ -120,6 +120,7 @@ const pasteItem = (canvas: fabric.Canvas): void => {
             top: clonedObj.top + 10,
             evented: true,
         });
+        disableRotation(clonedObj);
 
         if (clonedObj.type === "activeSelection") {
             // active selection needs a reference to the canvas.

--- a/ts/image-occlusion/tools/tool-ellipse.ts
+++ b/ts/image-occlusion/tools/tool-ellipse.ts
@@ -98,6 +98,7 @@ export const drawEllipse = (canvas: fabric.Canvas): void => {
         }
         if (ellipse.width < 5 || ellipse.height < 5) {
             canvas.remove(ellipse);
+            ellipse = undefined;
             return;
         }
 
@@ -118,5 +119,6 @@ export const drawEllipse = (canvas: fabric.Canvas): void => {
         ellipse.setCoords();
         canvas.setActiveObject(ellipse);
         undoStack.onObjectAdded(ellipse.id);
+        ellipse = undefined;
     });
 };

--- a/ts/image-occlusion/tools/tool-rect.ts
+++ b/ts/image-occlusion/tools/tool-rect.ts
@@ -93,6 +93,7 @@ export const drawRectangle = (canvas: fabric.Canvas): void => {
         }
         if (rect.width < 5 || rect.height < 5) {
             canvas.remove(rect);
+            rect = undefined;
             return;
         }
 
@@ -113,5 +114,6 @@ export const drawRectangle = (canvas: fabric.Canvas): void => {
         rect.setCoords();
         canvas.setActiveObject(rect);
         undoStack.onObjectAdded(rect.id);
+        rect = undefined;
     });
 };


### PR DESCRIPTION
Fixes  #2769 

Also, disables rotation when duplicating a shape.