### PR TITLE
Fix Linux install script CWD check

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -143,10 +143,10 @@ Sam Waechter <github.com/swektr>
 Michael Eliachevitch <m.eliachevitch@posteo.de>
 Carlo Quick <https://github.com/CarloQuick>
 Dominique Martinet <asmadeus@codewreck.org>
-Virinci
 chandraiyengar <github.com/chandraiyengar>
 user1823 <92206575+user1823@users.noreply.github.com>
 Gustaf Carefall <https://github.com/Gustaf-C>
+virinci <github.com/virinci>
 
 ********************
 

--- a/qt/bundle/lin/install.sh
+++ b/qt/bundle/lin/install.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-if ! test -f install.sh; then
+if [ "$(dirname "$(realpath "$0")")" != "$(realpath "$PWD")" ]; then
   echo "Please run from the folder install.sh is in."
   exit 1
 fi
@@ -13,7 +13,7 @@ fi
 
 rm -rf "$PREFIX"/share/anki "$PREFIX"/bin/anki
 mkdir -p "$PREFIX"/share/anki
-cp -av --no-preserve=owner,context * "$PREFIX"/share/anki/
+cp -av --no-preserve=owner,context -- * "$PREFIX"/share/anki/
 mkdir -p "$PREFIX"/bin
 ln -sf "$PREFIX"/share/anki/anki "$PREFIX"/bin/anki
 # fix a previous packaging issue where we created this as a file


### PR DESCRIPTION
This PR fixes:
1. A minor bug that results in unexpected behavior when the Linux `install.sh` script is executed from a directory that has any file named `install.sh`.

This can be tested as:
```shell
$ touch install.sh
$ ./anki/install.sh  # this proceeds to try and install all the files
```
where the actual install script is located in the sub-directory named `anki`.

The solution for this matches the CWD against the parent directory of the install script.

2. The second fix in the `cp` command was suggested by `shellcheck` in order to avoid unexpected behavior if any of the files being copied has a leading hyphen in its name.