### PR TITLE
Move a couple of IO webview internals to editor

### DIFF
--- a/qt/aqt/addcards.py
+++ b/qt/aqt/addcards.py
@@ -373,9 +373,9 @@ class AddCards(QMainWindow):
         self.ifCanClose(doClose)
 
     def add_io_note(self) -> None:
-        self.editor.web.eval("updateOcclusionsField();")
+        self.editor.update_occlusions_field()
         self.add_current_note()
-        self.editor.web.eval("resetIOImageLoaded()")
+        self.editor.reset_image_occlusion()
 
     # legacy aliases
 

--- a/qt/aqt/editor.py
+++ b/qt/aqt/editor.py
@@ -1124,6 +1124,12 @@ require("anki/ui").loaded.then(() => require("anki/NoteEditor").instances[0].too
             self.web.eval(f"setImageField({json.dumps(image_field_html)})")
         self._setup_mask_editor(io_options)
 
+    def reset_image_occlusion(self) -> None:
+        self.web.eval("resetIOImageLoaded()")
+
+    def update_occlusions_field(self) -> None:
+        self.web.eval("updateOcclusionsField()")
+
     def _setup_mask_editor(self, io_options: dict):
         self.web.eval(
             'require("anki/ui").loaded.then(() =>'


### PR DESCRIPTION
Abstracts IO internals away from `AddCards` and also allows add-on callers to more easily perform these actions.