### PR TITLE
add dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,14 @@
 FROM rust AS builder
 SHELL ["/bin/bash", "-uo", "pipefail", "-c"]
 
+ARG version
+
 ENV TARGET x86_64-unknown-linux-musl
 RUN rustup target add "$TARGET"
 
 RUN apt-get -y update && apt-get -y install protobuf-compiler musl musl-dev musl-tools
 ENV PROTOC=/usr/bin/protoc
-RUN cargo install --locked --target "$TARGET" --git https://github.com/ankitects/anki.git --tag 23.10 anki-sync-server
+RUN cargo install --locked --target "$TARGET" --git https://github.com/ankitects/anki.git --tag ${version} anki-sync-server
 RUN ldd /usr/local/cargo/bin/anki-sync-server
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM rust AS builder
+SHELL ["/bin/bash", "-uo", "pipefail", "-c"]
+
+ENV TARGET x86_64-unknown-linux-musl
+RUN rustup target add "$TARGET"
+
+RUN apt-get -y update && apt-get -y install protobuf-compiler musl musl-dev musl-tools
+ENV PROTOC=/usr/bin/protoc
+RUN cargo install --locked --target "$TARGET" --git https://github.com/ankitects/anki.git --tag 23.10 anki-sync-server
+RUN ldd /usr/local/cargo/bin/anki-sync-server
+
+
+FROM scratch
+ENV SYNC_BASE=/data
+COPY --from=builder --chmod=0755 /usr/local/cargo/bin/anki-sync-server /
+CMD ["./anki-sync-server"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '3.3'
+services:
+    crab-hole:
+        build: . 
+        environment:
+            - SYNC_USER1=user:pass
+        volumes:
+            - './data:/data'
+        ports:
+            - "8080:8080/tcp"


### PR DESCRIPTION
This pr add a dockerfile for the sync service. So it can easy self hosted.

It can be build by executing `docker build --build-arg version=23.10 . `.

I would recommend to build an publish it automatic on ghcr.io at release, by using the ci. Sadly I have no appearance with buildkite.