### PR TITLE
(FSRS) Improve presentation of log loss and RMSE

### DIFF
--- a/ts/deck-options/FsrsOptions.svelte
+++ b/ts/deck-options/FsrsOptions.svelte
@@ -121,10 +121,10 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
                         () =>
                             alert(
                                 `Log loss: ${resp.logLoss.toFixed(
-                                    3,
-                                )}, RMSE(bins): ${resp.rmseBins.toFixed(
-                                    3,
-                                )}. ${tr.deckConfigSmallerIsBetter()}`,
+                                    4,
+                                )}, RMSE(bins): ${(resp.rmseBins * 100).toFixed(
+                                    2,
+                                )}%. ${tr.deckConfigSmallerIsBetter()}`,
                             ),
                         200,
                     );

--- a/ts/deck-options/FsrsOptions.svelte
+++ b/ts/deck-options/FsrsOptions.svelte
@@ -120,11 +120,9 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
                     setTimeout(
                         () =>
                             alert(
-                                `Log loss: ${resp.logLoss.toFixed(
-                                    4,
-                                )}, RMSE(bins): ${(resp.rmseBins * 100).toFixed(
-                                    2,
-                                )}%. ${tr.deckConfigSmallerIsBetter()}`,
+                                `Log loss: ${resp.logLoss.toFixed(4)}, RMSE(bins): ${(
+                                    resp.rmseBins * 100
+                                ).toFixed(2)}%. ${tr.deckConfigSmallerIsBetter()}`,
                             ),
                         200,
                     );


### PR DESCRIPTION
The number of decimal places in log loss have been increased from 3 to 4. Can help in better comparison of weights especially when the log loss with both are same up to 3 places of decimal. Also makes it consistent with the Python optimizer.

RMSE has been expressed in percent, making it easier to interpret.