### PR TITLE
Fix overflowing filenames displacing import button

### DIFF
--- a/ts/components/StickyHeader.svelte
+++ b/ts/components/StickyHeader.svelte
@@ -53,4 +53,8 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
             margin-inline: 0.75rem;
         }
     }
+
+    .filename {
+        word-break: break-word;
+    }
 </style>


### PR DESCRIPTION
Fixes  #2793.

I now have to set `QTWEBENGINE_CHROMIUM_FLAGS=--remote-allow-origins=*` or else I get the error below when trying to access a web page in Chrome. Is it the same for you?

> [15680:11976:1104/093547.311:ERROR:devtools_http_handler.cc(766)] Rejected an incoming WebSocket connection from the http://localhost:8080 origin. Use the command line flag --remote-allow-origins=http://localhost:8080 to allow connections from this origin or --remote-allow-origins=* to allow all origins.
