### PR TITLE
Move anki.utils.html_to_text_line() to backend

### DIFF
--- a/proto/anki/card_rendering.proto
+++ b/proto/anki/card_rendering.proto
@@ -26,6 +26,7 @@ service CardRenderingService {
   rpc EncodeIriPaths(generic.String) returns (generic.String);
   rpc DecodeIriPaths(generic.String) returns (generic.String);
   rpc StripHtml(StripHtmlRequest) returns (generic.String);
+  rpc HtmlToTextLine(HtmlToTextLineRequest) returns (generic.String);
   rpc CompareAnswer(CompareAnswerRequest) returns (generic.String);
   rpc ExtractClozeForTyping(ExtractClozeForTypingRequest)
       returns (generic.String);
@@ -154,6 +155,11 @@ message StripHtmlRequest {
 
   string text = 1;
   Mode mode = 2;
+}
+
+message HtmlToTextLineRequest {
+  string text = 1;
+  bool preserve_media_filenames = 2;
 }
 
 message CompareAnswerRequest {

--- a/pylib/anki/utils.py
+++ b/pylib/anki/utils.py
@@ -7,7 +7,6 @@ import json as _json
 import os
 import platform
 import random
-import re
 import shutil
 import string
 import subprocess
@@ -69,15 +68,11 @@ def strip_html_media(txt: str) -> str:
 
 
 def html_to_text_line(txt: str) -> str:
-    txt = txt.replace("<br>", " ")
-    txt = txt.replace("<br />", " ")
-    txt = txt.replace("<div>", " ")
-    txt = txt.replace("\n", " ")
-    txt = re.sub(r"\[sound:[^]]+\]", "", txt)
-    txt = re.sub(r"\[\[type:[^]]+\]\]", "", txt)
-    txt = strip_html_media(txt)
-    txt = txt.strip()
-    return txt
+    import anki.lang
+
+    return anki.lang.current_i18n.html_to_text_line(
+        text=txt, preserve_media_filenames=True
+    )
 
 
 # IDs

--- a/rslib/src/card_rendering/service.rs
+++ b/rslib/src/card_rendering/service.rs
@@ -20,6 +20,7 @@ use crate::notetype::RenderCardOutput;
 use crate::template::RenderedNode;
 use crate::text::decode_iri_paths;
 use crate::text::encode_iri_paths;
+use crate::text::html_to_text_line;
 use crate::text::sanitize_html_no_images;
 use crate::text::strip_html;
 use crate::text::strip_html_preserving_media_filenames;
@@ -149,6 +150,17 @@ impl crate::services::CardRenderingService for Collection {
         input: anki_proto::card_rendering::StripHtmlRequest,
     ) -> Result<generic::String> {
         strip_html_proto(input)
+    }
+
+    fn html_to_text_line(
+        &mut self,
+        input: anki_proto::card_rendering::HtmlToTextLineRequest,
+    ) -> Result<generic::String> {
+        Ok(
+            html_to_text_line(&input.text, input.preserve_media_filenames)
+                .to_string()
+                .into(),
+        )
     }
 
     fn compare_answer(


### PR DESCRIPTION
For consistency and to handle forms such as `<br/>` produced by some add-ons