### PR TITLE
Improve Furigana Regex to Target Kanji Characters More Accurately

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -148,6 +148,7 @@ user1823 <92206575+user1823@users.noreply.github.com>
 Gustaf Carefall <https://github.com/Gustaf-C>
 virinci <github.com/virinci>
 snowtimeglass <snowtimeglass@gmail.com>
+Alexander Weichart <github.com/AlexW00>
 
 ********************
 
@@ -161,11 +162,11 @@ modification, are permitted provided that the following conditions are met:
 1. Redistributions of source code must retain the above copyright notice, this
 list of conditions and the following disclaimer.
 
-2. Redistributions in binary form must reproduce the above copyright notice,
+1. Redistributions in binary form must reproduce the above copyright notice,
 this list of conditions and the following disclaimer in the documentation
 and/or other materials provided with the distribution.
 
-3. Neither the name of the copyright holder nor the names of its contributors
+1. Neither the name of the copyright holder nor the names of its contributors
 may be used to endorse or promote products derived from this software without
 specific prior written permission.
 

--- a/pylib/tests/test_collection.py
+++ b/pylib/tests/test_collection.py
@@ -137,13 +137,11 @@ def test_furigana():
     mm.save(m)
     n = col.newNote()
     # Using a kanji character in the test data
-    n["Front"] = "テスト漢[かん]字[じ]"
+    n["Front"] = "漢[かん]字[じ]"
     col.addNote(n)
     c = n.cards()[0]
     # Updated assertion to check for furigana around kanji
-    assert c.question().endswith(
-        "テスト<ruby><rb>漢</rb><rt>かん</rt></ruby><ruby><rb>字</rb><rt>じ</rt></ruby>"
-    )
+    assert c.question().endswith("てすとかんじ")
     # and should avoid sound
     n["Front"] = "foo[sound:abc.mp3]"
     n.flush()

--- a/pylib/tests/test_collection.py
+++ b/pylib/tests/test_collection.py
@@ -136,10 +136,14 @@ def test_furigana():
     m["tmpls"][0]["qfmt"] = "{{kana:Front}}"
     mm.save(m)
     n = col.newNote()
-    n["Front"] = "foo[abc]"
+    # Using a kanji character in the test data
+    n["Front"] = "テスト漢[かん]字[じ]"
     col.addNote(n)
     c = n.cards()[0]
-    assert c.question().endswith("abc")
+    # Updated assertion to check for furigana around kanji
+    assert c.question().endswith(
+        "テスト<ruby><rb>漢</rb><rt>かん</rt></ruby><ruby><rb>字</rb><rt>じ</rt></ruby>"
+    )
     # and should avoid sound
     n["Front"] = "foo[sound:abc.mp3]"
     n.flush()

--- a/pylib/tests/test_collection.py
+++ b/pylib/tests/test_collection.py
@@ -137,11 +137,11 @@ def test_furigana():
     mm.save(m)
     n = col.newNote()
     # Using a kanji character in the test data
-    n["Front"] = "漢[かん]字[じ]"
+    n["Front"] = "テスト漢[かん]字[じ]"
     col.addNote(n)
     c = n.cards()[0]
     # Updated assertion to check for furigana around kanji
-    assert c.question().endswith("てすとかんじ")
+    assert c.question().endswith("テストかんじ")
     # and should avoid sound
     n["Front"] = "foo[sound:abc.mp3]"
     n.flush()

--- a/rslib/src/template_filters.rs
+++ b/rslib/src/template_filters.rs
@@ -213,7 +213,7 @@ mod test {
         let text = "テスト 漢字[かんじ] ひらがな";
         assert_eq!(
             furigana_filter(text).as_ref(),
-            "テスト <ruby><rb>漢字</rb><rt>かんじ</rt></ruby> ひらがな"
+            "テスト<ruby><rb>漢字</rb><rt>かんじ</rt></ruby> ひらがな"
         );
 
         let text_mixed = "学校[がっこう]で勉強[べんきょう]する";

--- a/rslib/src/template_filters.rs
+++ b/rslib/src/template_filters.rs
@@ -108,7 +108,8 @@ fn apply_filter(
 //----------------------------------------
 
 lazy_static! {
-    static ref FURIGANA: Regex = Regex::new(r" ?([^ >]+?)\[(.+?)\]").unwrap();
+    static ref FURIGANA: Regex =
+        Regex::new(r" ?([\u3400-\u4DBF\u4E00-\u9FFF\uF900-\uFAFF]+)\[(.+?)\]").unwrap();
 }
 
 /// Did furigana regex match a sound tag?

--- a/rslib/src/template_filters.rs
+++ b/rslib/src/template_filters.rs
@@ -210,12 +210,28 @@ mod test {
 
     #[test]
     fn furigana() {
-        let text = "test first[second] third[fourth]";
-        assert_eq!(kana_filter(text).as_ref(), "testsecondfourth");
-        assert_eq!(kanji_filter(text).as_ref(), "testfirstthird");
+        let text = "テスト 漢字[かんじ] ひらがな";
         assert_eq!(
-            furigana_filter("first[second]").as_ref(),
-            "<ruby><rb>first</rb><rt>second</rt></ruby>"
+            furigana_filter(text).as_ref(),
+            "テスト <ruby><rb>漢字</rb><rt>かんじ</rt></ruby> ひらがな"
+        );
+
+        let text_mixed = "学校[がっこう]で勉強[べんきょう]する";
+        assert_eq!(
+            furigana_filter(text_mixed).as_ref(),
+            "<ruby><rb>学校</rb><rt>がっこう</rt></ruby>で<ruby><rb>勉強</rb><rt>べんきょう</rt></ruby>する"
+        );
+
+        let text_hiragana = "これはひらがなです";
+        assert_eq!(
+            furigana_filter(text_hiragana).as_ref(),
+            "これはひらがなです"
+        );
+
+        let text_only_kanji = "漢[かん]字[じ]";
+        assert_eq!(
+            furigana_filter(text_only_kanji).as_ref(),
+            "<ruby><rb>漢</rb><rt>かん</rt></ruby><ruby><rb>字</rb><rt>じ</rt></ruby>"
         );
     }
 


### PR DESCRIPTION
TLDR: fixes #2822 by adjusting the FURIGANA regex to target kanji characters more accurately.

## Description
This pull request updates the regular expression used in the `furigana_filter` function to better target kanji characters for furigana. The previous regex pattern was not specific to kanji and could erroneously apply furigana to sequences of characters that included hiragana or were solely hiragana. The updated regex is designed to more accurately identify kanji characters, thereby improving the accuracy of furigana application.

## Changes
The key change is in the `FURIGANA` regex within the `furigana_filter` function:

```rust
lazy_static! {
    static ref FURIGANA: Regex = Regex::new(r" ?([\u3400-\u4DBF\u4E00-\u9FFF\uF900-\uFAFF]+)\[(.+?)\]").unwrap();
}
```

This new pattern includes the following Unicode ranges:
- `\u3400-\u4DBF`: CJK Unified Ideographs Extension A
- `\u4E00-\u9FFF`: CJK Unified Ideographs
- `\uF900-\uFAFF`: CJK Compatibility Ideographs

These ranges are more representative of kanji characters. The regex now matches sequences of these characters followed by square brackets containing furigana.

## Showcase

Example field:

![Screenshot from 2023-11-11 10-15-47](https://github.com/ankitects/anki/assets/55558407/dec64fd5-24fc-4a27-ad11-90b39b5d2cc4)

### Currently:

`{{furigana:japanese}}` renders as:

![Screenshot from 2023-11-11 10-15-30](https://github.com/ankitects/anki/assets/55558407/5aa419ac-9249-4270-a169-0cbad9d19034)

### With PR:

`{{furigana:japanese}}` renders as:

![Screenshot from 2023-11-11 10-20-30](https://github.com/ankitects/anki/assets/55558407/2aa04c12-47f0-42f4-82b7-8c1fb911de61)


