### PR TITLE
fix: refresh model list when legacy addon adds notetype

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -118,7 +118,7 @@ yellowjello <github.com/yellowjello>
 Ingemar Berg <github.com/ingemarberg>
 Ben Kerman <ben@kermanic.org>
 Euan Kemp <euank@euank.com>
-Kieran Black <kieranlblack@gmail.com>
+Kieran Black <kieranlblack@gmail.com> 
 XeR <github.com/XeR>
 mgrottenthaler <github.com/mgrottenthaler>
 Austin Siew <github.com/Aquafina-water-bottle>

--- a/qt/aqt/models.py
+++ b/qt/aqt/models.py
@@ -147,6 +147,7 @@ class Models(QDialog):
         def on_success(notetype: NotetypeDict) -> None:
             # if legacy add-ons already added the notetype, skip adding
             if notetype["id"]:
+                self.refresh_list()
                 return
 
             # prompt for name


### PR DESCRIPTION
When legacy addons add note types, they automatically add the note type to the collection models. When this was detected, the dialog box presenting the list of models was not being updated due to an early return in the code. This commit adds a list refresh along this path of execution to ensure the gui is updated with the newly added model.