### PR TITLE
Persist FSRS weights search in preset

### DIFF
--- a/proto/anki/deck_config.proto
+++ b/proto/anki/deck_config.proto
@@ -154,6 +154,7 @@ message DeckConfig {
     float desired_retention = 37;
     bool reschedule_fsrs_cards = 39;
     float sm2_retention = 40;
+    string weight_search = 45;
 
     bytes other = 255;
   }

--- a/rslib/src/deckconfig/mod.rs
+++ b/rslib/src/deckconfig/mod.rs
@@ -77,6 +77,7 @@ const DEFAULT_DECK_CONFIG_INNER: DeckConfigInner = DeckConfigInner {
     other: Vec::new(),
     reschedule_fsrs_cards: false,
     sm2_retention: 0.9,
+    weight_search: String::new(),
 };
 
 impl Default for DeckConfig {

--- a/rslib/src/deckconfig/schema11.rs
+++ b/rslib/src/deckconfig/schema11.rs
@@ -87,6 +87,8 @@ pub struct DeckConfSchema11 {
     reschedule_fsrs_cards: bool,
     #[serde(default)]
     sm2_retention: f32,
+    #[serde(default)]
+    weight_search: String,
 
     #[serde(flatten)]
     other: HashMap<String, Value>,
@@ -294,6 +296,7 @@ impl Default for DeckConfSchema11 {
             desired_retention: 0.9,
             reschedule_fsrs_cards: false,
             sm2_retention: 0.9,
+            weight_search: "".to_string(),
         }
     }
 }
@@ -371,6 +374,7 @@ impl From<DeckConfSchema11> for DeckConfig {
                 desired_retention: c.desired_retention,
                 reschedule_fsrs_cards: c.reschedule_fsrs_cards,
                 sm2_retention: c.sm2_retention,
+                weight_search: c.weight_search,
                 other: other_bytes,
             },
         }
@@ -477,6 +481,7 @@ impl From<DeckConfig> for DeckConfSchema11 {
             desired_retention: i.desired_retention,
             reschedule_fsrs_cards: i.reschedule_fsrs_cards,
             sm2_retention: i.sm2_retention,
+            weight_search: i.weight_search,
         }
     }
 }
@@ -507,6 +512,7 @@ static RESERVED_DECKCONF_KEYS: Set<&'static str> = phf_set! {
     "waitForAudio",
     "rescheduleFsrsCards",
     "sm2Retention",
+    "weightSearch",
 };
 
 static RESERVED_DECKCONF_NEW_KEYS: Set<&'static str> = phf_set! {

--- a/ts/deck-options/FsrsOptions.svelte
+++ b/ts/deck-options/FsrsOptions.svelte
@@ -42,7 +42,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         optimalRetention = 0;
     }
     $: computing = computingWeights || checkingWeights || computingRetention;
-    $: customSearch = `preset:"${$presetName}"`;
+    $: defaultWeightSearch = `preset:"${state.getCurrentName()}"`;
     $: desiredRetentionWarning = getRetentionWarning($config.desiredRetention);
     $: retentionWarningClass = getRetentionWarningClass($config.desiredRetention);
 
@@ -93,7 +93,9 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
             await runWithBackendProgress(
                 async () => {
                     const resp = await computeFsrsWeights({
-                        search: customSearch,
+                        search: $config.weightSearch
+                            ? $config.weightSearch
+                            : defaultWeightSearch,
                     });
                     if (computeWeightsProgress) {
                         computeWeightsProgress.current = computeWeightsProgress.total;
@@ -130,7 +132,8 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         try {
             await runWithBackendProgress(
                 async () => {
-                    const search = customSearch ?? `preset:"${state.getCurrentName()}"`;
+                    const search =
+                        $config.weightSearch ?? `preset:"${state.getCurrentName()}"`;
                     const resp = await evaluateWeights({
                         weights: $config.fsrsWeights,
                         search,
@@ -280,7 +283,11 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 <div class="m-2">
     <details>
         <summary>{tr.deckConfigComputeOptimalWeights()}</summary>
-        <input bind:value={customSearch} class="w-100 mb-1" />
+        <input
+            bind:value={$config.weightSearch}
+            placeholder={defaultWeightSearch}
+            class="w-100 mb-1"
+        />
         <button
             class="btn {computingWeights ? 'btn-warning' : 'btn-primary'}"
             disabled={!computingWeights && computing}


### PR DESCRIPTION
Closes #2814

> and replace the blank text with that text at save time.

If we leave the blank text at save time, the default search will continue to work normally if the user renames their preset. So I wonder whether we should do this?