### PR TITLE
Fix misalignment of IO masks in Qt5 when image is vertically long

### DIFF
--- a/qt/aqt/theme.py
+++ b/qt/aqt/theme.py
@@ -177,10 +177,8 @@ class ThemeManager:
             classes.append("reduce-motion")
         if not aqt.mw.pm.minimalist_mode():
             classes.append("fancy")
-        if qtmajor == 5:
-            classes.append("qt5")
-            if qtminor < 15:
-                classes.append("no-blur")
+        if qtmajor == 5 and qtminor < 15:
+            classes.append("no-blur")
         return " ".join(classes)
 
     def body_classes_for_card_ord(

--- a/ts/reviewer/reviewer.scss
+++ b/ts/reviewer/reviewer.scss
@@ -129,7 +129,3 @@ button {
 .nightMode img.drawing {
     filter: unquote("invert(1) hue-rotate(180deg)");
 }
-
-.qt5 #image-occlusion-container img {
-    position: relative;
-}


### PR DESCRIPTION
An alternative to c478689.

- This fixes an issue in Qt5 where the IO masks are misaligned if the image is vertically long.
- Also, as in Qt6, the IO image is now constrained to fit in the viewport.