### PR TITLE
Silently auto-convert non-string Inputs to strings in showText()

### DIFF
--- a/qt/aqt/utils.py
+++ b/qt/aqt/utils.py
@@ -327,6 +327,7 @@ def showText(
     layout = QVBoxLayout(diag)
     diag.setLayout(layout)
     text: QPlainTextEdit | QTextBrowser
+    txt = str(txt)
     if plain_text_edit:
         # used by the importer
         text = QPlainTextEdit()


### PR DESCRIPTION
The `showText()` function is explicitly typed to accept `txt` as a string (`str`). However, usage patterns indicate that users often pass non-string types, likely expecting automatic conversion due to the function's name and purpose. 

This tiny edit introduces an auto-conversion of the `txt` parameter to a string, enhancing the function's usability. It removes the necessity for manual string conversion by users, thereby ensuring handling of various input types and preventing potential runtime errors or unexpected behaviors.