### PR TITLE
Add windows batch file to install n2

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -150,6 +150,7 @@ virinci <github.com/virinci>
 snowtimeglass <snowtimeglass@gmail.com>
 Ben Olson <github.com/grepgrok>
 Akash Reddy <github.com/akashreddy03>
+Mike Hardy <github@mikehardy.net>
 
 ********************
 

--- a/tools/install-n2.bat
+++ b/tools/install-n2.bat
@@ -1,0 +1,3 @@
+@echo off
+
+cargo install --git https://github.com/ankitects/n2.git --rev 3b725cf9c321efb90496dd2458cf5c1abbef4dba


### PR DESCRIPTION
the setup-ninja github action is unmaintained, n2 appears to work for all operating systems now, would be nice to have n2-installer for all operating systems for use in github actions

I copied the `@echo off` from the other batch files
I don't think there is anything needed with regards to working directory manipulation

Could be this easy?