### PR TITLE
Improve visibility of clicked buttons in editor

### DIFF
--- a/sass/_button-mixins.scss
+++ b/sass/_button-mixins.scss
@@ -85,6 +85,7 @@
             &.#{$active-class} {
                 @include impressed-shadow(0.35);
                 background: var(--button-primary-bg);
+                color: white;
                 border-color: var(--border);
             }
         }

--- a/sass/_button-mixins.scss
+++ b/sass/_button-mixins.scss
@@ -84,6 +84,7 @@
         @if ($active-class != "") {
             &.#{$active-class} {
                 @include impressed-shadow(0.35);
+                background: var(--button-primary-bg);
                 border-color: var(--border);
             }
         }


### PR DESCRIPTION
As I suggested in the forums, this will turn any toggle-able button in the editor blue when clicked for increased visibility by setting the css of any activated button. Front end stuff is really not my thing, but so far I have found no side-effects from this change.

While testing this out I found several weird behaviours with the buttons in the editor, I just didn't notice them before when I could barely see if a button was clicked or not. My current knowledge of svelte is not enough to fix these though, so I plan to log them in a separate issue.