### PR TITLE
fix: shortcut update and shape corner transparent

### DIFF
--- a/ts/image-occlusion/MaskEditor.svelte
+++ b/ts/image-occlusion/MaskEditor.svelte
@@ -112,6 +112,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         border: 1px solid var(--border);
         overflow: auto;
         padding-bottom: 100px;
+        outline: none !important;
     }
 
     :global([dir="rtl"]) .editor-main {

--- a/ts/image-occlusion/Toolbar.svelte
+++ b/ts/image-occlusion/Toolbar.svelte
@@ -16,7 +16,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
     import { mdiEye, mdiFormatAlignCenter, mdiSquare, mdiViewDashboard } from "./icons";
     import { emitChangeSignal } from "./MaskEditor.svelte";
-    import { hideAllGuessOne, ioMaskEditorVisible } from "./store";
+    import { hideAllGuessOne, ioMaskEditorVisible, textEditingState } from "./store";
     import { drawEllipse, drawPolygon, drawRectangle, drawText } from "./tools/index";
     import { makeMaskTransparent } from "./tools/lib";
     import { enableSelectable, stopDraw } from "./tools/lib";
@@ -173,7 +173,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         >
             {@html tool.icon}
         </IconButton>
-        {#if $ioMaskEditorVisible}
+        {#if $ioMaskEditorVisible && !$textEditingState}
             <Shortcut
                 keyCombination={tool.shortcut}
                 on:action={() => {
@@ -234,7 +234,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
                 >
                     {@html tool.icon}
                 </IconButton>
-                {#if $ioMaskEditorVisible}
+                {#if $ioMaskEditorVisible && !$textEditingState}
                     <Shortcut keyCombination={tool.shortcut} on:action={tool.action} />
                 {/if}
             {/each}
@@ -255,7 +255,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
                 >
                     {@html tool.icon}
                 </IconButton>
-                {#if $ioMaskEditorVisible}
+                {#if $ioMaskEditorVisible && !$textEditingState}
                     <Shortcut
                         keyCombination={tool.shortcut}
                         on:action={() => {
@@ -271,7 +271,9 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
             <IconButton
                 class="top-tool-icon-button left-border-radius"
                 {iconSize}
-                tooltip={tr.editingImageOcclusionToggleTranslucent()}
+                tooltip="{tr.editingImageOcclusionToggleTranslucent()} ({getPlatformString(
+                    toggleTranslucentKeyCombination,
+                )})"
                 on:click={() => {
                     maksOpacity = !maksOpacity;
                     makeMaskTransparent(canvas, maksOpacity);
@@ -279,7 +281,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
             >
                 {@html mdiEye}
             </IconButton>
-            {#if $ioMaskEditorVisible}
+            {#if $ioMaskEditorVisible && !$textEditingState}
                 <Shortcut
                     keyCombination={toggleTranslucentKeyCombination}
                     on:action={() => {
@@ -303,7 +305,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
                 >
                     {@html tool.icon}
                 </IconButton>
-                {#if $ioMaskEditorVisible}
+                {#if $ioMaskEditorVisible && !$textEditingState}
                     <Shortcut
                         keyCombination={tool.shortcut}
                         on:action={() => {
@@ -331,7 +333,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
                 >
                     {@html tool.icon}
                 </IconButton>
-                {#if $ioMaskEditorVisible}
+                {#if $ioMaskEditorVisible && !$textEditingState}
                     <Shortcut
                         keyCombination={tool.shortcut}
                         on:action={() => {
@@ -370,7 +372,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
             >
                 {@html alignTool.icon}
             </IconButton>
-            {#if $ioMaskEditorVisible}
+            {#if $ioMaskEditorVisible && !$textEditingState}
                 <Shortcut
                     keyCombination={alignTool.shortcut}
                     on:action={() => {

--- a/ts/image-occlusion/mask-editor.ts
+++ b/ts/image-occlusion/mask-editor.ts
@@ -115,6 +115,7 @@ function initCanvas(onChange: () => void): fabric.Canvas {
     // disable rotation globally
     delete fabric.Object.prototype.controls.mtr;
     // add a border to corner to handle blend of control
+    fabric.Object.prototype.transparentCorners = false;
     fabric.Object.prototype.cornerStyle = "circle";
     fabric.Object.prototype.cornerStrokeColor = "#000000";
     moveShapeToCanvasBoundaries(canvas);

--- a/ts/image-occlusion/store.ts
+++ b/ts/image-occlusion/store.ts
@@ -19,3 +19,5 @@ export const zoomResetX = writable(0);
 export const ioImageLoadedStore = writable(false);
 // store opacity state of objects in canvas
 export const opacityStateStore = writable(false);
+// store state of text editing
+export const textEditingState = writable(false);

--- a/ts/image-occlusion/tools/shortcuts.ts
+++ b/ts/image-occlusion/tools/shortcuts.ts
@@ -1,25 +1,25 @@
 // Copyright: Ankitects Pty Ltd and contributors
 // License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
-export const cursorKeyCombination = "Control+S";
-export const rectangleKeyCombination = "Control+R";
-export const ellipseKeyCombination = "Control+E";
-export const polygonKeyCombination = "Control+P";
-export const textKeyCombination = "Control+T";
-export const magnifyKeyCombination = "Control+M";
+export const cursorKeyCombination = "S";
+export const rectangleKeyCombination = "R";
+export const ellipseKeyCombination = "E";
+export const polygonKeyCombination = "P";
+export const textKeyCombination = "T";
+export const magnifyKeyCombination = "M";
 export const undoKeyCombination = "Control+Z";
 export const redoKeyCombination = "Control+Y";
-export const zoomOutKeyCombination = "Control+-";
-export const zoomInKeyCombination = "Control++";
-export const zoomResetKeyCombination = "Control+F";
-export const toggleTranslucentKeyCombination = "Control+O";
+export const zoomOutKeyCombination = "[";
+export const zoomInKeyCombination = "]";
+export const zoomResetKeyCombination = "F";
+export const toggleTranslucentKeyCombination = "L";
 export const deleteKeyCombination = "Delete";
-export const duplicateKeyCombination = "Control+C";
-export const groupKeyCombination = "Control+G";
-export const ungroupKeyCombination = "Control+U";
-export const alignLeftKeyCombination = "Control+Shift+L";
-export const alignHorizontalCenterKeyCombination = "Control+Shift+H";
-export const alignRightKeyCombination = "Control+Shift+R";
-export const alignTopKeyCombination = "Control+Shift+T";
-export const alignVerticalCenterKeyCombination = "Control+Shift+V";
-export const alignBottomKeyCombination = "Control+Shift+B";
+export const duplicateKeyCombination = "D";
+export const groupKeyCombination = "G";
+export const ungroupKeyCombination = "U";
+export const alignLeftKeyCombination = "Shift+L";
+export const alignHorizontalCenterKeyCombination = "Shift+H";
+export const alignRightKeyCombination = "Shift+R";
+export const alignTopKeyCombination = "Shift+T";
+export const alignVerticalCenterKeyCombination = "Shift+V";
+export const alignBottomKeyCombination = "Shift+B";

--- a/ts/image-occlusion/tools/tool-text.ts
+++ b/ts/image-occlusion/tools/tool-text.ts
@@ -2,7 +2,7 @@
 // License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
 import { fabric } from "fabric";
-import { opacityStateStore } from "image-occlusion/store";
+import { opacityStateStore, textEditingState } from "image-occlusion/store";
 import { get } from "svelte/store";
 
 import { enableUniformScaling, stopDraw, TEXT_BACKGROUND_COLOR, TEXT_FONT_FAMILY, TEXT_PADDING } from "./lib";
@@ -37,5 +37,13 @@ export const drawText = (canvas: fabric.Canvas): void => {
         undoStack.onObjectAdded(text.id);
         text.enterEditing();
         text.selectAll();
+    });
+
+    canvas.on("text:editing:entered", function() {
+        textEditingState.set(true);
+    });
+
+    canvas.on("text:editing:exited", function() {
+        textEditingState.set(false);
     });
 };


### PR DESCRIPTION
Fix:
- remove transparent corner after undo/redo
- shortcut update, match with IOE