### PR TITLE
Update licensing information

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -150,6 +150,7 @@ virinci <github.com/virinci>
 snowtimeglass <snowtimeglass@gmail.com>
 Ben Olson <github.com/grepgrok>
 Akash Reddy <github.com/akashreddy03>
+Lucio Sauer <watermanpaint@posteo.net>
 
 ********************
 

--- a/LICENSE
+++ b/LICENSE
@@ -6,9 +6,9 @@ The following included source code items use a license other than AGPL3:
 
 In the pylib folder:
 
- * The SuperMemo importer: GPL3.
+ * The SuperMemo importer: GPL3 and 0BSD.
  * The Pauker importer: BSD-3.
- * statsbg.py: CC BY-SA 3.0.
+ * statsbg.py: CC BY 4.0.
 
 In the qt folder:
 

--- a/pylib/anki/importing/supermemo_xml.py
+++ b/pylib/anki/importing/supermemo_xml.py
@@ -22,6 +22,7 @@ class SmartDict(dict):
     """
     See http://www.peterbe.com/plog/SmartDict
     Copyright 2005, Peter Bengtsson, peter@fry-it.com
+    0BSD
 
     A smart dict can be instantiated either from a pythonic dict
     or an instance object (eg. SQL recordsets) but it ensures that you can

--- a/pylib/anki/statsbg.py
+++ b/pylib/anki/statsbg.py
@@ -1,6 +1,6 @@
 # pylint: disable=invalid-name
 
-# from subtlepatterns.com; CC BY-SA 3.0.
+# from subtlepatterns.com; CC BY 4.0.
 # by Daniel Beaton
 # https://www.toptal.com/designers/subtlepatterns/fancy-deboss/
 bg = """\


### PR DESCRIPTION
The supermemo importer contains the imported [`SmartDict`](https://github.com/ankitects/anki/blob/3713c86373bd57ba15aefd40a0c35b6378f63948/pylib/anki/importing/supermemo_xml.py#L21-L24) data structure.
Currently, there is no information available as to the licensing terms of it. The same problem arose for the exact license of the `statsbg.py` pattern.

In both cases I contacted the license holders and updated Anki's licensing information accordingly. I attached a copy of the email threads to this PR.

[mail_SmartDict.txt](https://github.com/ankitects/anki/files/13467261/mail_SmartDict.txt)
[mail_statsbg.txt](https://github.com/ankitects/anki/files/13467272/mail_statsbg.txt)
