### PR TITLE
Mention environment variable YARN_BINARY in documentation

### DIFF
--- a/docs/linux.md
+++ b/docs/linux.md
@@ -77,7 +77,7 @@ There are a few things to be aware of:
 ## Packaging considerations
 
 Python, node and protoc are downloaded as part of the build. You can optionally define
-PYTHON_BINARY, NODE_BINARY and/or PROTOC_BINARY to use locally-installed versions instead.
+PYTHON_BINARY, NODE_BINARY, YARN_BINARY and/or PROTOC_BINARY to use locally-installed versions instead.
 
 If rust-toolchain.toml is removed, newer Rust versions can be used. Older versions
 may or may not compile the code.


### PR DESCRIPTION
`YARN_BINARY` was introduced in 19cf37515284578090071d311e950805a4420ab5 but never documented. This environment variable is especially useful for package managers who need to adapt the build system for an offline-only build.

Edit: Please merge https://github.com/ankitects/anki/pull/2850 beforehand so that this PR passes the tests :)