### PR TITLE
add DSR into special fields

### DIFF
--- a/rslib/src/notetype/mod.rs
+++ b/rslib/src/notetype/mod.rs
@@ -77,6 +77,9 @@ lazy_static! {
         "Subdeck",
         "Tags",
         "Type",
+        "Difficulty",
+        "Stability",
+        "Retrievability"
     ]);
 }
 


### PR DESCRIPTION
In the custom scheduling version of FSRS, it supports to display memory state in card's front.

![image](https://github.com/ankitects/anki/assets/32575846/fee5079b-3af6-4cf3-b7a4-79e36c9d28d9)

This PR allows users to add DSR variables into their card template.

![image](https://github.com/ankitects/anki/assets/32575846/addf87e9-00da-4a3e-bb67-8f38fe23ea7d)

It would also allow users to display different fields under conditions of DSR.

But I don't know how to display them when FSRS is disabled. Help wanted.