### PR TITLE
Fix auto advance state not being restored after focus change in some cases

### DIFF
--- a/qt/aqt/main.py
+++ b/qt/aqt/main.py
@@ -161,11 +161,6 @@ class MainWebView(AnkiWebView):
             self.mw.bottomWeb.hide_timer.start()
             return True
 
-        if evt.type() == QEvent.Type.FocusOut:
-            self.mw._auto_advance_was_enabled = self.mw.reviewer.auto_advance_enabled
-            self.mw.reviewer.auto_advance_enabled = False
-            return True
-
         return False
 
 
@@ -834,6 +829,9 @@ class AnkiQt(QMainWindow):
                 self.overview.refresh_if_needed()
             elif self.state == "deckBrowser":
                 self.deckBrowser.refresh_if_needed()
+        elif (not new_focus or new_focus.window() != self) and self.state == "review":
+            self._auto_advance_was_enabled = self.reviewer.auto_advance_enabled
+            self.reviewer.auto_advance_enabled = False
 
     def fade_out_webview(self) -> None:
         self.web.eval("document.body.style.opacity = 0.3")


### PR DESCRIPTION
Probably fixes https://forums.ankiweb.net/t/anki-23-12-beta/37771/23

Using the FocusOut event proved to be problematic, because it's also received when the reviewer's context menu is opened but the focusChanged signal was not emitted in this case, resulting in auto advance staying disabled.