### PR TITLE
Include elapsed_secs in learning card state

### DIFF
--- a/proto/anki/scheduler.proto
+++ b/proto/anki/scheduler.proto
@@ -72,6 +72,7 @@ message SchedulingState {
   message Learning {
     uint32 remaining_steps = 1;
     uint32 scheduled_secs = 2;
+    int32 elapsed_time = 3;
     optional cards.FsrsMemoryState memory_state = 6;
   }
   message Review {

--- a/proto/anki/scheduler.proto
+++ b/proto/anki/scheduler.proto
@@ -72,7 +72,7 @@ message SchedulingState {
   message Learning {
     uint32 remaining_steps = 1;
     uint32 scheduled_secs = 2;
-    int32 elapsed_time = 3;
+    uint32 elapsed_secs = 3;
     optional cards.FsrsMemoryState memory_state = 6;
   }
   message Review {

--- a/rslib/src/scheduler/answering/learning.rs
+++ b/rslib/src/scheduler/answering/learning.rs
@@ -76,12 +76,12 @@ impl CardStateUpdater {
 
     /// Adds secs + fuzz to current time
     pub(super) fn fuzzed_next_learning_timestamp(&self, secs: u32) -> i32 {
-        TimestampSecs::now().0 as i32 + self.with_learning_fuzz(secs) as i32
+        TimestampSecs::now().0 as i32 + self.learning_ivl_with_fuzz(self.fuzz_seed, secs) as i32
     }
 
     /// Add up to 25% increase to seconds, but no more than 5 minutes.
-    fn with_learning_fuzz(&self, secs: u32) -> u32 {
-        if let Some(seed) = self.fuzz_seed {
+    pub(super) fn learning_ivl_with_fuzz(&self, input_seed: Option<u64>, secs: u32) -> u32 {
+        if let Some(seed) = input_seed {
             let mut rng = StdRng::seed_from_u64(seed);
             let upper_exclusive = secs + ((secs as f32) * 0.25).min(300.0).floor() as u32;
             if secs >= upper_exclusive {

--- a/rslib/src/scheduler/service/states/learning.rs
+++ b/rslib/src/scheduler/service/states/learning.rs
@@ -8,6 +8,7 @@ impl From<anki_proto::scheduler::scheduling_state::Learning> for LearnState {
         LearnState {
             remaining_steps: state.remaining_steps,
             scheduled_secs: state.scheduled_secs,
+            elapsed_time: state.elapsed_time,
             memory_state: state.memory_state.map(Into::into),
         }
     }
@@ -18,6 +19,7 @@ impl From<LearnState> for anki_proto::scheduler::scheduling_state::Learning {
         anki_proto::scheduler::scheduling_state::Learning {
             remaining_steps: state.remaining_steps,
             scheduled_secs: state.scheduled_secs,
+            elapsed_time: state.elapsed_time,
             memory_state: state.memory_state.map(Into::into),
         }
     }

--- a/rslib/src/scheduler/service/states/learning.rs
+++ b/rslib/src/scheduler/service/states/learning.rs
@@ -8,7 +8,7 @@ impl From<anki_proto::scheduler::scheduling_state::Learning> for LearnState {
         LearnState {
             remaining_steps: state.remaining_steps,
             scheduled_secs: state.scheduled_secs,
-            elapsed_time: state.elapsed_time,
+            elapsed_secs: state.elapsed_secs,
             memory_state: state.memory_state.map(Into::into),
         }
     }
@@ -19,7 +19,7 @@ impl From<LearnState> for anki_proto::scheduler::scheduling_state::Learning {
         anki_proto::scheduler::scheduling_state::Learning {
             remaining_steps: state.remaining_steps,
             scheduled_secs: state.scheduled_secs,
-            elapsed_time: state.elapsed_time,
+            elapsed_secs: state.elapsed_secs,
             memory_state: state.memory_state.map(Into::into),
         }
     }

--- a/rslib/src/scheduler/states/learning.rs
+++ b/rslib/src/scheduler/states/learning.rs
@@ -15,7 +15,7 @@ pub struct LearnState {
     pub scheduled_secs: u32,
     // Positive: Same day learning, elapsed time in seconds
     // Negative: Interday learning, elapsed time in days
-    pub elapsed_time: i32,
+    pub elapsed_secs: u32,
     pub memory_state: Option<FsrsMemoryState>,
 }
 
@@ -42,7 +42,7 @@ impl LearnState {
         LearnState {
             remaining_steps: ctx.steps.remaining_for_failed(),
             scheduled_secs: ctx.steps.again_delay_secs_learn(),
-            elapsed_time: 0,
+            elapsed_secs: 0,
             memory_state: ctx.fsrs_next_states.as_ref().map(|s| s.again.memory.into()),
         }
     }
@@ -54,7 +54,7 @@ impl LearnState {
                 .hard_delay_secs(self.remaining_steps)
                 // user has 0 learning steps, which the UI doesn't allow
                 .unwrap_or(60),
-            elapsed_time: 0,
+            elapsed_secs: 0,
             memory_state: ctx.fsrs_next_states.as_ref().map(|s| s.hard.memory.into()),
             ..self
         }
@@ -66,7 +66,7 @@ impl LearnState {
             LearnState {
                 remaining_steps: ctx.steps.remaining_for_good(self.remaining_steps),
                 scheduled_secs: good_delay,
-                elapsed_time: 0,
+                elapsed_secs: 0,
                 memory_state,
             }
             .into()

--- a/rslib/src/scheduler/states/learning.rs
+++ b/rslib/src/scheduler/states/learning.rs
@@ -13,6 +13,9 @@ use crate::revlog::RevlogReviewKind;
 pub struct LearnState {
     pub remaining_steps: u32,
     pub scheduled_secs: u32,
+    // Positive: Same day learning, elapsed time in seconds
+    // Negative: Interday learning, elapsed time in days
+    pub elapsed_time: i32,
     pub memory_state: Option<FsrsMemoryState>,
 }
 
@@ -39,6 +42,7 @@ impl LearnState {
         LearnState {
             remaining_steps: ctx.steps.remaining_for_failed(),
             scheduled_secs: ctx.steps.again_delay_secs_learn(),
+            elapsed_time: 0,
             memory_state: ctx.fsrs_next_states.as_ref().map(|s| s.again.memory.into()),
         }
     }
@@ -50,6 +54,7 @@ impl LearnState {
                 .hard_delay_secs(self.remaining_steps)
                 // user has 0 learning steps, which the UI doesn't allow
                 .unwrap_or(60),
+            elapsed_time: 0,
             memory_state: ctx.fsrs_next_states.as_ref().map(|s| s.hard.memory.into()),
             ..self
         }
@@ -61,6 +66,7 @@ impl LearnState {
             LearnState {
                 remaining_steps: ctx.steps.remaining_for_good(self.remaining_steps),
                 scheduled_secs: good_delay,
+                elapsed_time: 0,
                 memory_state,
             }
             .into()

--- a/rslib/src/scheduler/states/learning.rs
+++ b/rslib/src/scheduler/states/learning.rs
@@ -13,8 +13,6 @@ use crate::revlog::RevlogReviewKind;
 pub struct LearnState {
     pub remaining_steps: u32,
     pub scheduled_secs: u32,
-    // Positive: Same day learning, elapsed time in seconds
-    // Negative: Interday learning, elapsed time in days
     pub elapsed_secs: u32,
     pub memory_state: Option<FsrsMemoryState>,
 }

--- a/rslib/src/scheduler/states/normal.rs
+++ b/rslib/src/scheduler/states/normal.rs
@@ -44,6 +44,7 @@ impl NormalState {
                 let next_states = LearnState {
                     remaining_steps: ctx.steps.remaining_for_failed(),
                     scheduled_secs: 0,
+                    elapsed_time: 0,
                     memory_state: None,
                 }
                 .next_states(ctx);

--- a/rslib/src/scheduler/states/normal.rs
+++ b/rslib/src/scheduler/states/normal.rs
@@ -44,7 +44,7 @@ impl NormalState {
                 let next_states = LearnState {
                     remaining_steps: ctx.steps.remaining_for_failed(),
                     scheduled_secs: 0,
-                    elapsed_time: 0,
+                    elapsed_secs: 0,
                     memory_state: None,
                 }
                 .next_states(ctx);

--- a/rslib/src/scheduler/states/relearning.rs
+++ b/rslib/src/scheduler/states/relearning.rs
@@ -41,7 +41,7 @@ impl RelearnState {
                 learning: LearnState {
                     remaining_steps: ctx.relearn_steps.remaining_for_failed(),
                     scheduled_secs: again_delay,
-                    elapsed_time: 0,
+                    elapsed_secs: 0,
                     memory_state,
                 },
                 review: ReviewState {
@@ -93,7 +93,7 @@ impl RelearnState {
                     remaining_steps: ctx
                         .relearn_steps
                         .remaining_for_good(self.learning.remaining_steps),
-                    elapsed_time: 0,
+                    elapsed_secs: 0,
                     memory_state,
                 },
                 review: ReviewState {

--- a/rslib/src/scheduler/states/relearning.rs
+++ b/rslib/src/scheduler/states/relearning.rs
@@ -41,6 +41,7 @@ impl RelearnState {
                 learning: LearnState {
                     remaining_steps: ctx.relearn_steps.remaining_for_failed(),
                     scheduled_secs: again_delay,
+                    elapsed_time: 0,
                     memory_state,
                 },
                 review: ReviewState {
@@ -92,6 +93,7 @@ impl RelearnState {
                     remaining_steps: ctx
                         .relearn_steps
                         .remaining_for_good(self.learning.remaining_steps),
+                    elapsed_time: 0,
                     memory_state,
                 },
                 review: ReviewState {

--- a/rslib/src/scheduler/states/review.rs
+++ b/rslib/src/scheduler/states/review.rs
@@ -104,6 +104,7 @@ impl ReviewState {
                 learning: LearnState {
                     remaining_steps: ctx.relearn_steps.remaining_for_failed(),
                     scheduled_secs: again_delay,
+                    elapsed_time: 0,
                     memory_state,
                 },
                 review: again_review,

--- a/rslib/src/scheduler/states/review.rs
+++ b/rslib/src/scheduler/states/review.rs
@@ -104,7 +104,7 @@ impl ReviewState {
                 learning: LearnState {
                     remaining_steps: ctx.relearn_steps.remaining_for_failed(),
                     scheduled_secs: again_delay,
-                    elapsed_time: 0,
+                    elapsed_secs: 0,
                     memory_state,
                 },
                 review: again_review,


### PR DESCRIPTION
Closes #1557.

I decided to implement this where `elapsed_time` has a positive value in seconds for same day learning cards, and a negative value in days for interday learning cards. The other option I considered was to set it as the elapsed days in seconds for interday learning cards, but I figured that could give some weird results when cards that are "usually" same day learning cards are reviewed close to the rollover and get scheduled for the next day.

Since the calculation needs the current time, the pre-calculated state will differ from the answered state if a second passes between when a card is shown and when it is answered. To get around this simply set the `elapsed_times` to be equal for the two states, which feels a bit janky but should be fine since it shouldn't be needed after the next states have been calculated. Correct me if I'm wrong here.

The tests work but I am not completely satisfied with how they are done since they change the due value to trick the `elapsed_time` calculation, and they have a potential fail point where the tests succeeding depends on them not taking too long to run so the timestamp is unchanged. I have given it a one second leeway now which should avoid bad luck since the time sensitive part only takes ~3ms even on my old system, but if the tests were to slow down considerably they would fail due to this. However I don't know how I would fake the system clock for a proper test without these issues, but maybe they are acceptable as is?