### PR TITLE
Ignore rescheduled cards in old stats page

### DIFF
--- a/pylib/anki/stats.py
+++ b/pylib/anki/stats.py
@@ -746,9 +746,9 @@ select count(), avg(ivl), max(ivl) from cards where did in %s and queue = {QUEUE
                 "id > %d" % ((self.col.sched.day_cutoff - (days * 86400)) * 1000)
             )
         if lims:
-            lim = "where type != {REVLOG_RESCHED} and " + " and ".join(lims)
+            lim = "and " + " and ".join(lims)
         else:
-            lim = "where type != {REVLOG_RESCHED}"
+            lim = ""
         ease4repl = "ease"
         return self.col.db.all(
             f"""
@@ -756,7 +756,7 @@ select (case
 when type in ({REVLOG_LRN},{REVLOG_RELRN}) then 0
 when lastIvl < 21 then 1
 else 2 end) as thetype,
-(case when type in ({REVLOG_LRN},{REVLOG_RELRN}) and ease = 4 then %s else ease end), count() from revlog %s
+(case when type in ({REVLOG_LRN},{REVLOG_RELRN}) and ease = 4 then %s else ease end), count() from revlog where type != {REVLOG_RESCHED} %s
 group by thetype, ease
 order by thetype, ease"""
             % (ease4repl, lim)

--- a/pylib/anki/stats.py
+++ b/pylib/anki/stats.py
@@ -746,9 +746,9 @@ select count(), avg(ivl), max(ivl) from cards where did in %s and queue = {QUEUE
                 "id > %d" % ((self.col.sched.day_cutoff - (days * 86400)) * 1000)
             )
         if lims:
-            lim = "where " + " and ".join(lims)
+            lim = "where type != {REVLOG_RESCHED} and " + " and ".join(lims)
         else:
-            lim = ""
+            lim = "where type != {REVLOG_RESCHED}"
         ease4repl = "ease"
         return self.col.db.all(
             f"""
@@ -756,7 +756,7 @@ select (case
 when type in ({REVLOG_LRN},{REVLOG_RELRN}) then 0
 when lastIvl < 21 then 1
 else 2 end) as thetype,
-(case when type in ({REVLOG_LRN},{REVLOG_RELRN}) and ease = 4 then %s else ease end), count() from revlog %s where type != {REVLOG_RESCHED}
+(case when type in ({REVLOG_LRN},{REVLOG_RELRN}) and ease = 4 then %s else ease end), count() from revlog %s
 group by thetype, ease
 order by thetype, ease"""
             % (ease4repl, lim)

--- a/pylib/anki/stats.py
+++ b/pylib/anki/stats.py
@@ -146,7 +146,8 @@ body { direction: ltr !important; }
             lim = " and " + lim
         cards, thetime, failed, lrn, rev, relrn, filt = self.col.db.first(
             f"""
-select count(), sum(time)/1000,
+select count() - sum(case when type = {REVLOG_RESCHED} then 1 else 0 end), /* total count - rescheduled */
+sum(time)/1000,
 sum(case when ease = 1 then 1 else 0 end), /* failed */
 sum(case when type = {REVLOG_LRN} then 1 else 0 end), /* learning */
 sum(case when type = {REVLOG_REV} then 1 else 0 end), /* review */

--- a/pylib/anki/stats.py
+++ b/pylib/anki/stats.py
@@ -756,7 +756,7 @@ select (case
 when type in ({REVLOG_LRN},{REVLOG_RELRN}) then 0
 when lastIvl < 21 then 1
 else 2 end) as thetype,
-(case when type in ({REVLOG_LRN},{REVLOG_RELRN}) and ease = 4 then %s else ease end), count() from revlog %s
+(case when type in ({REVLOG_LRN},{REVLOG_RELRN}) and ease = 4 then %s else ease end), count() from revlog %s where type != {REVLOG_RESCHED}
 group by thetype, ease
 order by thetype, ease"""
             % (ease4repl, lim)

--- a/pylib/anki/stats.py
+++ b/pylib/anki/stats.py
@@ -146,14 +146,13 @@ body { direction: ltr !important; }
             lim = " and " + lim
         cards, thetime, failed, lrn, rev, relrn, filt = self.col.db.first(
             f"""
-select count() - sum(case when type = {REVLOG_RESCHED} then 1 else 0 end), /* total count - rescheduled */
-sum(time)/1000,
+select count(), sum(time)/1000,
 sum(case when ease = 1 then 1 else 0 end), /* failed */
 sum(case when type = {REVLOG_LRN} then 1 else 0 end), /* learning */
 sum(case when type = {REVLOG_REV} then 1 else 0 end), /* review */
 sum(case when type = {REVLOG_RELRN} then 1 else 0 end), /* relearn */
 sum(case when type = {REVLOG_CRAM} then 1 else 0 end) /* filter */
-from revlog where id > ? """
+from revlog where type != {REVLOG_RESCHED} and id > ? """
             + lim,
             (self.col.sched.day_cutoff - 86400) * 1000,
         )


### PR DESCRIPTION
Fixes https://github.com/open-spaced-repetition/fsrs4anki-helper/issues/320

Rescheduled cards are not actual reviews. So, including them in Cards Studied Today is inappropriate.