### PR TITLE
Remember endpoint we authenticated against in returned SyncAuth

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -152,6 +152,7 @@ Ben Olson <github.com/grepgrok>
 Akash Reddy <github.com/akashreddy03>
 Lucio Sauer <watermanpaint@posteo.net>
 Gustavo Sales <gustavosmendes14@gmail.com>
+Shawn M Moore <https://github.com/sartak>
 
 ********************
 

--- a/rslib/src/backend/sync.rs
+++ b/rslib/src/backend/sync.rs
@@ -283,7 +283,7 @@ impl Backend {
         let sync_fut = sync_login(
             input.username,
             input.password,
-            input.endpoint,
+            input.endpoint.clone(),
             self.web_client().clone(),
         );
         let abortable_sync = Abortable::new(sync_fut, abort_reg);
@@ -293,7 +293,7 @@ impl Backend {
         };
         ret.map(|a| anki_proto::sync::SyncAuth {
             hkey: a.hkey,
-            endpoint: None,
+            endpoint: input.endpoint,
             io_timeout_secs: None,
         })
     }


### PR DESCRIPTION
Hi, thanks for Anki. I have 1.1mil reviews going back 14 years. :)

I'm working on reusing the Rust backend in a project, and I hit a bug related to using a custom sync server.

```rust
let auth = backend.sync_login(SyncLoginRequest {
  username,
  password,
  endpoint: Some("http://custom-sync-endpoint"),
})?;

let status = backend.sync_status(auth)?;
```

This pair of method calls authenticates against `http://custom-sync-endpoint`, but then when it checks the sync status, it unexpectedly queries the public ankiweb. This is because the `anki_proto::sync::SyncAuth` returned in `sync_login_inner()` hardcodes `endpoint: None`.

With this PR, the `SyncAuth` is populated correctly so that `sync_status` method correctly queries `http://custom-sync-endpoint` instead of ankiweb. (And if the user isn't using a custom sync server, we still preserve the `endpoint: None` behavior.)

This bug doesn't affect desktop Anki because the Python client stashes the `hkey` out of the `SyncAuth` return value [here in sync_login](https://github.com/ankitects/anki/blob/0b8b168df1f9c2f1b9d85b5923eab79217789fd6/qt/aqt/sync.py#L305), and then constructs a new `SyncAuth` from scratch [later in sync_auth](https://github.com/ankitects/anki/blob/0b8b168df1f9c2f1b9d85b5923eab79217789fd6/qt/aqt/profiles.py#L659-L663).