### PR TITLE
Fix Mathjax can only be pasted once

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -149,7 +149,7 @@ Gustaf Carefall <https://github.com/Gustaf-C>
 virinci <github.com/virinci>
 snowtimeglass <snowtimeglass@gmail.com>
 Ben Olson <github.com/grepgrok>
-Akash Reddy <github.com/akashreddy03>
+Akash Reddy <akashreddy2003@gmail.com>
 Lucio Sauer <watermanpaint@posteo.net>
 Gustavo Sales <gustavosmendes14@gmail.com>
 Shawn M Moore <https://github.com/sartak>

--- a/qt/aqt/about.py
+++ b/qt/aqt/about.py
@@ -187,6 +187,7 @@ def show(mw: aqt.AnkiQt) -> QDialog:
             "Mateusz Wojewoda",
             "Jarrett Ye",
             "Gustavo Sales",
+            "Akash Reddy",
         )
     )
 

--- a/ts/editable/frame-element.ts
+++ b/ts/editable/frame-element.ts
@@ -17,6 +17,11 @@ function restoreFrameHandles(mutations: MutationRecord[]): void {
         const frameElement = mutation.target as FrameElement;
         const framed = frameElement.querySelector(frameElement.frames!) as HTMLElement;
 
+        if(!framed) {
+            frameElement.remove();
+            continue;
+        }
+
         for (const node of mutation.addedNodes) {
             if (node === framed || isFrameHandle(node)) {
                 continue;

--- a/ts/editable/frame-element.ts
+++ b/ts/editable/frame-element.ts
@@ -17,7 +17,7 @@ function restoreFrameHandles(mutations: MutationRecord[]): void {
         const frameElement = mutation.target as FrameElement;
         const framed = frameElement.querySelector(frameElement.frames!) as HTMLElement;
 
-        if(!framed) {
+        if (!framed) {
             frameElement.remove();
             continue;
         }


### PR DESCRIPTION
Fixes #2691  

When pasting Mathjax without selecting any text before and after, it creates an extra trailing space (empty FrameElement) which hinders consequent pastes and just keeps on adding space instead of the content. This PR removes that extra FrameElement after the paste.