### PR TITLE
Fix/keep two decimals for stability

### DIFF
--- a/rslib/src/storage/card/data.rs
+++ b/rslib/src/storage/card/data.rs
@@ -163,7 +163,7 @@ mod test {
         };
         assert_eq!(
             data.convert_to_json().unwrap(),
-            r#"{"s":123.5,"d":1.235,"dr":0.99}"#
+            r#"{"s":123.46,"d":1.235,"dr":0.99}"#
         );
     }
 }

--- a/rslib/src/storage/card/data.rs
+++ b/rslib/src/storage/card/data.rs
@@ -79,7 +79,7 @@ impl CardData {
 
     pub(crate) fn convert_to_json(&mut self) -> Result<String> {
         if let Some(v) = &mut self.fsrs_stability {
-            round_to_places(v, 1)
+            round_to_places(v, 2)
         }
         if let Some(v) = &mut self.fsrs_difficulty {
             round_to_places(v, 3)


### PR DESCRIPTION
Reason: some users reported that the rescheduling results are inconsistent between built-in FSRS and the helper add-on. For example, if the memory stability is 8.48, the built-in FSRS will schedule it with 8 days interval. However, it is stored as 8.5 in database. The helper will round it to 9 days. It would also induce the inconsistency during the fuzzing.