### PR TITLE
Correct the description of FSRS Difficulty in Stats

### DIFF
--- a/ftl/core/statistics.ftl
+++ b/ftl/core/statistics.ftl
@@ -99,7 +99,7 @@ statistics-card-stability-subtitle = The delay at which you're 90% likely to rem
 statistics-average-stability = Average stability
 statistics-card-retrievability-title = Card Retrievability
 statistics-card-ease-subtitle = The lower the ease, the more frequently a card will appear.
-statistics-card-difficulty-subtitle2 = The difficulty of increasing memory stability with review.
+statistics-card-difficulty-subtitle2 = The higher the difficulty, the slower stability will increase.
 statistics-retrievability-subtitle = The probability of recalling a card today.
 # eg "3 cards with 150-170% ease"
 statistics-card-ease-tooltip =

--- a/ftl/core/statistics.ftl
+++ b/ftl/core/statistics.ftl
@@ -99,7 +99,7 @@ statistics-card-stability-subtitle = The delay at which you're 90% likely to rem
 statistics-average-stability = Average stability
 statistics-card-retrievability-title = Card Retrievability
 statistics-card-ease-subtitle = The lower the ease, the more frequently a card will appear.
-statistics-card-difficulty-subtitle = The higher the difficulty, the harder it is to remember.
+statistics-card-difficulty-subtitle2 = The difficulty of increasing memory stability with review.
 statistics-retrievability-subtitle = The probability of recalling a card today.
 # eg "3 cards with 150-170% ease"
 statistics-card-ease-tooltip =

--- a/ts/graphs/DifficultyGraph.svelte
+++ b/ts/graphs/DifficultyGraph.svelte
@@ -32,7 +32,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     }
 
     const title = tr.statisticsCardDifficultyTitle();
-    const subtitle = tr.statisticsCardDifficultySubtitle();
+    const subtitle = tr.statisticsCardDifficultySubtitle2();
 </script>
 
 {#if sourceData?.fsrs}


### PR DESCRIPTION
The current description of Difficulty is misleading; it describes (1 − retrievability) better.