### PR TITLE
Fix macOS not registering some copy actions when Anki is not in focus

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -153,6 +153,7 @@ Akash Reddy <akashreddy2003@gmail.com>
 Lucio Sauer <watermanpaint@posteo.net>
 Gustavo Sales <gustavosmendes14@gmail.com>
 Shawn M Moore <https://github.com/sartak>
+Marko Sisovic <msisovic13@gmail.com>
 
 ********************
 

--- a/qt/aqt/about.py
+++ b/qt/aqt/about.py
@@ -188,6 +188,7 @@ def show(mw: aqt.AnkiQt) -> QDialog:
             "Jarrett Ye",
             "Gustavo Sales",
             "Akash Reddy",
+            "Marko Sisovic",
         )
     )
 

--- a/qt/aqt/editor.py
+++ b/qt/aqt/editor.py
@@ -1403,8 +1403,8 @@ class EditorWebView(AnkiWebView):
         # when we detect the user copying from a field, we store the content
         # here, and use it when they paste, so we avoid filtering field content
         self._internal_field_text_for_paste: str | None = None
+        self._last_known_clipboard_mime: QMimeData | None = None
         clip = self.editor.mw.app.clipboard()
-        qconnect(clip.dataChanged, self._on_clipboard_change)
         gui_hooks.editor_web_view_did_init(self)
 
     def user_cut_or_copied(self) -> None:
@@ -1444,6 +1444,9 @@ class EditorWebView(AnkiWebView):
         return not strip_html
 
     def _onPaste(self, mode: QClipboard.Mode) -> None:
+        if self._last_known_clipboard_mime != self.editor.mw.app.clipboard().mimeData():
+            self._last_known_clipboard_mime = self.editor.mw.app.clipboard().mimeData()
+            self._on_clipboard_change()
         extended = self._wantsExtendedPaste()
         if html := self._internal_field_text_for_paste:
             print("reuse internal")


### PR DESCRIPTION
Fixes #2843.

The `QClipboard.dataChanged` signal doesn't seem to work properly on macOS. In the [official Qt documentation](https://doc.qt.io/qt-6/qclipboard.html#dataChanged) it says: 

> With Qt version 4.3 or higher, clipboard changes made by other applications will only be detected when the application is activated.

I however found the signal triggers only if you unminimize the app, not just when you switch back focus to it. This looks like incorrect behavior to me.

That's why I propose a solution here where we remove reliance on that signal, and just check if the last known `QMimeData` clipboard content is equal to the current one on every paste, and see if a change happened that way. 
