### PR TITLE
Fix opening card info window closes it when already open

### DIFF
--- a/qt/aqt/browser/browser.py
+++ b/qt/aqt/browser/browser.py
@@ -687,7 +687,7 @@ class Browser(QMainWindow):
     ######################################################################
 
     def showCardInfo(self) -> None:
-        self._card_info.toggle()
+        self._card_info.show()
 
     def _update_card_info(self) -> None:
         self._card_info.set_card(self.current_card)

--- a/qt/aqt/browser/card_info.py
+++ b/qt/aqt/browser/card_info.py
@@ -95,9 +95,10 @@ class CardInfoManager:
         self._card: Card | None = None
         self._dialog: CardInfoDialog | None = None
 
-    def toggle(self) -> None:
+    def show(self) -> None:
         if self._dialog:
-            self._dialog.reject()
+            self._dialog.activateWindow()
+            self._dialog.raise_()
         else:
             self._dialog = CardInfoDialog(
                 None,
@@ -115,7 +116,7 @@ class CardInfoManager:
 
     def close(self) -> None:
         if self._dialog:
-            self.toggle()
+            self._dialog.reject()
 
     def _on_close(self) -> None:
         self._dialog = None

--- a/qt/aqt/reviewer.py
+++ b/qt/aqt/reviewer.py
@@ -1032,10 +1032,10 @@ timerStopped = false;
         confirm_deck_then_display_options(self.card)
 
     def on_previous_card_info(self) -> None:
-        self._previous_card_info.toggle()
+        self._previous_card_info.show()
 
     def on_card_info(self) -> None:
-        self._card_info.toggle()
+        self._card_info.show()
 
     def set_flag_on_current_card(self, desired_flag: int) -> None:
         # need to toggle off?


### PR DESCRIPTION
Fixes #2892  

Since we're already updating card info when the row changes in the browse window, this fix just brings the card info window to the front instead of closing when it is already open.