### PR TITLE
Fix macOS clipboard issues

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -153,6 +153,7 @@ Akash Reddy <akashreddy2003@gmail.com>
 Lucio Sauer <watermanpaint@posteo.net>
 Gustavo Sales <gustavosmendes14@gmail.com>
 Shawn M Moore <https://github.com/sartak>
+Marko Sisovic <msisovic13@gmail.com>
 
 ********************
 

--- a/qt/aqt/about.py
+++ b/qt/aqt/about.py
@@ -188,6 +188,7 @@ def show(mw: aqt.AnkiQt) -> QDialog:
             "Jarrett Ye",
             "Gustavo Sales",
             "Akash Reddy",
+            "Marko Sisovic",
         )
     )
 

--- a/qt/aqt/editor.py
+++ b/qt/aqt/editor.py
@@ -1403,8 +1403,9 @@ class EditorWebView(AnkiWebView):
         # when we detect the user copying from a field, we store the content
         # here, and use it when they paste, so we avoid filtering field content
         self._internal_field_text_for_paste: str | None = None
+        self._last_known_clipboard_mime: QMimeData | None = None
         clip = self.editor.mw.app.clipboard()
-        qconnect(clip.dataChanged, self._on_clipboard_change)
+        clip.dataChanged.connect(self._on_clipboard_change)
         gui_hooks.editor_web_view_did_init(self)
 
     def user_cut_or_copied(self) -> None:
@@ -1412,6 +1413,7 @@ class EditorWebView(AnkiWebView):
         self._internal_field_text_for_paste = None
 
     def _on_clipboard_change(self) -> None:
+        self._last_known_clipboard_mime = self.editor.mw.app.clipboard().mimeData()
         if self._store_field_content_on_next_clipboard_change:
             # if the flag was set, save the field data
             self._internal_field_text_for_paste = self._get_clipboard_html_for_field()
@@ -1444,6 +1446,8 @@ class EditorWebView(AnkiWebView):
         return not strip_html
 
     def _onPaste(self, mode: QClipboard.Mode) -> None:
+        if self._last_known_clipboard_mime != self.editor.mw.app.clipboard().mimeData():
+            self._on_clipboard_change()
         extended = self._wantsExtendedPaste()
         if html := self._internal_field_text_for_paste:
             print("reuse internal")

--- a/qt/aqt/editor.py
+++ b/qt/aqt/editor.py
@@ -1446,6 +1446,7 @@ class EditorWebView(AnkiWebView):
         return not strip_html
 
     def _onPaste(self, mode: QClipboard.Mode) -> None:
+        # Since _on_clipboard_change doesn't always trigger properly on macOS, we do a double check if any changes were made before pasting
         if self._last_known_clipboard_mime != self.editor.mw.app.clipboard().mimeData():
             self._on_clipboard_change()
         extended = self._wantsExtendedPaste()


### PR DESCRIPTION
Fixes #2843.

Also fixes [this issue](https://forums.ankiweb.net/t/copy-paste-of-screenshots-dont-work-once-i-copy-the-text-on-the-anki-app/34839), which actually wasn't properly fixed.

The issue is that `QClipboard.dataChanged` doesn't always properly fire on macOS when performing copy operations outiside of the app. I fixed this by adding just-in-time checking if the clipboard changed before pasting.

The ideal solution would be getting Qt to work properly, but until then this solution should be 100% working.