### PR TITLE
Allow > inside HTML attributes

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -154,6 +154,7 @@ Lucio Sauer <watermanpaint@posteo.net>
 Gustavo Sales <gustavosmendes14@gmail.com>
 Shawn M Moore <https://github.com/sartak>
 Marko Sisovic <msisovic13@gmail.com>
+Viktor Ricci <ricci@primateer.de>
 
 ********************
 

--- a/rslib/src/media/check.rs
+++ b/rslib/src/media/check.rs
@@ -794,4 +794,27 @@ Unused: unused.jpg
         );
         Ok(())
     }
+    #[test]
+    fn html_chevron_in_non_source_attribute() -> Result<()> {
+        let (_dir, _mgr, mut col) = common_setup()?;
+        let mut checker = col.media_checker()?;
+
+        let field = "<img alt=\"alt>\" src=\"foo.jpg\">";
+        let seen = normalize_and_maybe_rename_files_helper(&mut checker, field);
+        assert!(seen.contains("foo.jpg"));
+
+        let field = "<img alt='>a>l>t>' src='bar.jpg'>";
+        let seen = normalize_and_maybe_rename_files_helper(&mut checker, field);
+        assert!(seen.contains("bar.jpg"));
+
+        let field = "<img alt='\"alt>\"' src='double-in-single.jpg'>";
+        let seen = normalize_and_maybe_rename_files_helper(&mut checker, field);
+        assert!(seen.contains("double-in-single.jpg"));
+
+        let field = "<img alt='alt'> src='illegal.jpg'>";
+        let seen = normalize_and_maybe_rename_files_helper(&mut checker, field);
+        assert!(!seen.contains("illegal.jpg"));
+
+        Ok(())
+    }
 }

--- a/rslib/src/media/check.rs
+++ b/rslib/src/media/check.rs
@@ -794,6 +794,7 @@ Unused: unused.jpg
         );
         Ok(())
     }
+
     #[test]
     fn html_chevron_in_non_source_attribute() -> Result<()> {
         let (_dir, _mgr, mut col) = common_setup()?;

--- a/rslib/src/text.rs
+++ b/rslib/src/text.rs
@@ -110,9 +110,9 @@ lazy_static! {
             (?:
                 [^>]
             |
-                "(?:[^"]+?)"
+                "[^"]+?"
             |
-                '(?:[^']+?)'
+                '[^']+?'
             )+
 
             # capture `src` or `data` attribute

--- a/rslib/src/text.rs
+++ b/rslib/src/text.rs
@@ -104,7 +104,19 @@ lazy_static! {
     pub static ref HTML_MEDIA_TAGS: Regex = Regex::new(
         r#"(?xsi)
             # the start of the image, audio, or object tag
-            <\b(?:img|audio|video|object)\b[^>]+\b(?:src|data)\b=
+            <\b(?:img|audio|video|object)\b
+
+            # any non-`>`, except inside `"` or `'`
+            (?:
+                [^>]
+            |
+                "(?:[^"]+?)"
+            |
+                '(?:[^']+?)'
+            )+
+
+            # capture `src` or `data` attribute
+            \b(?:src|data)\b=
             (?:
                     # 1: double-quoted filename
                     "


### PR DESCRIPTION
Fixes #2913

Extends the `HTML_MEDIA_TAGS` regex to allow for `>` in non-matched attributes. The regex might not deal with things like nested escaped quotes, but neither does the original one, and I didn't want to complicate it even further.

Hope this helps. I'm new here, so sorry if I missed something.