### PR TITLE
add padding to control corner to shapes

### DIFF
--- a/ts/image-occlusion/mask-editor.ts
+++ b/ts/image-occlusion/mask-editor.ts
@@ -118,6 +118,7 @@ function initCanvas(onChange: () => void): fabric.Canvas {
     fabric.Object.prototype.transparentCorners = false;
     fabric.Object.prototype.cornerStyle = "circle";
     fabric.Object.prototype.cornerStrokeColor = "#000000";
+    fabric.Object.prototype.padding = 8;
     moveShapeToCanvasBoundaries(canvas);
     makeShapeRemainInCanvas(canvas);
     canvas.on("object:modified", (evt) => {


### PR DESCRIPTION
Add padding to control corner, so shapes can be selected, and control corner should be outside of the shape.