### PR TITLE
Fix toolbar button shifting on hover

### DIFF
--- a/qt/aqt/webview.py
+++ b/qt/aqt/webview.py
@@ -484,7 +484,7 @@ button {
     background: var(--canvas);
     border-radius: var(--border-radius);
     padding: 3px 12px;
-    border: 0.5px solid var(--border);
+    border: 1px solid var(--border);
     box-shadow: 0px 1px 3px var(--border-subtle);
     font-family: Helvetica
 }


### PR DESCRIPTION
Fixes toolbar buttons (Get Shared, Create Deck, Import File) shifting on hover because border width changes from 0.5px to 1px.

Fixed by universally increasing button border width to 1px. I'm not sure if `border: 0.5px` line is even applied anywhere other than the toolbar buttons as all other buttons borders seems to be modified using class selectors.