### PR TITLE
Make tags and tag suggestions able to be styled by add-ons

### DIFF
--- a/ts/tag-editor/AutocompleteItem.svelte
+++ b/ts/tag-editor/AutocompleteItem.svelte
@@ -22,10 +22,10 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 <div
     bind:this={buttonRef}
     tabindex="-1"
-    data-suggestion={suggestion}
     class="autocomplete-item"
     class:selected
     class:active
+    data-addon-suggestion={suggestion}
     on:mousedown|preventDefault
     on:mouseup
     on:mouseenter

--- a/ts/tag-editor/AutocompleteItem.svelte
+++ b/ts/tag-editor/AutocompleteItem.svelte
@@ -5,6 +5,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 <script lang="ts">
     export let selected = false;
     export let active = false;
+    export let suggestion: string; // used by add-ons to target individual suggestions
 
     let buttonRef: HTMLElement;
 
@@ -21,6 +22,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 <div
     bind:this={buttonRef}
     tabindex="-1"
+    data-suggestion={suggestion}
     class="autocomplete-item"
     class:selected
     class:active

--- a/ts/tag-editor/Tag.svelte
+++ b/ts/tag-editor/Tag.svelte
@@ -8,6 +8,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     let className: string = "";
     export { className as class };
 
+    export let tagName: string; // used by add-ons to target individual tag elements
     export let tooltip: string | undefined = undefined;
     export let selected = false;
 
@@ -32,6 +33,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     class:flashing
     tabindex="-1"
     title={tooltip}
+    data-tag-name={tagName}
     on:mousemove
     on:click
 >

--- a/ts/tag-editor/Tag.svelte
+++ b/ts/tag-editor/Tag.svelte
@@ -33,7 +33,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     class:flashing
     tabindex="-1"
     title={tooltip}
-    data-tag-name={tagName}
+    data-addon-tag={tagName}
     on:mousemove
     on:click
 >

--- a/ts/tag-editor/TagWithTooltip.svelte
+++ b/ts/tag-editor/TagWithTooltip.svelte
@@ -69,7 +69,12 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     class:empty={name === ""}
 >
     {#if active}
-        <Tag class={className} on:mousemove={setControlShift} on:click={onClick}>
+        <Tag
+            class={className}
+            tagName={name}
+            on:mousemove={setControlShift}
+            on:click={onClick}
+        >
             {name}
             <slot {selectMode} {hoverClass} />
         </Tag>
@@ -77,6 +82,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         <WithTooltip {tooltip} trigger="hover" placement="top" let:createTooltip>
             <Tag
                 class={className}
+                tagName={name}
                 bind:flash
                 bind:selected
                 on:mousemove={setControlShift}
@@ -90,6 +96,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     {:else}
         <Tag
             class={className}
+            tagName={name}
             bind:flash
             bind:selected
             on:mousemove={setControlShift}

--- a/ts/tag-editor/WithAutocomplete.svelte
+++ b/ts/tag-editor/WithAutocomplete.svelte
@@ -143,6 +143,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
                     <AutocompleteItem
                         selected
                         {active}
+                        {suggestion}
                         on:mousedown={() => setSelectedAndActive(index)}
                         on:mouseup={() => {
                             selectIndex(index);
@@ -155,6 +156,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
                     </AutocompleteItem>
                 {:else}
                     <AutocompleteItem
+                        {suggestion}
                         on:mousedown={() => setSelectedAndActive(index)}
                         on:mouseup={() => {
                             selectIndex(index);


### PR DESCRIPTION
I would like to extend [Colorful Tags](https://github.com/glutanimate/colorful-tags) with the ability to also render user-selected tag colors in the editor. Right now this is not really possible as there is no stable & performant way to target individual tags and suggestion components.

This PR introduces two new data attributes, `data-suggestion` and `data-tag-name` that are applied to the corresponding elements, making them very easy to target via CSS or JS.

A couple of thoughts:

- I was thinking of perhaps renaming the attributes to use a common `data-addon` prefix, e.g. `data-addon-tag` and `data-addon-suggestion`. That might be a more expressive way of highlighting that these are consumed by add-ons while also making it easier to grep for add-ons that might be accessing the attributes in the future. WDYT?
- Do you think it would be prudent to escape some characters in the tag content? I wasn't able to find any Svelte-specific recommendations here. Given that Svelte seems to render the attributes double-quoted, it seems like replacing potentially ambiguous `&` and `"` would be the [spec-conformant way](https://html.spec.whatwg.org/multipage/syntax.html#syntax-attributes). However, it doesn't look like we're doing this anywhere else and in some places we already are setting some attributes to values that could contain both `"`  and `&` (e.g. `button.title` on `Tag.svelte`).