### PR TITLE
Don't urllib.unquote when using requests

### DIFF
--- a/qt/aqt/editor.py
+++ b/qt/aqt/editor.py
@@ -911,21 +911,18 @@ require("anki/ui").loaded.then(() => require("anki/NoteEditor").instances[0].too
 
     def _retrieveURL(self, url: str) -> str | None:
         "Download file into media folder and return local filename or None."
-        # urllib doesn't understand percent-escaped utf8, but requires things like
-        # '#' to be escaped.
-        url = urllib.parse.unquote(url)
-        if url.lower().startswith("file://"):
-            url = url.replace("%", "%25")
-            url = url.replace("#", "%23")
-            local = True
-        else:
-            local = False
+        local = url.lower().startswith("file://")
         # fetch it into a temporary folder
         self.mw.progress.start(immediate=not local, parent=self.parentWindow)
         content_type = None
         error_msg: str | None = None
         try:
             if local:
+                # urllib doesn't understand percent-escaped utf8, but requires things like
+                # '#' to be escaped.
+                url = urllib.parse.unquote(url)
+                url = url.replace("%", "%25")
+                url = url.replace("#", "%23")
                 req = urllib.request.Request(
                     url, None, {"User-Agent": "Mozilla/5.0 (compatible; Anki)"}
                 )


### PR DESCRIPTION
See #2923

Please review carefully before merging. I have only tested this manually and superficially.

### Motivation
- The `urllib.parse.unquote(url)` line causes problems with downloading some images, e.g. Image 2 from the linked issue. In this case because the server expects a quoted URL.

### Rationale
- The comment explains that the unquoting is because of limitations in `urllib`.
- Probably more recently, remote downloading is done through `requests` instead of `urllib`, while `urllib` remains in use for local downloads.
- `requests` probably doesn't have any such limiation. At least it works fine on first glance.
- The solution is to pass `url` unmodified to `requests`, and unquoted to `urllib`.
- The unquote call is consequently only performed inside the local download block.
- There is already a second unquote call down the line before writing to file system, so it should only make a difference for the download step.
- Checking for `startswith("file://")` before unquoting should be fine, because that part should never be quoted.