### PR TITLE
 feat: support fld:in: fld:not:/fld:ex: fld:re:

### DIFF
--- a/proto/anki/search.proto
+++ b/proto/anki/search.proto
@@ -102,6 +102,7 @@ message SearchNode {
     uint32 introduced_in_days = 19;
     Field field = 20;
     string literal_text = 21;
+    string fld = 22;
   }
 }
 

--- a/rslib/src/search/parser.rs
+++ b/rslib/src/search/parser.rs
@@ -76,6 +76,7 @@ pub enum SearchNode {
         tag: String,
         is_re: bool,
     },
+    Fld(String),
     Duplicates {
         notetype_id: NotetypeId,
         text: String,
@@ -337,6 +338,7 @@ fn search_node_for_text_with_argument<'a>(
         "deck" => SearchNode::Deck(unescape(val)?),
         "note" => SearchNode::Notetype(unescape(val)?),
         "tag" => parse_tag(val)?,
+        "fld" => SearchNode::Fld(unescape(val)?),
         "card" => parse_template(val)?,
         "flag" => parse_flag(val)?,
         "resched" => parse_resched(val)?,

--- a/rslib/src/search/service/search_node.rs
+++ b/rslib/src/search/service/search_node.rs
@@ -28,6 +28,9 @@ impl TryFrom<anki_proto::search::SearchNode> for Node {
                 Filter::Tag(s) => SearchNode::from_tag_name(&s).into(),
                 Filter::Deck(s) => SearchNode::from_deck_name(&s).into(),
                 Filter::Note(s) => SearchNode::from_notetype_name(&s).into(),
+                Filter::Fld(s) => {
+                    Node::Search(SearchNode::Fld(escape_anki_wildcards_for_search_node(&s)))
+                }
                 Filter::Template(u) => {
                     Node::Search(SearchNode::CardTemplate(TemplateKind::Ordinal(u as u16)))
                 }

--- a/rslib/src/search/writer.rs
+++ b/rslib/src/search/writer.rs
@@ -81,6 +81,7 @@ fn write_search_node(node: &SearchNode) -> String {
         Notetype(s) => maybe_quote(&format!("note:{}", s)),
         Rated { days, ease } => write_rated(days, ease),
         Tag { tag, is_re } => write_single_field("tag", tag, *is_re),
+        Fld(s) => maybe_quote(&format!("fld:{}", s)),
         Duplicates { notetype_id, text } => write_dupe(notetype_id, text),
         State(k) => write_state(k),
         Flag(u) => format!("flag:{}", u),


### PR DESCRIPTION
 
    fld:in: means include in the field ie: fld:in:vote,god or fld:in:vote|god or fld:in:vote;god
    fld:not:/fld:ex: means exclude in the field ie: fld:not:vote,god  or fld:ex:vote|god or fld:not:vote;god
    fld:re: means regexp way match, ie: fld:re:^v[a-z]+

