### PR TITLE
Fix MathJax editor not opening when navigating into blocks

### DIFF
--- a/ts/editable/frame-element.ts
+++ b/ts/editable/frame-element.ts
@@ -59,7 +59,7 @@ function restoreFrameHandles(mutations: MutationRecord[]): void {
                 continue;
             }
 
-            if (frameElement.isConnected && !frameElement.block) {
+            if (frameElement.isConnected) {
                 frameElement.refreshHandles();
                 continue;
             }
@@ -114,13 +114,7 @@ export class FrameElement extends HTMLElement {
 
             case "block":
                 this.block = newValue !== "false";
-
-                if (!this.block) {
-                    this.refreshHandles();
-                } else {
-                    this.removeHandles();
-                }
-
+                this.refreshHandles();
                 break;
         }
     }
@@ -150,14 +144,6 @@ export class FrameElement extends HTMLElement {
         if (!this.handleEnd.isConnected) {
             this.append(this.handleEnd);
         }
-    }
-
-    removeHandles(): void {
-        this.handleStart?.remove();
-        this.handleStart = undefined;
-
-        this.handleEnd?.remove();
-        this.handleEnd = undefined;
     }
 
     removeStart?: () => void;


### PR DESCRIPTION
Closes #2914

This was added in #1547 and appears to be intentional but removing it doesn't seem to cause any issues.