### PR TITLE
Fixed future-due graph not showing last cards due on last day

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -155,6 +155,7 @@ Gustavo Sales <gustavosmendes14@gmail.com>
 Shawn M Moore <https://github.com/sartak>
 Marko Sisovic <msisovic13@gmail.com>
 Viktor Ricci <ricci@primateer.de>
+Isaac Beh <isaacwbeh@gmail.com>
 
 ********************
 

--- a/ts/graphs/future-due.ts
+++ b/ts/graphs/future-due.ts
@@ -85,7 +85,7 @@ export function buildHistogram(
             return m[0];
         })
         .domain(x.domain() as any)
-        .thresholds(x.ticks(desiredBars))(data.entries() as any);
+        .thresholds(desiredBars)(data.entries() as any);
 
     // empty graph?
     if (!sum(bins, (bin) => bin.length)) {


### PR DESCRIPTION
This is a small change to solve #2952.

The D3 `bin().thresholds` function was given an array, with the last value being the last day. However, the last bin collects everything smaller than (but not equal) to this last value (see the documentation [here](https://d3js.org/d3-array/bin#bin_thresholds)). Instead of calling `ticks` to provide the spacing, this patch provides the desired number of bars directly, which `thresholds` uses to make that number of equally sized bins.

I'm new to contributing, so please let me know if I've missed anything.