### PR TITLE
Make image occlusion's option buttons tabbable

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -156,6 +156,7 @@ Shawn M Moore <https://github.com/sartak>
 Marko Sisovic <msisovic13@gmail.com>
 Viktor Ricci <ricci@primateer.de>
 Harvey Randall <harveyrandall2001@gmail.com>
+Pedro Lameiras <pedrolameiras@tecnico.ulisboa.pt>
 
 ********************
 

--- a/ts/image-occlusion/ImageOcclusionPicker.svelte
+++ b/ts/image-occlusion/ImageOcclusionPicker.svelte
@@ -10,11 +10,13 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
     export let onPickImage: () => void;
     export let onPickImageFromClipboard: () => void;
+    let buttonsTabbable = true;
 </script>
 
 <Container class="image-occlusion-picker">
     <div id="io-pick-image-file" style="padding-top: 60px; text-align: center;">
         <LabelButton
+            bind:tabbable={buttonsTabbable}
             --border-left-radius="5px"
             --border-right-radius="5px"
             class="io-image-picker-button"
@@ -25,6 +27,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     </div>
     <div id="io-pick-image-clipboard" style="padding-top: 30px; text-align: center;">
         <LabelButton
+            bind:tabbable={buttonsTabbable}
             --border-left-radius="5px"
             --border-right-radius="5px"
             class="io-image-picker-button"

--- a/ts/image-occlusion/ImageOcclusionPicker.svelte
+++ b/ts/image-occlusion/ImageOcclusionPicker.svelte
@@ -10,13 +10,12 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
     export let onPickImage: () => void;
     export let onPickImageFromClipboard: () => void;
-    let buttonsTabbable = true;
 </script>
 
 <Container class="image-occlusion-picker">
     <div id="io-pick-image-file" style="padding-top: 60px; text-align: center;">
         <LabelButton
-            bind:tabbable={buttonsTabbable}
+            tabbable={true}
             --border-left-radius="5px"
             --border-right-radius="5px"
             class="io-image-picker-button"
@@ -27,7 +26,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     </div>
     <div id="io-pick-image-clipboard" style="padding-top: 30px; text-align: center;">
         <LabelButton
-            bind:tabbable={buttonsTabbable}
+            tabbable={true}
             --border-left-radius="5px"
             --border-right-radius="5px"
             class="io-image-picker-button"


### PR DESCRIPTION
Closes #2954

Speeds up the creation of image occlusion cards by enabling the selection of 'Select Image' or 'Paste Image from Clipboard' using the tab and space keys.