### PR TITLE
Fix corner rounding of alignment buttons in editor

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -158,6 +158,7 @@ Viktor Ricci <ricci@primateer.de>
 Harvey Randall <harveyrandall2001@gmail.com>
 Pedro Lameiras <pedrolameiras@tecnico.ulisboa.pt>
 Kai Knoblich  <kai@FreeBSD.org>
+Lucas Scharenbroch <lucasscharenbroch@gmail.com>
 
 ********************
 

--- a/ts/editor/editor-toolbar/BlockButtons.svelte
+++ b/ts/editor/editor-toolbar/BlockButtons.svelte
@@ -127,36 +127,42 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
                 <Popover slot="floating" --popover-padding-inline="0">
                     <ButtonToolbar wrap={false}>
                         <ButtonGroup>
-                            <CommandIconButton
-                                key="justifyLeft"
-                                tooltip={tr.editingAlignLeft()}
-                                --border-left-radius="5px"
-                                --border-right-radius="0px"
-                            >
-                                {@html justifyLeftIcon}
-                            </CommandIconButton>
 
-                            <CommandIconButton
-                                key="justifyCenter"
-                                tooltip={tr.editingCenter()}
-                            >
-                                {@html justifyCenterIcon}
-                            </CommandIconButton>
+                            <ButtonGroupItem>
+                                <CommandIconButton
+                                    key="justifyLeft"
+                                    tooltip={tr.editingAlignLeft()}
+                                >
+                                    {@html justifyLeftIcon}
+                                </CommandIconButton>
+                            </ButtonGroupItem>
 
-                            <CommandIconButton
-                                key="justifyRight"
-                                tooltip={tr.editingAlignRight()}
-                            >
-                                {@html justifyRightIcon}
-                            </CommandIconButton>
+                            <ButtonGroupItem>
+                                <CommandIconButton
+                                    key="justifyCenter"
+                                    tooltip={tr.editingCenter()}
+                                >
+                                    {@html justifyCenterIcon}
+                                </CommandIconButton>
+                            </ButtonGroupItem>
 
-                            <CommandIconButton
-                                key="justifyFull"
-                                tooltip={tr.editingJustify()}
-                                --border-right-radius="5px"
-                            >
-                                {@html justifyFullIcon}
-                            </CommandIconButton>
+                            <ButtonGroupItem>
+                                <CommandIconButton
+                                    key="justifyRight"
+                                    tooltip={tr.editingAlignRight()}
+                                >
+                                    {@html justifyRightIcon}
+                                </CommandIconButton>
+                            </ButtonGroupItem>
+
+                            <ButtonGroupItem>
+                                <CommandIconButton
+                                    key="justifyFull"
+                                    tooltip={tr.editingJustify()}
+                                >
+                                    {@html justifyFullIcon}
+                                </CommandIconButton>
+                            </ButtonGroupItem>
                         </ButtonGroup>
 
                         <ButtonGroup>


### PR DESCRIPTION
This resolves (6) from #2842

Before:
![before](https://github.com/ankitects/anki/assets/79030344/e4879ec9-872a-4954-9a76-5983c5dda186)
After:
![after](https://github.com/ankitects/anki/assets/79030344/c084c4f1-a18e-46de-91cf-cedf593ecf34)


