### PR TITLE
Improve typing `deck_due_tree()`

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -160,6 +160,7 @@ Pedro Lameiras <pedrolameiras@tecnico.ulisboa.pt>
 Kai Knoblich <kai@FreeBSD.org>
 Lucas Scharenbroch <lucasscharenbroch@gmail.com>
 Antonio Cavallo <a.cavallo@cavallinux.eu>
+Han Yeong-woo <han@yeongwoo.dev>
 
 ********************
 

--- a/pylib/anki/scheduler/base.py
+++ b/pylib/anki/scheduler/base.py
@@ -22,7 +22,7 @@ ScheduleCardsAsNewDefaults = scheduler_pb2.ScheduleCardsAsNewDefaultsResponse
 FilteredDeckForUpdate = decks_pb2.FilteredDeckForUpdate
 RepositionDefaults = scheduler_pb2.RepositionDefaultsResponse
 
-from typing import Sequence
+from typing import Sequence, overload
 
 from anki import config_pb2
 from anki.cards import CardId
@@ -64,6 +64,14 @@ class SchedulerBase(DeprecatedNamesMixin):
 
     # Deck list
     ##########################################################################
+
+    @overload
+    def deck_due_tree(self, top_deck_id: None = None) -> DeckTreeNode:
+        ...
+
+    @overload
+    def deck_due_tree(self, top_deck_id: DeckId) -> DeckTreeNode | None:
+        ...
 
     def deck_due_tree(self, top_deck_id: DeckId | None = None) -> DeckTreeNode | None:
         """Returns a tree of decks with counts.


### PR DESCRIPTION
I have improved the typing for `mw.col.sched.deck_due_tree()` by using overloading to specify that it will return `None` only when `top_deck_id` is received as a `DeckId` type.