### PR TITLE
Fix visual behavior of modal buttons in editor

### DIFF
--- a/ts/editor/editor-toolbar/BlockButtons.svelte
+++ b/ts/editor/editor-toolbar/BlockButtons.svelte
@@ -84,6 +84,8 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         "justifyRight",
         "justifyFull",
     ];
+
+    const listKeys = ["insertUnorderedList", "insertOrderedList"];
 </script>
 
 <ButtonGroup>
@@ -99,6 +101,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
                 key="insertUnorderedList"
                 tooltip={tr.editingUnorderedList()}
                 shortcut="Control+,"
+                modeVariantKeys={listKeys}
             >
                 {@html ulIcon}
             </CommandIconButton>
@@ -109,6 +112,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
                 key="insertOrderedList"
                 tooltip={tr.editingOrderedList()}
                 shortcut="Control+."
+                modeVariantKeys={listKeys}
             >
                 {@html olIcon}
             </CommandIconButton>

--- a/ts/editor/editor-toolbar/BlockButtons.svelte
+++ b/ts/editor/editor-toolbar/BlockButtons.svelte
@@ -77,6 +77,13 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     }
 
     const rtl = window.getComputedStyle(document.body).direction === "rtl";
+
+    const justificationKeys = [
+        "justifyLeft",
+        "justifyCenter",
+        "justifyRight",
+        "justifyFull",
+    ];
 </script>
 
 <ButtonGroup>
@@ -138,6 +145,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
                                     <CommandIconButton
                                         key="justifyLeft"
                                         tooltip={tr.editingAlignLeft()}
+                                        modeVariantKeys={justificationKeys}
                                     >
                                         {@html justifyLeftIcon}
                                     </CommandIconButton>
@@ -147,6 +155,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
                                     <CommandIconButton
                                         key="justifyCenter"
                                         tooltip={tr.editingCenter()}
+                                        modeVariantKeys={justificationKeys}
                                     >
                                         {@html justifyCenterIcon}
                                     </CommandIconButton>
@@ -156,6 +165,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
                                     <CommandIconButton
                                         key="justifyRight"
                                         tooltip={tr.editingAlignRight()}
+                                        modeVariantKeys={justificationKeys}
                                     >
                                         {@html justifyRightIcon}
                                     </CommandIconButton>
@@ -165,6 +175,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
                                     <CommandIconButton
                                         key="justifyFull"
                                         tooltip={tr.editingJustify()}
+                                        modeVariantKeys={justificationKeys}
                                     >
                                         {@html justifyFullIcon}
                                     </CommandIconButton>

--- a/ts/editor/editor-toolbar/CommandIconButton.svelte
+++ b/ts/editor/editor-toolbar/CommandIconButton.svelte
@@ -8,6 +8,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     import IconButton from "../../components/IconButton.svelte";
     import Shortcut from "../../components/Shortcut.svelte";
     import WithState from "../../components/WithState.svelte";
+    import { updateStateByKey } from "../../components/WithState.svelte";
     import { execCommand, queryCommandState } from "../../domlib";
     import { context as noteEditorContext } from "../NoteEditor.svelte";
     import { editingInputIsRichText } from "../rich-text-input";
@@ -15,6 +16,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     export let key: string;
     export let tooltip: string;
     export let shortcut: string | null = null;
+    export let modeVariantKeys: string[] = [key];
 
     $: theTooltip = shortcut ? `${tooltip} (${getPlatformString(shortcut)})` : tooltip;
 
@@ -38,19 +40,14 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         <Shortcut keyCombination={shortcut} on:action={action} />
     {/if}
 {:else}
-    <WithState
-        {key}
-        update={async () => queryCommandState(key)}
-        let:state={active}
-        let:updateState
-    >
+    <WithState {key} update={async () => queryCommandState(key)} let:state={active}>
         <IconButton
             tooltip={theTooltip}
             {active}
             {disabled}
             on:click={(event) => {
                 action();
-                updateState(event);
+                modeVariantKeys.map((key) => updateStateByKey(key, event));
             }}
         >
             <slot />
@@ -61,7 +58,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
                 keyCombination={shortcut}
                 on:action={(event) => {
                     action();
-                    updateState(event);
+                    modeVariantKeys.map((key) => updateStateByKey(key, event));
                 }}
             />
         {/if}


### PR DESCRIPTION
This resolves (8) and (5) from #2842.

Clicking on the justification/[un]ordered-list buttons now causes the corresponding variants to be updated (visually), which fixes the problem in the screenshot.

![screenshot](https://github.com/ankitects/anki/assets/79030344/32bb7cde-fea5-49d8-9332-184ca5a1c71b)

(Both lists and all 4 justification methods all enabled at once (technically only one of each is enabled, but they all appear to be enabled, because the buttons haven't been updated)).