### PR TITLE
Fix regex skipping over all src except the last

### DIFF
--- a/rslib/src/media/check.rs
+++ b/rslib/src/media/check.rs
@@ -818,4 +818,26 @@ Unused: unused.jpg
 
         Ok(())
     }
+    #[test]
+    fn multiple_images() -> Result<()> {
+        let (_dir, _mgr, mut col) = common_setup()?;
+        let mut checker = col.media_checker()?;
+
+        let field = "<img alt='foo' src='foo-ss.jpg'><img alt='bar' src='bar-ss.jpg'>";
+        let seen = normalize_and_maybe_rename_files_helper(&mut checker, field);
+        assert!(seen.contains("foo-ss.jpg"));
+        assert!(seen.contains("bar-ss.jpg"));
+
+        let field = "<img alt=\"foo\" src=\"foo-dd.jpg\"><img alt=\"bar\" src=\"bar-dd.jpg\">";
+        let seen = normalize_and_maybe_rename_files_helper(&mut checker, field);
+        assert!(seen.contains("foo-dd.jpg"));
+        assert!(seen.contains("bar-dd.jpg"));
+
+        let field = "<img alt='foo' src='foo-sd.jpg'><img alt=\"bar\" src=\"bar-sd.jpg\">";
+        let seen = normalize_and_maybe_rename_files_helper(&mut checker, field);
+        assert!(seen.contains("foo-sd.jpg"));
+        assert!(seen.contains("bar-sd.jpg"));
+
+        Ok(())
+    }
 }

--- a/rslib/src/text.rs
+++ b/rslib/src/text.rs
@@ -113,7 +113,7 @@ lazy_static! {
                 "[^"]+?"
             |
                 '[^']+?'
-            )+
+            )+?
 
             # capture `src` or `data` attribute
             \b(?:src|data)\b=


### PR DESCRIPTION
See #2918

Adapting HTML_MEDIA_TAGS to allow for `>` inside '' and "" led to multiple images inside a field sometimes being disregarded and marked as "unused". This seems to have been caused by a missing lazy (?) quantifier for the regex part skipping over non-`>`.

@meliache Thanks for finding this! If you can, please check if this resolves the bug from your end.