### PR TITLE
clamp interval before fuzz_bounds

### DIFF
--- a/rslib/src/scheduler/states/fuzz.rs
+++ b/rslib/src/scheduler/states/fuzz.rs
@@ -165,8 +165,8 @@ mod test {
         assert_lower_middle_upper!(20.1, 3, 1000, 17, 20, 23);
 
         // respect limits and preserve uniform distribution of valid intervals
-        assert_lower_middle_upper!(100.0, 101, 1000, 101, 104, 107);
-        assert_lower_middle_upper!(100.0, 1, 99, 93, 96, 99);
+        assert_lower_middle_upper!(100.0, 101, 1000, 101, 105, 108);
+        assert_lower_middle_upper!(100.0, 1, 99, 92, 96, 99);
         assert_lower_middle_upper!(100.0, 97, 103, 97, 100, 103);
     }
 

--- a/rslib/src/scheduler/states/fuzz.rs
+++ b/rslib/src/scheduler/states/fuzz.rs
@@ -77,6 +77,7 @@ pub(crate) fn with_review_fuzz(
 /// it and it is larger than 1.
 fn constrained_fuzz_bounds(interval: f32, minimum: u32, maximum: u32) -> (u32, u32) {
     let minimum = minimum.min(maximum);
+    let interval = interval.clamp(minimum as f32, maximum as f32);
     let (mut lower, mut upper) = fuzz_bounds(interval);
 
     // minimum <= maximum and lower <= upper are assumed


### PR DESCRIPTION
close #3015

original:

```
constrained_fuzz_bounds(500.0, 2, 365) = (
    365,
    365,
)
```

current:

```
constrained_fuzz_bounds(500.0, 2, 365) = (
    345,
    365,
)
```