### PR TITLE
Make backend.get_scheduling_states accessible via Collection

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -161,6 +161,7 @@ Kai Knoblich <kai@FreeBSD.org>
 Lucas Scharenbroch <lucasscharenbroch@gmail.com>
 Antonio Cavallo <a.cavallo@cavallinux.eu>
 Han Yeong-woo <han@yeongwoo.dev>
+Antoni Paduch <antoni.paduch@gmail.com>
 
 ********************
 

--- a/pylib/anki/scheduler/v3.py
+++ b/pylib/anki/scheduler/v3.py
@@ -56,6 +56,10 @@ class Scheduler(SchedulerBaseWithLegacy):
             fetch_limit=fetch_limit, intraday_learning_only=intraday_learning_only
         )
 
+    def get_scheduling_states(self, card_id: int) -> SchedulingStates:
+        "Return the next states that will be applied for each answer button."
+        return self.col._backend.get_scheduling_states(card_id)
+
     def describe_next_states(self, next_states: SchedulingStates) -> Sequence[str]:
         "Labels for each of the answer buttons."
         return self.col._backend.describe_next_states(next_states)


### PR DESCRIPTION
An add-on I was working on needed to use backend.get_scheduling_states, which made anki give a warning telling me to use a corresponding public method on Collection instead, but there wasn't any, so I'm adding it