### PR TITLE
fix text input custom style wiping out base user style

### DIFF
--- a/ts/editor/rich-text-input/RichTextStyles.svelte
+++ b/ts/editor/rich-text-input/RichTextStyles.svelte
@@ -29,6 +29,12 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     async function setStyling(property: string, value: unknown): Promise<void> {
         const rule = await userBaseRule;
         rule.style[property] = value;
+
+        // if we don't set the textContent of the underlying HTMLStyleElement, addons
+        // which extend the custom style and set textContent of their registered tags
+        // will cause the userBase style tag here to be ignored
+        const baseStyle = await userBaseStyle;
+        baseStyle.element.textContent = rule.cssText;
     }
 
     $: setStyling("color", color);


### PR DESCRIPTION
While trying to inject custom style for the chinese support addon I came across this issue, see Gustaf-C/anki-chinese-support-3#32.

In short, if an addon applies custom css to their own tag via `.textContent` after the `userBase` css has been applied, it wipes out most / all of the `userBase` custom tag. If the custom css from the addon is blessed by the microtasks queue and is applied before the `userBase` stuff is applied there are no issues. A somewhat interesting race condition.

Behaviour without the patch in this PR:

<img src="https://github.com/ankitects/anki/assets/48463323/19665a74-5c44-4d14-bb30-a3cfaeb71471" width="50%" height="50%"/>

Expected behaviour (behaviour with the PR patch):

<img src="https://github.com/ankitects/anki/assets/48463323/cdc0f74d-5ff4-4798-a1a2-d82040c5a2f9" width="50%" height="50%"/>



Find the related post on the forum about the issue here:
https://forums.ankiweb.net/t/customstyles-strange-behaviour/37432