### PR TITLE
Localize type-in preview strings

### DIFF
--- a/ftl/core/card-templates.ftl
+++ b/ftl/core/card-templates.ftl
@@ -61,4 +61,7 @@ card-templates-restore-to-default = Restore to Default
 card-templates-restore-to-default-confirmation = This will reset all fields and templates in this notetype to their default
     values, removing any extra fields/templates and their content, and any custom styling. Do you wish to proceed?
 card-templates-restored-to-default = Notetype has been restored to its original state.
-
+# Sample text to be used as the answer provided by the user in a "type in the answer" card preview
+card-templates-type-in-provided = example
+# Sample text to be used as the expected answer in a "type in the answer" card preview
+card-templates-type-in-expected = sample

--- a/qt/aqt/clayout.py
+++ b/qt/aqt/clayout.py
@@ -584,7 +584,10 @@ class CardLayout(QDialog):
         hadHR = origLen != len(txt)
 
         def answerRepl(match: Match) -> str:
-            res = self.mw.col.compare_answer("example", "sample")
+            res = self.mw.col.compare_answer(
+                tr.card_templates_type_in_expected(),
+                tr.card_templates_type_in_provided(),
+            )
             if hadHR:
                 res = f"<hr id=answer>{res}"
             return res
@@ -593,7 +596,7 @@ class CardLayout(QDialog):
         repl: Union[str, Callable]
 
         if type == "q":
-            repl = "<input id='typeans' type=text value='example' readonly='readonly'>"
+            repl = f"<input id='typeans' type=text value='{tr.card_templates_type_in_provided()}' readonly='readonly'>"
             repl = f"<center>{repl}</center>"
         else:
             repl = answerRepl


### PR DESCRIPTION
* Fixes #3032

also corrects the provided/expected strings comparison:

![image](https://github.com/ankitects/anki/assets/69634269/914d87e4-33f8-4aca-8f19-bb5327fa37ee)
