### PR TITLE
Divide id by float value so that precision is not lost

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -118,7 +118,7 @@ yellowjello <github.com/yellowjello>
 Ingemar Berg <github.com/ingemarberg>
 Ben Kerman <ben@kermanic.org>
 Euan Kemp <euank@euank.com>
-Kieran Black <kieranlblack@gmail.com> 
+Kieran Black <kieranlblack@gmail.com>
 XeR <github.com/XeR>
 mgrottenthaler <github.com/mgrottenthaler>
 Austin Siew <github.com/Aquafina-water-bottle>
@@ -138,7 +138,7 @@ Monty Evans <montyevans@gmail.com>
 Nil Admirari <https://github.com/nihil-admirari>
 Michael Winkworth <github.com/SteelColossus>
 Mateusz Wojewoda <kawa1.11@o2.pl>
-Jarrett Ye <jarrett.ye@outlook.com> 
+Jarrett Ye <jarrett.ye@outlook.com>
 Sam Waechter <github.com/swektr>
 Michael Eliachevitch <m.eliachevitch@posteo.de>
 Carlo Quick <https://github.com/CarloQuick>
@@ -162,6 +162,7 @@ Lucas Scharenbroch <lucasscharenbroch@gmail.com>
 Antonio Cavallo <a.cavallo@cavallinux.eu>
 Han Yeong-woo <han@yeongwoo.dev>
 Jean Khawand <jk@jeankhawand.com>
+Iulia Chiriac <iulia.chiriac@yahoo.com>
 ********************
 
 The text of the 3 clause BSD license follows:

--- a/pylib/anki/stats.py
+++ b/pylib/anki/stats.py
@@ -581,7 +581,7 @@ group by day order by day"""
         ret = self.col.db.first(
             """
 select count(), abs(min(day)) from (select
-(cast((id/1000 - ?) / 86400.0 as int)+1) as day
+(cast((id/1000.0 - ?) / 86400.0 as int)+1) as day
 from revlog %s
 group by day order by day)"""
             % lim,


### PR DESCRIPTION
Closes https://github.com/ankitects/anki/issues/2961.

Because of the integer division (`id / 1000`), `revlog` entries created in the first 999 milliseconds of a day are considered to be created in the previous day. 

For the use case described in the issue, the `stats._daysStudied()` function does the following: 
- considers a period of 365 days (`num = 365`)
- computes a `lim`: 365 days before `day_cutoff` (which is equal to next 4 AM)
- selects all records in `revlog` created after `lim`, grouped by `day` (an integer showing how many days ago the record was created)
- returns the total number of days and the earliest day in the period when the user (in which the user reviewed cards).

The total number of days should always be less than or equal to `num`, but, `revlog` entries created in the first 999 milliseconds of a day are considered to be created in the previous day. 

In order to reproduce this bug, I inserted some new rows in `revlog` table having the following `ids`:
- exactly 1 day before `col.sched.day_cutoff` (`id=1709262000000`)
- exactly 2 days before `col.sched.day_cutoff` (`id=1709175600000` - let's call this value `x`)
- `x` + 1 milliseconds (`id=1709175600001`)
- `x` + 2 milliseconds (`id=1709175600002`)
- `x` + 999 milliseconds (`id=1709175600999`)
- `x` + 1000 milliseconds (`id=1709175601000 `)

and ran the query first with the integer division:

```python
In [50]: query = """  
    ...: select (cast((id/1000 - ?) / 86400.0 as int)+1) as day, *
    ...: from revlog
    ...: """

In [51]: col.db.all(query, col.sched.day_cutoff)
Out[51]: 
[[-1, 1709175600000, 1709290591072, -1, 3, 1, -600, 2500, 2986, 0],
 [-1, 1709175600001, 1709290591072, -1, 3, 1, -600, 2500, 2986, 0],
 [-1, 1709175600002, 1709290591072, -1, 3, 1, -600, 2500, 2986, 0],
 [-1, 1709175600999, 1709290591072, -1, 3, 1, -600, 2500, 2986, 0],
 [0, 1709175601000, 1709290591072, -1, 3, 1, -600, 2500, 2986, 0],
 [0, 1709262000000, 1709290591072, -1, 3, 1, -600, 2500, 2986, 0],
 [1, 1709290604727, 1709290591072, -1, 3, -600, 0, 0, 5213, 0],
 [1, 1709290607718, 1709290591072, -1, 3, 1, -600, 2500, 2986, 0]]
```

and then with float division:

```python
In [52]: query = """  
    ...: select (cast((id/1000.0 - ?) / 86400.0 as int)+1) as day, *
    ...: from revlog
    ...: """

In [53]: col.db.all(query, col.sched.day_cutoff)
Out[53]: 
[[-1, 1709175600000, 1709290591072, -1, 3, 1, -600, 2500, 2986, 0],
 [0, 1709175600001, 1709290591072, -1, 3, 1, -600, 2500, 2986, 0],
 [0, 1709175600002, 1709290591072, -1, 3, 1, -600, 2500, 2986, 0],
 [0, 1709175600999, 1709290591072, -1, 3, 1, -600, 2500, 2986, 0],
 [0, 1709175601000, 1709290591072, -1, 3, 1, -600, 2500, 2986, 0],
 [0, 1709262000000, 1709290591072, -1, 3, 1, -600, 2500, 2986, 0],
 [1, 1709290604727, 1709290591072, -1, 3, -600, 0, 0, 5213, 0],
 [1, 1709290607718, 1709290591072, -1, 3, 1, -600, 2500, 2986, 0]]
```

As you can see, the three records created in the first 999 milliseconds of a day are correctly matched to the day in the second query. 

The proposed fix addresses the issue, but I think I found a related bug. This is the _Reviews_ panel for the records above:
<img width="767" alt="Screenshot 2024-03-01 at 17 37 54" src="https://github.com/ankitects/anki/assets/6183658/978bfe85-c731-4996-810d-0aaa1c55a9b6">

There are 8 reviews split between the last 3 days, but they seem to be distributed as if the `id` is divided by integer 1000 (4, 2, 2) and not as they should be (1, 5, 2). 

I also ran the code in `stats._done()` function in the interactive console and got the following results:
```python
[[-2, 1, 0, 0, 0, 0, 0.04976666666666667, 0.0, 0.0, 0.0, 0.0],
 [-1, 5, 0, 0, 0, 0, 0.24883333333333335, 0.0, 0.0, 0.0, 0.0],
 [0, 2, 0, 0, 0, 0, 0.13665, 0.0, 0.0, 0.0, 0.0]]
```
which seems to be correct (2 days ago 1 review, 1 day ago 5 reviews, today 2 reviews), but I'm not sure why these are not the values that reach the visual interface.