### PR TITLE
Use `Card %d` for IO template names

### DIFF
--- a/qt/aqt/clayout.py
+++ b/qt/aqt/clayout.py
@@ -293,7 +293,7 @@ class CardLayout(QDialog):
         qconnect(widg.returnPressed, self.on_search_next)
 
     def setup_cloze_number_box(self) -> None:
-        names = (tr.card_templates_cloze(val=n) for n in self.cloze_numbers)
+        names = (tr.card_templates_card(val=n) for n in self.cloze_numbers)
         self.pform.cloze_number_combo.addItems(names)
         try:
             idx = self.cloze_numbers.index(self.ord + 1)


### PR DESCRIPTION
* Fixes #3043

![image](https://github.com/ankitects/anki/assets/69634269/acc437ad-068d-4558-8db8-904bb854da95)

![image](https://github.com/ankitects/anki/assets/69634269/a844ba76-ac6a-4ceb-94eb-41b4bceec557)

