### PR TITLE
fix: blur in io, remove panzoom and use fabricjs for panzoom

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,8 @@
         "jquery-ui-dist": "^1.12.1",
         "lodash-es": "^4.17.21",
         "marked": "^5.1.0",
-        "mathjax": "^3.1.2"
+        "mathjax": "^3.1.2",
+        "hammerjs": "^2.0.8"
     },
     "resolutions": {
         "canvas": "npm:empty-npm-package"

--- a/package.json
+++ b/package.json
@@ -62,8 +62,7 @@
         "jquery-ui-dist": "^1.12.1",
         "lodash-es": "^4.17.21",
         "marked": "^5.1.0",
-        "mathjax": "^3.1.2",
-        "panzoom": "^9.4.3"
+        "mathjax": "^3.1.2"
     },
     "resolutions": {
         "canvas": "npm:empty-npm-package"

--- a/ts/image-occlusion/MaskEditor.svelte
+++ b/ts/image-occlusion/MaskEditor.svelte
@@ -13,24 +13,20 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 </script>
 
 <script lang="ts">
-    import type { PanZoom } from "panzoom";
-    import panzoom from "panzoom";
     import { createEventDispatcher, onDestroy, onMount } from "svelte";
 
     import type { IOMode } from "./lib";
     import {
         type ImageLoadedEvent,
-        setCanvasZoomRatio,
         setupMaskEditor,
         setupMaskEditorForEdit,
     } from "./mask-editor";
     import Toolbar from "./Toolbar.svelte";
     import { MaskEditorAPI } from "./tools/api";
-    import { setCenterXForZoom } from "./tools/lib";
+    import { onResize } from "./tools/tool-zoom";
 
     export let mode: IOMode;
     const iconSize = 80;
-    let instance: PanZoom;
     let innerWidth = 0;
     const startingTool = mode.kind === "add" ? "draw-rectangle" : "cursor";
     $: canvas = null;
@@ -51,26 +47,13 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
     $: $changeSignal, onChange();
 
-    function init(node) {
-        instance = panzoom(node, {
-            bounds: true,
-            maxZoom: 3,
-            minZoom: 0.1,
-            zoomDoubleClickSpeed: 1,
-            smoothScroll: false,
-            transformOrigin: { x: 0.5, y: 0.5 },
-        });
-        instance.pause();
-        globalThis.panzoom = instance;
-
+    function init(_node: HTMLDivElement) {
         if (mode.kind == "add") {
-            setupMaskEditor(mode.imagePath, instance, onChange, onImageLoaded).then(
-                (canvas1) => {
-                    canvas = canvas1;
-                },
-            );
+            setupMaskEditor(mode.imagePath, onChange, onImageLoaded).then((canvas1) => {
+                canvas = canvas1;
+            });
         } else {
-            setupMaskEditorForEdit(mode.noteId, instance, onChange, onImageLoaded).then(
+            setupMaskEditorForEdit(mode.noteId, onChange, onImageLoaded).then(
                 (canvas1) => {
                     canvas = canvas1;
                 },
@@ -80,20 +63,18 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
     onMount(() => {
         window.addEventListener("resize", () => {
-            setCanvasZoomRatio(canvas, instance);
-            setCenterXForZoom(canvas);
+            onResize(canvas);
         });
     });
 
     onDestroy(() => {
         window.removeEventListener("resize", () => {
-            setCanvasZoomRatio(canvas, instance);
-            setCenterXForZoom(canvas);
+            onResize(canvas);
         });
     });
 </script>
 
-<Toolbar {canvas} {instance} {iconSize} activeTool={startingTool} />
+<Toolbar {canvas} {iconSize} activeTool={startingTool} />
 <div class="editor-main" bind:clientWidth={innerWidth}>
     <div class="editor-container" use:init>
         <!-- svelte-ignore a11y-missing-attribute -->

--- a/ts/image-occlusion/MaskEditor.svelte
+++ b/ts/image-occlusion/MaskEditor.svelte
@@ -62,16 +62,16 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     }
 
     onMount(() => {
-        window.addEventListener("resize", () => {
-            onResize(canvas);
-        });
+        window.addEventListener("resize", resizeEvent);
     });
 
     onDestroy(() => {
-        window.removeEventListener("resize", () => {
-            onResize(canvas);
-        });
+        window.removeEventListener("resize", resizeEvent);
     });
+
+    const resizeEvent = () => {
+        onResize(canvas);
+    };
 </script>
 
 <Toolbar {canvas} {iconSize} activeTool={startingTool} />
@@ -92,7 +92,6 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         right: 2px;
         border: 1px solid var(--border);
         overflow: auto;
-        padding-bottom: 100px;
         outline: none !important;
     }
 
@@ -106,6 +105,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         height: 100%;
         position: relative;
         direction: ltr;
+        overflow: hidden;
     }
 
     #image {

--- a/ts/image-occlusion/Toolbar.svelte
+++ b/ts/image-occlusion/Toolbar.svelte
@@ -28,6 +28,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     } from "./tools/more-tools";
     import { toggleTranslucentKeyCombination } from "./tools/shortcuts";
     import { tools } from "./tools/tool-buttons";
+    import { drawCursor } from "./tools/tool-cursor";
     import { removeUnfinishedPolygon } from "./tools/tool-polygon";
     import { undoRedoTools, undoStack } from "./tools/tool-undo-redo";
     import { disableZoom, enableZoom } from "./tools/tool-zoom";
@@ -123,6 +124,9 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         removeUnfinishedPolygon(canvas);
 
         switch (activeTool) {
+            case "cursor":
+                drawCursor(canvas);
+                break;
             case "magnify":
                 enableZoom(canvas);
                 enableSelectable(canvas, false);
@@ -146,7 +150,6 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
     const disableFunctions = () => {
         stopDraw(canvas);
-        canvas.selectionColor = "rgba(100, 100, 255, 0.3)";
         disableZoom(canvas);
     };
 

--- a/ts/image-occlusion/mask-editor.ts
+++ b/ts/image-occlusion/mask-editor.ts
@@ -33,11 +33,11 @@ export const setupMaskEditor = async (
     // get image width and height
     const image = document.getElementById("image") as HTMLImageElement;
     image.src = getImageData(imageData.data!, path);
-    image.onload = async function() {
+    image.onload = function() {
         const size = optimumCssSizeForCanvas({ width: image.width, height: image.height }, containerSize());
         setCanvasSize(canvas);
         onImageLoaded({ path });
-        await setupBoundingBox(canvas, size);
+        setupBoundingBox(canvas, size);
         undoStack.reset();
     };
 
@@ -200,7 +200,7 @@ export async function resetIOImage(path: string, onImageLoaded: (event: ImageLoa
         image.height = size.height;
         setCanvasSize(canvas);
         onImageLoaded({ path });
-        await setupBoundingBox(canvas, size);
+        setupBoundingBox(canvas, size);
     };
 }
 globalThis.resetIOImage = resetIOImage;

--- a/ts/image-occlusion/shapes/to-cloze.ts
+++ b/ts/image-occlusion/shapes/to-cloze.ts
@@ -22,6 +22,10 @@ export function exportShapesToClozeDeletions(occludeInactive: boolean): {
     let clozes = "";
     let index = 0;
     shapes.forEach((shapeOrShapes) => {
+        // shapes with width or height less than 5 are not valid
+        if (shapeOrShapes === null) {
+            return;
+        }
         // if shape is Rect and fill is transparent, skip it
         if (shapeOrShapes instanceof Rectangle && shapeOrShapes.fill === "transparent") {
             return;
@@ -54,6 +58,9 @@ export function baseShapesFromFabric(): ShapeOrShapes[] {
             const parent = selectionContainingMultipleObjects?.contains(object)
                 ? selectionContainingMultipleObjects
                 : undefined;
+            if (object.width < 5 || object.height < 5) {
+                return null;
+            }
             return fabricObjectToBaseShapeOrShapes(
                 boundingBox,
                 object,
@@ -111,6 +118,10 @@ function fabricObjectToBaseShapeOrShapes(
         );
         shape.left = newPosition.x;
         shape.top = newPosition.y;
+    }
+
+    if (size == undefined) {
+        size = { width: 0, height: 0 };
     }
 
     shape = shape.toNormal(size);

--- a/ts/image-occlusion/shapes/to-cloze.ts
+++ b/ts/image-occlusion/shapes/to-cloze.ts
@@ -3,6 +3,7 @@
 
 import type { Canvas, Object as FabricObject } from "fabric";
 import { fabric } from "fabric";
+import { getBoundingBox } from "image-occlusion/tools/lib";
 import { cloneDeep } from "lodash-es";
 
 import type { Size } from "../types";
@@ -21,6 +22,10 @@ export function exportShapesToClozeDeletions(occludeInactive: boolean): {
     let clozes = "";
     let index = 0;
     shapes.forEach((shapeOrShapes) => {
+        // if shape is Rect and fill is transparent, skip it
+        if (shapeOrShapes instanceof Rectangle && shapeOrShapes.fill === "transparent") {
+            return;
+        }
         clozes += shapeOrShapesToCloze(shapeOrShapes, index, occludeInactive);
         if (!(shapeOrShapes instanceof Text)) {
             index++;
@@ -41,6 +46,7 @@ export function baseShapesFromFabric(): ShapeOrShapes[] {
         ? activeObject
         : null;
     const objects = canvas.getObjects() as FabricObject[];
+    const boundingBox = getBoundingBox();
     return objects
         .map((object) => {
             // If the object is in the active selection containing multiple objects,
@@ -49,7 +55,7 @@ export function baseShapesFromFabric(): ShapeOrShapes[] {
                 ? selectionContainingMultipleObjects
                 : undefined;
             return fabricObjectToBaseShapeOrShapes(
-                canvas,
+                boundingBox,
                 object,
                 parent,
             );

--- a/ts/image-occlusion/store.ts
+++ b/ts/image-occlusion/store.ts
@@ -5,16 +5,12 @@ import { writable } from "svelte/store";
 
 // it stores note's data for generate.ts, when function generate() is called it will be used to generate the note
 export const notesDataStore = writable({ id: "", title: "", divValue: "", textareaValue: "" }[0]);
-// it stores the value of zoom ratio for canvas
-export const zoomResetValue = writable(1);
 // it stores the tags for the note in note editor
 export const tagsWritable = writable([""]);
 // it stores the visibility of mask editor
 export const ioMaskEditorVisible = writable(true);
 // it store hide all or hide one mode
 export const hideAllGuessOne = writable(true);
-// store initial value of x for zoom reset
-export const zoomResetX = writable(0);
 // ioImageLoadedStore is used to store the image loaded event
 export const ioImageLoadedStore = writable(false);
 // store opacity state of objects in canvas

--- a/ts/image-occlusion/tools/add-from-cloze.ts
+++ b/ts/image-occlusion/tools/add-from-cloze.ts
@@ -10,13 +10,14 @@ import { redraw } from "./lib";
 
 export const addShapesToCanvasFromCloze = (
     canvas: fabric.Canvas,
+    boundingBox,
     occlusions: GetImageOcclusionNoteResponse_ImageOcclusion[],
 ): void => {
     for (const shapeOrShapes of extractShapesFromClozedField(occlusions)) {
         if (Array.isArray(shapeOrShapes)) {
-            addShapeGroup(canvas, shapeOrShapes);
+            addShapeGroup(canvas, boundingBox, shapeOrShapes);
         } else {
-            addShape(canvas, shapeOrShapes);
+            addShape(canvas, boundingBox, shapeOrShapes);
         }
     }
     redraw(canvas);

--- a/ts/image-occlusion/tools/add-from-cloze.ts
+++ b/ts/image-occlusion/tools/add-from-cloze.ts
@@ -10,7 +10,7 @@ import { redraw } from "./lib";
 
 export const addShapesToCanvasFromCloze = (
     canvas: fabric.Canvas,
-    boundingBox,
+    boundingBox: fabric.Rect,
     occlusions: GetImageOcclusionNoteResponse_ImageOcclusion[],
 ): void => {
     for (const shapeOrShapes of extractShapesFromClozedField(occlusions)) {

--- a/ts/image-occlusion/tools/api.ts
+++ b/ts/image-occlusion/tools/api.ts
@@ -27,12 +27,12 @@ export class MaskEditorAPI {
         this.canvas = canvas;
     }
 
-    addShape(shape: Shape): void {
-        addShape(this.canvas, shape);
+    addShape(bounding, shape: Shape): void {
+        addShape(this.canvas, bounding, shape);
     }
 
-    addShapeGroup(shapes: Shape[]): void {
-        addShapeGroup(this.canvas, shapes);
+    addShapeGroup(bounding, shapes: Shape[]): void {
+        addShapeGroup(this.canvas, bounding, shapes);
     }
 
     getClozes(occludeInactive: boolean): ClozeExportResult {

--- a/ts/image-occlusion/tools/from-shapes.ts
+++ b/ts/image-occlusion/tools/from-shapes.ts
@@ -8,9 +8,10 @@ import { addBorder, enableUniformScaling } from "./lib";
 
 export const addShape = (
     canvas: fabric.Canvas,
+    boundingBox,
     shape: Shape,
 ): void => {
-    const fabricShape = shape.toFabric(canvas);
+    const fabricShape = shape.toFabric(boundingBox);
     addBorder(fabricShape);
     if (fabricShape.type === "i-text") {
         enableUniformScaling(canvas, fabricShape);
@@ -20,11 +21,12 @@ export const addShape = (
 
 export const addShapeGroup = (
     canvas: fabric.Canvas,
+    boundingBox,
     shapes: Shape[],
 ): void => {
     const group = new fabric.Group();
     shapes.map((shape) => {
-        const fabricShape = shape.toFabric(canvas);
+        const fabricShape = shape.toFabric(boundingBox);
         addBorder(fabricShape);
         group.addWithUpdate(fabricShape);
     });

--- a/ts/image-occlusion/tools/from-shapes.ts
+++ b/ts/image-occlusion/tools/from-shapes.ts
@@ -8,7 +8,7 @@ import { addBorder, enableUniformScaling } from "./lib";
 
 export const addShape = (
     canvas: fabric.Canvas,
-    boundingBox,
+    boundingBox: fabric.Rect,
     shape: Shape,
 ): void => {
     const fabricShape = shape.toFabric(boundingBox);
@@ -21,7 +21,7 @@ export const addShape = (
 
 export const addShapeGroup = (
     canvas: fabric.Canvas,
-    boundingBox,
+    boundingBox: fabric.Rect,
     shapes: Shape[],
 ): void => {
     const group = new fabric.Group();

--- a/ts/image-occlusion/tools/lib.ts
+++ b/ts/image-occlusion/tools/lib.ts
@@ -26,6 +26,9 @@ export const enableSelectable = (
 ): void => {
     canvas.selection = select;
     canvas.forEachObject(function(o) {
+        if (o.fill === "transparent") {
+            return;
+        }
         o.selectable = select;
     });
     canvas.renderAll();
@@ -40,6 +43,7 @@ export const deleteItem = (canvas: fabric.Canvas): void => {
             canvas.discardActiveObject().renderAll();
         }
     }
+    redraw(canvas);
 };
 
 export const duplicateItem = (canvas: fabric.Canvas): void => {
@@ -89,14 +93,6 @@ export const unGroupShapes = (canvas: fabric.Canvas): void => {
     });
 
     redraw(canvas);
-};
-
-export const getCanvasCenter = () => {
-    const canvas = globalThis.canvas.getElement();
-    const rect = canvas.getBoundingClientRect();
-    const centerX = rect.x + rect.width / 2;
-    const centerY = rect.y + rect.height / 2;
-    return { x: centerX, y: centerY };
 };
 
 const copyItem = (canvas: fabric.Canvas): void => {
@@ -159,7 +155,7 @@ export const makeMaskTransparent = (
     canvas.renderAll();
 };
 
-export const moveShapeToCanvasBoundaries = (canvas: fabric.Canvas, boundingBox): void => {
+export const moveShapeToCanvasBoundaries = (canvas: fabric.Canvas, boundingBox: fabric.Rect): void => {
     canvas.on("object:modified", function(o) {
         const activeObject = o.target;
         if (!activeObject) {
@@ -178,7 +174,7 @@ export const moveShapeToCanvasBoundaries = (canvas: fabric.Canvas, boundingBox):
 };
 
 const modifiedRectangle = (
-    boundingBox,
+    boundingBox: fabric.Rect,
     object: fabric.Object,
 ): void => {
     const newWidth = object.width * object.scaleX;
@@ -194,7 +190,7 @@ const modifiedRectangle = (
 };
 
 const modifiedEllipse = (
-    boundingBox,
+    boundingBox: fabric.Rect,
     object: fabric.Object,
 ): void => {
     const newRx = object.rx * object.scaleX;
@@ -213,12 +209,12 @@ const modifiedEllipse = (
     setShapePosition(boundingBox, object);
 };
 
-const modifiedText = (boundingBox, object: fabric.Object): void => {
+const modifiedText = (boundingBox: fabric.Rect, object: fabric.Object): void => {
     setShapePosition(boundingBox, object);
 };
 
 const setShapePosition = (
-    boundingBox,
+    boundingBox: fabric.Rect,
     object: fabric.Object,
 ): void => {
     if (object.left < 0) {
@@ -262,7 +258,7 @@ export const clear = (canvas: fabric.Canvas): void => {
     canvas.clear();
 };
 
-export const makeShapeRemainInCanvas = (canvas: fabric.Canvas, boundingBox) => {
+export const makeShapeRemainInCanvas = (canvas: fabric.Canvas, boundingBox: fabric.Rect) => {
     canvas.on("object:moving", function(e) {
         const obj = e.target;
         if (obj.getScaledHeight() > boundingBox.height || obj.getScaledWidth() > boundingBox.width) {
@@ -307,5 +303,6 @@ export const isPointerInBoundingBox = (pointer): boolean => {
 };
 
 export const getBoundingBox = () => {
-    return globalThis.boundingBox;
+    const canvas = globalThis.canvas;
+    return canvas.getObjects().find((obj) => obj.fill === "transparent");
 };

--- a/ts/image-occlusion/tools/lib.ts
+++ b/ts/image-occlusion/tools/lib.ts
@@ -2,10 +2,9 @@
 // License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
 import { fabric } from "fabric";
-import type { PanZoom } from "panzoom";
 import { get } from "svelte/store";
 
-import { opacityStateStore, zoomResetValue, zoomResetX } from "../store";
+import { opacityStateStore } from "../store";
 
 export const SHAPE_MASK_COLOR = "#ffeba2";
 export const BORDER_COLOR = "#212121";
@@ -92,36 +91,12 @@ export const unGroupShapes = (canvas: fabric.Canvas): void => {
     redraw(canvas);
 };
 
-export const zoomIn = (instance: PanZoom): void => {
-    const center = getCanvasCenter();
-    instance.smoothZoom(center.x, center.y, 1.25);
-};
-
-export const zoomOut = (instance: PanZoom): void => {
-    const center = getCanvasCenter();
-    instance.smoothZoom(center.x, center.y, 0.8);
-};
-
-export const zoomReset = (instance: PanZoom): void => {
-    setCenterXForZoom(globalThis.canvas);
-    instance.moveTo(get(zoomResetX), 0);
-    instance.smoothZoomAbs(get(zoomResetX), 0, get(zoomResetValue));
-};
-
 export const getCanvasCenter = () => {
     const canvas = globalThis.canvas.getElement();
     const rect = canvas.getBoundingClientRect();
     const centerX = rect.x + rect.width / 2;
     const centerY = rect.y + rect.height / 2;
     return { x: centerX, y: centerY };
-};
-
-export const setCenterXForZoom = (canvas: fabric.Canvas) => {
-    const editor = document.querySelector(".editor-main")!;
-    const editorWidth = editor.clientWidth;
-    const canvasWidth = canvas.getElement().offsetWidth;
-    const centerX = editorWidth / 2 - canvasWidth / 2;
-    zoomResetX.set(centerX);
 };
 
 const copyItem = (canvas: fabric.Canvas): void => {
@@ -184,26 +159,26 @@ export const makeMaskTransparent = (
     canvas.renderAll();
 };
 
-export const moveShapeToCanvasBoundaries = (canvas: fabric.Canvas): void => {
+export const moveShapeToCanvasBoundaries = (canvas: fabric.Canvas, boundingBox): void => {
     canvas.on("object:modified", function(o) {
         const activeObject = o.target;
         if (!activeObject) {
             return;
         }
         if (activeObject.type === "rect") {
-            modifiedRectangle(canvas, activeObject);
+            modifiedRectangle(boundingBox, activeObject);
         }
         if (activeObject.type === "ellipse") {
-            modifiedEllipse(canvas, activeObject);
+            modifiedEllipse(boundingBox, activeObject);
         }
         if (activeObject.type === "i-text") {
-            modifiedText(canvas, activeObject);
+            modifiedText(boundingBox, activeObject);
         }
     });
 };
 
 const modifiedRectangle = (
-    canvas: fabric.Canvas,
+    boundingBox,
     object: fabric.Object,
 ): void => {
     const newWidth = object.width * object.scaleX;
@@ -215,11 +190,11 @@ const modifiedRectangle = (
         scaleX: 1,
         scaleY: 1,
     });
-    setShapePosition(canvas, object);
+    setShapePosition(boundingBox, object);
 };
 
 const modifiedEllipse = (
-    canvas: fabric.Canvas,
+    boundingBox,
     object: fabric.Object,
 ): void => {
     const newRx = object.rx * object.scaleX;
@@ -235,15 +210,15 @@ const modifiedEllipse = (
         scaleX: 1,
         scaleY: 1,
     });
-    setShapePosition(canvas, object);
+    setShapePosition(boundingBox, object);
 };
 
-const modifiedText = (canvas: fabric.Canvas, object: fabric.Object): void => {
-    setShapePosition(canvas, object);
+const modifiedText = (boundingBox, object: fabric.Object): void => {
+    setShapePosition(boundingBox, object);
 };
 
 const setShapePosition = (
-    canvas: fabric.Canvas,
+    boundingBox,
     object: fabric.Object,
 ): void => {
     if (object.left < 0) {
@@ -252,11 +227,11 @@ const setShapePosition = (
     if (object.top < 0) {
         object.set({ top: 0 });
     }
-    if (object.left + object.width * object.scaleX + object.strokeWidth > canvas.width) {
-        object.set({ left: canvas.width - object.width * object.scaleX });
+    if (object.left + object.width * object.scaleX + object.strokeWidth > boundingBox.width) {
+        object.set({ left: boundingBox.width - object.width * object.scaleX });
     }
-    if (object.top + object.height * object.scaleY + object.strokeWidth > canvas.height) {
-        object.set({ top: canvas.height - object.height * object.scaleY });
+    if (object.top + object.height * object.scaleY + object.strokeWidth > boundingBox.height) {
+        object.set({ top: boundingBox.height - object.height * object.scaleY });
     }
     object.setCoords();
 };
@@ -287,33 +262,25 @@ export const clear = (canvas: fabric.Canvas): void => {
     canvas.clear();
 };
 
-export const makeShapeRemainInCanvas = (canvas: fabric.Canvas) => {
+export const makeShapeRemainInCanvas = (canvas: fabric.Canvas, boundingBox) => {
     canvas.on("object:moving", function(e) {
         const obj = e.target;
-        if (obj.getScaledHeight() > obj.canvas.height || obj.getScaledWidth() > obj.canvas.width) {
+        if (obj.getScaledHeight() > boundingBox.height || obj.getScaledWidth() > boundingBox.width) {
             return;
         }
 
         obj.setCoords();
 
-        if (obj.getBoundingRect().top < 0 || obj.getBoundingRect().left < 0) {
-            obj.top = Math.max(obj.top, obj.top - obj.getBoundingRect().top);
-            obj.left = Math.max(obj.left, obj.left - obj.getBoundingRect().left);
-        }
+        const top = obj.top;
+        const left = obj.left;
 
-        if (
-            obj.getBoundingRect().top + obj.getBoundingRect().height > obj.canvas.height
-            || obj.getBoundingRect().left + obj.getBoundingRect().width > obj.canvas.width
-        ) {
-            obj.top = Math.min(
-                obj.top,
-                obj.canvas.height - obj.getBoundingRect().height + obj.top - obj.getBoundingRect().top,
-            );
-            obj.left = Math.min(
-                obj.left,
-                obj.canvas.width - obj.getBoundingRect().width + obj.left - obj.getBoundingRect().left,
-            );
-        }
+        const topBound = boundingBox.top;
+        const bottomBound = topBound + boundingBox.height;
+        const leftBound = boundingBox.left;
+        const rightBound = leftBound + boundingBox.width;
+
+        obj.left = Math.min(Math.max(left, leftBound), rightBound - obj.width);
+        obj.top = Math.min(Math.max(top, topBound), bottomBound - obj.height);
     });
 };
 
@@ -324,4 +291,21 @@ export const selectAllShapes = (canvas: fabric.Canvas) => {
     });
     canvas.setActiveObject(sel);
     redraw(canvas);
+};
+
+export const isPointerInBoundingBox = (pointer): boolean => {
+    const boundingBox = getBoundingBox();
+    if (
+        pointer.x < boundingBox.left
+        || pointer.x > boundingBox.left + boundingBox.width
+        || pointer.y < boundingBox.top
+        || pointer.y > boundingBox.top + boundingBox.height
+    ) {
+        return false;
+    }
+    return true;
+};
+
+export const getBoundingBox = () => {
+    return globalThis.boundingBox;
 };

--- a/ts/image-occlusion/tools/more-tools.ts
+++ b/ts/image-occlusion/tools/more-tools.ts
@@ -19,16 +19,7 @@ import {
     mdiZoomOut,
     mdiZoomReset,
 } from "../icons";
-import {
-    deleteItem,
-    duplicateItem,
-    groupShapes,
-    selectAllShapes,
-    unGroupShapes,
-    zoomIn,
-    zoomOut,
-    zoomReset,
-} from "./lib";
+import { deleteItem, duplicateItem, groupShapes, selectAllShapes, unGroupShapes } from "./lib";
 import {
     alignBottomKeyCombination,
     alignHorizontalCenterKeyCombination,
@@ -53,6 +44,7 @@ import {
     alignTop,
     alignVerticalCenter,
 } from "./tool-aligns";
+import { zoomIn, zoomOut, zoomReset } from "./tool-zoom";
 
 export const groupUngroupTools = [
     {

--- a/ts/image-occlusion/tools/tool-cursor.ts
+++ b/ts/image-occlusion/tools/tool-cursor.ts
@@ -1,0 +1,24 @@
+// Copyright: Ankitects Pty Ltd and contributors
+// License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
+
+import type { fabric } from "fabric";
+
+import { stopDraw } from "./lib";
+import { onPinchZoom } from "./tool-zoom";
+
+export const drawCursor = (canvas: fabric.Canvas): void => {
+    canvas.selectionColor = "rgba(100, 100, 255, 0.3)";
+    stopDraw(canvas);
+
+    canvas.on("mouse:down", function(o) {
+        if (o.target) {
+            return;
+        }
+    });
+
+    canvas.on("mouse:move", function(o) {
+        if (onPinchZoom(o)) {
+            return;
+        }
+    });
+};

--- a/ts/image-occlusion/tools/tool-ellipse.ts
+++ b/ts/image-occlusion/tools/tool-ellipse.ts
@@ -7,6 +7,7 @@ import { get } from "svelte/store";
 
 import { BORDER_COLOR, isPointerInBoundingBox, SHAPE_MASK_COLOR, stopDraw } from "./lib";
 import { undoStack } from "./tool-undo-redo";
+import { onPinchZoom } from "./tool-zoom";
 
 export const drawEllipse = (canvas: fabric.Canvas): void => {
     canvas.selectionColor = "rgba(0, 0, 0, 0)";
@@ -50,6 +51,10 @@ export const drawEllipse = (canvas: fabric.Canvas): void => {
     });
 
     canvas.on("mouse:move", function(o) {
+        if (onPinchZoom(o)) {
+            return;
+        }
+
         if (!isDown) {
             return;
         }

--- a/ts/image-occlusion/tools/tool-ellipse.ts
+++ b/ts/image-occlusion/tools/tool-ellipse.ts
@@ -5,7 +5,7 @@ import { fabric } from "fabric";
 import { opacityStateStore } from "image-occlusion/store";
 import { get } from "svelte/store";
 
-import { BORDER_COLOR, SHAPE_MASK_COLOR, stopDraw } from "./lib";
+import { BORDER_COLOR, isPointerInBoundingBox, SHAPE_MASK_COLOR, stopDraw } from "./lib";
 import { undoStack } from "./tool-undo-redo";
 
 export const drawEllipse = (canvas: fabric.Canvas): void => {
@@ -23,6 +23,11 @@ export const drawEllipse = (canvas: fabric.Canvas): void => {
         const pointer = canvas.getPointer(o.e);
         origX = pointer.x;
         origY = pointer.y;
+
+        if (!isPointerInBoundingBox(pointer)) {
+            isDown = false;
+            return;
+        }
 
         ellipse = new fabric.Ellipse({
             id: "ellipse-" + new Date().getTime(),

--- a/ts/image-occlusion/tools/tool-ellipse.ts
+++ b/ts/image-occlusion/tools/tool-ellipse.ts
@@ -52,6 +52,8 @@ export const drawEllipse = (canvas: fabric.Canvas): void => {
 
     canvas.on("mouse:move", function(o) {
         if (onPinchZoom(o)) {
+            canvas.remove(ellipse);
+            canvas.renderAll();
             return;
         }
 

--- a/ts/image-occlusion/tools/tool-polygon.ts
+++ b/ts/image-occlusion/tools/tool-polygon.ts
@@ -36,7 +36,9 @@ export const drawPolygon = (canvas: fabric.Canvas): void => {
     });
 
     canvas.on("mouse:move", function(options) {
+        // if pinch zoom is active, remove all points and lines
         if (onPinchZoom(options)) {
+            removeUnfinishedPolygon(canvas);
             return;
         }
 

--- a/ts/image-occlusion/tools/tool-polygon.ts
+++ b/ts/image-occlusion/tools/tool-polygon.ts
@@ -7,6 +7,7 @@ import { get } from "svelte/store";
 
 import { BORDER_COLOR, isPointerInBoundingBox, SHAPE_MASK_COLOR } from "./lib";
 import { undoStack } from "./tool-undo-redo";
+import { onPinchZoom } from "./tool-zoom";
 
 let activeLine;
 let activeShape;
@@ -35,6 +36,10 @@ export const drawPolygon = (canvas: fabric.Canvas): void => {
     });
 
     canvas.on("mouse:move", function(options) {
+        if (onPinchZoom(options)) {
+            return;
+        }
+
         if (activeLine && activeLine.class === "line") {
             const pointer = canvas.getPointer(options.e);
             activeLine.set({
@@ -163,6 +168,7 @@ const addPoint = (canvas: fabric.Canvas, options): void => {
 
     canvas.add(line);
     canvas.add(point);
+    canvas.renderAll();
 };
 
 const generatePolygon = (canvas: fabric.Canvas, pointsList): void => {

--- a/ts/image-occlusion/tools/tool-rect.ts
+++ b/ts/image-occlusion/tools/tool-rect.ts
@@ -53,6 +53,8 @@ export const drawRectangle = (canvas: fabric.Canvas): void => {
 
     canvas.on("mouse:move", function(o) {
         if (onPinchZoom(o)) {
+            canvas.remove(rect);
+            canvas.renderAll();
             return;
         }
 

--- a/ts/image-occlusion/tools/tool-rect.ts
+++ b/ts/image-occlusion/tools/tool-rect.ts
@@ -5,7 +5,7 @@ import { fabric } from "fabric";
 import { opacityStateStore } from "image-occlusion/store";
 import { get } from "svelte/store";
 
-import { BORDER_COLOR, SHAPE_MASK_COLOR, stopDraw } from "./lib";
+import { BORDER_COLOR, isPointerInBoundingBox, SHAPE_MASK_COLOR, stopDraw } from "./lib";
 import { undoStack } from "./tool-undo-redo";
 
 export const drawRectangle = (canvas: fabric.Canvas): void => {
@@ -23,6 +23,11 @@ export const drawRectangle = (canvas: fabric.Canvas): void => {
         const pointer = canvas.getPointer(o.e);
         origX = pointer.x;
         origY = pointer.y;
+
+        if (!isPointerInBoundingBox(pointer)) {
+            isDown = false;
+            return;
+        }
 
         rect = new fabric.Rect({
             id: "rect-" + new Date().getTime(),

--- a/ts/image-occlusion/tools/tool-rect.ts
+++ b/ts/image-occlusion/tools/tool-rect.ts
@@ -7,6 +7,7 @@ import { get } from "svelte/store";
 
 import { BORDER_COLOR, isPointerInBoundingBox, SHAPE_MASK_COLOR, stopDraw } from "./lib";
 import { undoStack } from "./tool-undo-redo";
+import { onPinchZoom } from "./tool-zoom";
 
 export const drawRectangle = (canvas: fabric.Canvas): void => {
     canvas.selectionColor = "rgba(0, 0, 0, 0)";
@@ -51,6 +52,10 @@ export const drawRectangle = (canvas: fabric.Canvas): void => {
     });
 
     canvas.on("mouse:move", function(o) {
+        if (onPinchZoom(o)) {
+            return;
+        }
+
         if (!isDown) {
             return;
         }

--- a/ts/image-occlusion/tools/tool-text.ts
+++ b/ts/image-occlusion/tools/tool-text.ts
@@ -20,6 +20,8 @@ export const drawText = (canvas: fabric.Canvas): void => {
     canvas.selectionColor = "rgba(0, 0, 0, 0)";
     stopDraw(canvas);
 
+    let text;
+
     canvas.on("mouse:down", function(o) {
         if (o.target) {
             return;
@@ -30,7 +32,7 @@ export const drawText = (canvas: fabric.Canvas): void => {
             return;
         }
 
-        const text = new fabric.IText("text", {
+        text = new fabric.IText("text", {
             id: "text-" + new Date().getTime(),
             left: pointer.x,
             top: pointer.y,
@@ -48,12 +50,13 @@ export const drawText = (canvas: fabric.Canvas): void => {
         canvas.add(text);
         canvas.setActiveObject(text);
         undoStack.onObjectAdded(text.id);
-        text.enterEditing();
         text.selectAll();
     });
 
     canvas.on("mouse:move", function(o) {
         if (onPinchZoom(o)) {
+            canvas.remove(text);
+            canvas.renderAll();
             return;
         }
     });

--- a/ts/image-occlusion/tools/tool-text.ts
+++ b/ts/image-occlusion/tools/tool-text.ts
@@ -5,7 +5,14 @@ import { fabric } from "fabric";
 import { opacityStateStore, textEditingState } from "image-occlusion/store";
 import { get } from "svelte/store";
 
-import { enableUniformScaling, stopDraw, TEXT_BACKGROUND_COLOR, TEXT_FONT_FAMILY, TEXT_PADDING } from "./lib";
+import {
+    enableUniformScaling,
+    isPointerInBoundingBox,
+    stopDraw,
+    TEXT_BACKGROUND_COLOR,
+    TEXT_FONT_FAMILY,
+    TEXT_PADDING,
+} from "./lib";
 import { undoStack } from "./tool-undo-redo";
 
 export const drawText = (canvas: fabric.Canvas): void => {
@@ -17,6 +24,11 @@ export const drawText = (canvas: fabric.Canvas): void => {
             return;
         }
         const pointer = canvas.getPointer(o.e);
+
+        if (!isPointerInBoundingBox(pointer)) {
+            return;
+        }
+
         const text = new fabric.IText("text", {
             id: "text-" + new Date().getTime(),
             left: pointer.x,

--- a/ts/image-occlusion/tools/tool-text.ts
+++ b/ts/image-occlusion/tools/tool-text.ts
@@ -14,6 +14,7 @@ import {
     TEXT_PADDING,
 } from "./lib";
 import { undoStack } from "./tool-undo-redo";
+import { onPinchZoom } from "./tool-zoom";
 
 export const drawText = (canvas: fabric.Canvas): void => {
     canvas.selectionColor = "rgba(0, 0, 0, 0)";
@@ -49,6 +50,12 @@ export const drawText = (canvas: fabric.Canvas): void => {
         undoStack.onObjectAdded(text.id);
         text.enterEditing();
         text.selectAll();
+    });
+
+    canvas.on("mouse:move", function(o) {
+        if (onPinchZoom(o)) {
+            return;
+        }
     });
 
     canvas.on("text:editing:entered", function() {

--- a/ts/image-occlusion/tools/tool-zoom.ts
+++ b/ts/image-occlusion/tools/tool-zoom.ts
@@ -1,0 +1,209 @@
+// Copyright: Ankitects Pty Ltd and contributors
+// License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
+
+// https://codepen.io/amsunny/pen/XWGLxye
+// canvas.viewportTransform = [ scaleX, skewX, skewY, scaleY, translateX, translateY ]
+
+let isDragging = false;
+
+export const enableZoom = (canvas) => {
+    canvas.on("mouse:wheel", onMouseWheel);
+    canvas.on("mouse:down", onMouseDown);
+    canvas.on("mouse:move", onMouseMove);
+    canvas.on("mouse:up", onMouseUp);
+};
+
+export const disableZoom = (canvas) => {
+    canvas.off("mouse:wheel", onMouseWheel);
+    canvas.off("mouse:down", onMouseDown);
+    canvas.off("mouse:move", onMouseMove);
+    canvas.off("mouse:up", onMouseUp);
+};
+
+export const zoomIn = (canvas): void => {
+    const zoom = canvas.getZoom();
+    canvas.zoomToPoint({ x: canvas.width / 2, y: canvas.height / 2 }, zoom * 1.1);
+};
+
+export const zoomOut = (canvas): void => {
+    const zoom = canvas.getZoom();
+    canvas.zoomToPoint({ x: canvas.width / 2, y: canvas.height / 2 }, zoom / 1.1);
+};
+
+export const zoomReset = (canvas): void => {
+    canvas.zoomToPoint({ x: canvas.width / 2, y: canvas.height / 2 }, 1);
+    fitCanvasVptScale(canvas);
+    constrainBoundsAroundBgImage(canvas);
+};
+
+export const onResize = (canvas) => {
+    setCanvasSize(canvas);
+    scaleCanvasBgImage(canvas);
+
+    const canvasBgImage = canvas.backgroundImage;
+    if (canvasBgImage) {
+        updateCanvasFocusPoint(canvas, canvasBgImage);
+    }
+
+    constrainBoundsAroundBgImage(canvas);
+    fitCanvasVptScale(canvas);
+};
+
+const onMouseWheel = (opt) => {
+    const canvas = globalThis.canvas;
+    const delta = opt.e.deltaY;
+    let zoom = canvas.getZoom();
+    zoom *= 0.999 ** delta;
+
+    if (zoom > 5) {
+        zoom = 5;
+    }
+
+    if (zoom < 0.2) {
+        zoom = 0.2;
+    }
+
+    canvas.zoomToPoint({ x: opt.pointer.x, y: opt.pointer.y }, zoom);
+    opt.e.preventDefault();
+    opt.e.stopPropagation();
+
+    constrainBoundsAroundBgImage(canvas);
+};
+
+const onMouseDown = (opt) => {
+    isDragging = true;
+    const canvas = globalThis.canvas;
+    canvas.discardActiveObject();
+    const { e } = opt;
+    canvas.lastPosX = e.clientX;
+    canvas.lastPosY = e.clientY;
+    canvas.requestRenderAll();
+};
+
+const onMouseMove = (opt) => {
+    const canvas = globalThis.canvas;
+    if (isDragging) {
+        canvas.discardActiveObject();
+        canvas.defaultCursor = "grabbing";
+        const { e } = opt;
+        if (!canvas.viewportTransform) {
+            return;
+        }
+        const vpt = canvas.viewportTransform;
+        vpt[4] += e.clientX - canvas.lastPosX;
+        vpt[5] += e.clientY - canvas.lastPosY;
+        canvas.lastPosX = e.clientX;
+        canvas.lastPosY = e.clientY;
+        canvas.requestRenderAll();
+    }
+};
+
+const onMouseUp = () => {
+    isDragging = false;
+    const canvas = globalThis.canvas;
+    canvas.setViewportTransform(canvas.viewportTransform);
+    canvas.defaultCursor = "default";
+    canvas.requestRenderAll();
+};
+
+const constrainBoundsAroundBgImage = (canvas) => {
+    const canvasWidth = canvas.getWidth();
+    const canvasHeight = canvas.getHeight();
+    const vpt = canvas.viewportTransform;
+    const canvasBgImage = canvas.backgroundImage;
+
+    if (!canvasBgImage) {
+        return;
+    }
+
+    const {
+        bgImageWidth,
+        bgImageHeight,
+    } = getCanvasBgImageCalculatedSize(canvas, canvasBgImage);
+
+    const minX = Math.min(0, canvasWidth - bgImageWidth);
+    const minY = Math.min(0, canvasHeight - bgImageHeight);
+
+    vpt[4] = Math.max(minX, Math.min(0, vpt[4]));
+    vpt[5] = Math.max(minY, Math.min(0, vpt[5]));
+
+    updateCanvasFocusPoint(canvas, canvasBgImage);
+};
+
+export const setCanvasSize = (canvas) => {
+    canvas.setHeight(window.innerHeight - 76);
+    canvas.setWidth(window.innerWidth - 39);
+};
+
+const scaleCanvasBgImage = (canvas) => {
+    const canvasBgImage = canvas.backgroundImage;
+    const boundingBox = globalThis.boundingBox;
+    if (!canvasBgImage) {
+        return;
+    }
+
+    canvasBgImage.scaleToWidth(canvas.width * canvas.getZoom());
+    canvasBgImage.scaleToHeight(canvas.height * canvas.getZoom());
+
+    const ratioW = boundingBox.width / canvasBgImage.width;
+    const ratioH = boundingBox.height / canvasBgImage.height;
+
+    if (ratioW > ratioH) {
+        canvasBgImage.scaleX = ratioW;
+        canvasBgImage.scaleY = ratioW;
+    } else {
+        canvasBgImage.scaleX = ratioH;
+        canvasBgImage.scaleY = ratioH;
+    }
+    canvas.requestRenderAll();
+};
+
+const updateCanvasFocusPoint = (canvas, canvasBgImage) => {
+    const vpt = canvas.viewportTransform;
+
+    vpt[4] = getCanvasFocusOffset(canvas, canvasBgImage).offsetX;
+    vpt[5] = getCanvasFocusOffset(canvas, canvasBgImage).offsetY;
+};
+
+const getCanvasFocusOffset = (canvas, canvasBgImage) => {
+    const {
+        bgImageWidth,
+        bgImageHeight,
+    } = getCanvasBgImageCalculatedSize(canvas, canvasBgImage);
+
+    const canvasWidth = canvas.getWidth();
+    const canvasHeight = canvas.getHeight();
+
+    const offsetX = Math.max(0, (canvasWidth - bgImageWidth) / 2);
+    const offsetY = Math.max(0, (canvasHeight - bgImageHeight) / 2);
+
+    return {
+        offsetX,
+        offsetY,
+    };
+};
+
+const getCanvasBgImageCalculatedSize = (canvas, canvasBgImage) => {
+    return {
+        bgImageWidth: canvasBgImage.width * canvasBgImage.scaleX * canvas.getZoom(),
+        bgImageHeight: canvasBgImage.height * canvasBgImage.scaleY * canvas.getZoom(),
+    };
+};
+
+const fitCanvasVptScale = (canvas) => {
+    const ratio = getScaleRatio();
+    const vpt = canvas.viewportTransform;
+    vpt[0] = ratio;
+    vpt[3] = ratio;
+    canvas.requestRenderAll();
+};
+
+const getScaleRatio = () => {
+    const boundingBox = globalThis.boundingBox;
+    const h1 = boundingBox.height;
+    const w1 = boundingBox.width;
+    const h2 = innerHeight - 78;
+    const w2 = innerWidth - 42;
+
+    return Math.min(w2 / w1, h2 / h1);
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1406,13 +1406,6 @@ ajv@^6.12.4:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
-amator@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/amator/-/amator-1.1.0.tgz#08c6b60bc93aec2b61bbfc0c4d677d30323cc0f1"
-  integrity sha512-V5+aH8pe+Z3u/UG3L3pG3BaFQGXAyXHVQDroRwjPHdh08bcUEchAVsU1MCuJSCaU5o60wTK6KaE6te5memzgYw==
-  dependencies:
-    bezier-easing "^2.0.3"
-
 ansi-escapes@^4.2.1:
   version "4.3.2"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-4.3.2.tgz#6b2291d1db7d98b6521d5f1efa42d0f3a9feb65e"
@@ -1656,11 +1649,6 @@ balanced-match@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
-
-bezier-easing@^2.0.3:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/bezier-easing/-/bezier-easing-2.1.0.tgz#c04dfe8b926d6ecaca1813d69ff179b7c2025d86"
-  integrity sha512-gbIqZ/eslnUFC1tjEvtz0sgx+xTK20wDnYMIA27VA04R7w6xxXQPZDbibjA9DTWZRA2CXtwHykkVzlCaAJAZig==
 
 binary-extensions@^2.0.0:
   version "2.2.0"
@@ -4170,11 +4158,6 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
 
-ngraph.events@^1.2.2:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/ngraph.events/-/ngraph.events-1.2.2.tgz#3ceb92d676a04a4e7ce60a09fa8e17a4f0346d7f"
-  integrity sha512-JsUbEOzANskax+WSYiAPETemLWYXmixuPAlmZmhIbIj6FH/WDgEGCGnRwUQBK0GjOnVm8Ui+e5IJ+5VZ4e32eQ==
-
 node-int64@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/node-int64/-/node-int64-0.4.0.tgz#87a9065cdb355d3182d8f94ce11188b825c68a3b"
@@ -4331,15 +4314,6 @@ p-try@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.2.0.tgz#cb2868540e313d61de58fafbe35ce9004d5540e6"
   integrity sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==
-
-panzoom@^9.4.3:
-  version "9.4.3"
-  resolved "https://registry.yarnpkg.com/panzoom/-/panzoom-9.4.3.tgz#195c4031bb643f2e6c42f1de0ca87cc10e224042"
-  integrity sha512-xaxCpElcRbQsUtIdwlrZA90P90+BHip4Vda2BC8MEb4tkI05PmR6cKECdqUCZ85ZvBHjpI9htJrZBxV5Gp/q/w==
-  dependencies:
-    amator "^1.1.0"
-    ngraph.events "^1.2.2"
-    wheel "^1.0.0"
 
 parent-module@^1.0.0:
   version "1.0.1"
@@ -5388,11 +5362,6 @@ whatwg-url@^11.0.0:
   dependencies:
     tr46 "^3.0.0"
     webidl-conversions "^7.0.0"
-
-wheel@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/wheel/-/wheel-1.0.0.tgz#6cf46e06a854181adb8649228077f8b0d5c574ce"
-  integrity sha512-XiCMHibOiqalCQ+BaNSwRoZ9FDTAvOsXxGHXChBugewDj7HC8VBIER71dEOiRH1fSdLbRCQzngKTSiZ06ZQzeA==
 
 which-boxed-primitive@^1.0.2:
   version "1.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3026,6 +3026,11 @@ graphemer@^1.4.0:
   resolved "https://registry.yarnpkg.com/graphemer/-/graphemer-1.4.0.tgz#fb2f1d55e0e3a1849aeffc90c4fa0dd53a0e66c6"
   integrity sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==
 
+hammerjs@^2.0.8:
+  version "2.0.8"
+  resolved "https://registry.yarnpkg.com/hammerjs/-/hammerjs-2.0.8.tgz#04ef77862cff2bb79d30f7692095930222bf60f1"
+  integrity sha512-tSQXBXS/MWQOn/RKckawJ61vvsDpCom87JgxiYdGwHdOa0ht0vzUWDlfioofFCRU0L+6NGDt6XzbgoJvZkMeRQ==
+
 has-bigints@^1.0.1, has-bigints@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/has-bigints/-/has-bigints-1.0.2.tgz#0871bd3e3d51626f6ca0966668ba35d5602d6eaa"


### PR DESCRIPTION
I have updated gradually so there are no atomic commits here, but I will explain what going on in this PR.

The panzoom library removed, the same functionality is implemented using 
https://codepen.io/amsunny/pen/XWGLxye
http://fabricjs.com/docs/fabric.Canvas.html#viewportTransform
http://fabricjs.com/using-transformations

The IO image is set as background image for canvas, it is easier for zoom/pan using canvas only.
A bounding rectangular area added with same width and height of background image, all shapes are allowed to draw inside bounding area only.

I have used large image for testing.

https://github.com/ankitects/anki/assets/12841290/9f487f34-7c46-42a1-815a-74be7b04ff38