### PR TITLE
alert when the resp.weights is empty

### DIFF
--- a/rslib/src/deckconfig/update.rs
+++ b/rslib/src/deckconfig/update.rs
@@ -346,10 +346,8 @@ impl Collection {
                 &config.inner.fsrs_weights,
             ) {
                 Ok(weights) => {
-                    if weights.fsrs_items >= 1000 {
-                        println!("{}: {:?}", config.name, weights.weights);
-                        config.inner.fsrs_weights = weights.weights;
-                    }
+                    println!("{}: {:?}", config.name, weights.weights);
+                    config.inner.fsrs_weights = weights.weights;
                 }
                 Err(AnkiError::Interrupted) => return Err(AnkiError::Interrupted),
                 Err(err) => {

--- a/rslib/src/scheduler/fsrs/weights.rs
+++ b/rslib/src/scheduler/fsrs/weights.rs
@@ -96,7 +96,7 @@ impl Collection {
         let mut weights =
             fsrs.compute_parameters(items.clone(), fsrs_items < 1000, Some(progress2))?;
         let metrics = fsrs.universal_metrics(items, &weights, |_| true)?;
-        if metrics.0 < metrics.1 {
+        if metrics.0 <= metrics.1 {
             weights = current_weights.to_vec();
         }
 

--- a/ts/deck-options/FsrsOptions.svelte
+++ b/ts/deck-options/FsrsOptions.svelte
@@ -117,11 +117,11 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
                         currentWeights: $config.fsrsWeights,
                     });
                     if (
-                        $config.fsrsWeights.length &&
-                        $config.fsrsWeights.every(
-                            (n, i) => n.toFixed(4) === resp.weights[i].toFixed(4),
-                        )
-                        || resp.weights.length === 0
+                        ($config.fsrsWeights.length &&
+                            $config.fsrsWeights.every(
+                                (n, i) => n.toFixed(4) === resp.weights[i].toFixed(4),
+                            )) ||
+                        resp.weights.length === 0
                     ) {
                         alert(tr.deckConfigFsrsParamsOptimal());
                     }

--- a/ts/deck-options/FsrsOptions.svelte
+++ b/ts/deck-options/FsrsOptions.svelte
@@ -121,6 +121,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
                         $config.fsrsWeights.every(
                             (n, i) => n.toFixed(4) === resp.weights[i].toFixed(4),
                         )
+                        || resp.weights.length === 0
                     ) {
                         alert(tr.deckConfigFsrsParamsOptimal());
                     }


### PR DESCRIPTION
When the current weights are empty and the new weights are worse than the default weights, the previous implementation doesn't pop up the `alert(tr.deckConfigFsrsParamsOptimal())` because `$config.fsrsWeights.length` is 0.

By the way, I also remove the condition `weights.fsrs_items >= 1000` when computing all weights.