### PR TITLE
fix: ensure proper drawing of shape tools after pan/zoom

### DIFF
--- a/ts/image-occlusion/ImageOcclusionPage.svelte
+++ b/ts/image-occlusion/ImageOcclusionPage.svelte
@@ -6,11 +6,11 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     import * as tr from "@tslib/ftl";
 
     import Container from "../components/Container.svelte";
+    import { addBrowserClasses } from "../reviewer/browser_selector";
     import { addOrUpdateNote } from "./add-or-update-note";
     import type { IOMode } from "./lib";
     import MasksEditor from "./MaskEditor.svelte";
     import Notes from "./Notes.svelte";
-    import StickyFooter from "./StickyFooter.svelte";
     import { hideAllGuessOne, textEditingState } from "./store";
 
     export let mode: IOMode;
@@ -18,6 +18,10 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     async function addNote(): Promise<void> {
         addOrUpdateNote(mode, $hideAllGuessOne);
     }
+    globalThis.imageOcclusion = {
+        mode,
+        addNote,
+    };
 
     const items = [
         { label: tr.notetypesOcclusionMask(), value: 1 },
@@ -29,6 +33,8 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         textEditingState.set(tabValue === 2);
         activeTabValue = tabValue;
     };
+
+    addBrowserClasses();
 </script>
 
 <Container class="image-occlusion">
@@ -51,8 +57,6 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     <div hidden={activeTabValue != 2}>
         <Notes />
     </div>
-
-    <StickyFooter {mode} {addNote} />
 </Container>
 
 <style lang="scss">

--- a/ts/image-occlusion/ImageOcclusionPage.svelte
+++ b/ts/image-occlusion/ImageOcclusionPage.svelte
@@ -6,22 +6,12 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     import * as tr from "@tslib/ftl";
 
     import Container from "../components/Container.svelte";
-    import { addBrowserClasses } from "../reviewer/browser_selector";
-    import { addOrUpdateNote } from "./add-or-update-note";
     import type { IOMode } from "./lib";
     import MasksEditor from "./MaskEditor.svelte";
     import Notes from "./Notes.svelte";
-    import { hideAllGuessOne, textEditingState } from "./store";
+    import { textEditingState } from "./store";
 
     export let mode: IOMode;
-
-    async function addNote(): Promise<void> {
-        addOrUpdateNote(mode, $hideAllGuessOne);
-    }
-    globalThis.imageOcclusion = {
-        mode,
-        addNote,
-    };
 
     const items = [
         { label: tr.notetypesOcclusionMask(), value: 1 },
@@ -33,8 +23,6 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         textEditingState.set(tabValue === 2);
         activeTabValue = tabValue;
     };
-
-    addBrowserClasses();
 </script>
 
 <Container class="image-occlusion">

--- a/ts/image-occlusion/Toolbar.svelte
+++ b/ts/image-occlusion/Toolbar.svelte
@@ -31,7 +31,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     import { drawCursor } from "./tools/tool-cursor";
     import { removeUnfinishedPolygon } from "./tools/tool-polygon";
     import { undoRedoTools, undoStack } from "./tools/tool-undo-redo";
-    import { disableZoom, enableZoom, onDragX, onDragY } from "./tools/tool-zoom";
+    import { disableZoom, enableZoom, onGesture, onWheelDrag } from "./tools/tool-zoom";
 
     export let canvas;
     export let iconSize;
@@ -50,9 +50,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     });
 
     // handle zoom event when mouse scroll and ctrl key are hold for panzoom
-    let ctrlClicked = false;
-    let altClicked = false;
-    let shiftClicked = false;
+    let clicked = false;
     let dbclicked = false;
     let move = false;
     let wheel = false;
@@ -60,12 +58,12 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     onMount(() => {
         window.addEventListener("mousedown", (event) => {
             if (event.ctrlKey) {
-                ctrlClicked = true;
+                clicked = true;
             }
         });
         window.addEventListener("mouseup", (event) => {
             if (event.ctrlKey) {
-                ctrlClicked = false;
+                clicked = false;
             }
         });
         window.addEventListener("mousemove", (event) => {
@@ -77,12 +75,6 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
             if (event.ctrlKey) {
                 wheel = true;
             }
-            if (event.altKey) {
-                wheel = true;
-            }
-            if (event.shiftKey) {
-                wheel = true;
-            }
         });
         window.addEventListener("dblclick", (event) => {
             if (event.ctrlKey) {
@@ -90,49 +82,34 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
             }
         });
         window.addEventListener("keyup", () => {
-            ctrlClicked = false;
-            altClicked = false;
-            shiftClicked = false;
+            clicked = false;
             move = false;
             wheel = false;
             dbclicked = false;
         });
         window.addEventListener("keydown", (event) => {
-            if (event.key == "Control" && activeTool != "magnify") {
+            if (event.key == "Control") {
                 stopDraw(canvas);
                 enableZoom(canvas);
-            }
-            if (event.key == "Alt") {
-                altClicked = true;
-            }
-            if (event.key == "Shift") {
-                shiftClicked = true;
             }
         });
         window.addEventListener("keyup", (event) => {
-            if (event.key == "Control" && activeTool != "magnify") {
+            if (event.key == "Control") {
                 disableFunctions();
                 handleToolChanges(activeTool);
             }
-            if (event.key == "Alt") {
-                altClicked = false;
-            }
-            if (event.key == "Shift") {
-                shiftClicked = false;
-            }
         });
         window.addEventListener("wheel", (event) => {
-            if (ctrlClicked && move && wheel && !dbclicked) {
+            if (clicked && move && wheel && !dbclicked) {
                 stopDraw(canvas);
                 enableZoom(canvas);
             }
-            if (altClicked && wheel) {
-                onDragX(canvas, event);
-            }
-            if (shiftClicked && wheel) {
-                onDragY(canvas, event);
-            }
+            onWheelDrag(canvas, event);
         });
+
+        window.addEventListener("gesturestart", onGesture);
+        window.addEventListener("gesturechange", onGesture);
+        window.addEventListener("gestureend", onGesture);
     });
 
     const handleToolChanges = (activeTool: string) => {
@@ -144,10 +121,6 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         switch (activeTool) {
             case "cursor":
                 drawCursor(canvas);
-                break;
-            case "magnify":
-                enableZoom(canvas);
-                enableSelectable(canvas, false);
                 break;
             case "draw-rectangle":
                 drawRectangle(canvas);

--- a/ts/image-occlusion/Toolbar.svelte
+++ b/ts/image-occlusion/Toolbar.svelte
@@ -106,6 +106,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         window.addEventListener("keyup", (event) => {
             if (event.key == "Control" && activeTool != "magnify") {
                 disableFunctions();
+                handleToolChanges(activeTool);
             }
         });
         window.addEventListener("wheel", () => {
@@ -116,8 +117,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         });
     });
 
-    // handle tool changes after initialization
-    $: if (canvas) {
+    const handleToolChanges = (activeTool: string) => {
         disableFunctions();
         enableSelectable(canvas, true);
         // remove unfinished polygon when switching to other tools
@@ -146,6 +146,11 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
             default:
                 break;
         }
+    };
+
+    // handle tool changes after initialization
+    $: if (canvas) {
+        handleToolChanges(activeTool);
     }
 
     const disableFunctions = () => {

--- a/ts/image-occlusion/Toolbar.svelte
+++ b/ts/image-occlusion/Toolbar.svelte
@@ -31,7 +31,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     import { drawCursor } from "./tools/tool-cursor";
     import { removeUnfinishedPolygon } from "./tools/tool-polygon";
     import { undoRedoTools, undoStack } from "./tools/tool-undo-redo";
-    import { disableZoom, enableZoom, onGesture, onWheelDrag } from "./tools/tool-zoom";
+    import { disableZoom, enableZoom, onWheelDrag } from "./tools/tool-zoom";
 
     export let canvas;
     export let iconSize;
@@ -57,27 +57,27 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
     onMount(() => {
         window.addEventListener("mousedown", (event) => {
-            if (event.ctrlKey) {
+            if (event.shiftKey) {
                 clicked = true;
             }
         });
         window.addEventListener("mouseup", (event) => {
-            if (event.ctrlKey) {
+            if (event.shiftKey) {
                 clicked = false;
             }
         });
         window.addEventListener("mousemove", (event) => {
-            if (event.ctrlKey) {
+            if (event.shiftKey) {
                 move = true;
             }
         });
         window.addEventListener("wheel", (event) => {
-            if (event.ctrlKey) {
+            if (event.shiftKey) {
                 wheel = true;
             }
         });
         window.addEventListener("dblclick", (event) => {
-            if (event.ctrlKey) {
+            if (event.shiftKey) {
                 dbclicked = true;
             }
         });
@@ -88,28 +88,30 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
             dbclicked = false;
         });
         window.addEventListener("keydown", (event) => {
-            if (event.key == "Control") {
+            if (event.key == "Shift") {
                 stopDraw(canvas);
                 enableZoom(canvas);
             }
         });
         window.addEventListener("keyup", (event) => {
-            if (event.key == "Control") {
+            if (event.key == "Shift") {
                 disableFunctions();
                 handleToolChanges(activeTool);
             }
         });
-        window.addEventListener("wheel", (event) => {
-            if (clicked && move && wheel && !dbclicked) {
-                stopDraw(canvas);
-                enableZoom(canvas);
-            }
-            onWheelDrag(canvas, event);
-        });
+        window.addEventListener(
+            "wheel",
+            (event) => {
+                event.preventDefault();
 
-        window.addEventListener("gesturestart", onGesture);
-        window.addEventListener("gesturechange", onGesture);
-        window.addEventListener("gestureend", onGesture);
+                if (clicked && move && wheel && !dbclicked) {
+                    stopDraw(canvas);
+                    enableZoom(canvas);
+                }
+                onWheelDrag(canvas, event);
+            },
+            { passive: false },
+        );
     });
 
     const handleToolChanges = (activeTool: string) => {

--- a/ts/image-occlusion/Toolbar.svelte
+++ b/ts/image-occlusion/Toolbar.svelte
@@ -5,6 +5,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 <script lang="ts">
     import { directionKey } from "@tslib/context-keys";
     import * as tr from "@tslib/ftl";
+    import { isApplePlatform } from "@tslib/platform";
     import { getPlatformString } from "@tslib/shortcuts";
     import DropdownItem from "components/DropdownItem.svelte";
     import IconButton from "components/IconButton.svelte";
@@ -54,47 +55,50 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     let dbclicked = false;
     let move = false;
     let wheel = false;
+    const controlKey = isApplePlatform() ? "Shift" : "Control";
 
     onMount(() => {
         window.addEventListener("mousedown", (event) => {
-            if (event.shiftKey) {
+            if (event.ctrlKey) {
                 clicked = true;
             }
         });
         window.addEventListener("mouseup", (event) => {
-            if (event.shiftKey) {
+            if (event.ctrlKey) {
                 clicked = false;
             }
         });
         window.addEventListener("mousemove", (event) => {
-            if (event.shiftKey) {
+            if (event.ctrlKey) {
                 move = true;
             }
         });
         window.addEventListener("wheel", (event) => {
-            if (event.shiftKey) {
+            if (event.ctrlKey) {
                 wheel = true;
             }
         });
         window.addEventListener("dblclick", (event) => {
-            if (event.shiftKey) {
+            if (event.ctrlKey) {
                 dbclicked = true;
             }
         });
-        window.addEventListener("keyup", () => {
-            clicked = false;
-            move = false;
-            wheel = false;
-            dbclicked = false;
+        window.addEventListener("keyup", (event) => {
+            if (event.key === controlKey) {
+                clicked = false;
+                move = false;
+                wheel = false;
+                dbclicked = false;
+            }
         });
         window.addEventListener("keydown", (event) => {
-            if (event.key == "Shift") {
+            if (event.key === controlKey) {
                 stopDraw(canvas);
                 enableZoom(canvas);
             }
         });
         window.addEventListener("keyup", (event) => {
-            if (event.key == "Shift") {
+            if (event.key === controlKey) {
                 disableFunctions();
                 handleToolChanges(activeTool);
             }

--- a/ts/image-occlusion/Toolbar.svelte
+++ b/ts/image-occlusion/Toolbar.svelte
@@ -31,7 +31,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     import { drawCursor } from "./tools/tool-cursor";
     import { removeUnfinishedPolygon } from "./tools/tool-polygon";
     import { undoRedoTools, undoStack } from "./tools/tool-undo-redo";
-    import { disableZoom, enableZoom } from "./tools/tool-zoom";
+    import { disableZoom, enableZoom, onDragX, onDragY } from "./tools/tool-zoom";
 
     export let canvas;
     export let iconSize;
@@ -50,7 +50,9 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     });
 
     // handle zoom event when mouse scroll and ctrl key are hold for panzoom
-    let clicked = false;
+    let ctrlClicked = false;
+    let altClicked = false;
+    let shiftClicked = false;
     let dbclicked = false;
     let move = false;
     let wheel = false;
@@ -58,12 +60,12 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     onMount(() => {
         window.addEventListener("mousedown", (event) => {
             if (event.ctrlKey) {
-                clicked = true;
+                ctrlClicked = true;
             }
         });
         window.addEventListener("mouseup", (event) => {
             if (event.ctrlKey) {
-                clicked = false;
+                ctrlClicked = false;
             }
         });
         window.addEventListener("mousemove", (event) => {
@@ -75,32 +77,36 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
             if (event.ctrlKey) {
                 wheel = true;
             }
+            if (event.altKey) {
+                wheel = true;
+            }
+            if (event.shiftKey) {
+                wheel = true;
+            }
         });
         window.addEventListener("dblclick", (event) => {
             if (event.ctrlKey) {
                 dbclicked = true;
             }
         });
-        window.addEventListener("keyup", (event) => {
-            if (event.key == "Control") {
-                clicked = false;
-                move = false;
-                wheel = false;
-                dbclicked = false;
-            }
-        });
-        window.addEventListener("keydown", (event) => {
-            if (event.key == "Control") {
-                clicked = false;
-                move = false;
-                wheel = false;
-                dbclicked = false;
-            }
+        window.addEventListener("keyup", () => {
+            ctrlClicked = false;
+            altClicked = false;
+            shiftClicked = false;
+            move = false;
+            wheel = false;
+            dbclicked = false;
         });
         window.addEventListener("keydown", (event) => {
             if (event.key == "Control" && activeTool != "magnify") {
                 stopDraw(canvas);
                 enableZoom(canvas);
+            }
+            if (event.key == "Alt") {
+                altClicked = true;
+            }
+            if (event.key == "Shift") {
+                shiftClicked = true;
             }
         });
         window.addEventListener("keyup", (event) => {
@@ -108,11 +114,23 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
                 disableFunctions();
                 handleToolChanges(activeTool);
             }
+            if (event.key == "Alt") {
+                altClicked = false;
+            }
+            if (event.key == "Shift") {
+                shiftClicked = false;
+            }
         });
-        window.addEventListener("wheel", () => {
-            if (clicked && move && wheel && !dbclicked) {
+        window.addEventListener("wheel", (event) => {
+            if (ctrlClicked && move && wheel && !dbclicked) {
                 stopDraw(canvas);
                 enableZoom(canvas);
+            }
+            if (altClicked && wheel) {
+                onDragX(canvas, event);
+            }
+            if (shiftClicked && wheel) {
+                onDragY(canvas, event);
             }
         });
     });

--- a/ts/image-occlusion/index.ts
+++ b/ts/image-occlusion/index.ts
@@ -4,10 +4,15 @@
 import "./image-occlusion-base.scss";
 
 import { ModuleName, setupI18n } from "@tslib/i18n";
+import { get } from "svelte/store";
 
 import { checkNightMode } from "../lib/nightmode";
+import { addOrUpdateNote } from "./add-or-update-note";
 import ImageOcclusionPage from "./ImageOcclusionPage.svelte";
 import type { IOMode } from "./lib";
+import { hideAllGuessOne } from "./store";
+
+globalThis.anki = globalThis.anki || {};
 
 const i18n = setupI18n({
     modules: [
@@ -24,6 +29,16 @@ const i18n = setupI18n({
 export async function setupImageOcclusion(mode: IOMode, target = document.body): Promise<ImageOcclusionPage> {
     checkNightMode();
     await i18n;
+
+    async function addNote(): Promise<void> {
+        addOrUpdateNote(mode, get(hideAllGuessOne));
+    }
+
+    // for adding note from mobile devices
+    globalThis.anki.imageOcclusion = {
+        mode,
+        addNote,
+    };
 
     return new ImageOcclusionPage({
         target: target,

--- a/ts/image-occlusion/mask-editor.ts
+++ b/ts/image-occlusion/mask-editor.ts
@@ -128,7 +128,6 @@ const setupBoundingBox = (canvas: fabric.Canvas, size: Size): fabric.Rect => {
         lockMovementY: true,
         selectable: false,
         evented: false,
-        stroke: "red",
     });
 
     canvas.add(boundingBox);

--- a/ts/image-occlusion/tools/lib.ts
+++ b/ts/image-occlusion/tools/lib.ts
@@ -291,6 +291,8 @@ export const selectAllShapes = (canvas: fabric.Canvas) => {
 
 export const isPointerInBoundingBox = (pointer): boolean => {
     const boundingBox = getBoundingBox();
+    boundingBox.selectable = false;
+    boundingBox.evented = false;
     if (
         pointer.x < boundingBox.left
         || pointer.x > boundingBox.left + boundingBox.width

--- a/ts/image-occlusion/tools/tool-buttons.ts
+++ b/ts/image-occlusion/tools/tool-buttons.ts
@@ -6,7 +6,6 @@ import * as tr from "@tslib/ftl";
 import {
     mdiCursorDefaultOutline,
     mdiEllipseOutline,
-    mdiMagnifyScan,
     mdiRectangleOutline,
     mdiTextBox,
     mdiVectorPolygonVariant,
@@ -14,7 +13,6 @@ import {
 import {
     cursorKeyCombination,
     ellipseKeyCombination,
-    magnifyKeyCombination,
     polygonKeyCombination,
     rectangleKeyCombination,
     textKeyCombination,
@@ -26,12 +24,6 @@ export const tools = [
         icon: mdiCursorDefaultOutline,
         tooltip: tr.editingImageOcclusionSelectTool,
         shortcut: cursorKeyCombination,
-    },
-    {
-        id: "magnify",
-        icon: mdiMagnifyScan,
-        tooltip: tr.editingImageOcclusionZoomTool,
-        shortcut: magnifyKeyCombination,
     },
     {
         id: "draw-rectangle",

--- a/ts/image-occlusion/tools/tool-zoom.ts
+++ b/ts/image-occlusion/tools/tool-zoom.ts
@@ -156,26 +156,50 @@ const onDrag = (canvas, opt) => {
     redraw(canvas);
 };
 
-export const onDragX = (canvas: fabric.Canvas, opt: WheelEvent) => {
-    const delta = opt.deltaX;
+export const onWheelDrag = (canvas: fabric.Canvas, event: WheelEvent) => {
+    const deltaX = event.deltaX;
+    const deltaY = event.deltaY;
     const vpt = canvas.viewportTransform;
-    canvas.lastPosX = opt.clientX;
+    canvas.lastPosX = event.clientX;
+    canvas.lastPosY = event.clientY;
 
-    vpt[4] -= delta;
-    canvas.lastPosX -= delta;
+    vpt[4] -= deltaX;
+    vpt[5] -= deltaY;
+
+    canvas.lastPosX -= deltaX;
+    canvas.lastPosY -= deltaY;
     canvas.setViewportTransform(vpt);
     constrainBoundsAroundBgImage(canvas);
     redraw(canvas);
 };
 
-export const onDragY = (canvas: fabric.Canvas, opt: WheelEvent) => {
-    const delta = opt.deltaY;
-    const vpt = canvas.viewportTransform;
-    canvas.lastPosY = opt.clientY;
+// for mac trackpad
+export const onGesture = (event) => {
+    event.preventDefault();
 
-    vpt[5] -= delta;
-    canvas.lastPosY -= delta;
-    canvas.setViewportTransform(vpt);
+    const canvas = globalThis.canvas;
+    const vpt = canvas.viewportTransform;
+
+    if (event.type === "gesturestart") {
+        canvas.lastPosX = event.screenX;
+        canvas.lastPosY = event.screenY;
+    }
+
+    if (event.type === "gesturechange") {
+        vpt[4] -= event.screenX;
+        vpt[5] -= event.screenY;
+
+        canvas.lastPosX -= event.screenX;
+        canvas.lastPosY -= event.screenY;
+
+        currentScale = Math.min(Math.max(minScale, event.scale * zoomScale), maxScale);
+        canvas.zoomToPoint({ x: canvas.width / 2, y: canvas.height / 2 }, currentScale);
+        constrainBoundsAroundBgImage(canvas);
+        redraw(canvas);
+    }
+
+    zoomScale = currentScale;
+    canvas.setViewportTransform(canvas.viewportTransform);
     constrainBoundsAroundBgImage(canvas);
     redraw(canvas);
 };

--- a/ts/image-occlusion/tools/tool-zoom.ts
+++ b/ts/image-occlusion/tools/tool-zoom.ts
@@ -176,8 +176,11 @@ export const constrainBoundsAroundBgImage = (canvas: fabric.Canvas) => {
 };
 
 export const setCanvasSize = (canvas: fabric.Canvas) => {
-    canvas.setHeight(window.innerHeight - 76);
-    canvas.setWidth(window.innerWidth - 39);
+    const width = window.innerWidth - 39;
+    let height = window.innerHeight;
+    height = isMobile() ? height - 46 : height - 76;
+    canvas.setHeight(height);
+    canvas.setWidth(width);
     redraw(canvas);
 };
 
@@ -205,8 +208,13 @@ const fitCanvasVptScale = (canvas: fabric.Canvas) => {
 const getScaleRatio = (boundingBox: fabric.Rect) => {
     const h1 = boundingBox.height;
     const w1 = boundingBox.width;
-    const h2 = innerHeight - 79;
     const w2 = innerWidth - 42;
-
+    let h2 = window.innerHeight;
+    h2 = isMobile() ? h2 - 48 : h2 - 79;
     return Math.min(w2 / w1, h2 / h1);
+};
+
+const isMobile = () => {
+    // mobile class is added to IO Page, so we can use it to check if the page is being viewed on a mobile device
+    return document.querySelector(".mobile") ? true : false;
 };

--- a/ts/image-occlusion/tools/tool-zoom.ts
+++ b/ts/image-occlusion/tools/tool-zoom.ts
@@ -174,37 +174,6 @@ export const onWheelDrag = (canvas: fabric.Canvas, event: WheelEvent) => {
     redraw(canvas);
 };
 
-// for mac trackpad
-export const onGesture = (event) => {
-    event.preventDefault();
-
-    const canvas = globalThis.canvas;
-    const vpt = canvas.viewportTransform;
-
-    if (event.type === "gesturestart") {
-        canvas.lastPosX = event.screenX;
-        canvas.lastPosY = event.screenY;
-    }
-
-    if (event.type === "gesturechange") {
-        vpt[4] -= event.screenX;
-        vpt[5] -= event.screenY;
-
-        canvas.lastPosX -= event.screenX;
-        canvas.lastPosY -= event.screenY;
-
-        currentScale = Math.min(Math.max(minScale, event.scale * zoomScale), maxScale);
-        canvas.zoomToPoint({ x: canvas.width / 2, y: canvas.height / 2 }, currentScale);
-        constrainBoundsAroundBgImage(canvas);
-        redraw(canvas);
-    }
-
-    zoomScale = currentScale;
-    canvas.setViewportTransform(canvas.viewportTransform);
-    constrainBoundsAroundBgImage(canvas);
-    redraw(canvas);
-};
-
 const onMouseUp = () => {
     isDragging = false;
     const canvas = globalThis.canvas;

--- a/ts/image-occlusion/tools/tool-zoom.ts
+++ b/ts/image-occlusion/tools/tool-zoom.ts
@@ -4,6 +4,7 @@
 // https://codepen.io/amsunny/pen/XWGLxye
 // canvas.viewportTransform = [ scaleX, skewX, skewY, scaleY, translateX, translateY ]
 
+import { isDesktop } from "@tslib/platform";
 import type { fabric } from "fabric";
 import Hammer from "hammerjs";
 
@@ -231,7 +232,7 @@ export const constrainBoundsAroundBgImage = (canvas: fabric.Canvas) => {
 export const setCanvasSize = (canvas: fabric.Canvas) => {
     const width = window.innerWidth - 39;
     let height = window.innerHeight;
-    height = isMobile() ? height - 46 : height - 76;
+    height = isDesktop() ? height - 76 : height - 46;
     canvas.setHeight(height);
     canvas.setWidth(width);
     redraw(canvas);
@@ -263,11 +264,6 @@ const getScaleRatio = (boundingBox: fabric.Rect) => {
     const w1 = boundingBox.width;
     const w2 = innerWidth - 42;
     let h2 = window.innerHeight;
-    h2 = isMobile() ? h2 - 48 : h2 - 79;
+    h2 = isDesktop() ? h2 - 79 : h2 - 48;
     return Math.min(w2 / w1, h2 / h1);
-};
-
-const isMobile = () => {
-    // mobile class is added to IO Page, so we can use it to check if the page is being viewed on a mobile device
-    return document.querySelector(".mobile") ? true : false;
 };

--- a/ts/image-occlusion/tools/tool-zoom.ts
+++ b/ts/image-occlusion/tools/tool-zoom.ts
@@ -47,9 +47,15 @@ export const zoomOut = (canvas): void => {
 };
 
 export const zoomReset = (canvas: fabric.Canvas): void => {
-    canvas.zoomToPoint({ x: canvas.width / 2, y: canvas.height / 2 }, 1);
+    zoomResetInner(canvas);
+    // reset again to update the viewportTransform
+    zoomResetInner(canvas);
+};
+
+const zoomResetInner = (canvas: fabric.Canvas): void => {
     fitCanvasVptScale(canvas);
-    constrainBoundsAroundBgImage(canvas);
+    const vpt = canvas.viewportTransform;
+    canvas.zoomToPoint({ x: canvas.width / 2, y: canvas.height / 2 }, vpt[0]);
 };
 
 export const enablePinchZoom = (canvas: fabric.Canvas) => {
@@ -74,8 +80,7 @@ export const disablePinchZoom = (canvas: fabric.Canvas) => {
 
 export const onResize = (canvas: fabric.Canvas) => {
     setCanvasSize(canvas);
-    constrainBoundsAroundBgImage(canvas);
-    fitCanvasVptScale(canvas);
+    zoomReset(canvas);
 };
 
 const onMouseWheel = (opt) => {
@@ -147,6 +152,30 @@ const onDrag = (canvas, opt) => {
     vpt[5] += clientY - canvas.lastPosY;
     canvas.lastPosX = clientX;
     canvas.lastPosY = clientY;
+    constrainBoundsAroundBgImage(canvas);
+    redraw(canvas);
+};
+
+export const onDragX = (canvas: fabric.Canvas, opt: WheelEvent) => {
+    const delta = opt.deltaX;
+    const vpt = canvas.viewportTransform;
+    canvas.lastPosX = opt.clientX;
+
+    vpt[4] -= delta;
+    canvas.lastPosX -= delta;
+    canvas.setViewportTransform(vpt);
+    constrainBoundsAroundBgImage(canvas);
+    redraw(canvas);
+};
+
+export const onDragY = (canvas: fabric.Canvas, opt: WheelEvent) => {
+    const delta = opt.deltaY;
+    const vpt = canvas.viewportTransform;
+    canvas.lastPosY = opt.clientY;
+
+    vpt[5] -= delta;
+    canvas.lastPosY -= delta;
+    canvas.setViewportTransform(vpt);
     constrainBoundsAroundBgImage(canvas);
     redraw(canvas);
 };


### PR DESCRIPTION
After pan/zoom the shape tools are not working, so the issue is fixed in this PR. Also removed bottom toolbar for more editing area in mobile devices.

In Android/iOS, the JS function can be called to add notes.

```js
const mode = imageOcclusion.mode;
imageOcclusion.addNote(mode);
```
Additional Context
https://github.com/ankidroid/Anki-Android/issues/15838