### PR TITLE
Adding a note to the import options to indicate that leech and marked tags will be removed if disabled

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -163,6 +163,7 @@ Antonio Cavallo <a.cavallo@cavallinux.eu>
 Han Yeong-woo <han@yeongwoo.dev>
 Jean Khawand <jk@jeankhawand.com>
 Foxy_null <https://github.com/Foxy-null>
+Arbyste <arbyste@outlook.com>
 ********************
 
 The text of the 3 clause BSD license follows:

--- a/ftl/core/importing.ftl
+++ b/ftl/core/importing.ftl
@@ -58,7 +58,8 @@ importing-with-deck-configs = Import any deck presets
 importing-updates = Updates
 importing-include-reviews-help =
     If enabled, any previous reviews that the deck sharer included will also be imported.
-    Otherwise, all cards will be imported as new cards.
+    Otherwise, all cards will be imported as new cards, and any "leech" or "marked"
+    tags will be removed.
 importing-with-deck-configs-help =
     If enabled, any deck options that the deck sharer included will also be imported.
     Otherwise, all decks will be assigned the default preset.


### PR DESCRIPTION
When importing a deck with "Import any learning progress" disabled, "leech" and "marked" tags are removed from the imported notes. This pull request adds this information to the info tooltip.