### PR TITLE
qt/aqt/__init__.py: Skip GL library workaround for FreeBSD

### DIFF
--- a/qt/aqt/__init__.py
+++ b/qt/aqt/__init__.py
@@ -414,7 +414,7 @@ def setupGL(pm: aqt.profiles.ProfileManager) -> None:
     driver_failed = False
 
     # work around pyqt loading wrong GL library
-    if is_lin:
+    if is_lin and not sys.platform.startswith("freebsd"):
         import ctypes
 
         ctypes.CDLL("libGL.so.1", ctypes.RTLD_GLOBAL)


### PR DESCRIPTION
The workaround to load explicitly "libGL.so.1" isn't required for FreeBSD and leads to segmentation faults if used in environments that have nVidia drivers loaded.

See also FreeBSD bug 270778 for further details. [1]

[1] https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=270778