### PR TITLE
speed up computing optimal retention

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1792,9 +1792,9 @@ dependencies = [
 
 [[package]]
 name = "fsrs"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50f8d2ba5394c6e36fa01d88df181206bcae8b7a4ef3c5653eb4d635e3f595e4"
+checksum = "8eca50c5f619d6fe0e00962be6f68bf45d67de2fa211a12645882619f5900ff3"
 dependencies = [
  "burn",
  "itertools 0.12.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ git = "https://github.com/ankitects/linkcheck.git"
 rev = "184b2ca50ed39ca43da13f0b830a463861adb9ca"
 
 [workspace.dependencies.fsrs]
-version = "0.5.3"
+version = "0.5.4"
 # git = "https://github.com/open-spaced-repetition/fsrs-rs.git"
 # rev = "58ca25ed2bc4bb1dc376208bbcaed7f5a501b941"
 # path = "../open-spaced-repetition/fsrs-rs"


### PR DESCRIPTION
I promise this PR is the last one related FSRS-rs before the release of Anki 24.04.

- https://github.com/open-spaced-repetition/fsrs-rs/pull/168

Before this PR, it costs ~47s to compute optimal retention when `Days to simulate` is 3650. Now it is ~36s. It's nearly 24% faster than the previous one.