### PR TITLE
Feat/fsrs simulator backend part

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1792,9 +1792,9 @@ dependencies = [
 
 [[package]]
 name = "fsrs"
-version = "0.5.4"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eca50c5f619d6fe0e00962be6f68bf45d67de2fa211a12645882619f5900ff3"
+checksum = "84a04c31041078628c5ce7310be96c987bf7f33a3f8815fa0fcdb084eb31feba"
 dependencies = [
  "burn",
  "itertools 0.12.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ git = "https://github.com/ankitects/linkcheck.git"
 rev = "184b2ca50ed39ca43da13f0b830a463861adb9ca"
 
 [workspace.dependencies.fsrs]
-version = "0.5.4"
+version = "0.5.5"
 # git = "https://github.com/open-spaced-repetition/fsrs-rs.git"
 # rev = "58ca25ed2bc4bb1dc376208bbcaed7f5a501b941"
 # path = "../open-spaced-repetition/fsrs-rs"

--- a/cargo/licenses.json
+++ b/cargo/licenses.json
@@ -1198,7 +1198,7 @@
   },
   {
     "name": "fsrs",
-    "version": "0.5.4",
+    "version": "0.5.5",
     "authors": "Open Spaced Repetition",
     "repository": "https://github.com/open-spaced-repetition/fsrs-rs",
     "license": "BSD-3-Clause",

--- a/proto/anki/scheduler.proto
+++ b/proto/anki/scheduler.proto
@@ -375,12 +375,13 @@ message FsrsReview {
 
 message SimulateFsrsReviewRequest {
   repeated float weights = 1;
-  uint32 deck_size = 2;
-  uint32 days_to_simulate = 3;
-  uint32 new_limit = 4;
-  uint32 review_limit = 5;
-  uint32 max_interval = 6;
-  string search = 7;
+  float desired_retention = 2;
+  uint32 deck_size = 3;
+  uint32 days_to_simulate = 4;
+  uint32 new_limit = 5;
+  uint32 review_limit = 6;
+  uint32 max_interval = 7;
+  string search = 8;
 }
 
 message SimulateFsrsReviewResponse {

--- a/proto/anki/scheduler.proto
+++ b/proto/anki/scheduler.proto
@@ -51,6 +51,8 @@ service SchedulerService {
       returns (GetOptimalRetentionParametersResponse);
   rpc ComputeOptimalRetention(ComputeOptimalRetentionRequest)
       returns (ComputeOptimalRetentionResponse);
+  rpc SimulateFsrsReview(SimulateFsrsReviewRequest)
+      returns (SimulateFsrsReviewResponse);
   rpc EvaluateWeights(EvaluateWeightsRequest) returns (EvaluateWeightsResponse);
   rpc ComputeMemoryState(cards.CardId) returns (ComputeMemoryStateResponse);
   // The number of days the calculated interval was fuzzed by on the previous
@@ -369,6 +371,23 @@ message FsrsItem {
 message FsrsReview {
   uint32 rating = 1;
   uint32 delta_t = 2;
+}
+
+message SimulateFsrsReviewRequest {
+  repeated float weights = 1;
+  uint32 deck_size = 2;
+  uint32 days_to_simulate = 3;
+  uint32 new_limit = 4;
+  uint32 review_limit = 5;
+  uint32 max_interval = 6;
+  string search = 7;
+}
+
+message SimulateFsrsReviewResponse {
+  repeated float accumulated_knowledge_acquisition = 1;
+  repeated uint32 daily_review_count = 2;
+  repeated uint32 daily_new_count = 3;
+  repeated float daily_time_cost = 4;
 }
 
 message ComputeOptimalRetentionRequest {

--- a/rslib/src/scheduler/fsrs/mod.rs
+++ b/rslib/src/scheduler/fsrs/mod.rs
@@ -3,5 +3,6 @@
 mod error;
 pub mod memory_state;
 pub mod retention;
+pub mod simulator;
 pub mod try_collect;
 pub mod weights;

--- a/rslib/src/scheduler/fsrs/retention.rs
+++ b/rslib/src/scheduler/fsrs/retention.rs
@@ -8,7 +8,8 @@ use fsrs::FSRS;
 use itertools::Itertools;
 
 use crate::prelude::*;
-use crate::revlog::{RevlogEntry, RevlogReviewKind};
+use crate::revlog::RevlogEntry;
+use crate::revlog::RevlogReviewKind;
 use crate::search::SortMode;
 
 #[derive(Default, Clone, Copy, Debug)]

--- a/rslib/src/scheduler/fsrs/retention.rs
+++ b/rslib/src/scheduler/fsrs/retention.rs
@@ -8,7 +8,7 @@ use fsrs::FSRS;
 use itertools::Itertools;
 
 use crate::prelude::*;
-use crate::revlog::RevlogReviewKind;
+use crate::revlog::{RevlogEntry, RevlogReviewKind};
 use crate::search::SortMode;
 
 #[derive(Default, Clone, Copy, Debug)]
@@ -27,7 +27,12 @@ impl Collection {
         if req.days_to_simulate == 0 {
             invalid_input!("no days to simulate")
         }
-        let p = self.get_optimal_retention_parameters(&req.search)?;
+        let revlogs = self
+            .search_cards_into_table(&req.search, SortMode::NoOrder)?
+            .col
+            .storage
+            .get_revlog_entries_for_searched_cards_in_card_order()?;
+        let p = self.get_optimal_retention_parameters(revlogs)?;
         let learn_span = req.days_to_simulate as usize;
         let learn_limit = 10;
         let deck_size = learn_span * learn_limit;
@@ -71,13 +76,8 @@ impl Collection {
 
     pub fn get_optimal_retention_parameters(
         &mut self,
-        search: &str,
+        revlogs: Vec<RevlogEntry>,
     ) -> Result<OptimalRetentionParameters> {
-        let revlogs = self
-            .search_cards_into_table(search, SortMode::NoOrder)?
-            .col
-            .storage
-            .get_revlog_entries_for_searched_cards_in_card_order()?;
         let first_rating_count = revlogs
             .iter()
             .group_by(|r| r.cid)

--- a/rslib/src/scheduler/fsrs/simulator.rs
+++ b/rslib/src/scheduler/fsrs/simulator.rs
@@ -1,3 +1,6 @@
+// Copyright: Ankitects Pty Ltd and contributors
+// License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
+
 use anki_proto::scheduler::SimulateFsrsReviewRequest;
 use anki_proto::scheduler::SimulateFsrsReviewResponse;
 use fsrs::simulate;

--- a/rslib/src/scheduler/fsrs/simulator.rs
+++ b/rslib/src/scheduler/fsrs/simulator.rs
@@ -1,6 +1,7 @@
 use anki_proto::scheduler::SimulateFsrsReviewRequest;
 use anki_proto::scheduler::SimulateFsrsReviewResponse;
-use fsrs::{simulate, SimulatorConfig};
+use fsrs::simulate;
+use fsrs::SimulatorConfig;
 use itertools::Itertools;
 
 use crate::prelude::*;

--- a/rslib/src/scheduler/fsrs/simulator.rs
+++ b/rslib/src/scheduler/fsrs/simulator.rs
@@ -11,7 +11,6 @@ impl Collection {
         req: SimulateFsrsReviewRequest,
     ) -> Result<SimulateFsrsReviewResponse> {
         let p = self.get_optimal_retention_parameters(&req.search)?;
-        let desired_retention = 0.9;
         let config = SimulatorConfig {
             deck_size: req.deck_size as usize,
             learn_span: req.days_to_simulate as usize,
@@ -43,7 +42,7 @@ impl Collection {
         ) = simulate(
             &config,
             &req.weights.iter().map(|w| *w as f64).collect_vec(),
-            desired_retention,
+            req.desired_retention as f64,
             None,
             None, // TODO: query cards reviewed in the deck and convert them into fsrs::Card
         );

--- a/rslib/src/scheduler/fsrs/simulator.rs
+++ b/rslib/src/scheduler/fsrs/simulator.rs
@@ -1,6 +1,6 @@
 use anki_proto::scheduler::SimulateFsrsReviewRequest;
 use anki_proto::scheduler::SimulateFsrsReviewResponse;
-use fsrs::{SimulatorConfig,simulate};
+use fsrs::{simulate, SimulatorConfig};
 use itertools::Itertools;
 
 use crate::prelude::*;

--- a/rslib/src/scheduler/fsrs/simulator.rs
+++ b/rslib/src/scheduler/fsrs/simulator.rs
@@ -1,0 +1,60 @@
+use anki_proto::scheduler::SimulateFsrsReviewRequest;
+use anki_proto::scheduler::SimulateFsrsReviewResponse;
+use fsrs::{SimulatorConfig,simulate};
+use itertools::Itertools;
+
+use crate::prelude::*;
+
+impl Collection {
+    pub fn simulate_review(
+        &mut self,
+        req: SimulateFsrsReviewRequest,
+    ) -> Result<SimulateFsrsReviewResponse> {
+        let p = self.get_optimal_retention_parameters(&req.search)?;
+        let desired_retention = 0.9;
+        let config = SimulatorConfig {
+            deck_size: req.deck_size as usize,
+            learn_span: req.days_to_simulate as usize,
+            max_cost_perday: f64::MAX,
+            max_ivl: req.max_interval as f64,
+            recall_costs: [p.recall_secs_hard, p.recall_secs_good, p.recall_secs_easy],
+            forget_cost: p.forget_secs,
+            learn_cost: p.learn_secs,
+            first_rating_prob: [
+                p.first_rating_probability_again,
+                p.first_rating_probability_hard,
+                p.first_rating_probability_good,
+                p.first_rating_probability_easy,
+            ],
+            review_rating_prob: [
+                p.review_rating_probability_hard,
+                p.review_rating_probability_good,
+                p.review_rating_probability_easy,
+            ],
+            loss_aversion: 1.0,
+            learn_limit: req.new_limit as usize,
+            review_limit: req.review_limit as usize,
+        };
+        let (
+            accumulated_knowledge_acquisition,
+            daily_review_count,
+            daily_new_count,
+            daily_time_cost,
+        ) = simulate(
+            &config,
+            &req.weights.iter().map(|w| *w as f64).collect_vec(),
+            desired_retention,
+            None,
+            None, // TODO: query cards reviewed in the deck and convert them into fsrs::Card
+        );
+        Ok(SimulateFsrsReviewResponse {
+            accumulated_knowledge_acquisition: accumulated_knowledge_acquisition
+                .iter()
+                .map(|x| *x as f32)
+                .collect_vec(),
+            daily_review_count: daily_review_count.iter().map(|x| *x as u32).collect_vec(),
+            daily_new_count: daily_new_count.iter().map(|x| *x as u32).collect_vec(),
+            daily_time_cost: daily_time_cost.iter().map(|x| *x as f32).collect_vec(),
+        })
+    }
+}

--- a/rslib/src/scheduler/service/mod.rs
+++ b/rslib/src/scheduler/service/mod.rs
@@ -26,6 +26,7 @@ use crate::prelude::*;
 use crate::scheduler::new::NewCardDueOrder;
 use crate::scheduler::states::CardState;
 use crate::scheduler::states::SchedulingStates;
+use crate::search::SortMode;
 use crate::stats::studied_today;
 
 impl crate::services::SchedulerService for Collection {
@@ -301,7 +302,12 @@ impl crate::services::SchedulerService for Collection {
         &mut self,
         input: scheduler::GetOptimalRetentionParametersRequest,
     ) -> Result<scheduler::GetOptimalRetentionParametersResponse> {
-        self.get_optimal_retention_parameters(&input.search)
+        let revlogs = self
+            .search_cards_into_table(&input.search, SortMode::NoOrder)?
+            .col
+            .storage
+            .get_revlog_entries_for_searched_cards_in_card_order()?;
+        self.get_optimal_retention_parameters(revlogs)
             .map(|params| GetOptimalRetentionParametersResponse {
                 params: Some(params),
             })

--- a/rslib/src/scheduler/service/mod.rs
+++ b/rslib/src/scheduler/service/mod.rs
@@ -15,6 +15,8 @@ use anki_proto::scheduler::FsrsBenchmarkResponse;
 use anki_proto::scheduler::FuzzDeltaRequest;
 use anki_proto::scheduler::FuzzDeltaResponse;
 use anki_proto::scheduler::GetOptimalRetentionParametersResponse;
+use anki_proto::scheduler::SimulateFsrsReviewRequest;
+use anki_proto::scheduler::SimulateFsrsReviewResponse;
 use fsrs::FSRSItem;
 use fsrs::FSRSReview;
 use fsrs::FSRS;
@@ -262,6 +264,13 @@ impl crate::services::SchedulerService for Collection {
             1,
             &input.current_weights,
         )
+    }
+
+    fn simulate_fsrs_review(
+        &mut self,
+        input: SimulateFsrsReviewRequest,
+    ) -> Result<SimulateFsrsReviewResponse> {
+        self.simulate_review(input)
     }
 
     fn compute_optimal_retention(


### PR DESCRIPTION
Related issues:
- https://github.com/open-spaced-repetition/fsrs4anki-helper/issues/322
- https://github.com/ankitects/anki/issues/3046

I plan to implement FSRS simulator. It will provide similar functionality of [Anki Simulator Add-on](https://ankiweb.net/shared/info/817108664).

The next steps:
- GUI design
  - The GUI of Anki Simulator Add-on is too complicated. To keep it simple, we'd better to query the most inputs from the settings and stats.
  - The graph of simulation result will plot the daily count of new cards and review cards. Maybe it should also display the cumulative memorized knowledge and daily workload (time) if the user want to know.
- option to simulate with existing cards

But I'm not good at frontend programming. Help wanted.