### PR TITLE
fix: custom study today's new/review card limit

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -165,6 +165,7 @@ Jean Khawand <jk@jeankhawand.com>
 Pedro Schreiber <schreiber.mmb@gmail.com>
 Foxy_null <https://github.com/Foxy-null>
 Arbyste <arbyste@outlook.com>
+Nandoka <nandoka1957@gmail.com>
 ********************
 
 The text of the 3 clause BSD license follows:

--- a/proto/anki/scheduler.proto
+++ b/proto/anki/scheduler.proto
@@ -330,6 +330,8 @@ message CustomStudyDefaultsResponse {
   // in v3, counts for children are provided separately
   uint32 available_new_in_children = 6;
   uint32 available_review_in_children = 7;
+  uint32 review_count = 8;
+  uint32 new_count = 9;
 }
 
 message RepositionDefaultsResponse {

--- a/qt/aqt/customstudy.py
+++ b/qt/aqt/customstudy.py
@@ -150,9 +150,39 @@ class CustomStudy(QDialog):
     def accept(self) -> None:
         request = CustomStudyRequest(deck_id=self.deck_id)
         if self.radioIdx == RADIO_NEW:
-            request.new_limit_delta = self.form.spin.value()
+            new_limit_delta = self.form.spin.value()
+            remaining_new = (
+                self.defaults.available_new
+                + self.defaults.available_new_in_children
+                - self.defaults.new_count
+            )
+
+            if new_limit_delta == 0:
+                request.new_limit_delta = 0
+            elif new_limit_delta >= remaining_new:
+                request.new_limit_delta = remaining_new
+            elif -new_limit_delta >= self.defaults.new_count:
+                request.new_limit_delta = -self.defaults.new_count
+            else:
+                request.new_limit_delta = new_limit_delta
+
         elif self.radioIdx == RADIO_REV:
-            request.review_limit_delta = self.form.spin.value()
+            review_limit_delta = self.form.spin.value()
+            remaining_review = (
+                self.defaults.available_review
+                + self.defaults.available_review_in_children
+                - self.defaults.review_count
+            )
+
+            if review_limit_delta == 0:
+                request.review_limit_delta = 0
+            elif review_limit_delta >= remaining_review:
+                request.review_limit_delta = remaining_review
+            elif -review_limit_delta >= self.defaults.review_count:
+                request.review_limit_delta = -self.defaults.review_count
+            else:
+                request.review_limit_delta = review_limit_delta
+
         elif self.radioIdx == RADIO_FORGOT:
             request.forgot_days = self.form.spin.value()
         elif self.radioIdx == RADIO_AHEAD:

--- a/rslib/src/scheduler/filtered/custom_study.rs
+++ b/rslib/src/scheduler/filtered/custom_study.rs
@@ -83,6 +83,8 @@ impl Collection {
                 }
             })
             .collect();
+        let review_count: u32 = subtree.review_count;
+        let new_count: u32 = subtree.new_count;
 
         Ok(anki_proto::scheduler::CustomStudyDefaultsResponse {
             tags,
@@ -92,6 +94,8 @@ impl Collection {
             available_review,
             available_new_in_children,
             available_review_in_children,
+            review_count,
+            new_count,
         })
     }
 }


### PR DESCRIPTION
* fix: "Increase today's new/review card limit: don't increase/decrease more than what's enough.
* add: `new_count` and `new_review` fields to `scheduler.proto`, so it is available by a custom study request by default.

Increasing/decreasing the spin of "increase today's new/review limit by" by more than the current available cards (e. g. 99999) consecutively will cause the review limit of the deck to be too large or too negative, causing the next custom study review/new limits to not correctly adjust for smaller cards when decreasing or increasing.

It's essentially possible to create an integer overflow/underflow as per the lack of checking in `review_limit` at `limits.rs`.