### PR TITLE
better pan zoom with space for drag, shift for horizontal scroll and ctrl for zoom

### DIFF
--- a/ts/image-occlusion/Toolbar.svelte
+++ b/ts/image-occlusion/Toolbar.svelte
@@ -32,7 +32,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     import { drawCursor } from "./tools/tool-cursor";
     import { removeUnfinishedPolygon } from "./tools/tool-polygon";
     import { undoRedoTools, undoStack } from "./tools/tool-undo-redo";
-    import { disableZoom, enableZoom, onWheelDrag } from "./tools/tool-zoom";
+    import { disablePan, disableZoom, enablePan, enableZoom, onWheelDrag, onWheelDragX } from "./tools/tool-zoom";
 
     export let canvas;
     export let iconSize;
@@ -51,56 +51,63 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     });
 
     // handle zoom event when mouse scroll and ctrl key are hold for panzoom
-    let clicked = false;
+    let spaceClicked = false;
+    let controlClicked = false;
+    let shiftClicked = false;
     let dbclicked = false;
     let move = false;
     let wheel = false;
-    const controlKey = isApplePlatform() ? "Shift" : "Control";
+    const spaceKey = " ";
+    const controlKey = "Control";
+    const shiftKey = "Shift";
 
     onMount(() => {
         window.addEventListener("mousedown", (event) => {
-            if (event.ctrlKey) {
-                clicked = true;
+            if (event.key === spaceKey) {
+                spaceClicked = true;
             }
-        });
-        window.addEventListener("mouseup", (event) => {
-            if (event.ctrlKey) {
-                clicked = false;
-            }
-        });
-        window.addEventListener("mousemove", (event) => {
-            if (event.ctrlKey) {
+            if (event.which === 2) {
                 move = true;
             }
         });
-        window.addEventListener("wheel", (event) => {
-            if (event.ctrlKey) {
-                wheel = true;
+        window.addEventListener("mousemove", () => {
+            if (spaceClicked || move) {
+                stopDraw(canvas);
+                enablePan(canvas);
             }
         });
-        window.addEventListener("dblclick", (event) => {
-            if (event.ctrlKey) {
-                dbclicked = true;
+        window.addEventListener("mouseup", () => {
+            if (spaceClicked) {
+                spaceClicked = false;
+            }
+            if (move) {
+                move = false;
+                disableFunctions();
+                handleToolChanges(activeTool);
             }
         });
         window.addEventListener("keyup", (event) => {
-            if (event.key === controlKey) {
-                clicked = false;
+            if (event.key === spaceKey || event.key === controlKey || event.key === shiftKey) {
+                spaceClicked = false;
+                controlClicked = false;
+                shiftClicked = false;
                 move = false;
                 wheel = false;
                 dbclicked = false;
+
+                disableFunctions();
+                handleToolChanges(activeTool);
             }
         });
         window.addEventListener("keydown", (event) => {
-            if (event.key === controlKey) {
-                stopDraw(canvas);
-                enableZoom(canvas);
+            if (event.key === spaceKey) {
+                spaceClicked = true;
             }
-        });
-        window.addEventListener("keyup", (event) => {
             if (event.key === controlKey) {
-                disableFunctions();
-                handleToolChanges(activeTool);
+                controlClicked = true;
+            }
+            if (event.key === shiftKey) {
+                shiftClicked = true;
             }
         });
         window.addEventListener(
@@ -108,10 +115,16 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
             (event) => {
                 event.preventDefault();
 
-                if (clicked && move && wheel && !dbclicked) {
+                if (controlClicked) {
                     stopDraw(canvas);
                     enableZoom(canvas);
                 }
+
+                if (shiftClicked) {
+                    onWheelDragX(canvas, event);
+                    return;
+                }
+
                 onWheelDrag(canvas, event);
             },
             { passive: false },
@@ -119,7 +132,6 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     });
 
     const handleToolChanges = (activeTool: string) => {
-        disableFunctions();
         enableSelectable(canvas, true);
         // remove unfinished polygon when switching to other tools
         removeUnfinishedPolygon(canvas);
@@ -153,6 +165,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     const disableFunctions = () => {
         stopDraw(canvas);
         disableZoom(canvas);
+        disablePan(canvas);
     };
 
     function changeOcclusionType(occlusionType: "all" | "one"): void {

--- a/ts/image-occlusion/Toolbar.svelte
+++ b/ts/image-occlusion/Toolbar.svelte
@@ -85,9 +85,9 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
             }
             if (move) {
                 move = false;
-                disableFunctions();
-                handleToolChanges(activeTool);
             }
+            disableFunctions();
+            handleToolChanges(activeTool);
         });
         window.addEventListener("keyup", (event) => {
             if (

--- a/ts/image-occlusion/Toolbar.svelte
+++ b/ts/image-occlusion/Toolbar.svelte
@@ -5,7 +5,6 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 <script lang="ts">
     import { directionKey } from "@tslib/context-keys";
     import * as tr from "@tslib/ftl";
-    import { isApplePlatform } from "@tslib/platform";
     import { getPlatformString } from "@tslib/shortcuts";
     import DropdownItem from "components/DropdownItem.svelte";
     import IconButton from "components/IconButton.svelte";
@@ -32,7 +31,14 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     import { drawCursor } from "./tools/tool-cursor";
     import { removeUnfinishedPolygon } from "./tools/tool-polygon";
     import { undoRedoTools, undoStack } from "./tools/tool-undo-redo";
-    import { disablePan, disableZoom, enablePan, enableZoom, onWheelDrag, onWheelDragX } from "./tools/tool-zoom";
+    import {
+        disablePan,
+        disableZoom,
+        enablePan,
+        enableZoom,
+        onWheelDrag,
+        onWheelDragX,
+    } from "./tools/tool-zoom";
 
     export let canvas;
     export let iconSize;
@@ -54,19 +60,20 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     let spaceClicked = false;
     let controlClicked = false;
     let shiftClicked = false;
-    let dbclicked = false;
     let move = false;
-    let wheel = false;
     const spaceKey = " ";
     const controlKey = "Control";
     const shiftKey = "Shift";
 
     onMount(() => {
         window.addEventListener("mousedown", (event) => {
-            if (event.key === spaceKey) {
-                spaceClicked = true;
-            }
-            if (event.which === 2) {
+            window.addEventListener("keydown", (ev) => {
+                if (ev.key === spaceKey) {
+                    spaceClicked = true;
+                }
+            });
+            // middle mouse button
+            if (event.button === 1) {
                 move = true;
             }
         });
@@ -87,13 +94,15 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
             }
         });
         window.addEventListener("keyup", (event) => {
-            if (event.key === spaceKey || event.key === controlKey || event.key === shiftKey) {
+            if (
+                event.key === spaceKey ||
+                event.key === controlKey ||
+                event.key === shiftKey
+            ) {
                 spaceClicked = false;
                 controlClicked = false;
                 shiftClicked = false;
                 move = false;
-                wheel = false;
-                dbclicked = false;
 
                 disableFunctions();
                 handleToolChanges(activeTool);
@@ -110,6 +119,14 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
                 shiftClicked = true;
             }
         });
+        window.addEventListener("wheel", (event) => {
+            if (event.ctrlKey) {
+                controlClicked = true;
+            }
+            if (event.shiftKey) {
+                shiftClicked = true;
+            }
+        });
         window.addEventListener(
             "wheel",
             (event) => {
@@ -118,6 +135,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
                 if (controlClicked) {
                     stopDraw(canvas);
                     enableZoom(canvas);
+                    return;
                 }
 
                 if (shiftClicked) {

--- a/ts/image-occlusion/Toolbar.svelte
+++ b/ts/image-occlusion/Toolbar.svelte
@@ -66,20 +66,16 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     const shiftKey = "Shift";
 
     onMount(() => {
-        window.addEventListener("mousedown", (event) => {
+        window.addEventListener("mousedown", () => {
             window.addEventListener("keydown", (ev) => {
                 if (ev.key === spaceKey) {
                     spaceClicked = true;
                 }
             });
-            // middle mouse button
-            if (event.button === 1) {
-                move = true;
-            }
         });
         window.addEventListener("mousemove", () => {
             if (spaceClicked || move) {
-                stopDraw(canvas);
+                disableFunctions();
                 enablePan(canvas);
             }
         });
@@ -133,7 +129,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
                 event.preventDefault();
 
                 if (controlClicked) {
-                    stopDraw(canvas);
+                    disableFunctions();
                     enableZoom(canvas);
                     return;
                 }
@@ -150,6 +146,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     });
 
     const handleToolChanges = (activeTool: string) => {
+        disableFunctions();
         enableSelectable(canvas, true);
         // remove unfinished polygon when switching to other tools
         removeUnfinishedPolygon(canvas);

--- a/ts/image-occlusion/mask-editor.ts
+++ b/ts/image-occlusion/mask-editor.ts
@@ -86,9 +86,7 @@ export const setupMaskEditorForEdit = async (
 };
 
 function initCanvas(onChange: () => void): fabric.Canvas {
-    const canvas = new fabric.Canvas("canvas", {
-        fireMiddleClick: true,
-    });
+    const canvas = new fabric.Canvas("canvas");
     tagsWritable.set([]);
     globalThis.canvas = canvas;
     undoStack.setCanvas(canvas);

--- a/ts/image-occlusion/mask-editor.ts
+++ b/ts/image-occlusion/mask-editor.ts
@@ -86,7 +86,9 @@ export const setupMaskEditorForEdit = async (
 };
 
 function initCanvas(onChange: () => void): fabric.Canvas {
-    const canvas = new fabric.Canvas("canvas");
+    const canvas = new fabric.Canvas("canvas", {
+        fireMiddleClick: true,
+    });
     tagsWritable.set([]);
     globalThis.canvas = canvas;
     undoStack.setCanvas(canvas);

--- a/ts/image-occlusion/tools/tool-zoom.ts
+++ b/ts/image-occlusion/tools/tool-zoom.ts
@@ -124,6 +124,12 @@ export const onMouseMove = (opt) => {
         return;
     }
 
+    // initializes lastPosX and lastPosY because it is undefined before the first mousemove event
+    if (canvas.lastPosX === undefined || canvas.lastPosY === undefined) {
+        canvas.lastPosX = opt.e.clientX;
+        canvas.lastPosY = opt.e.clientY;
+    }
+
     onDrag(canvas, opt);
 };
 

--- a/ts/image-occlusion/tools/tool-zoom.ts
+++ b/ts/image-occlusion/tools/tool-zoom.ts
@@ -124,12 +124,6 @@ export const onMouseMove = (opt) => {
         return;
     }
 
-    // initializes lastPosX and lastPosY because it is undefined before the first mousemove event
-    if (canvas.lastPosX === undefined || canvas.lastPosY === undefined) {
-        canvas.lastPosX = opt.e.clientX;
-        canvas.lastPosY = opt.e.clientY;
-    }
-
     onDrag(canvas, opt);
 };
 
@@ -138,6 +132,17 @@ document.addEventListener("touchstart", (e) => {
     const canvas = globalThis.canvas;
     canvas.lastPosX = e.touches[0].clientX;
     canvas.lastPosY = e.touches[0].clientY;
+});
+
+// initializes lastPosX and lastPosY because it is undefined before mousemove event
+document.addEventListener("mousemove", (event) => {
+    document.addEventListener("keydown", (e) => {
+        if (e.key === " ") {
+            const canvas = globalThis.canvas;
+            canvas.lastPosX = event.clientX;
+            canvas.lastPosY = event.clientY;
+        }
+    });
 });
 
 export const onPinchZoom = (opt): boolean => {
@@ -158,8 +163,8 @@ const onDrag = (canvas, opt) => {
 
     vpt[4] += clientX - canvas.lastPosX;
     vpt[5] += clientY - canvas.lastPosY;
-    canvas.lastPosX = clientX;
-    canvas.lastPosY = clientY;
+    canvas.lastPosX += clientX - canvas.lastPosX;
+    canvas.lastPosY += clientY - canvas.lastPosY;
     constrainBoundsAroundBgImage(canvas);
     redraw(canvas);
 };

--- a/ts/image-occlusion/tools/tool-zoom.ts
+++ b/ts/image-occlusion/tools/tool-zoom.ts
@@ -10,8 +10,6 @@ import Hammer from "hammerjs";
 
 import { getBoundingBox, redraw } from "./lib";
 
-let isDragging = false;
-
 const minScale = 0.5;
 const maxScale = 5;
 let zoomScale = 1;
@@ -19,6 +17,9 @@ export let currentScale = 1;
 
 export const enableZoom = (canvas: fabric.Canvas) => {
     canvas.on("mouse:wheel", onMouseWheel);
+};
+
+export const enablePan = (canvas: fabric.Canvas) => {
     canvas.on("mouse:down", onMouseDown);
     canvas.on("mouse:move", onMouseMove);
     canvas.on("mouse:up", onMouseUp);
@@ -26,6 +27,9 @@ export const enableZoom = (canvas: fabric.Canvas) => {
 
 export const disableZoom = (canvas: fabric.Canvas) => {
     canvas.off("mouse:wheel", onMouseWheel);
+};
+
+export const disablePan = (canvas: fabric.Canvas) => {
     canvas.off("mouse:down", onMouseDown);
     canvas.off("mouse:move", onMouseMove);
     canvas.off("mouse:up", onMouseUp);
@@ -98,7 +102,6 @@ const onMouseWheel = (opt) => {
 };
 
 const onMouseDown = (opt) => {
-    isDragging = true;
     const canvas = globalThis.canvas;
     canvas.discardActiveObject();
     const { e } = opt;
@@ -111,19 +114,17 @@ const onMouseDown = (opt) => {
 
 export const onMouseMove = (opt) => {
     const canvas = globalThis.canvas;
-    if (isDragging) {
-        canvas.discardActiveObject();
-        if (!canvas.viewportTransform) {
-            return;
-        }
-
-        // handle pinch zoom and pan for mobile devices
-        if (onPinchZoom(opt)) {
-            return;
-        }
-
-        onDrag(canvas, opt);
+    canvas.discardActiveObject();
+    if (!canvas.viewportTransform) {
+        return;
     }
+
+    // handle pinch zoom and pan for mobile devices
+    if (onPinchZoom(opt)) {
+        return;
+    }
+
+    onDrag(canvas, opt);
 };
 
 // initializes lastPosX and lastPosY because it is undefined in touchmove event
@@ -174,8 +175,18 @@ export const onWheelDrag = (canvas: fabric.Canvas, event: WheelEvent) => {
     redraw(canvas);
 };
 
+export const onWheelDragX = (canvas: fabric.Canvas, event: WheelEvent) => {
+    const delta = event.deltaY;
+    const vpt = canvas.viewportTransform;
+    canvas.lastPosY = event.clientY;
+    vpt[4] -= delta;
+    canvas.lastPosX -= delta;
+    canvas.setViewportTransform(vpt);
+    constrainBoundsAroundBgImage(canvas);
+    redraw(canvas);
+};
+
 const onMouseUp = () => {
-    isDragging = false;
     const canvas = globalThis.canvas;
     canvas.setViewportTransform(canvas.viewportTransform);
     constrainBoundsAroundBgImage(canvas);


### PR DESCRIPTION
> Some more thoughts regarding a potential follow-up:
>
> Regarding panning: Using different bindings across different platforms is reasonable workaround, but could be confusing to users and I think we should avoid it if we can.
>
> Another approach could be to either go with holding the middle mouse button or right mouse button to drag. This seems to be a common pattern in drawing apps (e.g. Inkscape, Krita, various websites). Another common assignment seems to be Space + LMB drag (Krita, Illustrator).
>
> RMB-dragging seems like it could be annoying and cause ambiguity with context menu bindings. My personal preference would be to go the [Krita way](https://docs.krita.org/en/reference_manual/tools/pan.html) and implement both MMB drag and Space + LMB drag. That should give users an option they will likely be familiar with, regardless of which other app they came from - and also one that works for all mouses.
>
> Finally, a nice to have would be to have the mouse pointer switch to a grabbing state while panning is active.
>
> Regarding zooming: If the panning situation is resolved, I would recommend to universally go with Ctrl+Wheel on all platforms
>
> Regarding scrolling: Similarly, I would suggest to switch the horizontal scroll binding to Shift+Wheel, as that seems to be the more common convention (Inkscape, Chrome, etc.).

https://github.com/ankitects/anki/pull/3066#pullrequestreview-1940796645