### PR TITLE
sync-server: add option to store hashed passwords

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -166,6 +166,7 @@ Pedro Schreiber <schreiber.mmb@gmail.com>
 Foxy_null <https://github.com/Foxy-null>
 Arbyste <arbyste@outlook.com>
 Vasll <github.com/vasll>
+laalsaas <laalsaas@systemli.org>
 ********************
 
 The text of the 3 clause BSD license follows:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -132,6 +132,7 @@ dependencies = [
  "num_cpus",
  "num_enum",
  "once_cell",
+ "pbkdf2 0.12.2",
  "percent-encoding-iri",
  "phf 0.11.2",
  "pin-project",
@@ -3700,6 +3701,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "password-hash"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
+dependencies = [
+ "base64ct",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
 name = "paste"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3719,7 +3731,19 @@ checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
 dependencies = [
  "digest",
  "hmac",
- "password-hash",
+ "password-hash 0.4.2",
+ "sha2",
+]
+
+[[package]]
+name = "pbkdf2"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
+dependencies = [
+ "digest",
+ "hmac",
+ "password-hash 0.5.0",
  "sha2",
 ]
 
@@ -6881,7 +6905,7 @@ dependencies = [
  "crossbeam-utils",
  "flate2",
  "hmac",
- "pbkdf2",
+ "pbkdf2 0.11.0",
  "sha1",
  "time",
  "zstd 0.11.2+zstd.1.5.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,6 +96,7 @@ num-format = "0.4.4"
 num_cpus = "1.16.0"
 num_enum = "0.7.2"
 once_cell = "1.19.0"
+pbkdf2 = { version = "0.12", features = ["simple"] }
 phf = { version = "0.11.2", features = ["macros"] }
 pin-project = "1.1.4"
 plist = "1.5.1"

--- a/cargo/licenses.json
+++ b/cargo/licenses.json
@@ -2511,6 +2511,15 @@
     "description": "Traits which describe the functionality of password hashing algorithms, as well as a `no_std`-friendly implementation of the PHC string format (a well-defined subset of the Modular Crypt Format a.k.a. MCF)"
   },
   {
+    "name": "password-hash",
+    "version": "0.5.0",
+    "authors": "RustCrypto Developers",
+    "repository": "https://github.com/RustCrypto/traits/tree/master/password-hash",
+    "license": "Apache-2.0 OR MIT",
+    "license_file": null,
+    "description": "Traits which describe the functionality of password hashing algorithms, as well as a `no_std`-friendly implementation of the PHC string format (a well-defined subset of the Modular Crypt Format a.k.a. MCF)"
+  },
+  {
     "name": "paste",
     "version": "1.0.14",
     "authors": "David Tolnay <dtolnay@gmail.com>",
@@ -2522,6 +2531,15 @@
   {
     "name": "pbkdf2",
     "version": "0.11.0",
+    "authors": "RustCrypto Developers",
+    "repository": "https://github.com/RustCrypto/password-hashes/tree/master/pbkdf2",
+    "license": "Apache-2.0 OR MIT",
+    "license_file": null,
+    "description": "Generic implementation of PBKDF2"
+  },
+  {
+    "name": "pbkdf2",
+    "version": "0.12.2",
     "authors": "RustCrypto Developers",
     "repository": "https://github.com/RustCrypto/password-hashes/tree/master/pbkdf2",
     "license": "Apache-2.0 OR MIT",

--- a/rslib/Cargo.toml
+++ b/rslib/Cargo.toml
@@ -73,6 +73,7 @@ nom.workspace = true
 num_cpus.workspace = true
 num_enum.workspace = true
 once_cell.workspace = true
+pbkdf2.workspace = true
 percent-encoding-iri.workspace = true
 phf.workspace = true
 pin-project.workspace = true

--- a/rslib/src/sync/http_server/user.rs
+++ b/rslib/src/sync/http_server/user.rs
@@ -15,6 +15,7 @@ use crate::sync::http_server::media_manager::ServerMediaManager;
 
 pub(in crate::sync) struct User {
     pub name: String,
+    pub password_hash: String,
     pub col: Option<Collection>,
     pub sync_state: Option<ServerSyncState>,
     pub media: ServerMediaManager,


### PR DESCRIPTION
Storing passwords in cleartext is immoral, and because I don't want to do that I wrote this PR.

I don't know rust very well, so please have a thorough look through my code and tell me if there are ways that are more rust-idiomatic.

Also, I'm willing to write tests/docs as soon as it's clear this goes in the right direction, but maybe I'll need some guidance for this.