### PR TITLE
Reset original id when cloning notetypes

### DIFF
--- a/pylib/anki/models.py
+++ b/pylib/anki/models.py
@@ -259,6 +259,7 @@ class ModelManager(DeprecatedNamesMixin):
             self.col.tr.notetypes_copy(val=cloned["name"])
         )
         cloned["id"] = 0
+        cloned["originalId"] = None
         if add:
             self.add(cloned)
         return cloned


### PR DESCRIPTION
https://forums.ankiweb.net/t/merge-note-types-on-import-bug/42686

The fix is trivial, but I'm unsure what to do about collections that contain those bad original ids now. 😕 
Do you have an idea? Should merged notetypes be listed so users at least can revert the import? Should there even be an option to reset a given original id?