### PR TITLE
Fix summary string for notes failed to be imported

### DIFF
--- a/ftl/core/importing.ftl
+++ b/ftl/core/importing.ftl
@@ -170,6 +170,11 @@ importing-existing-notes-skipped =
         [one] { $count } note already present in your collection.
        *[other] { $count } notes already present in your collection.
     }
+importing-notes-failed =
+    { $count ->
+        [one] { $count } note could not be imported.
+        *[other] { $count } notes could not be imported.
+    }
 importing-conflicting-notes-skipped =
     { $count ->
         [one] { $count } note was not imported, because its note type has changed.
@@ -194,6 +199,7 @@ importing-duplicate-note-added = Duplicate note added
 importing-added-new-note = New note added
 importing-existing-note-skipped = Note skipped, as an up-to-date copy is already in your collection
 importing-note-skipped-update-due-to-notetype = Note not updated, as notetype has been modified since you first imported the note
+importing-note-skipped-update-due-to-notetype2 = Note not updated, as notetype has been modified since you first imported the note, and '{ importing-merge-notetypes }' was not enabled
 importing-note-updated-as-file-had-newer = Note updated, as file had newer version
 importing-note-skipped-due-to-missing-notetype = Note skipped, as its notetype was missing
 importing-note-skipped-due-to-missing-deck = Note skipped, as its deck was missing

--- a/ts/import-page/lib.ts
+++ b/ts/import-page/lib.ts
@@ -74,7 +74,7 @@ export function getSummaries(log: ImportResponse_Log): SummarizedLogQueues[] {
             queues: [
                 {
                     notes: log.conflicting,
-                    reason: tr.importingNoteSkippedUpdateDueToNotetype(),
+                    reason: tr.importingNoteSkippedUpdateDueToNotetype2(),
                 },
                 {
                     notes: log.missingNotetype,
@@ -90,7 +90,7 @@ export function getSummaries(log: ImportResponse_Log): SummarizedLogQueues[] {
                 },
             ],
             action: tr.importingSkipped(),
-            summaryTemplate: tr.importingConflictingNotesSkipped2,
+            summaryTemplate: tr.importingNotesFailed,
             canBrowse: false,
             icon: closeBox,
         },


### PR DESCRIPTION
https://forums.ankiweb.net/t/bug-csv-import-error-bc-merge-notetype-disabled/40644

This makes the summary string more generic, and moves the part concerning notetype merging into the tooltip for actually affected notes.