### PR TITLE
Replace deprecated method `chrono::NaiveDateTime::timestamp_millis`

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -167,6 +167,7 @@ Foxy_null <https://github.com/Foxy-null>
 Arbyste <arbyste@outlook.com>
 Vasll <github.com/vasll>
 laalsaas <laalsaas@systemli.org>
+ijqq <ijqq@protonmail.ch>
 ********************
 
 The text of the 3 clause BSD license follows:

--- a/rslib/src/scheduler/fsrs/weights.rs
+++ b/rslib/src/scheduler/fsrs/weights.rs
@@ -36,6 +36,7 @@ fn ignore_revlogs_before_date_to_ms(
         s => NaiveDate::parse_from_str(s.as_str(), "%Y-%m-%d")
             .or_else(|err| invalid_input!(err, "Error parsing date: {s}"))?
             .and_time(NaiveTime::from_hms_milli_opt(0, 0, 0, 0).unwrap())
+            .and_utc()
             .timestamp_millis(),
     }
     .into())


### PR DESCRIPTION
I was trying to include rslib in my project and while building it gave this warning:
```
warning: use of deprecated method `chrono::NaiveDateTime::timestamp_millis`: use `.and_utc().timestamp_millis()` instead
  --> ..rslib/src/scheduler/fsrs/weights.rs:39:14
   |
39 |             .timestamp_millis(),
   |              ^^^^^^^^^^^^^^^^
   |
   = note: `#[warn(deprecated)]` on by default
```
