### PR TITLE
Use "importing-added" string in importing detail table

### DIFF
--- a/pylib/anki/importing/anki2.py
+++ b/pylib/anki/importing/anki2.py
@@ -177,7 +177,7 @@ class Anki2Importer(Importer):
                 self._logNoteRow(self.dst.tr.importing_updated(), row)
         if add:
             for row in add:
-                self._logNoteRow(self.dst.tr.adding_added(), row)
+                self._logNoteRow(self.dst.tr.importing_added(), row)
         if dupesIdentical:
             for row in dupesIdentical:
                 self._logNoteRow(self.dst.tr.importing_identical(), row)


### PR DESCRIPTION
Supplement to the task of the commit 184ad80 (Clone "added" string for importing)

Currently, for the "Added" as an importing status in the table in the "Import File" window, `adding-added` string seems to be used, as before.

This commit is intended to fix it, that is, to use `importing-added` string for the status text.