### PR TITLE
Corrected minor non-idiomatic snippet of code

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -169,6 +169,7 @@ Vasll <github.com/vasll>
 laalsaas <laalsaas@systemli.org>
 ijqq <ijqq@protonmail.ch>
 AntoineQ1 <https://github.com/AntoineQ1>
+jthulhu <https://github.com/jthulhu>
 ********************
 
 The text of the 3 clause BSD license follows:

--- a/rslib/process/src/lib.rs
+++ b/rslib/process/src/lib.rs
@@ -2,6 +2,7 @@
 // License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
 use std::ffi::OsStr;
+use std::iter::once;
 use std::process::Command;
 use std::string::FromUtf8Error;
 
@@ -96,8 +97,7 @@ impl CommandExt for Command {
 }
 
 fn get_cmdline(arg: &mut Command) -> String {
-    [arg.get_program().to_string_lossy()]
-        .into_iter()
+    once(arg.get_program().to_string_lossy())
         .chain(arg.get_args().map(|arg| arg.to_string_lossy()))
         .join(" ")
 }


### PR DESCRIPTION
Creating an array with a single iterator just for the purpose of iterating over it can be achieved more clearly by using the standard library function `once` which serves exactly the same purpose.