### PR TITLE
Fix IO mask position slightly off in edit mode

### DIFF
--- a/ts/routes/image-occlusion/tools/from-shapes.ts
+++ b/ts/routes/image-occlusion/tools/from-shapes.ts
@@ -11,7 +11,7 @@ export const addShape = (
     boundingBox: fabric.Rect,
     shape: Shape,
 ): void => {
-    const fabricShape = shape.toFabric(boundingBox.getBoundingRect());
+    const fabricShape = shape.toFabric(boundingBox.getBoundingRect(true));
     addBorder(fabricShape);
     if (fabricShape.type === "i-text") {
         enableUniformScaling(canvas, fabricShape);
@@ -26,7 +26,7 @@ export const addShapeGroup = (
 ): void => {
     const group = new fabric.Group();
     shapes.map((shape) => {
-        const fabricShape = shape.toFabric(boundingBox.getBoundingRect());
+        const fabricShape = shape.toFabric(boundingBox.getBoundingRect(true));
         addBorder(fabricShape);
         group.addWithUpdate(fabricShape);
     });


### PR DESCRIPTION
I was looking into #2986 again and noticed all shapes suffer from a positioning issue (probably introduced after the recent zoom changes).

## How to reproduce

1.  Add a new note with a mask
![image](https://github.com/ankitects/anki/assets/41397710/760beb0f-679f-45cc-af84-066763bc50a0)
2. Edit the note and notice the position of the mask
![image](https://github.com/ankitects/anki/assets/41397710/53ee6609-3099-4d8a-bdd4-8f85f9f541aa)

## Reference

http://fabricjs.com/docs/fabric.Object.html#getBoundingRect