### PR TITLE
Update deck-config.ftl to clarify what optimal retention means

### DIFF
--- a/ftl/core/deck-config.ftl
+++ b/ftl/core/deck-config.ftl
@@ -343,7 +343,7 @@ deck-config-must-have-400-reviews =
 # Numbers that control how aggressively the FSRS algorithm schedules cards
 deck-config-weights = FSRS parameters
 deck-config-compute-optimal-weights = Optimize FSRS parameters
-deck-config-compute-optimal-retention = Compute minimum recommended retention
+deck-config-compute-minimum-recommended-retention = Compute minimum recommended retention
 deck-config-optimize-button = Optimize
 deck-config-compute-button = Compute
 deck-config-ignore-before = Ignore reviews before
@@ -357,7 +357,7 @@ deck-config-get-params = Get Params
 deck-config-fsrs-on-all-clients =
     Please ensure all of your Anki clients are Anki(Mobile) 23.10+ or AnkiDroid 2.17+. FSRS will
     not work correctly if one of your clients is older.
-deck-config-predicted-optimal-retention = Minimum recommended retention: { $num }
+deck-config-predicted-minimum-recommended-retention = Minimum recommended retention: { $num }
 deck-config-complete = { $num }% complete.
 deck-config-iterations = Iteration: { $count }...
 deck-config-reschedule-cards-on-change = Reschedule cards on change
@@ -473,3 +473,6 @@ deck-config-compute-optimal-retention-tooltip =
     if it significantly differs from 0.9, it's a sign that the time you've allocated each day is either too low
     or too high for the amount of cards you're trying to learn. This number can be useful as a reference, but it
     is not recommended to copy it into the desired retention field.
+
+deck-config-compute-optimal-retention = Compute minimum recommended retention
+deck-config-predicted-optimal-retention = Minimum recommended retention: { $num }

--- a/ftl/core/deck-config.ftl
+++ b/ftl/core/deck-config.ftl
@@ -357,7 +357,7 @@ deck-config-get-params = Get Params
 deck-config-fsrs-on-all-clients =
     Please ensure all of your Anki clients are Anki(Mobile) 23.10+ or AnkiDroid 2.17+. FSRS will
     not work correctly if one of your clients is older.
-deck-config-predicted-optimal-retention = Predicted minimum recommended retention: { $num }
+deck-config-predicted-optimal-retention = Minimum recommended retention: { $num }
 deck-config-complete = { $num }% complete.
 deck-config-iterations = Iteration: { $count }...
 deck-config-reschedule-cards-on-change = Reschedule cards on change

--- a/ftl/core/deck-config.ftl
+++ b/ftl/core/deck-config.ftl
@@ -334,7 +334,7 @@ deck-config-updating-cards = Updating cards: { $current_cards_count }/{ $total_c
 deck-config-invalid-weights = Parameters must be either left blank to use the defaults, or must be 17 comma-separated numbers.
 deck-config-not-enough-history = Insufficient review history to perform this operation.
 deck-config-unable-to-determine-desired-retention =
-    Unable to determine an optimal retention.
+    Unable to determine a minimum recommended retention.
 deck-config-must-have-400-reviews =
     { $count ->
         [one] Only { $count } review was found.
@@ -343,7 +343,7 @@ deck-config-must-have-400-reviews =
 # Numbers that control how aggressively the FSRS algorithm schedules cards
 deck-config-weights = FSRS parameters
 deck-config-compute-optimal-weights = Optimize FSRS parameters
-deck-config-compute-optimal-retention = Compute optimal retention
+deck-config-compute-optimal-retention = Compute minimum recommended retention
 deck-config-optimize-button = Optimize
 deck-config-compute-button = Compute
 deck-config-ignore-before = Ignore reviews before
@@ -357,7 +357,7 @@ deck-config-get-params = Get Params
 deck-config-fsrs-on-all-clients =
     Please ensure all of your Anki clients are Anki(Mobile) 23.10+ or AnkiDroid 2.17+. FSRS will
     not work correctly if one of your clients is older.
-deck-config-predicted-optimal-retention = Predicted optimal retention: { $num }
+deck-config-predicted-optimal-retention = Predicted minimum recommended retention: { $num }
 deck-config-complete = { $num }% complete.
 deck-config-iterations = Iteration: { $count }...
 deck-config-reschedule-cards-on-change = Reschedule cards on change

--- a/ftl/core/deck-config.ftl
+++ b/ftl/core/deck-config.ftl
@@ -343,7 +343,7 @@ deck-config-must-have-400-reviews =
 # Numbers that control how aggressively the FSRS algorithm schedules cards
 deck-config-weights = FSRS parameters
 deck-config-compute-optimal-weights = Optimize FSRS parameters
-deck-config-compute-minimum-recommended-retention = Compute minimum recommended retention
+deck-config-compute-minimum-recommended-retention = Minimum recommended retention
 deck-config-optimize-button = Optimize
 deck-config-compute-button = Compute
 deck-config-ignore-before = Ignore reviews before


### PR DESCRIPTION
Renaming “Optimal retention” to “Minimum recommended retention".
_Currently, only the text has been changed, not the variables (e.g. "deck-config-compute-optimal-retention")._

Resolves #3118.