### PR TITLE
Return current weights if fsrs items is zero & handle error in evaluation and optimal retention

### DIFF
--- a/rslib/src/scheduler/fsrs/weights.rs
+++ b/rslib/src/scheduler/fsrs/weights.rs
@@ -162,9 +162,6 @@ impl Collection {
             .get_revlog_entries_for_searched_cards_in_card_order()?;
         let (items, review_count) =
             fsrs_items_for_training(revlogs, timing.next_day_at, ignore_revlogs_before);
-        if items.is_empty() {
-            return Err(AnkiError::FsrsInsufficientData);
-        }
         anki_progress.state.reviews = review_count as u32;
         let fsrs = FSRS::new(Some(weights))?;
         Ok(fsrs.evaluate(items, |ip| {

--- a/rslib/src/scheduler/fsrs/weights.rs
+++ b/rslib/src/scheduler/fsrs/weights.rs
@@ -162,6 +162,9 @@ impl Collection {
             .get_revlog_entries_for_searched_cards_in_card_order()?;
         let (items, review_count) =
             fsrs_items_for_training(revlogs, timing.next_day_at, ignore_revlogs_before);
+        if items.is_empty() {
+            return Err(AnkiError::FsrsInsufficientData);
+        }
         anki_progress.state.reviews = review_count as u32;
         let fsrs = FSRS::new(Some(weights))?;
         Ok(fsrs.evaluate(items, |ip| {

--- a/rslib/src/scheduler/fsrs/weights.rs
+++ b/rslib/src/scheduler/fsrs/weights.rs
@@ -65,6 +65,12 @@ impl Collection {
             fsrs_items_for_training(revlogs.clone(), timing.next_day_at, ignore_revlogs_before);
 
         let fsrs_items = items.len() as u32;
+        if fsrs_items == 0 {
+            return Ok(ComputeFsrsWeightsResponse {
+                weights: current_weights.to_vec(),
+                fsrs_items,
+            });
+        }
         anki_progress.update(false, |p| {
             p.current_preset = current_preset;
             p.total_presets = total_presets;

--- a/ts/routes/deck-options/FsrsOptions.svelte
+++ b/ts/routes/deck-options/FsrsOptions.svelte
@@ -219,8 +219,6 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
                     }
                 },
             );
-        } catch (err) {
-            // TODO: handle error
         } finally {
             computingRetention = false;
         }

--- a/ts/routes/deck-options/FsrsOptions.svelte
+++ b/ts/routes/deck-options/FsrsOptions.svelte
@@ -219,6 +219,8 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
                     }
                 },
             );
+        } catch (err) {
+            // TODO: handle error
         } finally {
             computingRetention = false;
         }

--- a/ts/routes/deck-options/FsrsOptions.svelte
+++ b/ts/routes/deck-options/FsrsOptions.svelte
@@ -185,8 +185,6 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
                     }
                 },
             );
-        } catch (err) {
-            alert(tr.deckConfigNotEnoughHistory());
         } finally {
             checkingWeights = false;
         }

--- a/ts/routes/deck-options/FsrsOptions.svelte
+++ b/ts/routes/deck-options/FsrsOptions.svelte
@@ -185,6 +185,8 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
                     }
                 },
             );
+        } catch (err) {
+            alert(tr.deckConfigNotEnoughHistory());
         } finally {
             checkingWeights = false;
         }


### PR DESCRIPTION
Related discussion: https://forums.ankiweb.net/t/anki-24-04-2-beta/43562/8?u=l.m.sherlock

I don't know why the error isn't handled like Anki 24.04.1:

<img width="773" alt="image" src="https://github.com/ankitects/anki/assets/32575846/9c1322d8-b1a3-4c19-8d58-06348d11f853">

So I handle it in the `.svelte` file. I'm not sure it is a right way to handle it. Please feel free to modify it.