### PR TITLE
Avoid locale.getdefaultlocale() if possible

### DIFF
--- a/pylib/anki/lang.py
+++ b/pylib/anki/lang.py
@@ -183,6 +183,8 @@ def get_def_lang(lang: str | None = None) -> tuple[int, str]:
     or English if not available."""
     try:
         (sys_lang, enc) = locale.getdefaultlocale()
+    except AttributeError:
+        (sys_lang, enc) = locale.getlocale()
     except:
         # fails on osx
         sys_lang = "en_US"

--- a/pylib/anki/lang.py
+++ b/pylib/anki/lang.py
@@ -183,6 +183,7 @@ def get_def_lang(lang: str | None = None) -> tuple[int, str]:
     """Return lang converted to name used on disk and its index, defaulting to system language
     or English if not available."""
     try:
+        # getdefaultlocale() is deprecated since Python 3.11 but we need to keep using it due to a bug: https://bugs.python.org/issue38805
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", DeprecationWarning)
             (sys_lang, enc) = locale.getdefaultlocale()

--- a/pylib/anki/lang.py
+++ b/pylib/anki/lang.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import locale
 import re
+import warnings
 import weakref
 from typing import TYPE_CHECKING, Any
 
@@ -182,7 +183,9 @@ def get_def_lang(lang: str | None = None) -> tuple[int, str]:
     """Return lang converted to name used on disk and its index, defaulting to system language
     or English if not available."""
     try:
-        (sys_lang, enc) = locale.getdefaultlocale()
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            (sys_lang, enc) = locale.getdefaultlocale()
     except AttributeError:
         (sys_lang, enc) = locale.getlocale()
     except:

--- a/pylib/anki/lang.py
+++ b/pylib/anki/lang.py
@@ -183,11 +183,13 @@ def get_def_lang(lang: str | None = None) -> tuple[int, str]:
     """Return lang converted to name used on disk and its index, defaulting to system language
     or English if not available."""
     try:
-        # getdefaultlocale() is deprecated since Python 3.11 but we need to keep using it due to a bug: https://bugs.python.org/issue38805
+        # getdefaultlocale() is deprecated since Python 3.11, but we need to keep using it as getlocale() behaves differently: https://bugs.python.org/issue38805
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", DeprecationWarning)
             (sys_lang, enc) = locale.getdefaultlocale()
     except AttributeError:
+        # this will return a different format on Windows (e.g. Italian_Italy), resulting in us falling back to en_US
+        # further below
         (sys_lang, enc) = locale.getlocale()
     except:
         # fails on osx


### PR DESCRIPTION
Closes #3115

locale.getlocale() returns "English_United States" as the language code on my system: https://bugs.python.org/issue38805

This PR falls back to locale.getlocale() when locale.getdefaultlocale() is not available.