### PR TITLE
HMR on Windows

### DIFF
--- a/.vscode.dist/launch.json
+++ b/.vscode.dist/launch.json
@@ -6,9 +6,13 @@
     "configurations": [
         {
             "name": "Run",
-            "type": "python",
+            "type": "debugpy",
             "request": "launch",
             "program": "tools/run.py",
+            "args": [
+                // "-p",
+                // "My test profile"
+            ],
             "console": "integratedTerminal",
             "cwd": "${workspaceFolder}",
             "python": "${workspaceFolder}/out/pyenv/bin/python",
@@ -20,7 +24,12 @@
                 "PYTHONPYCACHEPREFIX": "out/pycache",
                 "ANKIDEV": "1",
                 "QTWEBENGINE_REMOTE_DEBUGGING": "8080",
-                "QTWEBENGINE_CHROMIUM_FLAGS": "--remote-allow-origins=http://localhost:8080"
+                "QTWEBENGINE_CHROMIUM_FLAGS": "--remote-allow-origins=http://localhost:8080",
+                "RUST_BACKTRACE": "1",
+                // "TRACESQL": "1",
+                // "HMR": "1",
+                "ANKI_API_PORT": "40000",
+                "ANKI_API_HOST": "127.0.0.1"
             },
             "justMyCode": true,
             "preLaunchTask": "ninja"

--- a/.vscode.dist/tasks.json
+++ b/.vscode.dist/tasks.json
@@ -9,14 +9,8 @@
                 "qt"
             ],
             "windows": {
-                "command": "bash",
-                "options": {
-                    "env": {
-                        "PATH": "c:\\msys64\\usr\\bin;${env:Path}"
-                    }
-                },
+                "command": "tools/ninja.bat",
                 "args": [
-                    "ninja",
                     "pylib",
                     "qt",
                     "extract:win_amd64_audio"

--- a/run.bat
+++ b/run.bat
@@ -6,6 +6,8 @@ set PYTHONPYCACHEPREFIX=out\pycache
 set ANKIDEV=1
 set QTWEBENGINE_REMOTE_DEBUGGING=8080
 set QTWEBENGINE_CHROMIUM_FLAGS=--remote-allow-origins=http://localhost:8080
+set ANKI_API_PORT=40000
+set ANKI_API_HOST=127.0.0.1
 
 call tools\ninja pylib qt extract:win_amd64_audio || exit /b 1
 .\out\pyenv\scripts\python tools\run.py %* || exit /b 1

--- a/ts/vite.config.ts
+++ b/ts/vite.config.ts
@@ -29,6 +29,7 @@ export default defineConfig({
         reportCompressedSize: false,
     },
     server: {
+        host: "127.0.0.1",
         fs: {
             // Allow serving files project root and out dir
             allow: [


### PR DESCRIPTION
With 9f40f0c7034594d283a7a01b64ec9a3e48f85d28, I got HMR working in the browser. But if I understood you correctly in #3077, it should also work in Qt. There I only get `ERR_CONNECTION_REFUSED` with `HMR=1`. Did it work for you, @abdnh?
The console shows nothing. Turning off the firewall didn't make a difference.