### PR TITLE
Fix spacebar causing stutter when editing cards

### DIFF
--- a/ts/routes/image-occlusion/Toolbar.svelte
+++ b/ts/routes/image-occlusion/Toolbar.svelte
@@ -144,6 +144,22 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
             },
             { passive: false },
         );
+
+        // initializes lastPosX and lastPosY because it is undefined in touchmove event
+        document.addEventListener("touchstart", (e) => {
+            canvas.lastPosX = e.touches[0].clientX;
+            canvas.lastPosY = e.touches[0].clientY;
+        });
+
+        // initializes lastPosX and lastPosY because it is undefined before mousemove event
+        document.addEventListener("mousemove", (event) => {
+            document.addEventListener("keydown", (e) => {
+                if (e.key === " ") {
+                    canvas.lastPosX = event.clientX;
+                    canvas.lastPosY = event.clientY;
+                }
+            });
+        });
     });
 
     const handleToolChanges = (activeTool: string) => {

--- a/ts/routes/image-occlusion/Toolbar.svelte
+++ b/ts/routes/image-occlusion/Toolbar.svelte
@@ -69,14 +69,6 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         }
     }
 
-    function onMousedown() {
-        window.addEventListener("keydown", (ev) => {
-            if (ev.key === spaceKey) {
-                spaceClicked = true;
-            }
-        });
-    }
-
     function onMousemove() {
         if (spaceClicked || move) {
             disableFunctions();
@@ -155,12 +147,10 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
     // initializes lastPosX and lastPosY because it is undefined before mousemove event
     function onMousemoveDocument(event: MouseEvent) {
-        document.addEventListener("keydown", (e) => {
-            if (e.key === " ") {
-                canvas.lastPosX = event.clientX;
-                canvas.lastPosY = event.clientY;
-            }
-        });
+        if (spaceClicked) {
+            canvas.lastPosX = event.clientX;
+            canvas.lastPosY = event.clientY;
+        }
     }
 
     const handleToolChanges = (activeTool: string) => {
@@ -209,7 +199,6 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     onMount(() => {
         removeHandlers = singleCallback(
             on(document, "click", onClick),
-            on(window, "mousedown", onMousedown),
             on(window, "mousemove", onMousemove),
             on(window, "mouseup", onMouseup),
             on(window, "keyup", onKeyup),

--- a/ts/routes/image-occlusion/tools/tool-zoom.ts
+++ b/ts/routes/image-occlusion/tools/tool-zoom.ts
@@ -132,24 +132,6 @@ export const onMouseMove = (opt) => {
     onDrag(canvas, opt);
 };
 
-// initializes lastPosX and lastPosY because it is undefined in touchmove event
-document.addEventListener("touchstart", (e) => {
-    const canvas = globalThis.canvas;
-    canvas.lastPosX = e.touches[0].clientX;
-    canvas.lastPosY = e.touches[0].clientY;
-});
-
-// initializes lastPosX and lastPosY because it is undefined before mousemove event
-document.addEventListener("mousemove", (event) => {
-    document.addEventListener("keydown", (e) => {
-        if (e.key === " ") {
-            const canvas = globalThis.canvas;
-            canvas.lastPosX = event.clientX;
-            canvas.lastPosY = event.clientY;
-        }
-    });
-});
-
 export const onPinchZoom = (opt): boolean => {
     const { e } = opt;
     const canvas = globalThis.canvas;


### PR DESCRIPTION
Some image occlusion event handlers were getting triggered globally in the editor. The keydown handler is registered inside a mousemove handler, which is resulting in countless handlers.

Closes #3131

