### PR TITLE
Add minimalist mode tooltip

### DIFF
--- a/ftl/core/preferences.ftl
+++ b/ftl/core/preferences.ftl
@@ -62,6 +62,7 @@ preferences-review = Review
 preferences-answer-keys = Answer keys
 preferences-distractions = Distractions
 preferences-minimalist-mode = Minimalist mode
+preferences-minimalist-mode-tooltip = Make the interface more compact/less fancy
 preferences-editing = Editing
 preferences-browsing = Browsing
 preferences-default-deck = Default deck

--- a/qt/aqt/forms/preferences.ui
+++ b/qt/aqt/forms/preferences.ui
@@ -208,6 +208,9 @@
               <verstretch>0</verstretch>
              </sizepolicy>
             </property>
+            <property name="toolTip">
+             <string>preferences_minimalist_mode_tooltip</string>
+            </property>
             <property name="text">
              <string>preferences_minimalist_mode</string>
             </property>

--- a/qt/aqt/forms/preferences.ui
+++ b/qt/aqt/forms/preferences.ui
@@ -208,9 +208,6 @@
               <verstretch>0</verstretch>
              </sizepolicy>
             </property>
-            <property name="toolTip">
-             <string>preferences_minimalist_mode_tooltip</string>
-            </property>
             <property name="text">
              <string>preferences_minimalist_mode</string>
             </property>


### PR DESCRIPTION
Hi again,

I'm attempting to fix the build issues; not entirely sure why it keeps failing, but I will keep testing it.

I am not sure if you are accepting PRs for tooltips, but this is just a small PR to add a tooltip to the minimalist mode option in preferences.

Please let me know if there are any required changes (I hope I did it correctly).

Harvey
