### PR TITLE
Add number truncation before back-end translation

### DIFF
--- a/rslib/i18n/src/lib.rs
+++ b/rslib/i18n/src/lib.rs
@@ -482,6 +482,10 @@ mod test {
             "You have 1 hat."
         );
         assert_eq!(
+            tr.translate("plural", Some(tr_args!["hats"=>1.001])),
+            "You have 1 hat."
+        );
+        assert_eq!(
             tr.translate("plural", Some(tr_args!["hats"=>1.1])),
             "You have 1.1 hats."
         );

--- a/rslib/i18n/src/lib.rs
+++ b/rslib/i18n/src/lib.rs
@@ -231,6 +231,23 @@ impl I18n {
         }
     }
 
+    fn preprocess_translation_args(args: FluentArgs) -> FluentArgs {
+        args.into_iter()
+            .map(|(key, value)| {
+                let value = match value {
+                    FluentValue::Number(num) => {
+                        let new_value = (num.value * 100.0).trunc() / 100.0;
+
+                        FluentValue::Number(FluentNumber::new(new_value, num.options))
+                    }
+                    _ => value,
+                };
+
+                (key, value)
+            })
+            .collect()
+    }
+
     pub fn translate_via_index(
         &self,
         module_index: usize,
@@ -242,6 +259,8 @@ impl I18n {
     }
 
     fn translate<'a>(&'a self, key: &str, args: Option<FluentArgs>) -> Cow<'a, str> {
+        let args = args.map(Self::preprocess_translation_args);
+
         for bundle in &self.inner.lock().unwrap().bundles {
             let msg = match bundle.get_message(key) {
                 Some(msg) => msg,

--- a/rslib/i18n/src/lib.rs
+++ b/rslib/i18n/src/lib.rs
@@ -236,7 +236,7 @@ impl I18n {
             .map(|(key, value)| {
                 let value = match value {
                     FluentValue::Number(num) => {
-                        let new_value = (num.value * 100.0).trunc() / 100.0;
+                        let new_value = (num.value * 100.0).round() / 100.0;
 
                         FluentValue::Number(FluentNumber::new(new_value, num.options))
                     }

--- a/rslib/i18n/src/lib.rs
+++ b/rslib/i18n/src/lib.rs
@@ -483,14 +483,8 @@ mod test {
     fn decimal_rounding() {
         let tr = I18n::new(&["en"]);
 
-        assert_eq!(
-            tr.browsing_cards_deleted(1.001),
-            "1 card deleted."
-        );
-        assert_eq!(
-            tr.browsing_cards_deleted(1.01),
-            "1.01 cards deleted."
-        );
+        assert_eq!(tr.browsing_cards_deleted(1.001), "1 card deleted.");
+        assert_eq!(tr.browsing_cards_deleted(1.01), "1.01 cards deleted.");
     }
 
     #[test]

--- a/rslib/i18n/src/lib.rs
+++ b/rslib/i18n/src/lib.rs
@@ -480,6 +480,20 @@ mod test {
     }
 
     #[test]
+    fn decimal_rounding() {
+        let tr = I18n::new(&["en"]);
+
+        assert_eq!(
+            tr.browsing_cards_deleted(1.001),
+            "1 card deleted."
+        );
+        assert_eq!(
+            tr.browsing_cards_deleted(1.01),
+            "1.01 cards deleted."
+        );
+    }
+
+    #[test]
     fn i18n() {
         // English template
         let tr = I18n::new(&["zz"]);
@@ -493,10 +507,6 @@ mod test {
 
         assert_eq!(
             tr.translate("plural", Some(tr_args!["hats"=>1.0])),
-            "You have 1 hat."
-        );
-        assert_eq!(
-            tr.translate("plural", Some(tr_args!["hats"=>1.001])),
             "You have 1 hat."
         );
         assert_eq!(

--- a/rslib/i18n/write_strings.rs
+++ b/rslib/i18n/write_strings.rs
@@ -97,8 +97,7 @@ fn build_vars(translation: &Translation) -> String {
             let rust_name = v.name.to_snake_case();
             let trailer = match v.kind {
                 VariableKind::Any => "",
-                VariableKind::Int => ".into()",
-                VariableKind::Float => ".round().into()",
+                VariableKind::Int | VariableKind::Float => ".round().into()",
                 VariableKind::String => ".into()",
             };
             writeln!(

--- a/rslib/i18n/write_strings.rs
+++ b/rslib/i18n/write_strings.rs
@@ -97,7 +97,8 @@ fn build_vars(translation: &Translation) -> String {
             let rust_name = v.name.to_snake_case();
             let trailer = match v.kind {
                 VariableKind::Any => "",
-                VariableKind::Int | VariableKind::Float => ".into()",
+                VariableKind::Int => ".into()",
+                VariableKind::Float => ".round().into()",
                 VariableKind::String => ".into()",
             };
             writeln!(


### PR DESCRIPTION
Fixes #3102

When the [front-end `translate`](https://github.com/ankitects/anki/blob/839fd7bc8bcafd73aac0259d2efdc273486c6a98/ts/lib/generated/ftl-helpers.ts#L17) is called, [all numbers are truncated to 2 decimal places](https://github.com/ankitects/anki/blob/839fd7bc8bcafd73aac0259d2efdc273486c6a98/ts/lib/generated/ftl-helpers.ts#L23).
The same was not true for the back-end `translate`, which seems to be the cause of this corner-case.

It appears that the Rust implementation of Fluent doesn't automatically do the truncation (before the comparison to `[one]` in FTL) according to the FluentNumberOptions (`maximum_fraction_digits`), while the JS version does. This is why my code explicitly rounds the number, where the TS only sets `maximumFractionDigits`.