### PR TITLE
Use key instead of code in type-in field

### DIFF
--- a/ts/lib/sveltelib/input-handler.ts
+++ b/ts/lib/sveltelib/input-handler.ts
@@ -116,7 +116,7 @@ function useInputHandler(): [InputHandlerAPI, SetupInputHandlerAction] {
             specialKey.dispatch({ event, action: "caretRight" });
         } else if (isArrowLeft(event)) {
             specialKey.dispatch({ event, action: "caretLeft" });
-        } else if (event.code === "Enter" || event.code === "NumpadEnter") {
+        } else if (event.key === "Enter") {
             specialKey.dispatch({ event, action: "enter" });
         } else if (event.code === "Tab") {
             specialKey.dispatch({ event, action: "tab" });

--- a/ts/reviewer/index.ts
+++ b/ts/reviewer/index.ts
@@ -222,8 +222,8 @@ export function _drawMark(mark: boolean): void {
 }
 
 export function _typeAnsPress(): void {
-    const code = (window.event as KeyboardEvent).code;
-    if (["Enter", "NumpadEnter"].includes(code)) {
+    const key = (window.event as KeyboardEvent).key;
+    if (key === "Enter") {
         bridgeCommand("ans");
     }
 }


### PR DESCRIPTION
Closes #3069

This only switches to KeyboardEvent.key when Enter is handled to avoid any potential issues.