### PR TITLE
fix polygon tool draw

### DIFF
--- a/ts/routes/image-occlusion/Toolbar.svelte
+++ b/ts/routes/image-occlusion/Toolbar.svelte
@@ -89,8 +89,6 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         if (move) {
             move = false;
         }
-        disableFunctions();
-        handleToolChanges(activeTool);
     }
 
     function onKeyup(event: KeyboardEvent) {
@@ -230,6 +228,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
             active={activeTool === tool.id}
             on:click={() => {
                 activeTool = tool.id;
+                handleToolChanges(activeTool);
             }}
         >
             <Icon icon={tool.icon} />
@@ -239,6 +238,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
                 keyCombination={tool.shortcut}
                 on:action={() => {
                     activeTool = tool.id;
+                    handleToolChanges(activeTool);
                 }}
             />
         {/if}


### PR DESCRIPTION
> > Also, I found that the polygon  tool of image occlusion doesn’t work in in anki 24.04.1.
> 
> Originally reported on https://forums.ankiweb.net/t/is-this-bug-or-the-new-modification-in-anki-desktop/44072
> 

