### PR TITLE
add template filter "cloze-show"

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -173,6 +173,7 @@ jthulhu <https://github.com/jthulhu>
 Escape0707 <tothesong@gmail.com>
 Loudwig <https://github.com/Loudwig>
 Wu Yi-Wei <https://github.com/Ianwu0812>
+jake <https://github.com/jakeprobst>
 
 ********************
 

--- a/rslib/src/cloze.rs
+++ b/rslib/src/cloze.rs
@@ -461,13 +461,10 @@ pub(crate) fn cloze_only_filter<'a>(text: &'a str, context: &RenderContext) -> C
 }
 
 pub(crate) fn cloze_show<'a>(text: &'a str, context: &RenderContext) -> Cow<'a, str> {
-    strip_html_inside_mathjax(
-        reveal_cloze_text(text, context.card_ord + 1, false).as_ref(),
-    )
-    .into_owned()
-    .into()
+    strip_html_inside_mathjax(reveal_cloze_text(text, context.card_ord + 1, false).as_ref())
+        .into_owned()
+        .into()
 }
-
 
 #[cfg(test)]
 mod test {

--- a/rslib/src/cloze.rs
+++ b/rslib/src/cloze.rs
@@ -460,6 +460,15 @@ pub(crate) fn cloze_only_filter<'a>(text: &'a str, context: &RenderContext) -> C
     reveal_cloze_text_only(text, context.card_ord + 1, context.frontside.is_none())
 }
 
+pub(crate) fn cloze_show<'a>(text: &'a str, context: &RenderContext) -> Cow<'a, str> {
+    strip_html_inside_mathjax(
+        reveal_cloze_text(text, context.card_ord + 1, false).as_ref(),
+    )
+    .into_owned()
+    .into()
+}
+
+
 #[cfg(test)]
 mod test {
     use std::collections::HashSet;

--- a/rslib/src/template.rs
+++ b/rslib/src/template.rs
@@ -882,7 +882,11 @@ fn find_field_references<'a>(
         match node {
             ParsedNode::Text(_) => {}
             ParsedNode::Replacement { key, filters } => {
-                if !cloze_only || filters.iter().any(|f| ["cloze", "cloze-show"].iter().any(|k| k == f)) {
+                if !cloze_only
+                    || filters
+                        .iter()
+                        .any(|f| ["cloze", "cloze-show"].iter().any(|k| k == f))
+                {
                     fields.insert(key);
                 }
             }

--- a/rslib/src/template.rs
+++ b/rslib/src/template.rs
@@ -882,7 +882,7 @@ fn find_field_references<'a>(
         match node {
             ParsedNode::Text(_) => {}
             ParsedNode::Replacement { key, filters } => {
-                if !cloze_only || filters.iter().any(|f| f == "cloze") {
+                if !cloze_only || filters.iter().any(|f| ["cloze", "cloze-show"].iter().any(|k| k == f)) {
                     fields.insert(key);
                 }
             }

--- a/rslib/src/template_filters.rs
+++ b/rslib/src/template_filters.rs
@@ -10,6 +10,7 @@ use regex::Regex;
 
 use crate::cloze::cloze_filter;
 use crate::cloze::cloze_only_filter;
+use crate::cloze::cloze_show;
 use crate::template::RenderContext;
 use crate::text::strip_html;
 
@@ -83,6 +84,7 @@ fn apply_filter(
         "hint" => hint_filter(text, field_name),
         "cloze" => cloze_filter(text, context),
         "cloze-only" => cloze_only_filter(text, context),
+        "cloze-show" => cloze_show(text, context),
         // an empty filter name (caused by using two colons) is ignored
         "" => text.into(),
         _ => {


### PR DESCRIPTION
This is a feature request dressed up as a PR.

I have found that what I like about clozes is how they make creating multiple cards from a single sentence very easy.
What I don't like is how it hides the word I would like to focus on.

So I added a template filter where instead of hiding the word, it highlights it.
![cloze-show1](https://github.com/ankitects/anki/assets/226173/a8d4ec63-189d-4ee7-bf84-343db3c39848)
![cloze-show2](https://github.com/ankitects/anki/assets/226173/3018ede6-51b1-469d-b1f1-eca582522b95)
![cloze-show3](https://github.com/ankitects/anki/assets/226173/368f90fd-71a0-46bd-9858-46df4a5d68ec)

Long ago in old anki I had written an addon to do exactly this: https://ankiweb.net/shared/info/1224266113. But with how things are now it seems if I want this functionality it needs to be in anki proper.

I am very open to changing the template tag name `cloze-show` to something more fitting, but nothing has come to mind.

(I have been out of the anki-game for many years and am coming back and trying to get feature parity with how I used to do things)