### PR TITLE
Use SplashScreen flag for all aqt tooltips

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -173,6 +173,7 @@ jthulhu <https://github.com/jthulhu>
 Escape0707 <tothesong@gmail.com>
 Loudwig <https://github.com/Loudwig>
 Wu Yi-Wei <https://github.com/Ianwu0812>
+Voczi <dev@voczi.com>
 
 ********************
 

--- a/qt/aqt/utils.py
+++ b/qt/aqt/utils.py
@@ -976,7 +976,7 @@ def tooltip(
     )
     lab.setFrameStyle(QFrame.Shape.Panel)
     lab.setLineWidth(2)
-    lab.setWindowFlags(Qt.WindowType.ToolTip)
+    lab.setWindowFlags(Qt.WindowType.SplashScreen)
     if not theme_manager.night_mode:
         p = QPalette()
         p.setColor(QPalette.ColorRole.Window, QColor("#feffc4"))


### PR DESCRIPTION
Prevents tooltip from showing when parent is out of focus. Noticeable at startup with the collection sync tooltip, but also with all other tooltips. WindowType reference: https://doc.qt.io/qt-6/qt.html#WindowType-enum