### PR TITLE
Fix IO event handlers being run on normal notes

### DIFF
--- a/ts/editor/NoteEditor.svelte
+++ b/ts/editor/NoteEditor.svelte
@@ -644,8 +644,8 @@ the AddCards dialog) should be implemented in the user of this component.
         </Absolute>
     {/if}
 
-    {#if imageOcclusionMode}
-        <div style="display: {$ioMaskEditorVisible ? 'block' : 'none'}">
+    {#if $ioMaskEditorVisible && imageOcclusionMode}
+        <div>
             <ImageOcclusionPage
                 mode={imageOcclusionMode}
                 on:change={updateOcclusionsField}


### PR DESCRIPTION
Report: https://forums.ankiweb.net/t/24-04-2-beta1-browser-image-occlusion-interferes-with-scroll-wheel/44703

I tried to fix this in #3150 but the fix was not working because ImageOcclusionPage is not unmounted when switching notes.