### PR TITLE
Call profile_did_open hook at the end of loadProfile

### DIFF
--- a/qt/aqt/main.py
+++ b/qt/aqt/main.py
@@ -494,7 +494,6 @@ class AnkiQt(QMainWindow):
             else:
                 self.handleImport(self.pendingImport)
             self.pendingImport = None
-        gui_hooks.profile_did_open()
 
         def _onsuccess(synced: bool) -> None:
             if synced:
@@ -527,8 +526,8 @@ class AnkiQt(QMainWindow):
             )
 
         refresh_reviewer_on_day_rollover_change()
-
         self.maybe_auto_sync_on_open_close(_onsuccess)
+        gui_hooks.profile_did_open()
 
     def unloadProfile(self, onsuccess: Callable) -> None:
         def callback() -> None:


### PR DESCRIPTION
This is just to ensure variables such as _reviewer_refresh_timer are initialized to prevent spurious shutdown errors when some add-on throws an exception in the profile_did_open hook.