### PR TITLE
do not recreate io page when toggle button used

### DIFF
--- a/ts/editor/NoteEditor.svelte
+++ b/ts/editor/NoteEditor.svelte
@@ -633,8 +633,8 @@ the AddCards dialog) should be implemented in the user of this component.
         </Absolute>
     {/if}
 
-    {#if $ioMaskEditorVisible && imageOcclusionMode}
-        <div>
+    {#if imageOcclusionMode}
+        <div style="display: {$ioMaskEditorVisible ? 'block' : 'none'};">
             <ImageOcclusionPage
                 mode={imageOcclusionMode}
                 on:change={updateOcclusionsField}


### PR DESCRIPTION
> On 24.6 rc1, in the Add window, if you toggle the mask editor (either via the button or Ctrl+Shift+M), all the masks will be deleted.

https://forums.ankiweb.net/t/anki-24-06-release-candidate/44926/40