### PR TITLE
Fixes shift click selection after programmatic selection in most cases, Issue #2469

### DIFF
--- a/qt/aqt/browser/table/table.py
+++ b/qt/aqt/browser/table/table.py
@@ -608,7 +608,8 @@ class Table:
                 direction,
                 self.browser.mw.app.keyboardModifiers(),
             )
-        self._view.selectionModel().setCurrentIndex(
+        self._view.setCurrentIndex(index)
+        self._view.selectionModel().select(
             index,
             QItemSelectionModel.SelectionFlag.Clear
             | QItemSelectionModel.SelectionFlag.Select


### PR DESCRIPTION
Proposed fix for issue #2469

Some things I noticed while looking into this.

- Changing the selection programmatically followed by shift-click selecting is what causes the issue. 
This would happen when:
    - `<` /  `>` buttons were pushed in the preview window
    - `Shift + N` or `Shift + P` table shortcuts were used in the browser window
    - `Home` or `End` table shortcuts were used in the browser window
- Some quick googling showed that this was a common issue with Qt. I'm not sure if it is a bug with qt itself, or if there is some better/ more proper way to select items in a TableView from code.

The fix I added feels like a work-around more than a proper fix. As far as I can tell, it fixes all the mentioned scenarios.
**However**, if the user holds `Shift` while pressing the `<` or `>`  buttons in the preview window the same bug reappears.


