### PR TITLE
Fixes shift click selection after programmatic selection in most cases, Issue #2469

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -173,6 +173,7 @@ jthulhu <https://github.com/jthulhu>
 Escape0707 <tothesong@gmail.com>
 Loudwig <https://github.com/Loudwig>
 Wu Yi-Wei <https://github.com/Ianwu0812>
+RRomeroJr <117.rromero@gmail.com>
 
 
 ********************

--- a/qt/aqt/browser/table/table.py
+++ b/qt/aqt/browser/table/table.py
@@ -608,6 +608,7 @@ class Table:
                 direction,
                 self.browser.mw.app.keyboardModifiers(),
             )
+        # Setting current like this avoids a bug with shift-click selection
         self._view.setCurrentIndex(index)
         self._view.selectionModel().select(
             index,

--- a/qt/aqt/browser/table/table.py
+++ b/qt/aqt/browser/table/table.py
@@ -608,7 +608,8 @@ class Table:
                 direction,
                 self.browser.mw.app.keyboardModifiers(),
             )
-        self._view.selectionModel().setCurrentIndex(
+        self._view.setCurrentIndex(index)
+        self._view.selectionModel().select(
             index,
             QItemSelectionModel.SelectionFlag.Clear
             | QItemSelectionModel.SelectionFlag.Select

--- a/qt/aqt/browser/table/table.py
+++ b/qt/aqt/browser/table/table.py
@@ -609,6 +609,7 @@ class Table:
                 self.browser.mw.app.keyboardModifiers(),
             )
         # Setting current like this avoids a bug with shift-click selection
+        # https://github.com/ankitects/anki/issues/2469
         self._view.setCurrentIndex(index)
         self._view.selectionModel().select(
             index,


### PR DESCRIPTION
Proposed fix for issue #2469
Original thread:
https://forums.ankiweb.net/t/bug-arrow-keys-in-preview-break-shift-click-selection-in-card-browser/29282

Some things I noticed while looking into this.

- Changing the selection programmatically followed by shift-click selecting is what causes the issue. 
This would happen when:
    - `<` /  `>` buttons were clicked in the preview window
    - `Ctrl + N` or `Ctrl+ P` table shortcuts were used in the browser window
    - `Home` or `End` table shortcuts were used in the browser window
   
   Then..
   - `Shift + Left Click` selecting in the table view
- Some quick googling showed that this was a common issue with Qt, and I reproduced it in a small mockup program I made. I'm not sure if it is a bug with Qt itself, or if there is some better/ more proper way to select items in a TableView from code.

What I added feels like a work-around more than a proper fix, but, as far as I can tell, it fixes all the mentioned scenarios.

**However**, if the user holds `Shift` while clicking the `<` or `>`  buttons in the preview window the same bug reappears. I haven't been able to figure out why this still happens.