### PR TITLE
Add StartupWMClass for anki.desktop

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -173,7 +173,7 @@ jthulhu <https://github.com/jthulhu>
 Escape0707 <tothesong@gmail.com>
 Loudwig <https://github.com/Loudwig>
 Wu Yi-Wei <https://github.com/Ianwu0812>
-
+Xidorn Quan <me@upsuper.org>
 
 ********************
 

--- a/qt/bundle/lin/anki.desktop
+++ b/qt/bundle/lin/anki.desktop
@@ -13,3 +13,4 @@ MimeType=application/x-apkg;application/x-anki;application/x-ankiaddon;
 #should be removed eventually as it was upstreamed as to be an XDG specification called SingleMainWindow
 X-GNOME-SingleWindow=true
 SingleMainWindow=true
+StartupWMClass=anki


### PR DESCRIPTION
This ensures that the system can correctly assign the windows of Anki to the desktop launcher item, e.g. in Ubuntu's dock.

Before:
![image](https://github.com/upsuper-forks/anki/assets/333750/0d247443-3473-43ec-aad4-119ed5d5072c)

After:
![image](https://github.com/upsuper-forks/anki/assets/333750/8d503d1f-b2e2-4d00-951f-a4e7c02f2d57)
