### PR TITLE
Reword sync conflict explanation

### DIFF
--- a/ftl/core/sync.ftl
+++ b/ftl/core/sync.ftl
@@ -27,14 +27,14 @@ sync-resync-required = Please sync again. If this message keeps appearing, pleas
 sync-must-wait-for-end = Anki is currently syncing. Please wait for the sync to complete, then try again.
 sync-confirm-empty-download = Local collection has no cards. Download from AnkiWeb?
 sync-confirm-empty-upload = AnkiWeb collection has no cards. Replace it with local collection?
-sync-conflict-explanation =
-    Your decks here and on AnkiWeb differ in such a way that they can't be merged together, so it's necessary to overwrite the decks on one side with the decks from the other.
-    
-    If you choose download, Anki will fetch the collection from AnkiWeb, and any changes you have made on this device since the last sync will be lost.
-    
-    If you choose upload, Anki will send this device's data to AnkiWeb, and any changes that are waiting on AnkiWeb will be lost.
-    
-    After all devices are in sync, future reviews and added cards can be merged automatically.
+sync-conflict-explanation2 =
+    There is a conflict between decks on this device and AnkiWeb. You must choose which version to keep:
+
+    - Select **{ sync-download-from-ankiweb }** to replace decks here with AnkiWeb’s version. You will lose any changes you made on this device since your last sync.
+    - Select **{ sync-upload-to-ankiweb }** to overwrite AnkiWeb’s versions with decks from this device and delete any changes on AnkiWeb.
+
+    Once the conflict is resolved, syncing will work as usual.
+
 sync-ankiweb-id-label = AnkiWeb ID:
 sync-password-label = Password:
 sync-account-required =

--- a/ftl/core/sync.ftl
+++ b/ftl/core/sync.ftl
@@ -27,11 +27,19 @@ sync-resync-required = Please sync again. If this message keeps appearing, pleas
 sync-must-wait-for-end = Anki is currently syncing. Please wait for the sync to complete, then try again.
 sync-confirm-empty-download = Local collection has no cards. Download from AnkiWeb?
 sync-confirm-empty-upload = AnkiWeb collection has no cards. Replace it with local collection?
+sync-conflict-explanation =
+    Your decks here and on AnkiWeb differ in such a way that they can't be merged together, so it's necessary to overwrite the decks on one side with the decks from the other.
+    
+    If you choose download, Anki will fetch the collection from AnkiWeb, and any changes you have made on this device since the last sync will be lost.
+    
+    If you choose upload, Anki will send this device's data to AnkiWeb, and any changes that are waiting on AnkiWeb will be lost.
+    
+    After all devices are in sync, future reviews and added cards can be merged automatically.
 sync-conflict-explanation2 =
     There is a conflict between decks on this device and AnkiWeb. You must choose which version to keep:
 
     - Select **{ sync-download-from-ankiweb }** to replace decks here with AnkiWeb’s version. You will lose any changes you made on this device since your last sync.
-    - Select **{ sync-upload-to-ankiweb }** to overwrite AnkiWeb’s versions with decks from this device and delete any changes on AnkiWeb.
+    - Select **{ sync-upload-to-ankiweb }** to overwrite AnkiWeb’s versions with decks from this device, and delete any changes on AnkiWeb.
 
     Once the conflict is resolved, syncing will work as usual.
 

--- a/qt/aqt/sync.py
+++ b/qt/aqt/sync.py
@@ -157,11 +157,12 @@ def full_sync(
                 on_done()
 
         ask_user_dialog(
-            tr.sync_conflict_explanation(),
+            tr.sync_conflict_explanation2(),
             callback=callback,
             buttons=button_labels,
             default_button=2,
             parent=mw,
+            textFormat=Qt.TextFormat.MarkdownText,
         )
 
 


### PR DESCRIPTION
This PR tries to improve the wording of the sync conflict message to be like this:

![image](https://github.com/ankitects/anki/assets/41397710/92aa7ce8-ab6c-4930-8637-142a31040e49)

_Note: This is submitted on behalf of the AnkiHub team._ @andrewsanchez 