### PR TITLE
fix sveltekit respecting yarn env var

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -175,6 +175,7 @@ Loudwig <https://github.com/Loudwig>
 Wu Yi-Wei <https://github.com/Ianwu0812>
 RRomeroJr <117.rromero@gmail.com>
 Xidorn Quan <me@upsuper.org>
+Alexander Bocken <alexander@bocken.org>
 
 ********************
 

--- a/build/ninja_gen/src/node.rs
+++ b/build/ninja_gen/src/node.rs
@@ -460,7 +460,7 @@ impl BuildAction for SveltekitBuild {
             if cfg!(windows) {
                 "cmd /c yarn build"
             } else {
-                "./yarn build"
+                "$yarn build"
             }
         } else {
             "echo"
@@ -469,6 +469,7 @@ impl BuildAction for SveltekitBuild {
 
     fn files(&mut self, build: &mut impl build::FilesHandle) {
         build.add_inputs("node_modules", inputs![":node_modules"]);
+        build.add_inputs("yarn", inputs![":yarn:bin"]);
         build.add_inputs("", &self.deps);
         build.add_inputs("", inputs!["yarn.lock"]);
         build.add_output_stamp("sveltekit.marker");


### PR DESCRIPTION
With the replacement of Svelte with SvelteKit I've noticed how anki can no longer build successfully when using an the env var `YARN_BINARY`. 

Investigating a bit, I’ve noticed how in `build/ninja_gen/src/node.rs`, the function in question has `./yarn` hardcoded in as opposed to reading in the env var if appropriate.

This PR reads-in the yarn variable for `SveltekitBuild` in the same manner as it already does for the other functions.