### PR TITLE
Fix image occlusion errors in previewer and card template editor

### DIFF
--- a/qt/aqt/mediasrv.py
+++ b/qt/aqt/mediasrv.py
@@ -69,15 +69,17 @@ class NotFound:
 DynamicRequest = Callable[[], Response]
 
 
-class PageContext(enum.Enum):
-    UNKNOWN = 0
-    EDITOR = 1
-    REVIEWER = 2
+class PageContext(enum.IntEnum):
+    UNKNOWN = enum.auto()
+    EDITOR = enum.auto()
+    REVIEWER = enum.auto()
+    PREVIEWER = enum.auto()
+    CARD_LAYOUT = enum.auto()
     # something in /_anki/pages/
-    NON_LEGACY_PAGE = 3
+    NON_LEGACY_PAGE = enum.auto()
     # Do not use this if you present user content (e.g. content from cards), as it's a
     # security issue.
-    ADDON_PAGE = 4
+    ADDON_PAGE = enum.auto()
 
 
 @dataclass
@@ -693,6 +695,11 @@ def _check_dynamic_request_permissions():
         "/_anki/i18nResources",
     ):
         # reviewer is only allowed to access custom study methods
+        pass
+    elif (
+        context == PageContext.PREVIEWER or context == PageContext.CARD_LAYOUT
+    ) and request.path == "/_anki/i18nResources":
+        # previewers are only allowed to access i18n resources
         pass
     else:
         # other legacy pages may contain third-party JS, so we do not

--- a/qt/aqt/webview.py
+++ b/qt/aqt/webview.py
@@ -584,6 +584,8 @@ html {{ {font} }}
 {web_content.body}</body>
 </html>"""
         # print(html)
+        import aqt.browser.previewer
+        import aqt.clayout
         import aqt.editor
         import aqt.reviewer
         from aqt.mediasrv import PageContext
@@ -592,6 +594,10 @@ html {{ {font} }}
             page_context = PageContext.EDITOR
         elif isinstance(context, aqt.reviewer.Reviewer):
             page_context = PageContext.REVIEWER
+        elif isinstance(context, aqt.browser.previewer.Previewer):
+            page_context = PageContext.PREVIEWER
+        elif isinstance(context, aqt.clayout.CardLayout):
+            page_context = PageContext.CARD_LAYOUT
         else:
             page_context = PageContext.UNKNOWN
         self.setHtml(html, page_context)


### PR DESCRIPTION
A quick follow-up fix for IO rendering in the previewer and card layout screens, following the example of 71311f201e8c5eb6b89539b1283f655a5eec7fb8