### PR TITLE
Add option to automatically refresh card browser

### DIFF
--- a/ftl/core/preferences.ftl
+++ b/ftl/core/preferences.ftl
@@ -41,6 +41,8 @@ preferences-theme-follow-system = Follow System
 preferences-theme-light = Light
 preferences-theme-dark = Dark
 preferences-v3-scheduler = V3 scheduler
+preferences-auto-refresh = Automatically refresh browser
+preferences-auto-refresh-tooltip = Refresh the card browser whenever a new note is added. Might cause performance issues.
 preferences-ignore-accents-in-search = Ignore accents in search (slower)
 preferences-backup-explanation =
     Anki periodically backs up your collection. After backups are more than 2 days old,

--- a/proto/anki/config.proto
+++ b/proto/anki/config.proto
@@ -54,6 +54,7 @@ message ConfigKey {
     RANDOM_ORDER_REPOSITION = 23;
     SHIFT_POSITION_OF_EXISTING_CARDS = 24;
     RENDER_LATEX = 25;
+    AUTO_REFRESH = 26;
   }
   enum String {
     SET_DUE_BROWSER = 0;
@@ -123,6 +124,7 @@ message Preferences {
     string default_search_text = 4;
     bool ignore_accents_in_search = 5;
     bool render_latex = 6;
+    bool auto_refresh = 7;
   }
   message BackupLimits {
     uint32 daily = 1;

--- a/qt/aqt/forms/preferences.ui
+++ b/qt/aqt/forms/preferences.ui
@@ -577,6 +577,22 @@
             </property>
            </widget>
           </item>
+          <item>
+           <widget class="QCheckBox" name="auto_refresh">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="toolTip">
+             <string>preferences_auto_refresh_tooltip</string>
+            </property>
+            <property name="text">
+             <string>preferences_auto_refresh</string>
+            </property>
+           </widget>
+          </item>
          </layout>
         </widget>
        </item>

--- a/qt/aqt/preferences.py
+++ b/qt/aqt/preferences.py
@@ -125,6 +125,7 @@ class Preferences(QDialog):
         )
         form.paste_strips_formatting.setChecked(editing.paste_strips_formatting)
         form.ignore_accents_in_search.setChecked(editing.ignore_accents_in_search)
+        form.auto_refresh.setChecked(editing.auto_refresh)
         form.pastePNG.setChecked(editing.paste_images_as_png)
         form.render_latex.setChecked(editing.render_latex)
         form.default_search_text.setText(editing.default_search_text)
@@ -160,6 +161,7 @@ class Preferences(QDialog):
         editing.ignore_accents_in_search = (
             self.form.ignore_accents_in_search.isChecked()
         )
+        editing.auto_refresh = self.form.auto_refresh.isChecked()
 
         self.prefs.backups.daily = form.daily_backups.value()
         self.prefs.backups.weekly = form.weekly_backups.value()

--- a/rslib/src/backend/config.rs
+++ b/rslib/src/backend/config.rs
@@ -37,6 +37,7 @@ impl From<BoolKeyProto> for BoolKey {
             BoolKeyProto::RandomOrderReposition => BoolKey::RandomOrderReposition,
             BoolKeyProto::ShiftPositionOfExistingCards => BoolKey::ShiftPositionOfExistingCards,
             BoolKeyProto::RenderLatex => BoolKey::RenderLatex,
+            BoolKeyProto::AutoRefresh => BoolKey::AutoRefresh,
         }
     }
 }

--- a/rslib/src/config/bool.rs
+++ b/rslib/src/config/bool.rs
@@ -40,6 +40,7 @@ pub enum BoolKey {
     WithScheduling,
     WithDeckConfigs,
     Fsrs,
+    AutoRefresh,
     #[strum(to_string = "normalize_note_text")]
     NormalizeNoteText,
     #[strum(to_string = "dayLearnFirst")]

--- a/rslib/src/preferences.rs
+++ b/rslib/src/preferences.rs
@@ -129,6 +129,7 @@ impl Collection {
             default_search_text: self.get_config_string(StringKey::DefaultSearchText),
             ignore_accents_in_search: self.get_config_bool(BoolKey::IgnoreAccentsInSearch),
             render_latex: self.get_config_bool(BoolKey::RenderLatex),
+            auto_refresh: self.get_config_bool(BoolKey::AutoRefresh),
         })
     }
 
@@ -143,6 +144,7 @@ impl Collection {
         self.set_config_string_inner(StringKey::DefaultSearchText, &s.default_search_text)?;
         self.set_config_bool_inner(BoolKey::IgnoreAccentsInSearch, s.ignore_accents_in_search)?;
         self.set_config_bool_inner(BoolKey::RenderLatex, s.render_latex)?;
+        self.set_config_bool_inner(BoolKey::AutoRefresh, s.auto_refresh)?;
         Ok(())
     }
 }


### PR DESCRIPTION
Add option to automatically refresh card browser whenever a new note is added to the collection. Off by default. Discussed here: https://forums.ankiweb.net/t/browser-auto-refresh/45866
Suggestions for potential improvements are appreciated.