### PR TITLE
A11Y: Improve the accessibility of the Preferences dialog

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -177,6 +177,7 @@ RRomeroJr <117.rromero@gmail.com>
 Xidorn Quan <me@upsuper.org>
 Alexander Bocken <alexander@bocken.org>
 James Elmore <email@jameselmore.org>
+Rastislav Kish <rastislav.kish@protonmail.com>
 
 ********************
 

--- a/qt/aqt/forms/preferences.ui
+++ b/qt/aqt/forms/preferences.ui
@@ -44,6 +44,9 @@
             <property name="text">
              <string>preferences_language</string>
             </property>
+            <property name="buddy">
+             <cstring>lang</cstring>
+            </property>
            </widget>
           </item>
           <item row="0" column="1">
@@ -63,6 +66,9 @@
            <widget class="QLabel" name="video_driver_label">
             <property name="text">
              <string>preferences_video_driver</string>
+            </property>
+            <property name="buddy">
+             <cstring>video_driver</cstring>
             </property>
            </widget>
           </item>
@@ -116,6 +122,9 @@
             <property name="text">
              <string>preferences_style</string>
             </property>
+            <property name="buddy">
+             <cstring>styleComboBox</cstring>
+            </property>
            </widget>
           </item>
           <item row="0" column="0">
@@ -123,12 +132,18 @@
             <property name="text">
              <string>preferences_theme</string>
             </property>
+            <property name="buddy">
+             <cstring>theme</cstring>
+            </property>
            </widget>
           </item>
           <item row="2" column="0">
            <widget class="QLabel" name="uiSizeLabel">
             <property name="text">
              <string>preferences_user_interface_size</string>
+            </property>
+            <property name="buddy">
+             <cstring>uiScale</cstring>
             </property>
            </widget>
           </item>
@@ -285,6 +300,9 @@
               <property name="text">
                <string>preferences_timebox_time_limit</string>
               </property>
+              <property name="buddy">
+               <cstring>timeLimit</cstring>
+              </property>
              </widget>
             </item>
             <item row="0" column="2">
@@ -312,12 +330,18 @@
               <property name="text">
                <string>preferences_learn_ahead_limit</string>
               </property>
+              <property name="buddy">
+               <cstring>lrnCutoff</cstring>
+              </property>
              </widget>
             </item>
             <item row="0" column="0">
              <widget class="QLabel" name="label_23">
               <property name="text">
                <string>preferences_next_day_starts_at</string>
+              </property>
+              <property name="buddy">
+               <cstring>dayOffset</cstring>
               </property>
              </widget>
             </item>
@@ -513,6 +537,9 @@
               <property name="text">
                <string>preferences_default_deck</string>
               </property>
+              <property name="buddy">
+               <cstring>useCurrent</cstring>
+              </property>
              </widget>
             </item>
             <item>
@@ -552,6 +579,9 @@
              <widget class="QLabel" name="search_text_label">
               <property name="text">
                <string>preferences_default_search_text</string>
+              </property>
+              <property name="buddy">
+               <cstring>default_search_text</cstring>
               </property>
              </widget>
             </item>
@@ -705,6 +735,9 @@
               <property name="text">
                <string>preferences_network_timeout</string>
               </property>
+              <property name="buddy">
+               <cstring>network_timeout</cstring>
+              </property>
              </widget>
             </item>
             <item>
@@ -853,6 +886,9 @@
            <property name="text">
             <string>preferences_custom_sync_url</string>
            </property>
+           <property name="buddy">
+            <cstring>custom_sync_url</cstring>
+           </property>
           </widget>
          </item>
         </layout>
@@ -954,6 +990,9 @@
               <property name="text">
                <string>preferences_daily_backups</string>
               </property>
+              <property name="buddy">
+               <cstring>daily_backups</cstring>
+              </property>
              </widget>
             </item>
             <item row="4" column="2">
@@ -968,6 +1007,9 @@
               <property name="text">
                <string>preferences_monthly_backups</string>
               </property>
+              <property name="buddy">
+               <cstring>monthly_backups</cstring>
+              </property>
              </widget>
             </item>
             <item row="4" column="0">
@@ -975,12 +1017,18 @@
               <property name="text">
                <string>preferences_weekly_backups</string>
               </property>
+              <property name="buddy">
+               <cstring>weekly_backups</cstring>
+              </property>
              </widget>
             </item>
             <item row="1" column="0">
              <widget class="QLabel" name="label_7">
               <property name="text">
                <string>preferences_minutes_between_backups</string>
+              </property>
+              <property name="buddy">
+               <cstring>minutes_between_backups</cstring>
               </property>
              </widget>
             </item>

--- a/qt/aqt/forms/preferences.ui
+++ b/qt/aqt/forms/preferences.ui
@@ -286,11 +286,7 @@
               <property name="maximum">
                <number>999</number>
               </property>
-             </widget>
-            </item>
-            <item row="1" column="2">
-             <widget class="QLabel" name="label_29">
-              <property name="text">
+              <property name="suffix">
                <string>preferences_mins</string>
               </property>
              </widget>
@@ -305,13 +301,6 @@
               </property>
              </widget>
             </item>
-            <item row="0" column="2">
-             <widget class="QLabel" name="label_40">
-              <property name="text">
-               <string>preferences_hours_past_midnight</string>
-              </property>
-             </widget>
-            </item>
             <item row="0" column="1">
              <widget class="QSpinBox" name="dayOffset">
               <property name="maximumSize">
@@ -322,6 +311,9 @@
               </property>
               <property name="maximum">
                <number>23</number>
+              </property>
+              <property name="suffix">
+               <string>preferences_hours_past_midnight</string>
               </property>
              </widget>
             </item>
@@ -345,17 +337,13 @@
               </property>
              </widget>
             </item>
-            <item row="2" column="2">
-             <widget class="QLabel" name="label_39">
-              <property name="text">
-               <string>preferences_mins</string>
-              </property>
-             </widget>
-            </item>
             <item row="2" column="1">
              <widget class="QSpinBox" name="timeLimit">
               <property name="maximum">
                <number>9999</number>
+              </property>
+              <property name="suffix">
+               <string>preferences_mins</string>
               </property>
              </widget>
             </item>
@@ -748,11 +736,7 @@
               <property name="maximum">
                <number>99999</number>
               </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QLabel" name="label_8">
-              <property name="text">
+              <property name="suffix">
                <string>scheduling_seconds</string>
               </property>
              </widget>


### PR DESCRIPTION
Hello,

I'm a blind developer, who would like to use Anki. :) The app does have some serious a11y problems at the moment, but after having looked through the codebase, I believe it should be possible to do something about most of them and make the app a really pleasant and engaging experience for screenreader users.

I have started implementing the necessary fixes, and would like to upstream as many of them as possible. I think it would be best to address the improvements gradually in several thematic PRs rather than one big single a11y refactor, so they can be easily reviewed and discussed case by case.

This PR enhances the Preferences screen. Specifically, there are two kind of issues addressed:

* Configure buddy widget for labels.
* Move unit labels of spinboxes into spinbox suffix property.

The former creates a semantic link between components such as textboxes, comboboxes etc. and the labels used to describe them, for example the "Language:" label and the language selector. This allows screenreaders to present input widget functionality during keyboard navigation. It's a purely semantic change that doesn't have any visual implications.

The latter changes how Anki displays spinbox units (for example, Network timeout: 60 s). QSpinBox has a dedicated suffix property intended for this purpose, which exposes the unit to screenreaders together with the value. Anki seems to use frequently an alternative approach, placing a separate label next to the spinbox, losing the semantics.

I have removed these unit labels and moved their content into the suffix properties of their respective spinboxes. There is likely a minor visual disproportion caused by the removal of the widgets that will need to be addressed by someone sighted. But primarily I wonder if Anki is okay with this way of representing units from stylistical standpoint, as this is going to be one of the more frequent a11y fixes from what I've seen so far.

Thanks for all the amazing work, really impressively structured codebase, and keeping the project open-source!

## Reproduction steps

1. Launch a screenreader (Orca on Linux, NVDA on Windows (not tested))
2. Launch Anki
3. Open Preferences
4. use Tab and arrow keys to move around the interface. Namely, make sure to cross the language combobox and the spinboxes on the Review tab.

## Before the PR

The screenreader would read "English (United States) ComboBox" instead of "Language: English (United States) ComboBox" and "20 SpinBox" instead of "Learn ahead limit: 20 mins SpinBox", to name some examples.

## After the PR

All input components of the Preferences dialog shall be presented with their respective description labels, SpinBoxes shall present their units.

## Additional notes

Removing the unit labels may have left some gaps in the interface which may need to be fixed stylistically.

## Environment

Tested on Ubuntu Mate 22.04, Orca 44.2 compiled from gnome-44 branch of the [Orca repo](https://gitlab.gnome.org/GNOME/orca).

Another test carried out with Orca main branch (47.alpha at the time of testing) on Ubuntu Mate 24.04. Under this configuration, the value of spinboxes is not read at all by the screenreader, however this seems like a bug in either Orca or QT, not Anki.
