### PR TITLE
Fix FSRS easy interval being same as good interval in relearning cards

### DIFF
--- a/rslib/src/scheduler/states/relearning.rs
+++ b/rslib/src/scheduler/states/relearning.rs
@@ -134,14 +134,16 @@ impl RelearnState {
 
     fn answer_easy(self, ctx: &StateContext) -> ReviewState {
         let scheduled_days = if let Some(states) = &ctx.fsrs_next_states {
-            let (minimum, maximum) = ctx.min_and_max_review_intervals(1);
+            let (mut minimum, maximum) = ctx.min_and_max_review_intervals(1);
+            let good = ctx.with_review_fuzz(states.good.interval as f32, minimum, maximum);
+            minimum = good + 1;
             let interval = states.easy.interval;
             ctx.with_review_fuzz(interval as f32, minimum, maximum)
         } else {
-            self.review.scheduled_days
+            self.review.scheduled_days + 1
         };
         ReviewState {
-            scheduled_days: scheduled_days + 1,
+            scheduled_days,
             elapsed_days: 0,
             memory_state: ctx.fsrs_next_states.as_ref().map(|s| s.easy.memory.into()),
             ..self.review

--- a/rslib/src/scheduler/states/relearning.rs
+++ b/rslib/src/scheduler/states/relearning.rs
@@ -135,13 +135,13 @@ impl RelearnState {
     fn answer_easy(self, ctx: &StateContext) -> ReviewState {
         let scheduled_days = if let Some(states) = &ctx.fsrs_next_states {
             let (minimum, maximum) = ctx.min_and_max_review_intervals(1);
-            let interval = states.easy.interval + 1;
+            let interval = states.easy.interval;
             ctx.with_review_fuzz(interval as f32, minimum, maximum)
         } else {
-            self.review.scheduled_days + 1
+            self.review.scheduled_days
         };
         ReviewState {
-            scheduled_days,
+            scheduled_days + 1,
             elapsed_days: 0,
             memory_state: ctx.fsrs_next_states.as_ref().map(|s| s.easy.memory.into()),
             ..self.review

--- a/rslib/src/scheduler/states/relearning.rs
+++ b/rslib/src/scheduler/states/relearning.rs
@@ -135,7 +135,7 @@ impl RelearnState {
     fn answer_easy(self, ctx: &StateContext) -> ReviewState {
         let scheduled_days = if let Some(states) = &ctx.fsrs_next_states {
             let (minimum, maximum) = ctx.min_and_max_review_intervals(1);
-            let interval = states.easy.interval;
+            let interval = states.easy.interval + 1;
             ctx.with_review_fuzz(interval as f32, minimum, maximum)
         } else {
             self.review.scheduled_days + 1

--- a/rslib/src/scheduler/states/relearning.rs
+++ b/rslib/src/scheduler/states/relearning.rs
@@ -141,7 +141,7 @@ impl RelearnState {
             self.review.scheduled_days
         };
         ReviewState {
-            scheduled_days + 1,
+            scheduled_days: scheduled_days + 1,
             elapsed_days: 0,
             memory_state: ctx.fsrs_next_states.as_ref().map(|s| s.easy.memory.into()),
             ..self.review

--- a/rslib/src/scheduler/states/relearning.rs
+++ b/rslib/src/scheduler/states/relearning.rs
@@ -135,8 +135,11 @@ impl RelearnState {
     fn answer_easy(self, ctx: &StateContext) -> ReviewState {
         let scheduled_days = if let Some(states) = &ctx.fsrs_next_states {
             let (mut minimum, maximum) = ctx.min_and_max_review_intervals(1);
+            // ensure 1 greater than good where possible
             let good = ctx.with_review_fuzz(states.good.interval as f32, minimum, maximum);
-            minimum = good + 1;
+            if minimum < maximum {
+                minimum = good + 1;
+            }
             let interval = states.easy.interval;
             ctx.with_review_fuzz(interval as f32, minimum, maximum)
         } else {


### PR DESCRIPTION
https://github.com/ankitects/anki/pull/3236#issuecomment-2187787774

Before https://github.com/ankitects/anki/pull/3236, the Easy interval for relearning cards was Good interval + 1. This PR restores that behaviour.

~This is intended to be a temporary change. When FSRS will consider short-term reviews (in V5), the Easy interval will automatically become larger than the Good interval.~