### PR TITLE
Fix profile manager used before checked for None

### DIFF
--- a/qt/aqt/__init__.py
+++ b/qt/aqt/__init__.py
@@ -671,11 +671,6 @@ def _run(argv: Optional[list[str]] = None, exec: bool = True) -> Optional[AnkiAp
         # we've signaled the primary instance, so we should close
         return None
 
-    setup_logging(
-        pm.addon_logs(),
-        level=logging.DEBUG if int(os.getenv("ANKIDEV", "0")) else logging.INFO,
-    )
-
     if not pm:
         if i18n_setup:
             QMessageBox.critical(
@@ -686,6 +681,11 @@ def _run(argv: Optional[list[str]] = None, exec: bool = True) -> Optional[AnkiAp
         else:
             QMessageBox.critical(None, "Startup Failed", "Unable to create data folder")
         return None
+    
+    setup_logging(
+        pm.addon_logs(),
+        level=logging.DEBUG if int(os.getenv("ANKIDEV", "0")) else logging.INFO,
+    )
 
     # disable icons on mac; this must be done before window created
     if is_mac:

--- a/qt/aqt/__init__.py
+++ b/qt/aqt/__init__.py
@@ -681,7 +681,7 @@ def _run(argv: Optional[list[str]] = None, exec: bool = True) -> Optional[AnkiAp
         else:
             QMessageBox.critical(None, "Startup Failed", "Unable to create data folder")
         return None
-    
+
     setup_logging(
         pm.addon_logs(),
         level=logging.DEBUG if int(os.getenv("ANKIDEV", "0")) else logging.INFO,


### PR DESCRIPTION
If pm is None it will throw here:
https://github.com/ankitects/anki/blob/d678e39350a2d243242a69f4e22f5192b04398f2/qt/aqt/__init__.py#L674-L677
instead of giving a descriptive error message as it should.

[Bugged reddit user](https://www.reddit.com/r/Anki/comments/1dr7r14/traceback_error_aqt_line_556_in_run_i_have_a_mac/)