### PR TITLE
fix-toggle-mask-shortcut

### DIFF
--- a/ts/routes/image-occlusion/tools/shortcuts.ts
+++ b/ts/routes/image-occlusion/tools/shortcuts.ts
@@ -24,4 +24,4 @@ export const alignRightKeyCombination = "Shift+R";
 export const alignTopKeyCombination = "Shift+T";
 export const alignVerticalCenterKeyCombination = "Shift+V";
 export const alignBottomKeyCombination = "Shift+B";
-export const toggleMaskEditorKeyCombination = "Control+Shift+M";
+export const toggleMaskEditorKeyCombination = "Shift+M";


### PR DESCRIPTION
Changes the shortcut for Toggle Mask on edit occlusion, that is conflicting with another shortcut.

Apologies for the negligence on #3136

Closes #3276 