### PR TITLE
Remove check for small IO rects

### DIFF
--- a/ts/routes/image-occlusion/shapes/to-cloze.ts
+++ b/ts/routes/image-occlusion/shapes/to-cloze.ts
@@ -106,9 +106,8 @@ export function baseShapesFromFabric(): ShapeOrShapes[] {
             const parent = selectionContainingMultipleObjects?.contains(object)
                 ? selectionContainingMultipleObjects
                 : undefined;
-            // shapes with width or height less than 5 are not valid
             // if shape is Rect and fill is transparent, skip it
-            if (object.width! < 5 || object.height! < 5 || object.fill == "transparent") {
+            if (object.fill == "transparent") {
                 return null;
             }
             return fabricObjectToBaseShapeOrShapes(

--- a/ts/routes/image-occlusion/tools/tool-ellipse.ts
+++ b/ts/routes/image-occlusion/tools/tool-ellipse.ts
@@ -97,11 +97,6 @@ export const drawEllipse = (canvas: fabric.Canvas): void => {
         if (!ellipse) {
             return;
         }
-        if (ellipse.width < 5 || ellipse.height < 5) {
-            canvas.remove(ellipse);
-            ellipse = undefined;
-            return;
-        }
 
         if (ellipse.originX === "right") {
             ellipse.set({

--- a/ts/routes/image-occlusion/tools/tool-rect.ts
+++ b/ts/routes/image-occlusion/tools/tool-rect.ts
@@ -92,11 +92,6 @@ export const drawRectangle = (canvas: fabric.Canvas): void => {
         if (!rect) {
             return;
         }
-        if (rect.width < 5 || rect.height < 5) {
-            canvas.remove(rect);
-            rect = undefined;
-            return;
-        }
 
         if (rect.originX === "right") {
             rect.set({


### PR DESCRIPTION
Closes #3267

@krmanik Regarding your comment
> The issue is that on clicking on canvas it add empty width/height shapes, so to exclude it, we need to check the size, the size can be decreased also.

I actually can't reproduce this. No shapes are added if I click on the canvas. Maybe something has changed since then?