### PR TITLE
replace showWarning with show_warning

### DIFF
--- a/qt/aqt/sync.py
+++ b/qt/aqt/sync.py
@@ -29,8 +29,8 @@ from aqt.qt import (
 from aqt.utils import (
     ask_user_dialog,
     disable_help_button,
-    showText,
     show_warning,
+    showText,
     tooltip,
     tr,
 )

--- a/qt/aqt/sync.py
+++ b/qt/aqt/sync.py
@@ -30,7 +30,7 @@ from aqt.utils import (
     ask_user_dialog,
     disable_help_button,
     showText,
-    showWarning,
+    show_warning,
     tooltip,
     tr,
 )
@@ -70,7 +70,7 @@ def handle_sync_error(mw: aqt.main.AnkiQt, err: Exception) -> None:
     elif isinstance(err, Interrupted):
         # no message to show
         return
-    showWarning(str(err))
+    show_warning(str(err))
 
 
 def on_normal_sync_timer(mw: aqt.main.AnkiQt) -> None:

--- a/qt/aqt/sync.py
+++ b/qt/aqt/sync.py
@@ -31,6 +31,7 @@ from aqt.utils import (
     disable_help_button,
     show_warning,
     showText,
+    showWarning,
     tooltip,
     tr,
 )


### PR DESCRIPTION
When there's no internet connection, `showWarning()` causes Anki to get stuck when an add-on is performing a long operation using `QueryOp().with_progress().run_in_background()`. I replaced `showWarning()` with `show_warning()` to avoid the block.