### PR TITLE
Create `notes_were_updated` hook

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -181,6 +181,7 @@ James Elmore <email@jameselmore.org>
 Ian Samir Yep Manzano <https://github.com/isym444>
 David Culley <6276049+davidculley@users.noreply.github.com>
 Rastislav Kish <rastislav.kish@protonmail.com>
+Aleksey Yablokov <alex_ya@mailbox.org>
 
 ********************
 

--- a/pylib/anki/collection.py
+++ b/pylib/anki/collection.py
@@ -494,9 +494,11 @@ class Collection(DeprecatedNamesMixin):
         self, notes: Sequence[Note], skip_undo_entry: bool = False
     ) -> OpChanges:
         """Save note changes to database."""
-        return self._backend.update_notes(
+        changes: OpChanges = self._backend.update_notes(
             notes=[n._to_backend_note() for n in notes], skip_undo_entry=skip_undo_entry
         )
+        hooks.notes_were_updated(self, notes)
+        return changes
 
     def update_note(self, note: Note, skip_undo_entry: bool = False) -> OpChanges:
         """Save note changes to database."""

--- a/pylib/tools/genhooks.py
+++ b/pylib/tools/genhooks.py
@@ -21,6 +21,14 @@ hooks = [
     Hook(name="card_odue_was_invalid"),
     Hook(name="schema_will_change", args=["proceed: bool"], return_type="bool"),
     Hook(
+        name="notes_were_updated",
+        args=["col: anki.collection.Collection", "notes: Sequence[anki.notes.Note]"],
+        doc="""Allows code execution after notes have been updated in the collection.
+        
+        This hook may be called both when users edit notes manually, 
+        and when add-ons like AnkiConnect update notes.""",
+    ),
+    Hook(
         name="notes_will_be_deleted",
         args=["col: anki.collection.Collection", "ids: Sequence[anki.notes.NoteId]"],
         legacy_hook="remNotes",


### PR DESCRIPTION
Add gen hook `notes_were_updated` which is invoked when a user updates notes from the UI or **by using an add-on**.

### Use case
I am developing the ["Note Size"](https://ankiweb.net/shared/info/1188705668) add-on which displays a "Size" column in the Browser. I have to cache note sizes; otherwise, the Browser will be slow when the user searches for many notes.
The cache entries need to be updated when individual notes are updated: manually from the UI or programmatically by add-ons (e.g. generating sounds by TTS, loading images from the Internet, compressing images by add-ons, etc.).
Without this hook, users claim that they need to close the Browser to see the updated note size.

Using existing hooks can't achieve the same result.

