### PR TITLE
chore(mypy): update Python version assumed by mypy

### DIFF
--- a/.mypy.ini
+++ b/.mypy.ini
@@ -1,5 +1,5 @@
 [mypy]
-python_version = 3.9
+python_version = 3.10
 pretty = false
 no_strict_optional = true
 show_error_codes = true


### PR DESCRIPTION
Since we use the `|` operator, we use at least Python 3.10, but mypy (and probably some other things too) still assumes we use Python 3.9.