### PR TITLE
Specify Python version for auto-formatters

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,4 +1,5 @@
 [settings]
+py_version=39
 known_first_party=anki,aqt,tests
 profile=black
 extend_skip=qt/bundle

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,1 +1,2 @@
 target-version = "py39"
+extend-exclude = ["qt/bundle"]

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,0 +1,1 @@
+target-version = "py39"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.black]
+target-version = ["py39", "py310", "py311", "py312"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,3 @@
 [tool.black]
 target-version = ["py39", "py310", "py311", "py312"]
+extend-exclude = "qt/bundle"

--- a/qt/.isort.cfg
+++ b/qt/.isort.cfg
@@ -1,4 +1,5 @@
 [settings]
+py_version=39
 profile=black
 known_first_party=anki,aqt
 extend_skip=aqt/forms,hooks_gen.py


### PR DESCRIPTION
Told `isort`, `black` and `ruff` which version(s) of Python to assume.

These tools shall not change code such that it isn't recognized by Python 3.9, the version we currently use.