### PR TITLE
refactor: use `not in` and `is not` as recommended

### DIFF
--- a/pylib/anki/models.py
+++ b/pylib/anki/models.py
@@ -313,7 +313,7 @@ class ModelManager(DeprecatedNamesMixin):
     def rename_field(
         self, notetype: NotetypeDict, field: FieldDict, new_name: str
     ) -> None:
-        if not field in notetype["flds"]:
+        if field not in notetype["flds"]:
             raise Exception("invalid field")
         field["name"] = new_name
 

--- a/pylib/anki/stats.py
+++ b/pylib/anki/stats.py
@@ -974,7 +974,7 @@ from cards where did in %s"""
         else:
             conf["legend"] = {"container": "#%sLegend" % id, "noColumns": 10}
         conf["series"] = dict(stack=True)
-        if not "yaxis" in conf:
+        if "yaxis" not in conf:
             conf["yaxis"] = {}
         conf["yaxis"]["labelWidth"] = 40
         if "xaxis" not in conf:

--- a/qt/aqt/addcards.py
+++ b/qt/aqt/addcards.py
@@ -178,7 +178,7 @@ class AddCards(QMainWindow):
                     break
                 # copy non-empty old fields
                 if (
-                    not old_field_value in copied_field_names
+                    old_field_value not in copied_field_names
                     and old_note.fields[old_idx]
                 ):
                     new_note.fields[new_idx] = old_note.fields[old_idx]

--- a/qt/aqt/browser/sidebar/tree.py
+++ b/qt/aqt/browser/sidebar/tree.py
@@ -149,7 +149,7 @@ class SidebarTreeView(QTreeView):
     def op_executed(
         self, changes: OpChanges, handler: object | None, focused: bool
     ) -> None:
-        if changes.browser_sidebar and not handler is self:
+        if changes.browser_sidebar and handler is not self:
             self._refresh_needed = True
         if focused:
             self.refresh_if_needed()

--- a/qt/tools/extract_sass_vars.py
+++ b/qt/tools/extract_sass_vars.py
@@ -38,7 +38,7 @@ for line in re.split(r"[;\{\}]|\*\/", data):
     if not m:
         if (
             line != "}"
-            and not ":root" in line
+            and ":root" not in line
             and "Copyright" not in line
             and "License" not in line
             and "color-scheme" not in line
@@ -55,13 +55,13 @@ for line in re.split(r"[;\{\}]|\*\/", data):
         # remove trailing ms from time props
         val = re.sub(r"^(\d+)ms$", r"\1", val)
 
-        if not var in props:
+        if var not in props:
             props.setdefault(var, {})["comment"] = comment
             props[var]["light"] = val
         else:
             props[var]["dark"] = val
     else:
-        if not var in colors:
+        if var not in colors:
             colors.setdefault(var, {})["comment"] = comment
             colors[var]["light"] = val
         else:
@@ -80,7 +80,7 @@ with open(colors_py, "w") as buf:
     buf.write("# This file was automatically generated from _root-vars.scss\n")
 
     for color, val in colors.items():
-        if not "dark" in val:
+        if "dark" not in val:
             val["dark"] = val["light"]
 
         buf.write(re.sub(r"\"\n", '",\n', f"{color} = {json.dumps(val, indent=4)}\n"))
@@ -91,7 +91,7 @@ with open(props_py, "w") as buf:
     buf.write("# This file was automatically generated from _root-vars.scss\n")
 
     for prop, val in props.items():
-        if not "dark" in val:
+        if "dark" not in val:
             val["dark"] = val["light"]
 
         buf.write(re.sub(r"\"\n", '",\n', f"{prop} = {json.dumps(val, indent=4)}\n"))


### PR DESCRIPTION
According to [PEP 8](https://peps.python.org/pep-0008/#programming-recommendations), the `is not` operator is more readable than the negation of the test with the `is` operator.

> Use `is not` operator rather than `not ... is`. While both expressions are functionally identical, the former is more readable and preferred.

See also:

- https://docs.astral.sh/ruff/rules/not-is-test/
- https://docs.astral.sh/ruff/rules/not-in-test/