### PR TITLE
Add hook to browser for refresh on new card

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -188,7 +188,7 @@ Asuka Minato <https://asukaminato.eu.org>
 Dillon Baldwin <https://github.com/DillBal>
 Voczi <https://github.com/voczi>
 Ben Nguyen <105088397+bpnguyen107@users.noreply.github.com>  
-Taylor Obyen <https://github.com/taylorobyen>
+Taylor Obyen <https://github.com/taylorobyen> 
 ********************
 
 The text of the 3 clause BSD license follows:

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -186,6 +186,7 @@ Christian Donat <https://github.com/cdonat2>
 Asuka Minato <https://asukaminato.eu.org>
 Dillon Baldwin <https://github.com/DillBal>
 Voczi <https://github.com/voczi>
+Taylor Obyen <https://github.com/taylorobyen>
 ********************
 
 The text of the 3 clause BSD license follows:

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -3,31 +3,28 @@
 For info on contributing things other than code, such as translations, decks
 and add-ons, please see https://docs.ankiweb.net/contrib
 
-With most users now on 2.1, the past 2 years have been focused on paying down some
-of the technical debt that Anki's codebase has built up over the years, and making
-changes that will make future maintenance and refactoring easier. A lot of Anki's
-"business logic" has been migrated to Rust, which AnkiMobile and AnkiDroid
-can also take advantage of - previously a lot of effort was wasted writing the same
-code for each platform, and then debugging differences in the implementations.
-Considerable effort has also been put into improving the Python side of things,
-with type hints added to the majority of the codebase, automatic linting/formatting,
-and refactoring of parts of the code.
-
-The import/export code remains to be done, and this will likely
-take a number of months to work through. Until that is complete, new features
-will not be the top priority, unless they are easy wins as part of the refactoring
-process.
-
-If you are planning to contribute any non-trivial changes, please reach out
-on the support site before you begin work. Some areas (primarily pylib/) are
-likely to change/conflict with other work, and larger changes will likely need
-to wait until the refactoring process is done.
-
 ## Help wanted
 
 If you'd like to contribute but don't know what to work on, please take a look
 at the [issues tab](https://github.com/ankitects/anki/issues) of the Anki repo
 on GitHub.
+
+## Larger changes
+
+Before starting work on larger changes, especially ones that aren't listed on the
+issue tracker, please reach out on the forums before you begin work, so we can let
+you know whether they're likely to be accepted or not. When you spent a bunch of time
+on a PR that ends up getting rejected, it's no fun for either you or us.
+
+## Refactoring
+
+Please avoid PRs that focus on refactoring. Every PR has a cost to review, and a chance
+of introducing accidental regressions, and often these costs are not worth it for
+slightly more elegant code.
+
+That's not to say there's no value in refactoring. But such changes are usually better done
+in a PR that happens to be working in the same area - for example, making small changes
+to the code as part of fixing a bug, or a larger refactor when introducing a new feature.
 
 ## Type hints
 

--- a/qt/aqt/browser/browser.py
+++ b/qt/aqt/browser/browser.py
@@ -20,7 +20,7 @@ from anki.collection import Collection, Config, OpChanges, SearchNode
 from anki.consts import *
 from anki.errors import NotFoundError
 from anki.lang import without_unicode_isolation
-from anki.notes import NoteId
+from anki.notes import Note, NoteId
 from anki.scheduler.base import ScheduleCardsAsNew
 from anki.tags import MARKED_TAG
 from anki.utils import is_mac
@@ -1027,6 +1027,7 @@ class Browser(QMainWindow):
         gui_hooks.focus_did_change.append(self.on_focus_change)
         gui_hooks.flag_label_did_change.append(self._update_flag_labels)
         gui_hooks.collection_will_temporarily_close.append(self._on_temporary_close)
+        gui_hooks.add_cards_did_add_note.append(self.on_new_note)
 
     def teardownHooks(self) -> None:
         gui_hooks.undo_state_did_change.remove(self.on_undo_state_change)
@@ -1036,10 +1037,18 @@ class Browser(QMainWindow):
         gui_hooks.focus_did_change.remove(self.on_focus_change)
         gui_hooks.flag_label_did_change.remove(self._update_flag_labels)
         gui_hooks.collection_will_temporarily_close.remove(self._on_temporary_close)
+        gui_hooks.add_cards_did_add_note.remove(self.on_new_note)
 
     def _on_temporary_close(self, col: Collection) -> None:
         # we could reload browser columns in the future; for now we just close
         self.close()
+
+    def on_new_note(self, note: Note) -> None:
+        """
+        When a new note is added, the current search filter is reapplied
+        to refresh the browser table.
+        """
+        self.search()
 
     # Undo
     ######################################################################

--- a/qt/aqt/browser/browser.py
+++ b/qt/aqt/browser/browser.py
@@ -1048,7 +1048,9 @@ class Browser(QMainWindow):
         When a new note is added, the current search filter is reapplied
         to refresh the browser table.
         """
+        self.table._model.begin_blocking()
         self.search()
+        self.table._model.end_blocking()
 
     # Undo
     ######################################################################


### PR DESCRIPTION
This change connects a new hook in the Browser class to automatically refresh upon the creation of a new card. I often have the card browser open when adding cards to my decks and always found it strange I had to reclick the deck in the browser to see my new additions. So I thought this would be a nice QoL improvement.

Since the `add_cards_did_add_note` hook returns an extra value I added a helper method of `on_new_note` to the Browser class to call the `search` method. The `search` method seemed to be the best way to update the contents of the browser, but if there is a better way I am happy to hook into a different method. I look forward to your feedback.