### PR TITLE
chore: add initial configuration for `pyright`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,8 @@
 [tool.black]
 target-version = ["py39", "py310", "py311", "py312"]
 extend-exclude = "qt/bundle"
+
+[tool.pyright]
+include = ["pylib/anki", "qt/aqt"]
+stubPath = ""
+pythonVersion = "3.9"


### PR DESCRIPTION
If you don't use Visual Studio Code as your text editor, and therefore can't use the Pylance extension, but nonetheless use `pyright` as a CLI application (which you installed, for example, like so: `npm install --save-dev pyright`).