### PR TITLE
Right click context menu on images not useful

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -186,7 +186,7 @@ Christian Donat <https://github.com/cdonat2>
 Asuka Minato <https://asukaminato.eu.org>
 Dillon Baldwin <https://github.com/DillBal>
 Voczi <https://github.com/voczi>
-Ben Nguyen <105088397+bpnguyen107@users.noreply.github.com> 
+Ben Nguyen <105088397+bpnguyen107@users.noreply.github.com>  
 ********************
 
 The text of the 3 clause BSD license follows:

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -186,7 +186,7 @@ Christian Donat <https://github.com/cdonat2>
 Asuka Minato <https://asukaminato.eu.org>
 Dillon Baldwin <https://github.com/DillBal>
 Voczi <https://github.com/voczi>
-Ben Nguyen <105088397+bpnguyen107@users.noreply.github.com>
+Ben Nguyen <105088397+bpnguyen107@users.noreply.github.com> 
 ********************
 
 The text of the 3 clause BSD license follows:

--- a/ftl/core/editing.ftl
+++ b/ftl/core/editing.ftl
@@ -10,6 +10,7 @@ editing-center = Center
 editing-change-color = Change color
 editing-cloze-deletion = Cloze deletion (new card)
 editing-cloze-deletion-repeat = Cloze deletion (same card)
+editing-copy-image = Copy image
 editing-couldnt-record-audio-have-you-installed = Couldn't record audio. Have you installed 'lame'?
 editing-customize-card-templates = Customize Card Templates
 editing-customize-fields = Customize Fields

--- a/qt/aqt/editor.py
+++ b/qt/aqt/editor.py
@@ -1433,12 +1433,12 @@ class EditorWebView(AnkiWebView):
     def onCopy(self) -> None:
         copy_action = (
             QWebEnginePage.WebAction.CopyImageToClipboard
-            if self._is_image_context()
+            if self._opened_context_menu_on_image()
             else QWebEnginePage.WebAction.Copy
         )
         self.triggerPageAction(copy_action)
 
-    def _is_image_context(self) -> bool:
+    def _opened_context_menu_on_image(self) -> bool:
         context_menu_request = self.lastContextMenuRequest()
         return (
             context_menu_request.mediaType()

--- a/qt/aqt/editor.py
+++ b/qt/aqt/editor.py
@@ -1433,7 +1433,7 @@ class EditorWebView(AnkiWebView):
     def onCopy(self) -> None:
         self.triggerPageAction(QWebEnginePage.WebAction.Copy)
 
-    def onCopyImage(self) -> None:
+    def on_copy_image(self) -> None:
         self.triggerPageAction(QWebEnginePage.WebAction.CopyImageToClipboard)
 
     def _opened_context_menu_on_image(self) -> bool:
@@ -1606,7 +1606,7 @@ class EditorWebView(AnkiWebView):
     def _maybe_add_copy_image_action(self, menu: QMenu) -> None:
         if self._opened_context_menu_on_image():
             a = menu.addAction(tr.editing_copy_image())
-            qconnect(a.triggered, self.onCopyImage)
+            qconnect(a.triggered, self.on_copy_image)
 
 
 # QFont returns "Kozuka Gothic Pro L" but WebEngine expects "Kozuka Gothic Pro Light"

--- a/qt/aqt/editor.py
+++ b/qt/aqt/editor.py
@@ -1431,7 +1431,19 @@ class EditorWebView(AnkiWebView):
         self.triggerPageAction(QWebEnginePage.WebAction.Cut)
 
     def onCopy(self) -> None:
-        self.triggerPageAction(QWebEnginePage.WebAction.Copy)
+        copy_action = (
+            QWebEnginePage.WebAction.CopyImageToClipboard
+            if self._is_image_context()
+            else QWebEnginePage.WebAction.Copy
+        )
+        self.triggerPageAction(copy_action)
+
+    def _is_image_context(self) -> bool:
+        context_menu_request = self.lastContextMenuRequest()
+        return (
+            context_menu_request.mediaType()
+            == context_menu_request.MediaType.MediaTypeImage
+        )
 
     def _wantsExtendedPaste(self) -> bool:
         strip_html = self.editor.mw.col.get_config_bool(


### PR DESCRIPTION
Closes #3337 

- I added a "Copy image" action to the editor context menu that shows up when right-clicking on an image. This allows the user to choose what to do when the image is selected together with text if they want to copy the image or copy all the selected content. I think this also matches the behavior of the context menus in browsers like Edge or Chrome.
- I also added hiding the "Cut" and "Copy" actions in the context menu if nothing is selected so the user isn't misled that cutting the image does anything without selecting it first as the forum post said.

Video:
https://github.com/user-attachments/assets/d466f97f-50e5-4ab7-b620-317cd854414d


