### PR TITLE
mypy: fix type checking error

### DIFF
--- a/qt/aqt/reviewer.py
+++ b/qt/aqt/reviewer.py
@@ -596,14 +596,11 @@ class Reviewer:
             for ease in aqt.mw.pm.default_answer_keys:
                 key = aqt.mw.pm.get_answer_key(ease)
                 if key:
-                    if ease in (1, 2, 3, 4):
-                        ease = cast(Literal[1, 2, 3, 4], ease)
-                        answer_card_according_to_pressed_shortkey = functools.partial(
-                            self._answerCard, ease
-                        )
-                        yield (key, answer_card_according_to_pressed_shortkey)
-                    else:
-                        raise ValueError("Invalid value")
+                    ease = cast(Literal[1, 2, 3, 4], ease)
+                    answer_card_according_to_pressed_shortkey = functools.partial(
+                        self._answerCard, ease
+                    )
+                    yield (key, answer_card_according_to_pressed_shortkey)
 
         return [
             ("e", self.mw.onEditCurrent),

--- a/qt/aqt/reviewer.py
+++ b/qt/aqt/reviewer.py
@@ -591,6 +591,20 @@ class Reviewer:
     def _shortcutKeys(
         self,
     ) -> Sequence[tuple[str, Callable] | tuple[Qt.Key, Callable]]:
+
+        def generate_default_answer_keys():
+            for ease in aqt.mw.pm.default_answer_keys:
+                key = aqt.mw.pm.get_answer_key(ease)
+                if key:
+                    if ease in (1, 2, 3, 4):
+                        ease = cast(Literal[1, 2, 3, 4], ease)
+                        answer_card_according_to_pressed_shortkey = functools.partial(
+                            self._answerCard, ease
+                        )
+                        yield (key, answer_card_according_to_pressed_shortkey)
+                    else:
+                        raise ValueError("Invalid value")
+
         return [
             ("e", self.mw.onEditCurrent),
             (" ", self.onEnterKey),
@@ -617,11 +631,7 @@ class Reviewer:
             ("o", self.onOptions),
             ("i", self.on_card_info),
             ("Ctrl+Alt+i", self.on_previous_card_info),
-            *(
-                (key, functools.partial(self._answerCard, ease))
-                for ease in aqt.mw.pm.default_answer_keys
-                if (key := aqt.mw.pm.get_answer_key(ease))
-            ),
+            *generate_default_answer_keys(),
             ("u", self.mw.undo),
             ("5", self.on_pause_audio),
             ("6", self.on_seek_backward),

--- a/qt/aqt/reviewer.py
+++ b/qt/aqt/reviewer.py
@@ -597,7 +597,7 @@ class Reviewer:
         ):
             for ease in aqt.mw.pm.default_answer_keys:
                 key = aqt.mw.pm.get_answer_key(ease)
-                if not key:
+                if key is None:
                     continue
                 ease = cast(Literal[1, 2, 3, 4], ease)
                 answer_card_according_to_pressed_key = partial(self._answerCard, ease)

--- a/qt/aqt/reviewer.py
+++ b/qt/aqt/reviewer.py
@@ -597,12 +597,11 @@ class Reviewer:
         ):
             for ease in aqt.mw.pm.default_answer_keys:
                 key = aqt.mw.pm.get_answer_key(ease)
-                if key:
-                    ease = cast(Literal[1, 2, 3, 4], ease)
-                    answer_card_according_to_pressed_key = partial(
-                        self._answerCard, ease
-                    )
-                    yield (key, answer_card_according_to_pressed_key)
+                if not key:
+                    continue
+                ease = cast(Literal[1, 2, 3, 4], ease)
+                answer_card_according_to_pressed_key = partial(self._answerCard, ease)
+                yield (key, answer_card_according_to_pressed_key)
 
         return [
             ("e", self.mw.onEditCurrent),

--- a/qt/aqt/reviewer.py
+++ b/qt/aqt/reviewer.py
@@ -7,7 +7,7 @@ import functools
 import json
 import random
 import re
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Generator, Sequence
 from dataclasses import dataclass
 from enum import Enum, auto
 from typing import Any, Literal, Match, Union, cast
@@ -592,7 +592,9 @@ class Reviewer:
         self,
     ) -> Sequence[tuple[str, Callable] | tuple[Qt.Key, Callable]]:
 
-        def generate_default_answer_keys():
+        def generate_default_answer_keys() -> (
+            Generator[tuple[str, functools.partial], None, None]
+        ):
             for ease in aqt.mw.pm.default_answer_keys:
                 key = aqt.mw.pm.get_answer_key(ease)
                 if key:

--- a/qt/aqt/reviewer.py
+++ b/qt/aqt/reviewer.py
@@ -3,13 +3,13 @@
 
 from __future__ import annotations
 
-import functools
 import json
 import random
 import re
 from collections.abc import Callable, Generator, Sequence
 from dataclasses import dataclass
 from enum import Enum, auto
+from functools import partial
 from typing import Any, Literal, Match, Union, cast
 
 import aqt
@@ -593,13 +593,13 @@ class Reviewer:
     ) -> Sequence[tuple[str, Callable] | tuple[Qt.Key, Callable]]:
 
         def generate_default_answer_keys() -> (
-            Generator[tuple[str, functools.partial], None, None]
+            Generator[tuple[str, partial], None, None]
         ):
             for ease in aqt.mw.pm.default_answer_keys:
                 key = aqt.mw.pm.get_answer_key(ease)
                 if key:
                     ease = cast(Literal[1, 2, 3, 4], ease)
-                    answer_card_according_to_pressed_key = functools.partial(
+                    answer_card_according_to_pressed_key = partial(
                         self._answerCard, ease
                     )
                     yield (key, answer_card_according_to_pressed_key)

--- a/qt/aqt/reviewer.py
+++ b/qt/aqt/reviewer.py
@@ -597,10 +597,10 @@ class Reviewer:
                 key = aqt.mw.pm.get_answer_key(ease)
                 if key:
                     ease = cast(Literal[1, 2, 3, 4], ease)
-                    answer_card_according_to_pressed_shortkey = functools.partial(
+                    answer_card_according_to_pressed_key = functools.partial(
                         self._answerCard, ease
                     )
-                    yield (key, answer_card_according_to_pressed_shortkey)
+                    yield (key, answer_card_according_to_pressed_key)
 
         return [
             ("e", self.mw.onEditCurrent),

--- a/qt/aqt/reviewer.py
+++ b/qt/aqt/reviewer.py
@@ -597,7 +597,7 @@ class Reviewer:
         ):
             for ease in aqt.mw.pm.default_answer_keys:
                 key = aqt.mw.pm.get_answer_key(ease)
-                if key is None:
+                if not key:
                     continue
                 ease = cast(Literal[1, 2, 3, 4], ease)
                 answer_card_according_to_pressed_key = partial(self._answerCard, ease)


### PR DESCRIPTION
To have an easier time in my other pull requests, when figuring out which type errors were introduced by me and which already existed, I'm fixing some of the type errors on the current main branch.

This pull request fixes this mypy error:

> error: Argument 1 to "_answerCard" of "Reviewer" has incompatible type "int"; expected "Literal[1, 2, 3, 4]"  [arg-type]

The function `_answerCard` wants only numbers 1, 2, 3 or 4 (that is, a variable of type `Literal[1, 2, 3, 4]`. But we're passing a variable of type `int` which can hold many more numbers than these mentioned four.

I'm basically just

- casting `int` to `Literal[1, 2, 3, 4]` (which by itself would already suffice)
- adding a check that the given number is indeed one of the four numbers, so that we don't mute mypy only to miss runtime errors when there actually is one because mypy stayed silent since we muted it.