### PR TITLE
Fix imports of decks with file paths using special URL characters

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -187,7 +187,8 @@ Christian Donat <https://github.com/cdonat2>
 Asuka Minato <https://asukaminato.eu.org>
 Dillon Baldwin <https://github.com/DillBal>
 Voczi <https://github.com/voczi>
-Ben Nguyen <105088397+bpnguyen107@users.noreply.github.com>  
+Ben Nguyen <105088397+bpnguyen107@users.noreply.github.com>
+Themis Demetriades <themis100@outlook.com>
 ********************
 
 The text of the 3 clause BSD license follows:

--- a/qt/aqt/import_export/import_dialog.py
+++ b/qt/aqt/import_export/import_dialog.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import json
 from dataclasses import dataclass
+from urllib.parse import quote
 
 import aqt
 import aqt.deckconf
@@ -65,7 +66,7 @@ class ImportDialog(QDialog):
 
         self.web = AnkiWebView(kind=self.args.kind)
         self.web.setVisible(False)
-        self.web.load_sveltekit_page(f"{self.args.ts_page}/{self.args.path}")
+        self.web.load_sveltekit_page(f"{self.args.ts_page}/{quote(self.args.path)}")
         layout = QVBoxLayout()
         layout.setContentsMargins(0, 0, 0, 0)
         layout.addWidget(self.web)


### PR DESCRIPTION
This fixes #3352 by escaping special characters in the file path selected by the user for importing a deck, ensuring that the path is interpreted correctly as a URL (i.e. "#" is converted to "%23") using the quote() function from 'urllib.parse'.