### PR TITLE
Fix field focus lost when pressing alt in the editor

### DIFF
--- a/qt/aqt/addcards.py
+++ b/qt/aqt/addcards.py
@@ -58,6 +58,7 @@ class AddCards(QMainWindow):
         gui_hooks.operation_did_execute.append(self.on_operation_did_execute)
         restoreGeom(self, "add")
         gui_hooks.add_cards_did_init(self)
+        self.setMenuBar(None)
         self.show()
 
     def set_note(self, note: Note, deck_id: DeckId | None = None) -> None:

--- a/qt/aqt/editcurrent.py
+++ b/qt/aqt/editcurrent.py
@@ -21,6 +21,7 @@ class EditCurrent(QMainWindow):
         self.setWindowTitle(tr.editing_edit_current())
         self.setMinimumHeight(400)
         self.setMinimumWidth(250)
+        self.setMenuBar(None)
         self.editor = aqt.editor.Editor(
             self.mw,
             self.form.fieldsArea,


### PR DESCRIPTION
https://forums.ankiweb.net/t/bug-field-loses-focus-when-switching-to-katakana-input-mode/47767