### PR TITLE
Fix Svelte exports not working in Deck Options

### DIFF
--- a/ts/routes/deck-options/DeckOptionsPage.svelte
+++ b/ts/routes/deck-options/DeckOptionsPage.svelte
@@ -5,6 +5,8 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 <script lang="ts">
     import type { Writable } from "svelte/store";
 
+    import "$lib/sveltelib/export-runtime";
+
     import Container from "$lib/components/Container.svelte";
     import Row from "$lib/components/Row.svelte";
     import type { DynamicSvelteComponent } from "$lib/sveltelib/dynamicComponent";


### PR DESCRIPTION
#2629 came back recently (after the switch to SvelteKit I guess).

This broke the Exam Notifier add-on: https://github.com/AnKing-VIP/exam-notifier/issues/26