### PR TITLE
Create a nice website for the developer's documentation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: ci
+on:
+  push:
+    branches:
+      - main
+permissions:
+  contents: write
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Configure Git Credentials
+        run: |
+          git config user.name github-actions[bot]
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.x
+      - run: echo "cache_id=$(date --utc '+%V')" >> $GITHUB_ENV
+      - uses: actions/cache@v4
+        with:
+          key: mkdocs-material-${{ env.cache_id }}
+          path: .cache
+          restore-keys: |
+            mkdocs-material-
+      - run: pip install mkdocs-material
+      - run: mkdocs gh-deploy --force

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,11 @@
+site_name: Anki development
+site_description: Documentation for developers of Anki
+site_url: https://apps.ankiweb.net
+repo_url: https://github.com/ankitects/anki
+repo_name: ankitects/anki
+
+theme:
+  name: "material"
+
+plugins:
+  - search


### PR DESCRIPTION
Added a minimal proof of concept that compiles the `.md` files in `/docs/` into a beautiful website (using MkDocs) and then hosts that website using GitHub Pages.

The website should become available at the following URL after merging this pull request:

https://ankitects.github.io/anki/

Browsing that website should provide a better experience than the `.md` files rendered by GitHub.

I can continue work on this website if it is considered useful.

For a preview of how this could look like, see (for example) the [documentation of FastAPI](https://fastapi.tiangolo.com/learn/).