### PR TITLE
Change Wayland app_id to net.ankiweb.Anki

### DIFF
--- a/qt/aqt/__init__.py
+++ b/qt/aqt/__init__.py
@@ -667,7 +667,7 @@ def _run(argv: list[str] | None = None, exec: bool = True) -> AnkiApp | None:
 
     # create the app
     QCoreApplication.setApplicationName("Anki")
-    QGuiApplication.setDesktopFileName("anki.desktop")
+    QGuiApplication.setDesktopFileName("net.ankiweb.Anki")
     app = AnkiApp(argv)
     if app.secondInstance():
         # we've signaled the primary instance, so we should close

--- a/qt/aqt/about.py
+++ b/qt/aqt/about.py
@@ -199,6 +199,7 @@ def show(mw: aqt.AnkiQt) -> QDialog:
             "Ian Samir Yep Manzano",
             "Asuka Minato",
             "Eros Cardoso",
+            "Ingemar Berg",
         )
     )
 

--- a/qt/bundle/lin/install.sh
+++ b/qt/bundle/lin/install.sh
@@ -23,13 +23,13 @@ mkdir -p "$PREFIX"/share/applications
 mkdir -p "$PREFIX"/share/man/man1
 cd "$PREFIX"/share/anki && (\
 mv -Z anki.xpm anki.png "$PREFIX"/share/pixmaps/;\
-mv -Z anki.desktop "$PREFIX"/share/applications/;\
+mv -Z net.ankiweb.Anki.desktop "$PREFIX"/share/applications/;\
 mv -Z anki.1 "$PREFIX"/share/man/man1/)
 
 xdg-mime install anki.xml --novendor
-xdg-mime default anki.desktop application/x-colpkg
-xdg-mime default anki.desktop application/x-apkg
-xdg-mime default anki.desktop application/x-ankiaddon
+xdg-mime default net.ankiweb.Anki.desktop application/x-colpkg
+xdg-mime default net.ankiweb.Anki.desktop application/x-apkg
+xdg-mime default net.ankiweb.Anki.desktop application/x-ankiaddon
 
 rm install.sh
 

--- a/qt/bundle/lin/net.ankiweb.Anki.desktop
+++ b/qt/bundle/lin/net.ankiweb.Anki.desktop
@@ -13,4 +13,4 @@ MimeType=application/x-apkg;application/x-anki;application/x-ankiaddon;
 #should be removed eventually as it was upstreamed as to be an XDG specification called SingleMainWindow
 X-GNOME-SingleWindow=true
 SingleMainWindow=true
-StartupWMClass=anki
+StartupWMClass=net.ankiweb.Anki

--- a/qt/bundle/lin/net.ankiweb.Anki.desktop
+++ b/qt/bundle/lin/net.ankiweb.Anki.desktop
@@ -13,4 +13,4 @@ MimeType=application/x-apkg;application/x-anki;application/x-ankiaddon;
 #should be removed eventually as it was upstreamed as to be an XDG specification called SingleMainWindow
 X-GNOME-SingleWindow=true
 SingleMainWindow=true
-StartupWMClass=net.ankiweb.Anki
+StartupWMClass=anki

--- a/qt/bundle/lin/uninstall.sh
+++ b/qt/bundle/lin/uninstall.sh
@@ -12,7 +12,9 @@ rm -rf "$PREFIX"/share/anki
 rm -rf "$PREFIX"/bin/anki
 rm -rf "$PREFIX"/share/pixmaps/anki.xpm
 rm -rf "$PREFIX"/share/pixmaps/anki.png
+# anki.desktop has been renamed net.ankiweb.Anki.desktop for better Wayland compatibility
 rm -rf "$PREFIX"/share/applications/anki.desktop
+rm -rf "$PREFIX"/share/applications/net.ankiweb.Anki.desktop
 rm -rf "$PREFIX"/share/man/man1/anki.1
 
 echo "Uninstall complete."


### PR DESCRIPTION
Anki's icon is not displayed when Anki is running on KDE Plasma 6 on Wayland. Instead of displaying the correct icon, Plasma instead defaults to a generic Wayland icon. This was originally [reported on the forums](https://forums.ankiweb.net/t/missing-icon-on-wayland-for-flatpak/46243) and was initially thought to be a [Flatpak bug](https://github.com/flathub/net.ankiweb.Anki/issues/154). However, after some investigation, I believe that this is related to Plasma instead. Plasma expects the Wayland app_id to be set according to the reverse domain standard, which it currently is not (the current value is `anki.desktop`). I've been able to confirm the same behaviour for both the git main repo and the official Anki 24.06.3 Qt6 build running on Plasma 6.1.4 as well. GNOME seems to be more forgiving with the Wayland app_id, which is probably why this problem only occurs on Plasma.

This PR fixes this by setting the Wayland app_id to `net.ankiweb.Anki` and renaming `anki.desktop`. I've also updated the install and uninstall scripts with the renamed .desktop file, as well as the changed StartupWMClass value. Please see the [KDE Community Wiki](https://community.kde.org/Guidelines_and_HOWTOs/Wayland_Porting_Notes#Application_Icon) for details. However, I'm not sure if this is best way to handle the renamed .desktop file. Would it be a good idea to add a check to the install script in order to delete the old `anki.desktop` file if it exists? Will my small change to the uninstall script be enough?

The following warning would be resolved as well:
`Qt warning: QGuiApplication::setDesktopFileName: the specified desktop file name ends with .desktop. For compatibility reasons, the .desktop suffix will be removed. Please specify a desktop file name without .desktop suffix`

I've tested this on Plasma 6.1.4 running on both X11 and Wayland, and on GNOME 46. The only problem I've ran into is the window decorations when building from source on GNOME. I can see the same behaviour when building from source without making any changes, so perhaps this is to be expected in this case?

Official Anki 24.06.3 Qt6 build
![image](https://github.com/user-attachments/assets/25b2da02-ddab-4f7b-801c-0bea0ef8f89b)

Building from source
![image](https://github.com/user-attachments/assets/78fbdd67-9011-4100-ab5a-f05e6b060377)

Oh, and one last thing. I've made one [minor contribution](https://github.com/ankitects/anki/pull/2433) before and forgot to add myself to `qt/aqt/about.py`. Would it be appropriate to do so with this PR?