### PR TITLE
Add comment about the usage of the input field in the statistics page (#3394)

### DIFF
--- a/ts/routes/graphs/RangeBox.svelte
+++ b/ts/routes/graphs/RangeBox.svelte
@@ -83,6 +83,8 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
             {collection}
         </label>
 
+	<!-- This form is an external API and should not be changed -
+	other clients e.g. AnkiDroid programmatically update this form -->
         <input
             type="text"
             bind:value={displayedSearch}


### PR DESCRIPTION
Resolve #3394 which requested that a comment be added to describe the usage of the input form in the statistics page in external apps.