### PR TITLE
Updated error message to provide help for import if 'Legacy Import/Export' is enabled

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -189,6 +189,7 @@ Dillon Baldwin <https://github.com/DillBal>
 Voczi <https://github.com/voczi>
 Ben Nguyen <105088397+bpnguyen107@users.noreply.github.com>   
 Themis Demetriades <themis100@outlook.com>
+Gregory Abrasaldo <degeemon@gmail.com>
 
 ********************
 

--- a/qt/aqt/importing.py
+++ b/qt/aqt/importing.py
@@ -390,7 +390,7 @@ def importFile(mw: AnkiQt, file: str) -> None:
                 showWarning(invalidZipMsg())
             except MediaMapInvalid:
                 showWarning(
-                    "Unable to read file. It probably requires a newer version of Anki to import."
+                    "Unable to read file. It probably requires a newer version of Anki to import. Try unchecking 'Legacy import/export Handling' under Preferences > Editing > Import/Export and see if the problem persists."
                 )
             except V2ImportIntoV1:
                 showWarning(


### PR DESCRIPTION
I updated to the latest version but error still persisted. Figured out that it was the Legacy Importing that was the culprit

Enhanced the error message from "Unable to read file. It probably requires a newer version of Anki to import." 
  to include a suggestion for users to try unchecking 'Legacy import/export Handling' under Preferences > Editing > 
  Import/Export if they encounter the issue.

I also did not do the _Test must pass_ check under the `contributing.md` since i just changed a string.

First time contributing to the project! Very very grateful to the team!!!