### PR TITLE
change links to new knowledge base

### DIFF
--- a/rslib/src/template.rs
+++ b/rslib/src/template.rs
@@ -29,11 +29,11 @@ pub type FieldMap<'a> = HashMap<&'a str, u16>;
 type TemplateResult<T> = std::result::Result<T, TemplateError>;
 
 static TEMPLATE_ERROR_LINK: &str =
-    "https://anki.tenderapp.com/kb/problems/card-template-has-a-problem";
+    "https://faqs.ankiweb.net/card-template-has-a-problem.html";
 static TEMPLATE_BLANK_LINK: &str =
     "https://anki.tenderapp.com/kb/card-appearance/the-front-of-this-card-is-blank";
 static TEMPLATE_BLANK_CLOZE_LINK: &str =
-    "https://anki.tenderapp.com/kb/problems/no-cloze-found-on-card";
+    "https://faqs.ankiweb.net/no-cloze-found-on-card.html";
 
 // Lexing
 //----------------------------------------


### PR DESCRIPTION
Found these links in reviewer were outdated so merely replaced them here with ones. I couldn't find a FAQ entry for "front of the card is blank" though. Maybe we need to create one.