### PR TITLE
Add a delete option to the card right-click menu in the browser

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -118,7 +118,7 @@ yellowjello <github.com/yellowjello>
 Ingemar Berg <github.com/ingemarberg>
 Ben Kerman <ben@kermanic.org>
 Euan Kemp <euank@euank.com>
-Kieran Black <kieranlblack@gmail.com> 
+Kieran Black <kieranlblack@gmail.com>
 XeR <github.com/XeR>
 mgrottenthaler <github.com/mgrottenthaler>
 Austin Siew <github.com/Aquafina-water-bottle>
@@ -138,7 +138,7 @@ Monty Evans <montyevans@gmail.com>
 Nil Admirari <https://github.com/nihil-admirari>
 Michael Winkworth <github.com/SteelColossus>
 Mateusz Wojewoda <kawa1.11@o2.pl>
-Jarrett Ye <jarrett.ye@outlook.com> 
+Jarrett Ye <jarrett.ye@outlook.com>
 Sam Waechter <github.com/swektr>
 Michael Eliachevitch <m.eliachevitch@posteo.de>
 Carlo Quick <https://github.com/CarloQuick>
@@ -163,7 +163,7 @@ Lucas Scharenbroch <lucasscharenbroch@gmail.com>
 Antonio Cavallo <a.cavallo@cavallinux.eu>
 Han Yeong-woo <han@yeongwoo.dev>
 Jean Khawand <jk@jeankhawand.com>
-Pedro Schreiber <schreiber.mmb@gmail.com> 
+Pedro Schreiber <schreiber.mmb@gmail.com>
 Foxy_null <https://github.com/Foxy-null>
 Arbyste <arbyste@outlook.com>
 Vasll <github.com/vasll>
@@ -187,10 +187,11 @@ Christian Donat <https://github.com/cdonat2>
 Asuka Minato <https://asukaminato.eu.org>
 Dillon Baldwin <https://github.com/DillBal>
 Voczi <https://github.com/voczi>
-Ben Nguyen <105088397+bpnguyen107@users.noreply.github.com>   
+Ben Nguyen <105088397+bpnguyen107@users.noreply.github.com>
 Themis Demetriades <themis100@outlook.com>
 Gregory Abrasaldo <degeemon@gmail.com>
 Taylor Obyen <https://github.com/taylorobyen>
+Kris Cherven <https://github.com/krischerven>
 
 ********************
 

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -191,7 +191,7 @@ Ben Nguyen <105088397+bpnguyen107@users.noreply.github.com>
 Themis Demetriades <themis100@outlook.com>
 Gregory Abrasaldo <degeemon@gmail.com>
 Taylor Obyen <https://github.com/taylorobyen>
-Kris Cherven <https://github.com/krischerven>
+Kris Cherven <krischerven@gmail.com>
 
 ********************
 

--- a/qt/aqt/forms/browser.ui
+++ b/qt/aqt/forms/browser.ui
@@ -276,6 +276,8 @@
     <addaction name="menuFlag"/>
     <addaction name="separator"/>
     <addaction name="action_Info"/>
+    <addaction name="separator"/>
+    <addaction name="actionDelete"/>
    </widget>
    <widget class="QMenu" name="menu_Notes">
     <property name="title">


### PR DESCRIPTION
This would be a duplicate of the option under Notes, but it would be more intuitive for newcomers to not have to go into a nested submenu to find an option that you would normally expect to find in the main right-click menu. It's also more efficient for non-hotkey users.