### PR TITLE
Fix Qt desktop file name warning

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -118,7 +118,7 @@ yellowjello <github.com/yellowjello>
 Ingemar Berg <github.com/ingemarberg>
 Ben Kerman <ben@kermanic.org>
 Euan Kemp <euank@euank.com>
-Kieran Black <kieranlblack@gmail.com> 
+Kieran Black <kieranlblack@gmail.com>
 XeR <github.com/XeR>
 mgrottenthaler <github.com/mgrottenthaler>
 Austin Siew <github.com/Aquafina-water-bottle>
@@ -138,7 +138,7 @@ Monty Evans <montyevans@gmail.com>
 Nil Admirari <https://github.com/nihil-admirari>
 Michael Winkworth <github.com/SteelColossus>
 Mateusz Wojewoda <kawa1.11@o2.pl>
-Jarrett Ye <jarrett.ye@outlook.com> 
+Jarrett Ye <jarrett.ye@outlook.com>
 Sam Waechter <github.com/swektr>
 Michael Eliachevitch <m.eliachevitch@posteo.de>
 Carlo Quick <https://github.com/CarloQuick>
@@ -163,7 +163,7 @@ Lucas Scharenbroch <lucasscharenbroch@gmail.com>
 Antonio Cavallo <a.cavallo@cavallinux.eu>
 Han Yeong-woo <han@yeongwoo.dev>
 Jean Khawand <jk@jeankhawand.com>
-Pedro Schreiber <schreiber.mmb@gmail.com> 
+Pedro Schreiber <schreiber.mmb@gmail.com>
 Foxy_null <https://github.com/Foxy-null>
 Arbyste <arbyste@outlook.com>
 Vasll <github.com/vasll>
@@ -187,10 +187,11 @@ Christian Donat <https://github.com/cdonat2>
 Asuka Minato <https://asukaminato.eu.org>
 Dillon Baldwin <https://github.com/DillBal>
 Voczi <https://github.com/voczi>
-Ben Nguyen <105088397+bpnguyen107@users.noreply.github.com>   
+Ben Nguyen <105088397+bpnguyen107@users.noreply.github.com>
 Themis Demetriades <themis100@outlook.com>
 Gregory Abrasaldo <degeemon@gmail.com>
 Taylor Obyen <https://github.com/taylorobyen>
+Kris Cherven <krischerven@gmail.com>
 
 ********************
 

--- a/qt/aqt/__init__.py
+++ b/qt/aqt/__init__.py
@@ -667,7 +667,7 @@ def _run(argv: list[str] | None = None, exec: bool = True) -> AnkiApp | None:
 
     # create the app
     QCoreApplication.setApplicationName("Anki")
-    QGuiApplication.setDesktopFileName("anki.desktop")
+    QGuiApplication.setDesktopFileName("anki")
     app = AnkiApp(argv)
     if app.secondInstance():
         # we've signaled the primary instance, so we should close


### PR DESCRIPTION
When running Anki from the terminal, you receive the following warning:

> Qt warning: QGuiApplication::setDesktopFileName: the specified desktop file name ends with .desktop. For compatibility reasons, the .desktop suffix will be removed. Please specify a desktop file name without .desktop suffix

This PR removes that warning.