### PR TITLE
Call the profile_did_open() hook earlier

### DIFF
--- a/qt/aqt/main.py
+++ b/qt/aqt/main.py
@@ -529,8 +529,8 @@ class AnkiQt(QMainWindow):
             )
 
         refresh_reviewer_on_day_rollover_change()
-        self.maybe_auto_sync_on_open_close(_onsuccess)
         gui_hooks.profile_did_open()
+        self.maybe_auto_sync_on_open_close(_onsuccess)
 
     def unloadProfile(self, onsuccess: Callable) -> None:
         def callback() -> None:


### PR DESCRIPTION
The AnkiHub add-on does some stuff in the `profile_did_open` hook that can affect auto sync, so it needs to be called before `maybe_auto_sync_on_open_close`.

I moved the hook call down in #3202 recently, so this shouldn't cause problems.