### PR TITLE
polish graphs of simulator, true retention table and forgetting curve

### DIFF
--- a/rslib/src/stats/graphs/retention.rs
+++ b/rslib/src/stats/graphs/retention.rs
@@ -53,43 +53,25 @@ impl GraphsContext {
         self.revlog
             .iter()
             .filter(|review| {
-                review.button_chosen > 0 // not manually rescheduled
+                // not manually rescheduled
+                review.button_chosen > 0
+                    // not cramming
                     && (review.review_kind != RevlogReviewKind::Filtered || review.ease_factor != 0)
-                // not cramming
+                    // cards with an interval ≥ 1 day
+                    && (review.review_kind == RevlogReviewKind::Review
+                        || review.last_interval <= -86400
+                        || review.last_interval >= 1)
             })
             .for_each(|review| {
                 for (period_name, start, end) in &periods {
                     if review.id.as_secs() >= *start && review.id.as_secs() < *end {
                         let period_stat = period_stats.get_mut(period_name).unwrap();
                         const MATURE_IVL: i32 = 21; // mature interval is 21 days
-                        if review.last_interval < MATURE_IVL
-                            && review.button_chosen == 1
-                            && (review.review_kind == RevlogReviewKind::Review
-                                || review.last_interval <= -86400
-                                || review.last_interval >= 1)
-                        {
-                            period_stat.young_failed += 1;
-                        } else if review.last_interval < MATURE_IVL
-                            && review.button_chosen > 1
-                            && (review.review_kind == RevlogReviewKind::Review
-                                || review.last_interval <= -86400
-                                || review.last_interval >= 1)
-                        {
-                            period_stat.young_passed += 1;
-                        } else if review.last_interval >= MATURE_IVL
-                            && review.button_chosen == 1
-                            && (review.review_kind == RevlogReviewKind::Review
-                                || review.last_interval <= -86400
-                                || review.last_interval >= 1)
-                        {
-                            period_stat.mature_failed += 1;
-                        } else if review.last_interval >= MATURE_IVL
-                            && review.button_chosen > 1
-                            && (review.review_kind == RevlogReviewKind::Review
-                                || review.last_interval <= -86400
-                                || review.last_interval >= 1)
-                        {
-                            period_stat.mature_passed += 1;
+                        match (review.last_interval < MATURE_IVL, review.button_chosen) {
+                            (true, 1) => period_stat.young_failed += 1,
+                            (true, _) => period_stat.young_passed += 1,
+                            (false, 1) => period_stat.mature_failed += 1,
+                            (false, _) => period_stat.mature_passed += 1,
                         }
                     }
                 }

--- a/ts/routes/card-info/ForgettingCurve.svelte
+++ b/ts/routes/card-info/ForgettingCurve.svelte
@@ -10,54 +10,66 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     import AxisTicks from "../graphs/AxisTicks.svelte";
     import { writable } from "svelte/store";
     import InputBox from "../graphs/InputBox.svelte";
-    import { prepareData, renderForgettingCurve, TimeRange } from "./forgetting-curve";
+    import {
+        renderForgettingCurve,
+        TimeRange,
+        calculateMaxDays,
+    } from "./forgetting-curve";
     import { defaultGraphBounds } from "../graphs/graph-helpers";
     import HoverColumns from "../graphs/HoverColumns.svelte";
 
     export let revlog: RevlogEntry[];
     let svg = null as HTMLElement | SVGElement | null;
     const bounds = defaultGraphBounds();
-    const timeRange = writable(TimeRange.AllTime);
     const title = tr.cardStatsFsrsForgettingCurveTitle();
-    const data = prepareData(revlog, TimeRange.AllTime);
+    const maxDays = calculateMaxDays(revlog, TimeRange.AllTime);
+    let defaultTimeRange = TimeRange.Week;
+    if (maxDays > 365) {
+        defaultTimeRange = TimeRange.AllTime;
+    } else if (maxDays > 30) {
+        defaultTimeRange = TimeRange.Year;
+    } else if (maxDays > 7) {
+        defaultTimeRange = TimeRange.Month;
+    }
+    const timeRange = writable(defaultTimeRange);
 
     $: renderForgettingCurve(revlog, $timeRange, svg as SVGElement, bounds);
 </script>
 
 <div class="forgetting-curve">
-    {#if data.length > 0}
-        <InputBox>
-            <div class="time-range-selector">
-                {#if data.some((point) => point.daysSinceFirstLearn > 7)}
-                    <label>
-                        <input
-                            type="radio"
-                            bind:group={$timeRange}
-                            value={TimeRange.Week}
-                        />
-                        {tr.cardStatsFsrsForgettingCurveFirstWeek()}
-                    </label>
-                {/if}
-                {#if data.some((point) => point.daysSinceFirstLearn > 30)}
-                    <label>
-                        <input
-                            type="radio"
-                            bind:group={$timeRange}
-                            value={TimeRange.Month}
-                        />
-                        {tr.cardStatsFsrsForgettingCurveFirstMonth()}
-                    </label>
-                {/if}
-                {#if data.some((point) => point.daysSinceFirstLearn > 365)}
-                    <label>
-                        <input
-                            type="radio"
-                            bind:group={$timeRange}
-                            value={TimeRange.Year}
-                        />
-                        {tr.cardStatsFsrsForgettingCurveFirstYear()}
-                    </label>
-                {/if}
+    <InputBox>
+        <div class="time-range-selector">
+            {#if maxDays > 0}
+                <label>
+                    <input
+                        type="radio"
+                        bind:group={$timeRange}
+                        value={TimeRange.Week}
+                    />
+                    {tr.cardStatsFsrsForgettingCurveFirstWeek()}
+                </label>
+            {/if}
+            {#if maxDays > 7}
+                <label>
+                    <input
+                        type="radio"
+                        bind:group={$timeRange}
+                        value={TimeRange.Month}
+                    />
+                    {tr.cardStatsFsrsForgettingCurveFirstMonth()}
+                </label>
+            {/if}
+            {#if maxDays > 30}
+                <label>
+                    <input
+                        type="radio"
+                        bind:group={$timeRange}
+                        value={TimeRange.Year}
+                    />
+                    {tr.cardStatsFsrsForgettingCurveFirstYear()}
+                </label>
+            {/if}
+            {#if maxDays > 365}
                 <label>
                     <input
                         type="radio"
@@ -66,9 +78,9 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
                     />
                     {tr.cardStatsFsrsForgettingCurveAllTime()}
                 </label>
-            </div>
-        </InputBox>
-    {/if}
+            {/if}
+        </div>
+    </InputBox>
     <Graph {title}>
         <svg bind:this={svg} viewBox={`0 0 ${bounds.width} ${bounds.height}`}>
             <AxisTicks {bounds} />

--- a/ts/routes/card-info/ForgettingCurve.svelte
+++ b/ts/routes/card-info/ForgettingCurve.svelte
@@ -25,32 +25,50 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 </script>
 
 <div class="forgetting-curve">
-    <InputBox>
-        <div class="time-range-selector">
-            <label>
-                <input type="radio" bind:group={$timeRange} value={TimeRange.Week} />
-                {tr.cardStatsFsrsForgettingCurveFirstWeek()}
-            </label>
-            <label>
-                <input type="radio" bind:group={$timeRange} value={TimeRange.Month} />
-                {tr.cardStatsFsrsForgettingCurveFirstMonth()}
-            </label>
-            {#if data.length > 0 && data.some((point) => point.daysSinceFirstLearn > 365)}
+    {#if data.length > 0}
+        <InputBox>
+            <div class="time-range-selector">
+                {#if data.some((point) => point.daysSinceFirstLearn > 7)}
+                    <label>
+                        <input
+                            type="radio"
+                            bind:group={$timeRange}
+                            value={TimeRange.Week}
+                        />
+                        {tr.cardStatsFsrsForgettingCurveFirstWeek()}
+                    </label>
+                {/if}
+                {#if data.some((point) => point.daysSinceFirstLearn > 30)}
+                    <label>
+                        <input
+                            type="radio"
+                            bind:group={$timeRange}
+                            value={TimeRange.Month}
+                        />
+                        {tr.cardStatsFsrsForgettingCurveFirstMonth()}
+                    </label>
+                {/if}
+                {#if data.some((point) => point.daysSinceFirstLearn > 365)}
+                    <label>
+                        <input
+                            type="radio"
+                            bind:group={$timeRange}
+                            value={TimeRange.Year}
+                        />
+                        {tr.cardStatsFsrsForgettingCurveFirstYear()}
+                    </label>
+                {/if}
                 <label>
                     <input
                         type="radio"
                         bind:group={$timeRange}
-                        value={TimeRange.Year}
+                        value={TimeRange.AllTime}
                     />
-                    {tr.cardStatsFsrsForgettingCurveFirstYear()}
+                    {tr.cardStatsFsrsForgettingCurveAllTime()}
                 </label>
-            {/if}
-            <label>
-                <input type="radio" bind:group={$timeRange} value={TimeRange.AllTime} />
-                {tr.cardStatsFsrsForgettingCurveAllTime()}
-            </label>
-        </div>
-    </InputBox>
+            </div>
+        </InputBox>
+    {/if}
     <Graph {title}>
         <svg bind:this={svg} viewBox={`0 0 ${bounds.width} ${bounds.height}`}>
             <AxisTicks {bounds} />

--- a/ts/routes/card-info/ForgettingCurve.svelte
+++ b/ts/routes/card-info/ForgettingCurve.svelte
@@ -14,6 +14,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         renderForgettingCurve,
         TimeRange,
         calculateMaxDays,
+        filterRevlog,
     } from "./forgetting-curve";
     import { defaultGraphBounds } from "../graphs/graph-helpers";
     import HoverColumns from "../graphs/HoverColumns.svelte";
@@ -22,7 +23,8 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     let svg = null as HTMLElement | SVGElement | null;
     const bounds = defaultGraphBounds();
     const title = tr.cardStatsFsrsForgettingCurveTitle();
-    const maxDays = calculateMaxDays(revlog, TimeRange.AllTime);
+    const filteredRevlog = filterRevlog(revlog);
+    const maxDays = calculateMaxDays(filteredRevlog, TimeRange.AllTime);
     let defaultTimeRange = TimeRange.Week;
     if (maxDays > 365) {
         defaultTimeRange = TimeRange.AllTime;
@@ -33,7 +35,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     }
     const timeRange = writable(defaultTimeRange);
 
-    $: renderForgettingCurve(revlog, $timeRange, svg as SVGElement, bounds);
+    $: renderForgettingCurve(filteredRevlog, $timeRange, svg as SVGElement, bounds);
 </script>
 
 <div class="forgetting-curve">

--- a/ts/routes/card-info/Revlog.svelte
+++ b/ts/routes/card-info/Revlog.svelte
@@ -7,7 +7,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     import { RevlogEntry_ReviewKind as ReviewKind } from "@generated/anki/stats_pb";
     import * as tr2 from "@generated/ftl";
     import { timeSpan, Timestamp } from "@tslib/time";
-    import { filterRevlogByReviewKind } from "./forgetting-curve";
+    import { filterRevlogEntryByReviewKind } from "./forgetting-curve";
 
     export let revlog: RevlogEntry[];
     export let fsrsEnabled: boolean = false;
@@ -84,7 +84,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         let prevValidEntry: RevlogEntry | undefined;
         let i = index + 1;
         while (i < revlog.length) {
-            if (filterRevlogByReviewKind(revlog[i])) {
+            if (filterRevlogEntryByReviewKind(revlog[i])) {
                 prevValidEntry = revlog[i];
                 break;
             }
@@ -92,7 +92,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         }
 
         let elapsedTime = "N/A";
-        if (filterRevlogByReviewKind(entry)) {
+        if (filterRevlogEntryByReviewKind(entry)) {
             elapsedTime = prevValidEntry
                 ? timeSpan(Number(entry.time) - Number(prevValidEntry.time))
                 : "0";

--- a/ts/routes/card-info/forgetting-curve.ts
+++ b/ts/routes/card-info/forgetting-curve.ts
@@ -45,11 +45,23 @@ function filterDataByTimeRange(data: DataPoint[], maxDays: number): DataPoint[] 
     return data.filter((point) => point.daysSinceFirstLearn <= maxDays);
 }
 
-export function filterRevlogByReviewKind(entry: RevlogEntry): boolean {
+export function filterRevlogEntryByReviewKind(entry: RevlogEntry): boolean {
     return (
         entry.reviewKind !== RevlogEntry_ReviewKind.MANUAL
         && (entry.reviewKind !== RevlogEntry_ReviewKind.FILTERED || entry.ease !== 0)
     );
+}
+
+export function filterRevlog(revlog: RevlogEntry[]): RevlogEntry[] {
+    const result: RevlogEntry[] = [];
+    for (const entry of revlog) {
+        if (entry.reviewKind === RevlogEntry_ReviewKind.MANUAL && entry.ease === 0) {
+            break;
+        }
+        result.push(entry);
+    }
+
+    return result.filter((entry) => filterRevlogEntryByReviewKind(entry));
 }
 
 export function prepareData(revlog: RevlogEntry[], maxDays: number) {
@@ -144,14 +156,13 @@ export function calculateMaxDays(filteredRevlog: RevlogEntry[], timeRange: TimeR
 }
 
 export function renderForgettingCurve(
-    revlog: RevlogEntry[],
+    filteredRevlog: RevlogEntry[],
     timeRange: TimeRange,
     svgElem: SVGElement,
     bounds: GraphBounds,
 ) {
     const svg = select(svgElem);
     const trans = svg.transition().duration(600) as any;
-    const filteredRevlog = revlog.filter((entry) => filterRevlogByReviewKind(entry));
     if (filteredRevlog.length === 0) {
         setDataAvailable(svg, false);
         return;

--- a/ts/routes/card-info/forgetting-curve.ts
+++ b/ts/routes/card-info/forgetting-curve.ts
@@ -106,7 +106,7 @@ export function prepareData(revlog: RevlogEntry[], maxDays: number) {
     }
 
     const now = Date.now() / 1000;
-    const totalDaysSinceLastReview = Math.floor((now - lastReviewTime) / (24 * 60 * 60));
+    const totalDaysSinceLastReview = (now - lastReviewTime) / (24 * 60 * 60);
     let elapsedDays = 0;
     while (elapsedDays < totalDaysSinceLastReview) {
         elapsedDays += step;

--- a/ts/routes/deck-options/FsrsOptions.svelte
+++ b/ts/routes/deck-options/FsrsOptions.svelte
@@ -324,7 +324,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
             if (resp) {
                 const dailyTimeCost = movingAverage(
                     resp.dailyTimeCost,
-                    Math.round(simulateFsrsRequest.daysToSimulate / 50),
+                    Math.ceil(simulateFsrsRequest.daysToSimulate / 50),
                 );
                 points = points.concat(
                     dailyTimeCost.map((v, i) => ({

--- a/ts/routes/graphs/TrueRetention.svelte
+++ b/ts/routes/graphs/TrueRetention.svelte
@@ -36,6 +36,5 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         overflow-x: auto;
         margin-top: 1rem;
         display: flex;
-        justify-content: center;
     }
 </style>

--- a/ts/routes/graphs/simulator.ts
+++ b/ts/routes/graphs/simulator.ts
@@ -107,7 +107,6 @@ export function renderSimulationChart(
         .selectAll("path")
         .data(Array.from(groups.entries()))
         .join("path")
-        .style("mix-blend-mode", "multiply")
         .attr("stroke", (d, i) => color[i % color.length])
         .attr("d", d => line()(d[1].map(p => [p[0], p[1]])))
         .attr("data-group", d => d[0]);

--- a/ts/routes/graphs/simulator.ts
+++ b/ts/routes/graphs/simulator.ts
@@ -148,7 +148,10 @@ export function renderSimulationChart(
         .attr("height", bounds.height - bounds.marginTop - bounds.marginBottom)
         .attr("fill", "transparent")
         .on("mousemove", mousemove)
-        .on("mouseout", hideTooltip);
+        .on("mouseout", () => {
+            focusLine.style("opacity", 0);
+            hideTooltip();
+        });
 
     function mousemove(event: MouseEvent, d: any): void {
         pointer(event, document.body);
@@ -189,15 +192,15 @@ export function renderSimulationChart(
         .on("click", (event, d) => toggleGroup(event, d));
 
     legend.append("rect")
-        .attr("x", bounds.width - bounds.marginRight + 10)
-        .attr("width", 19)
-        .attr("height", 19)
+        .attr("x", bounds.width - bounds.marginRight - 16)
+        .attr("width", 12)
+        .attr("height", 12)
         .attr("fill", (d, i) => color[i % color.length]);
 
     legend.append("text")
-        .attr("x", bounds.width - bounds.marginRight + 34)
-        .attr("y", 9.5)
-        .attr("dy", "0.32em")
+        .attr("x", bounds.width - bounds.marginRight)
+        .attr("y", 7)
+        .attr("dy", "0.3em")
         .text(d => `Simulation ${d}`);
 
     const toggleGroup = (event: MouseEvent, d: number) => {

--- a/ts/routes/graphs/simulator.ts
+++ b/ts/routes/graphs/simulator.ts
@@ -179,17 +179,17 @@ export function renderSimulationChart(
         .on("click", (event, d) => toggleGroup(event, d));
 
     legend.append("rect")
-        .attr("x", bounds.width - bounds.marginRight - 16)
+        .attr("x", bounds.width - bounds.marginRight + 36)
         .attr("width", 12)
         .attr("height", 12)
         .attr("fill", (d, i) => color[i % color.length]);
 
     legend.append("text")
-        .attr("x", bounds.width - bounds.marginRight)
+        .attr("x", bounds.width - bounds.marginRight + 52)
         .attr("y", 7)
         .attr("dy", "0.3em")
         .attr("fill", "currentColor")
-        .text(d => `Simulation ${d}`);
+        .text(d => `#${d}`);
 
     const toggleGroup = (event: MouseEvent, d: number) => {
         const group = d;

--- a/ts/routes/graphs/simulator.ts
+++ b/ts/routes/graphs/simulator.ts
@@ -1,7 +1,7 @@
 // Copyright: Ankitects Pty Ltd and contributors
 // License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
-import { localizedDate, localizedNumber } from "@tslib/i18n";
+import { localizedDate } from "@tslib/i18n";
 import {
     axisBottom,
     axisLeft,
@@ -14,7 +14,6 @@ import {
     scaleTime,
     schemeCategory10,
     select,
-    timeFormat,
 } from "d3";
 
 import { timeSpan } from "@tslib/time";

--- a/ts/routes/graphs/simulator.ts
+++ b/ts/routes/graphs/simulator.ts
@@ -189,6 +189,7 @@ export function renderSimulationChart(
         .attr("x", bounds.width - bounds.marginRight)
         .attr("y", 7)
         .attr("dy", "0.3em")
+        .attr("fill", "currentColor")
         .text(d => `Simulation ${d}`);
 
     const toggleGroup = (event: MouseEvent, d: number) => {

--- a/ts/routes/graphs/true-retention.ts
+++ b/ts/routes/graphs/true-retention.ts
@@ -50,8 +50,9 @@ export function renderTrueRetention(data: GraphsResponse, revlogRange: RevlogRan
             td.trl { border: 1px solid; text-align: left; padding: 5px; }
             td.trr { border: 1px solid; text-align: right; padding: 5px; }
             td.trc { border: 1px solid; text-align: center; padding: 5px; }
+            table { width: 100%; margin: 0px 25px 20px 25px; }
         </style>
-        <table style="border-collapse: collapse;" cellspacing="0" cellpadding="2">
+        <table cellspacing="0" cellpadding="2">
             <tr>
                 <td class="trl" rowspan=3><b>${tr.statisticsTrueRetentionRange()}</b></td>
                 <td class="trc" colspan=9><b>${tr.statisticsReviewsTitle()}</b></td>

--- a/ts/routes/graphs/true-retention.ts
+++ b/ts/routes/graphs/true-retention.ts
@@ -17,7 +17,7 @@ function calculateRetention(passed: number, failed: number): string {
     if (total === 0) {
         return "0%";
     }
-    return localizedNumber((passed / total) * 100) + "%";
+    return localizedNumber((passed / total) * 100, 1) + "%";
 }
 
 function createStatsRow(name: string, data: TrueRetentionData): string {


### PR DESCRIPTION
Source: https://forums.ankiweb.net/t/anki-24-10-beta/49989/23?u=l.m.sherlock

Simulator: “Simulation” is not cut off now.

<img width="512" alt="image" src="https://github.com/user-attachments/assets/d3315f10-3395-42da-9a46-cc89aa9b8575">

True retention: the width is more adaptive.

<img width="512" alt="image" src="https://github.com/user-attachments/assets/60198bc9-d72c-4a2c-9f9a-52ff5ac1b78a"><br/>

<img width="512" alt="image" src="https://github.com/user-attachments/assets/6678e151-64e6-4656-a3c1-a4dd7406f9aa"><br/>

<img width="512" alt="image" src="https://github.com/user-attachments/assets/42933964-0bb0-4f65-b985-17eb2130eb36">

Forgetting curve: don't display time, only date when the total elapsed time is >=365 days AND the currently selected timeframe is either “First year”.

<img width="791" alt="image" src="https://github.com/user-attachments/assets/97652a81-4f52-48b7-a417-cbdac09090f6">

<img width="742" alt="image" src="https://github.com/user-attachments/assets/e16b0bc4-b171-4c32-ba77-bca7fc702810">

also fix: 
- #3453