### PR TITLE
Fix Mnemosyne importer chokes on due dates >= 2038

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -187,7 +187,7 @@ Christian Donat <https://github.com/cdonat2>
 Asuka Minato <https://asukaminato.eu.org>
 Dillon Baldwin <https://github.com/DillBal>
 Voczi <https://github.com/voczi>
-Ben Nguyen <105088397+bpnguyen107@users.noreply.github.com>  
+Ben Nguyen <105088397+bpnguyen107@users.noreply.github.com>   
 Themis Demetriades <themis100@outlook.com>
 Luke Bartholomew <lukesbart@icloud.com>
 Gregory Abrasaldo <degeemon@gmail.com>

--- a/rslib/src/import_export/text/import.rs
+++ b/rslib/src/import_export/text/import.rs
@@ -635,9 +635,9 @@ impl ForeignCard {
     }
 
     fn native_due(self, timing: &SchedTimingToday) -> i32 {
-        let day_start = timing.next_day_at.0 as i32 - 86_400;
+        let day_start = timing.next_day_at.0 - 86_400;
         let due_delta = (self.due - day_start) / 86_400;
-        due_delta + timing.days_elapsed as i32
+        due_delta as i32 + timing.days_elapsed as i32
     }
 }
 

--- a/rslib/src/import_export/text/mod.rs
+++ b/rslib/src/import_export/text/mod.rs
@@ -40,7 +40,7 @@ pub struct ForeignNote {
 #[serde(default)]
 pub struct ForeignCard {
     /// Seconds-based timestamp
-    pub due: i32,
+    pub due: i64,
     /// In days
     pub interval: u32,
     pub ease_factor: f32,


### PR DESCRIPTION
I believe this fixes #3428. It seems to be a [well-known problem](https://en.wikipedia.org/wiki/Year_2038_problem).

I haven't tested it yet though. Can you share the problematic .db with me so I can see if this fixes the problem @dae? Even if it doesn't, we probably want to keep this change thinking ahead towards 2038... It'd probably be a good idea to make sure anywhere else Unix time is used in the codebase is also at least 64 bits.