### PR TITLE
Allow addon page URL on AddonsDialog

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -194,6 +194,7 @@ Gregory Abrasaldo <degeemon@gmail.com>
 Taylor Obyen <162023405+taylorobyen@users.noreply.github.com>
 Kris Cherven <krischerven@gmail.com>
 twwn <github.com/twwn>
+Park Hyunwoo <phu54321@naver.com>
 
 ********************
 

--- a/qt/aqt/addons.py
+++ b/qt/aqt/addons.py
@@ -1066,7 +1066,12 @@ class GetAddons(QDialog):
     def accept(self) -> None:
         # get codes
         try:
-            ids = [int(n) for n in self.form.code.text().split()]
+            sids = self.form.code.text().split()
+            sids = [
+                re.sub(r"^https://ankiweb.net/shared/info/(\d+)$", r"\1", id_)
+                for id_ in sids
+            ]
+            ids = [int(id_) for id_ in sids]
         except ValueError:
             showWarning(tr.addons_invalid_code())
             return


### PR DESCRIPTION
* Allow users to just copy&paste addon page URL to addon 'code' field.

![image](https://github.com/user-attachments/assets/206783f2-ac02-447f-a0f1-a09f6f8086f9)

https://forums.ankiweb.net/t/get-addons-allow-url-on-code-section/36370