### PR TITLE
Change links in error messages

### DIFF
--- a/rslib/src/template.rs
+++ b/rslib/src/template.rs
@@ -28,7 +28,8 @@ use crate::template_filters::apply_filters;
 pub type FieldMap<'a> = HashMap<&'a str, u16>;
 type TemplateResult<T> = std::result::Result<T, TemplateError>;
 
-static TEMPLATE_ERROR_LINK: &str = "https://docs.ankiweb.net/templates/errors/replacement-errors.md";
+static TEMPLATE_ERROR_LINK: &str =
+    "https://docs.ankiweb.net/templates/errors/replacement-errors.md";
 static TEMPLATE_BLANK_LINK: &str = "https://docs.ankiweb.net/templates/errors/empty-error.html";
 static TEMPLATE_BLANK_CLOZE_LINK: &str = "https://docs.ankiweb.net/templates/errors/cloze-error.md";
 

--- a/rslib/src/template.rs
+++ b/rslib/src/template.rs
@@ -28,10 +28,10 @@ use crate::template_filters::apply_filters;
 pub type FieldMap<'a> = HashMap<&'a str, u16>;
 type TemplateResult<T> = std::result::Result<T, TemplateError>;
 
-static TEMPLATE_ERROR_LINK: &str = "https://faqs.ankiweb.net/card-template-has-a-problem.html";
+static TEMPLATE_ERROR_LINK: &str = "https://docs.ankiweb.net/templates/errors/replacement-errors.md";
 static TEMPLATE_BLANK_LINK: &str =
-    "https://anki.tenderapp.com/kb/card-appearance/the-front-of-this-card-is-blank";
-static TEMPLATE_BLANK_CLOZE_LINK: &str = "https://faqs.ankiweb.net/no-cloze-found-on-card.html";
+    "https://docs.ankiweb.net/templates/errors/empty-error.html";
+static TEMPLATE_BLANK_CLOZE_LINK: &str = "https://docs.ankiweb.net/templates/errors/cloze-error.md";
 
 // Lexing
 //----------------------------------------

--- a/rslib/src/template.rs
+++ b/rslib/src/template.rs
@@ -29,8 +29,7 @@ pub type FieldMap<'a> = HashMap<&'a str, u16>;
 type TemplateResult<T> = std::result::Result<T, TemplateError>;
 
 static TEMPLATE_ERROR_LINK: &str = "https://docs.ankiweb.net/templates/errors/replacement-errors.md";
-static TEMPLATE_BLANK_LINK: &str =
-    "https://docs.ankiweb.net/templates/errors/empty-error.html";
+static TEMPLATE_BLANK_LINK: &str = "https://docs.ankiweb.net/templates/errors/empty-error.html";
 static TEMPLATE_BLANK_CLOZE_LINK: &str = "https://docs.ankiweb.net/templates/errors/cloze-error.md";
 
 // Lexing


### PR DESCRIPTION
This changes links in card template error messages. The links here will not work now as the pages haven't been created. Before merging this in, I suggest merging this PR:

* https://github.com/ankitects/anki-manual/pull/280