### PR TITLE
Add card position column and always show position in card info

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -191,7 +191,7 @@ Ben Nguyen <105088397+bpnguyen107@users.noreply.github.com>
 Themis Demetriades <themis100@outlook.com>
 Luke Bartholomew <lukesbart@icloud.com>
 Gregory Abrasaldo <degeemon@gmail.com>
-Taylor Obyen <162023405+taylorobyen@users.noreply.github.com>
+Taylor Obyen <taylorobyen@gmail.com>
 Kris Cherven <krischerven@gmail.com>
 twwn <github.com/twwn>
 Shirish Pokhrel <singurty@gmail.com>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -191,7 +191,7 @@ Ben Nguyen <105088397+bpnguyen107@users.noreply.github.com>
 Themis Demetriades <themis100@outlook.com>
 Luke Bartholomew <lukesbart@icloud.com>
 Gregory Abrasaldo <degeemon@gmail.com>
-Taylor Obyen <taylorobyen@gmail.com>
+Taylor Obyen <162023405+taylorobyen@users.noreply.github.com>
 Kris Cherven <krischerven@gmail.com>
 twwn <github.com/twwn>
 Shirish Pokhrel <singurty@gmail.com>

--- a/rslib/src/browser_table.rs
+++ b/rslib/src/browser_table.rs
@@ -46,6 +46,7 @@ pub enum Column {
     NoteMod,
     #[strum(serialize = "note")]
     Notetype,
+    OriginalPosition,
     Question,
     #[strum(serialize = "cardReps")]
     Reps,
@@ -161,6 +162,7 @@ impl Column {
             Self::NoteCreation => tr.browsing_created(),
             Self::NoteMod => tr.search_note_modified(),
             Self::Notetype => tr.card_stats_note_type(),
+            Self::OriginalPosition => tr.card_stats_new_card_position(),
             Self::Question => tr.browsing_question(),
             Self::Reps => tr.scheduling_reviews(),
             Self::SortField => tr.browsing_sort_field(),
@@ -226,6 +228,7 @@ impl Column {
             | Column::Interval
             | Column::NoteCreation
             | Column::NoteMod
+            | Column::OriginalPosition
             | Column::Reps => Sorting::Descending,
             Column::Stability | Column::Difficulty | Column::Retrievability => {
                 if notes {
@@ -432,6 +435,7 @@ impl RowContext {
             Column::NoteCreation => self.note_creation_str(),
             Column::SortField => self.note_field_str(),
             Column::NoteMod => self.note.mtime.date_and_time_string(),
+            Column::OriginalPosition => self.card_original_position(),
             Column::Tags => self.note.tags.join(" "),
             Column::Notetype => self.notetype.name.to_owned(),
             Column::Stability => self.fsrs_stability_str(),
@@ -439,6 +443,13 @@ impl RowContext {
             Column::Retrievability => self.fsrs_retrievability_str(),
             Column::Custom => "".to_string(),
         })
+    }
+
+    fn card_original_position(&self) -> String {
+        match self.cards[0].original_position {
+            Some(pos) => pos.to_string(),
+            None => self.cards[0].due.to_string(),
+        }
     }
 
     fn note_creation_str(&self) -> String {

--- a/rslib/src/browser_table.rs
+++ b/rslib/src/browser_table.rs
@@ -446,9 +446,13 @@ impl RowContext {
     }
 
     fn card_original_position(&self) -> String {
-        match self.cards[0].original_position {
-            Some(pos) => pos.to_string(),
-            None => self.cards[0].due.to_string(),
+        let card = &self.cards[0];
+        if let Some(pos) = &card.original_position {
+            pos.to_string()
+        } else if card.ctype == CardType::New {
+            card.due.to_string()
+        } else {
+            String::new()
         }
     }
 

--- a/rslib/src/search/mod.rs
+++ b/rslib/src/search/mod.rs
@@ -370,7 +370,7 @@ fn card_order_from_sort_column(column: Column, timing: SchedTimingToday) -> Cow<
         Column::NoteCreation => "n.id asc, c.ord asc".into(),
         Column::NoteMod => "n.mod asc, c.ord asc".into(),
         Column::Notetype => "(select pos from sort_order where ntid = n.mid) asc".into(),
-        Column::OriginalPosition => "get_original_position(c.due, c.data) asc".into(),
+        Column::OriginalPosition => "coalesce(extract_original_position(c.data), c.due) asc".into(),
         Column::Reps => "c.reps asc".into(),
         Column::SortField => "n.sfld collate nocase asc, c.ord asc".into(),
         Column::Tags => "n.tags asc".into(),

--- a/rslib/src/search/mod.rs
+++ b/rslib/src/search/mod.rs
@@ -370,6 +370,7 @@ fn card_order_from_sort_column(column: Column, timing: SchedTimingToday) -> Cow<
         Column::NoteCreation => "n.id asc, c.ord asc".into(),
         Column::NoteMod => "n.mod asc, c.ord asc".into(),
         Column::Notetype => "(select pos from sort_order where ntid = n.mid) asc".into(),
+        Column::OriginalPosition => "get_original_position(c.due, c.data) asc".into(),
         Column::Reps => "c.reps asc".into(),
         Column::SortField => "n.sfld collate nocase asc, c.ord asc".into(),
         Column::Tags => "n.tags asc".into(),
@@ -394,6 +395,7 @@ fn note_order_from_sort_column(column: Column) -> Cow<'static, str> {
         | Column::Ease
         | Column::Interval
         | Column::Lapses
+        | Column::OriginalPosition
         | Column::Reps => "(select pos from sort_order where nid = n.id) asc".into(),
         Column::NoteCreation => "n.id asc".into(),
         Column::NoteMod => "n.mod asc".into(),
@@ -429,6 +431,7 @@ fn prepare_sort(col: &mut Collection, column: Column, item_type: ReturnItemType)
             Column::Ease => include_str!("note_ease_order.sql"),
             Column::Interval => include_str!("note_interval_order.sql"),
             Column::Lapses => include_str!("note_lapses_order.sql"),
+            Column::OriginalPosition => include_str!("note_original_position_order.sql"),
             Column::Reps => include_str!("note_reps_order.sql"),
             Column::Notetype => include_str!("notetype_order.sql"),
             _ => return Ok(()),

--- a/rslib/src/search/mod.rs
+++ b/rslib/src/search/mod.rs
@@ -370,7 +370,7 @@ fn card_order_from_sort_column(column: Column, timing: SchedTimingToday) -> Cow<
         Column::NoteCreation => "n.id asc, c.ord asc".into(),
         Column::NoteMod => "n.mod asc, c.ord asc".into(),
         Column::Notetype => "(select pos from sort_order where ntid = n.mid) asc".into(),
-        Column::OriginalPosition => "coalesce(extract_original_position(c.data), c.due) asc".into(),
+        Column::OriginalPosition => "(select pos from sort_order where nid = c.nid) asc".into(),
         Column::Reps => "c.reps asc".into(),
         Column::SortField => "n.sfld collate nocase asc, c.ord asc".into(),
         Column::Tags => "n.tags asc".into(),
@@ -418,6 +418,7 @@ fn prepare_sort(col: &mut Collection, column: Column, item_type: ReturnItemType)
             Column::Cards => include_str!("template_order.sql"),
             Column::Deck => include_str!("deck_order.sql"),
             Column::Notetype => include_str!("notetype_order.sql"),
+            Column::OriginalPosition => include_str!("note_original_position_order.sql"),
             _ => return Ok(()),
         },
         ReturnItemType::Notes => match column {

--- a/rslib/src/search/note_original_position_order.sql
+++ b/rslib/src/search/note_original_position_order.sql
@@ -7,4 +7,4 @@ INSERT INTO sort_order (nid)
 SELECT nid
 FROM cards
 GROUP BY nid
-ORDER BY COALESCE(odue, due);
+ORDER BY COALESCE(extract_original_position(data), due);

--- a/rslib/src/search/note_original_position_order.sql
+++ b/rslib/src/search/note_original_position_order.sql
@@ -7,4 +7,10 @@ INSERT INTO sort_order (nid)
 SELECT nid
 FROM cards
 GROUP BY nid
-ORDER BY COALESCE(extract_original_position(data), due);
+ORDER BY COALESCE(
+    extract_original_position(data),
+    CASE
+      WHEN type == 0 THEN due
+      ELSE 0
+    END
+  );

--- a/rslib/src/search/note_original_position_order.sql
+++ b/rslib/src/search/note_original_position_order.sql
@@ -1,0 +1,10 @@
+DROP TABLE IF EXISTS sort_order;
+CREATE TEMPORARY TABLE sort_order (
+  pos integer PRIMARY KEY,
+  nid integer NOT NULL UNIQUE
+);
+INSERT INTO sort_order (nid)
+SELECT nid
+FROM cards
+GROUP BY nid
+ORDER BY COALESCE(odue, due);

--- a/rslib/src/stats/card.rs
+++ b/rslib/src/stats/card.rs
@@ -86,10 +86,9 @@ impl Collection {
     }
 
     fn due_date_and_position(&mut self, card: &Card) -> Result<(Option<i64>, Option<i32>)> {
-        let due = if card.original_due != 0 {
-            card.original_due
-        } else {
-            card.due
+        let due = match card.original_position {
+            Some(pos) => pos as i32,
+            None => card.due,
         };
         Ok(match card.ctype {
             CardType::New => {
@@ -111,7 +110,7 @@ impl Collection {
                         Some(due as i64)
                     }
                 },
-                None,
+                Some(due),
             ),
         })
     }

--- a/rslib/src/stats/card.rs
+++ b/rslib/src/stats/card.rs
@@ -105,7 +105,7 @@ impl Collection {
             return Some(original_pos as i32);
         }
         match card.ctype {
-            CardType::New => Some(card.due.into()),
+            CardType::New => Some(card.due),
             _ => None,
         }
     }

--- a/rslib/src/stats/card.rs
+++ b/rslib/src/stats/card.rs
@@ -3,7 +3,6 @@
 
 use fsrs::FSRS;
 
-use crate::card::CardQueue;
 use crate::card::CardType;
 use crate::prelude::*;
 use crate::revlog::RevlogEntry;
@@ -28,7 +27,6 @@ impl Collection {
         let revlog = self.storage.get_revlog_entries_for_card(card.id)?;
 
         let (average_secs, total_secs) = average_and_total_secs_strings(&revlog);
-        let (due_date, due_position) = self.due_date_and_position(&card)?;
         let timing = self.timing_today()?;
         let days_elapsed = self
             .storage
@@ -62,8 +60,8 @@ impl Collection {
             added: card.id.as_secs().0,
             first_review: revlog.first().map(|entry| entry.id.as_secs().0),
             latest_review: revlog.last().map(|entry| entry.id.as_secs().0),
-            due_date,
-            due_position,
+            due_date: self.due_date(&card)?,
+            due_position: self.position(&card),
             interval: card.interval,
             ease: card.ease_factor as u32,
             reviews: card.reps,
@@ -85,34 +83,31 @@ impl Collection {
         })
     }
 
-    fn due_date_and_position(&mut self, card: &Card) -> Result<(Option<i64>, Option<i32>)> {
-        let due = match card.original_position {
-            Some(pos) => pos as i32,
-            None => card.due,
-        };
+    fn due_date(&mut self, card: &Card) -> Result<Option<i64>> {
         Ok(match card.ctype {
-            CardType::New => {
-                if matches!(card.queue, CardQueue::Review | CardQueue::DayLearn) {
-                    // new preview card not answered yet
-                    (None, card.original_position.map(|u| u as i32))
+            CardType::New => None,
+            CardType::Review | CardType::Learn | CardType::Relearn => {
+                let due = card.due;
+                if !is_unix_epoch_timestamp(due) {
+                    let days_remaining = due - (self.timing_today()?.days_elapsed as i32);
+                    let mut due_timestamp = TimestampSecs::now();
+                    due_timestamp.0 += (days_remaining as i64) * 86_400;
+                    Some(due_timestamp.0)
                 } else {
-                    (None, Some(due))
+                    Some(due as i64)
                 }
             }
-            CardType::Review | CardType::Learn | CardType::Relearn => (
-                {
-                    if !is_unix_epoch_timestamp(due) {
-                        let days_remaining = due - (self.timing_today()?.days_elapsed as i32);
-                        let mut due = TimestampSecs::now();
-                        due.0 += (days_remaining as i64) * 86_400;
-                        Some(due.0)
-                    } else {
-                        Some(due as i64)
-                    }
-                },
-                Some(due),
-            ),
         })
+    }
+
+    fn position(&mut self, card: &Card) -> Option<i32> {
+        if let Some(original_pos) = card.original_position {
+            return Some(original_pos as i32);
+        }
+        match card.ctype {
+            CardType::New => Some(card.due.into()),
+            _ => None,
+        }
     }
 
     fn stats_revlog_entries_with_memory_state(

--- a/rslib/src/storage/sqlite.rs
+++ b/rslib/src/storage/sqlite.rs
@@ -70,7 +70,7 @@ fn open_or_create_collection_db(path: &Path) -> Result<Connection> {
     add_regexp_tags_function(&db)?;
     add_without_combining_function(&db)?;
     add_fnvhash_function(&db)?;
-    add_get_original_position_function(&db)?;
+    add_extract_original_position_function(&db)?;
     add_extract_custom_data_function(&db)?;
     add_extract_fsrs_variable(&db)?;
     add_extract_fsrs_retrievability(&db)?;
@@ -206,31 +206,24 @@ fn add_regexp_tags_function(db: &Connection) -> rusqlite::Result<()> {
     )
 }
 
-/// eg. get_original_position(c.due, c.data) -> i64
-/// Check if c.data contains the position, if not it's still in c.due
-fn add_get_original_position_function(db: &Connection) -> rusqlite::Result<()> {
+/// eg. extract_original_position(c.data) -> number | null
+/// Parse original card position from c.data (this is only populated after card
+/// has been reviewed)
+fn add_extract_original_position_function(db: &Connection) -> rusqlite::Result<()> {
     db.create_scalar_function(
-        "get_original_position",
-        2,
+        "extract_original_position",
+        1,
         FunctionFlags::SQLITE_DETERMINISTIC,
         move |ctx| {
-            assert_eq!(ctx.len(), 2, "called with unexpected number of arguments");
+            assert_eq!(ctx.len(), 1, "called with unexpected number of arguments");
 
-            let Ok(current_due) = ctx.get_raw(0).as_i64() else {
-                return Ok(0);
-            };
-
-            let Ok(card_data) = ctx.get_raw(1).as_str() else {
-                return Ok(current_due);
-            };
-
-            if card_data.is_empty() {
-                return Ok(current_due);
+            let Ok(card_data) = ctx.get_raw(0).as_str() else {
+                return Ok(None);
             };
 
             match &CardData::from_str(card_data).original_position {
-                Some(position) => Ok(*position as i64),
-                None => Ok(current_due),
+                Some(position) => Ok(Some(*position as i64)),
+                None => Ok(None),
             }
         },
     )


### PR DESCRIPTION
Implements #3336

- New position column that displays the original position of the card, supported with cards and notes sortable
![image](https://github.com/user-attachments/assets/826425f6-26df-4eea-ad94-8fe971087013)
- Original position now always show in card info
![image](https://github.com/user-attachments/assets/740556f9-8831-42ae-911a-ba72373e6061)

