### PR TITLE
NF: `assert mw` to improve typing

### DIFF
--- a/qt/aqt/addons.py
+++ b/qt/aqt/addons.py
@@ -238,6 +238,8 @@ class AddonManager:
     def loadAddons(self) -> None:
         from aqt import mw
 
+        assert mw
+
         broken: list[str] = []
         error_text = ""
         for addon in self.all_addon_meta():

--- a/qt/aqt/errors.py
+++ b/qt/aqt/errors.py
@@ -322,6 +322,8 @@ def addon_fmt(addmgr: AddonManager, addon: AddonMeta) -> str:
 def addon_debug_info() -> str:
     from aqt import mw
 
+    assert mw
+
     addmgr = mw.addonManager
     active = []
     activeids = []

--- a/qt/aqt/preferences.py
+++ b/qt/aqt/preferences.py
@@ -268,6 +268,8 @@ class Preferences(QDialog):
     def confirm_sync_after_login(self) -> None:
         from aqt import mw
 
+        assert mw
+
         if askUser(tr.preferences_login_successful_sync_now(), parent=mw):
             self.accept_with_callback(self.mw.on_sync_button_clicked)
 

--- a/qt/aqt/sound.py
+++ b/qt/aqt/sound.py
@@ -446,6 +446,8 @@ class MpvManager(MPV, SoundOrVideoPlayer):
         if value and self._on_done:
             from aqt import mw
 
+            assert mw
+
             mw.taskman.run_on_main(self._on_done)
 
     def shutdown(self) -> None:

--- a/qt/aqt/update.py
+++ b/qt/aqt/update.py
@@ -13,6 +13,8 @@ from aqt.utils import openLink, show_warning, showText, tr
 def check_for_update() -> None:
     from aqt import mw
 
+    assert mw
+
     def do_check(_col: Collection) -> CheckForUpdateResponse:
         return mw.backend.check_for_update(
             version=int_version(),

--- a/qt/aqt/utils.py
+++ b/qt/aqt/utils.py
@@ -909,6 +909,8 @@ def _show_in_folder_win32(path: str) -> None:
 
     from aqt import mw
 
+    assert mw
+
     def focus_explorer():
         hwnd = win32gui.FindWindow("CabinetWClass", None)
         if hwnd:
@@ -1140,6 +1142,8 @@ def disallow_full_screen() -> bool:
     from aqt import mw
     from aqt.profiles import VideoDriver
 
+    assert mw
+
     return is_win and (
         mw.pm.video_driver() == VideoDriver.OpenGL
         and not os.environ.get("ANKI_SOFTWAREOPENGL")
@@ -1161,6 +1165,8 @@ def supportText() -> str:
     import platform
 
     from aqt import mw
+
+    assert mw
 
     platname = platform.platform()
 
@@ -1299,6 +1305,8 @@ class KeyboardModifiersPressed:
 
     def __init__(self) -> None:
         from aqt import mw
+
+        assert mw
 
         self._modifiers = mw.app.keyboardModifiers()
 

--- a/qt/aqt/webview.py
+++ b/qt/aqt/webview.py
@@ -150,6 +150,8 @@ class AnkiWebPage(QWebEnginePage):
         # catch buggy <a href='#' onclick='func()'> links
         from aqt import mw
 
+        assert mw
+
         if url.matches(
             QUrl(mw.serverURL()), cast(Any, QUrl.UrlFormattingOption.RemoveFragment)
         ):
@@ -351,6 +353,8 @@ class AnkiWebView(QWebEngineView):
             if isinstance(w, QDialog) or isinstance(w, QMainWindow):
                 from aqt import mw
 
+                assert mw
+
                 # esc in a child window closes the window
                 if w != mw:
                     w.close()
@@ -415,6 +419,8 @@ class AnkiWebView(QWebEngineView):
         maximum size limit, and due to security changes, it
         will stop working in the future."""
         from aqt import mw
+
+        assert mw
 
         oldFocus = mw.app.focusWidget()
         self._domDone = False
@@ -563,6 +569,8 @@ html {{ {font} }}
 
         from aqt import mw
 
+        assert mw
+
         head = mw.baseHTML() + csstxt + web_content.head
         body_class = theme_manager.body_class()
 
@@ -612,6 +620,8 @@ html {{ {font} }}
     @classmethod
     def webBundlePath(cls, path: str) -> str:
         from aqt import mw
+
+        assert mw
 
         if path.startswith("/"):
             subpath = ""
@@ -672,6 +682,8 @@ html {{ {font} }}
         # or the underlying webview has been deleted
         from aqt import mw
 
+        assert mw
+
         if sip.isdeleted(self):
             return True
         if not mw.col and self.requiresCol:
@@ -714,6 +726,8 @@ html {{ {font} }}
 
     def _onHeight(self, qvar: int | None) -> None:
         from aqt import mw
+
+        assert mw
 
         if qvar is None:
             mw.progress.single_shot(1000, mw.reset)
@@ -766,6 +780,8 @@ html {{ {font} }}
     def load_ts_page(self, name: str) -> None:
         from aqt import mw
 
+        assert mw
+
         self.set_open_links_externally(True)
         if theme_manager.night_mode:
             extra = "#night"
@@ -776,6 +792,8 @@ html {{ {font} }}
 
     def load_sveltekit_page(self, path: str) -> None:
         from aqt import mw
+
+        assert mw
 
         self.set_open_links_externally(True)
         if theme_manager.night_mode:
@@ -805,6 +823,7 @@ html {{ {font} }}
             # this will fail when __del__ is called during app shutdown
             return
 
+        assert mw
         gui_hooks.theme_did_change.remove(self.on_theme_did_change)
         gui_hooks.body_classes_need_update.remove(self.on_body_classes_need_update)
         # defer page cleanup so that in-flight requests have a chance to complete first
@@ -840,6 +859,8 @@ html {{ {font} }}
 
     def on_body_classes_need_update(self) -> None:
         from aqt import mw
+
+        assert mw
 
         self.eval(
             f"""document.body.classList.toggle("fancy", {json.dumps(not mw.pm.minimalist_mode())}); """


### PR DESCRIPTION
My looking at some code, the IDE showed a lot of warning that we accessed a value that is not defined on None. Indeed `mw` could be None.

By adding those assert, the IDE know that `mw` is non null. If it were not the case, a null pointer exception would be called a few lines later anyway.

I did it only for `mw`, as it's a very special variable in anki and my goal was not to remove all ide's null warning.