### PR TITLE
Deck options warn users if they are in a text field

### DIFF
--- a/ts/routes/deck-options/[deckId]/+page.svelte
+++ b/ts/routes/deck-options/[deckId]/+page.svelte
@@ -13,7 +13,14 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
     globalThis.anki ||= {};
     globalThis.anki.deckOptionsPendingChanges = () => {
-        return data.state.isModified();
+        if (data.state.isModified()) {
+            return true;
+        }
+        // The state does not know of any modified data.
+        // Still, the user may have edited the content of an input field. This would not have updated the state until the focus left the field.
+        // Forcing the loss of focus, a.k.a. `blur` requires a change in the DOM, and thus is async.
+        // Instead, we'll assume that if any HTMLElement is currently selected, there may have been a change.
+        return document.activeElement instanceof HTMLInputElement;
     };
     onMount(() => {
         globalThis.$deckOptions = new Promise((resolve, _reject) => {


### PR DESCRIPTION
The state is updated only when the field is left. This means that `deckOptionsPendingChanges` return False when the UI is updated and the update was not propagated to the state.

This means any local change could be lost if the user press "esc".

With this commit, the user will get asked to confirm they want to leave even if they ended up not making any changes, as long as they are focused in an input field.

Here are the alternative considered.

1. The `save` function avoid this issue by first calling `blur` to remove the focus to the text field. This is a DOM operation, it's async, so `save` wait for one tick.

We can't use async operation, the expressions needs to return a value tha can be encoded as JSON, and a promise can't be returned to python.

2. having js explicitly send the answer with `pycmd`. The added complexity does not seems worthwhile.

3. reflecting all changes from the UI immediately to the state.
4. having a method that checks whether the current value is equal to the initial value of the field

Both case requires deep change to the UI. It's not clear to me that this bug is worth the added complexity.

5. Do nothing. After all, the current state is not that bad. Most change are still preserved by the recent improvement to the deck options. And if the previous state has been acceptable for a long time, current state is certainly acceptable too.

Fixed: #3472