### PR TITLE
Add "Show on leech tooltips" review preference

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -196,6 +196,7 @@ Kris Cherven <krischerven@gmail.com>
 twwn <github.com/twwn>
 Shirish Pokhrel <singurty@gmail.com>
 Park Hyunwoo <phu54321@naver.com>
+KolbyML <31669092+KolbyML@users.noreply.github.com>
 
 ********************
 

--- a/ftl/core/preferences.ftl
+++ b/ftl/core/preferences.ftl
@@ -23,6 +23,7 @@ preferences-show-learning-cards-with-larger-steps = Show learning cards with lar
 preferences-show-next-review-time-above-answer = Show next review time above answer buttons
 preferences-spacebar-rates-card = Spacebar (or enter) also answers card
 preferences-show-play-buttons-on-cards-with = Show play buttons on cards with audio
+preferences-show-on-leech-tooltips = Show on leech tooltips
 preferences-show-remaining-card-count = Show remaining card count
 preferences-some-settings-will-take-effect-after = Some settings will take effect after you restart Anki.
 preferences-tab-synchronisation = Synchronization

--- a/proto/anki/config.proto
+++ b/proto/anki/config.proto
@@ -55,6 +55,7 @@ message ConfigKey {
     SHIFT_POSITION_OF_EXISTING_CARDS = 24;
     RENDER_LATEX = 25;
     LOAD_BALANCER_ENABLED = 26;
+    HIDE_ON_LEECH_TOOLTIPS = 27;
   }
   enum String {
     SET_DUE_BROWSER = 0;
@@ -117,6 +118,7 @@ message Preferences {
     bool show_intervals_on_buttons = 4;
     uint32 time_limit_secs = 5;
     bool load_balancer_enabled = 6;
+    bool hide_on_leech_tooltips = 7;
   }
   message Editing {
     bool adding_defaults_to_current_deck = 1;

--- a/qt/aqt/forms/preferences.ui
+++ b/qt/aqt/forms/preferences.ui
@@ -451,6 +451,19 @@
               </property>
              </widget>
             </item>
+            <item>
+             <widget class="QCheckBox" name="showOnLeechTooltips">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="text">
+               <string>preferences_show_on_leech_tooltips</string>
+              </property>
+             </widget>
+            </item>
            </layout>
           </widget>
          </item>

--- a/qt/aqt/preferences.py
+++ b/qt/aqt/preferences.py
@@ -127,6 +127,7 @@ class Preferences(QDialog):
         form.showEstimates.setChecked(reviewing.show_intervals_on_buttons)
         form.showProgress.setChecked(reviewing.show_remaining_due_counts)
         form.showPlayButtons.setChecked(not reviewing.hide_audio_play_buttons)
+        form.showOnLeechTooltips.setChecked(not reviewing.hide_on_leech_tooltips)
         form.interrupt_audio.setChecked(reviewing.interrupt_audio_when_answering)
 
         editing = self.prefs.editing
@@ -159,6 +160,7 @@ class Preferences(QDialog):
         reviewing.show_intervals_on_buttons = form.showEstimates.isChecked()
         reviewing.time_limit_secs = form.timeLimit.value() * 60
         reviewing.hide_audio_play_buttons = not self.form.showPlayButtons.isChecked()
+        reviewing.hide_on_leech_tooltips = not self.form.showOnLeechTooltips.isChecked()
         reviewing.interrupt_audio_when_answering = self.form.interrupt_audio.isChecked()
 
         editing = self.prefs.editing

--- a/qt/aqt/reviewer.py
+++ b/qt/aqt/reviewer.py
@@ -938,6 +938,9 @@ timerStopped = false;
     ##########################################################################
 
     def onLeech(self, card: Card | None = None) -> None:
+        if self.mw.col.get_config_bool(Config.Bool.HIDE_ON_LEECH_TOOLTIPS):
+            return
+
         # for now
         s = tr.studying_card_was_a_leech()
         # v3 scheduler doesn't report this

--- a/rslib/src/backend/config.rs
+++ b/rslib/src/backend/config.rs
@@ -38,6 +38,7 @@ impl From<BoolKeyProto> for BoolKey {
             BoolKeyProto::ShiftPositionOfExistingCards => BoolKey::ShiftPositionOfExistingCards,
             BoolKeyProto::RenderLatex => BoolKey::RenderLatex,
             BoolKeyProto::LoadBalancerEnabled => BoolKey::LoadBalancerEnabled,
+            BoolKeyProto::HideOnLeechTooltips => BoolKey::HideOnLeechTooltips,
         }
     }
 }

--- a/rslib/src/config/bool.rs
+++ b/rslib/src/config/bool.rs
@@ -22,6 +22,7 @@ pub enum BoolKey {
     CollapseToday,
     FutureDueShowBacklog,
     HideAudioPlayButtons,
+    HideOnLeechTooltips,
     IgnoreAccentsInSearch,
     InterruptAudioWhenAnswering,
     NewCardsIgnoreReviewLimit,

--- a/rslib/src/preferences.rs
+++ b/rslib/src/preferences.rs
@@ -99,6 +99,7 @@ impl Collection {
                 .get_config_bool(BoolKey::ShowIntervalsAboveAnswerButtons),
             time_limit_secs: self.get_answer_time_limit_secs(),
             load_balancer_enabled: self.get_config_bool(BoolKey::LoadBalancerEnabled),
+            hide_on_leech_tooltips: self.get_config_bool(BoolKey::HideOnLeechTooltips),
         })
     }
 
@@ -119,6 +120,7 @@ impl Collection {
         )?;
         self.set_answer_time_limit_secs(s.time_limit_secs)?;
         self.set_config_bool_inner(BoolKey::LoadBalancerEnabled, s.load_balancer_enabled)?;
+        self.set_config_bool_inner(BoolKey::HideOnLeechTooltips, s.hide_on_leech_tooltips)?;
 
         Ok(())
     }


### PR DESCRIPTION
# The problem
I have been using AnkiMobile for over a year now, and Anki longer then that. I find AnkiMobile makes it a lot easier to focus on repping my cards, whereas I get easily distracted on PC. On AnkiMobile I also disabled "Show remaining card count" which massively helped me not get distracted.

This brings me to my last major pain point using AnkiMobile. I have leech threshold set low, but every time `onLeech()` is called a Tooltip pops up which tells me `onLeech()` was called this distracts me in a few ways.

- The tooltip on AnkiMobile blocks visibility of my next card, so I have to wait for the tooltip to go away to see the important part of my next card which is covered by the tooltip, which becomes tedious when you see it every day.
- My main issue with the tooltip is that it gives me major confirmation basis as in I think when I am repping my cards, my leech threshold suspends a lot more cards then it actually does, which is very distracting. I think, wow, I am failing all my cards, but in reality, barely any cards are actually being suspended. So due to confirmation basis I think `onLeech` is being called for over 50% of cards, when reality it is only 5% of cards which is find reasonable. This causes me to hesitate repping my cards as I am scared of seeing the `onLeech()` tooltip again

# Solution

Add a review preference to disable the `onLeech()` tooltips from showing to remove the major distraction/(pain point) I have been having with anki for months now to where it is just getting more and more tedious slowly over time to the point I made this PR.