### PR TITLE
Add .venv to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ node_modules
 /extra
 yarn-error.log
 ts/.svelte-kit
+/.venv


### PR DESCRIPTION
Not sure what the typical Anki developer uses as a dev environment. But I like to have a venv for every Python project so I can easily get code completion and such, without having to worry about local system dependency conflicts.