### PR TITLE
Add 127.0.0.1 to allowed origins

### DIFF
--- a/run
+++ b/run
@@ -7,7 +7,7 @@ export PYTHONPYCACHEPREFIX=out/pycache
 # define these as blank before calling the script if you want to disable them
 export ANKIDEV=${ANKIDEV-1}
 export QTWEBENGINE_REMOTE_DEBUGGING=${QTWEBENGINE_REMOTE_DEBUGGING-8080}
-export QTWEBENGINE_CHROMIUM_FLAGS=${QTWEBENGINE_CHROMIUM_FLAGS---remote-allow-origins=http://localhost:$QTWEBENGINE_REMOTE_DEBUGGING}
+export QTWEBENGINE_CHROMIUM_FLAGS=${QTWEBENGINE_CHROMIUM_FLAGS---remote-allow-origins=http://localhost:$QTWEBENGINE_REMOTE_DEBUGGING,http://127.0.0.1:$QTWEBENGINE_REMOTE_DEBUGGING}
 
 # The pages can be accessed by, e.g. surfing to
 # http://localhost:40000/_anki/pages/deckconfig.html

--- a/run.bat
+++ b/run.bat
@@ -5,7 +5,7 @@ set PYTHONWARNINGS=default
 set PYTHONPYCACHEPREFIX=out\pycache
 set ANKIDEV=1
 set QTWEBENGINE_REMOTE_DEBUGGING=8080
-set QTWEBENGINE_CHROMIUM_FLAGS=--remote-allow-origins=http://localhost:8080
+set QTWEBENGINE_CHROMIUM_FLAGS=--remote-allow-origins=http://localhost:8080,http://127.0.0.1:8080
 set ANKI_API_PORT=40000
 set ANKI_API_HOST=127.0.0.1
 


### PR DESCRIPTION
Otherwise, you'd get this error when trying to debug the app through 127.0.0.1:
`[12114:12114:1006/133417.997114:ERROR:devtools_http_handler.cc(766)] Rejected an incoming WebSocket connection from the http://127.0.0.1:8080 origin. Use the command line flag --remote-allow-origins=http://127.0.0.1:8080 to allow connections from this origin or --remote-allow-origins=* to allow all origins.`