### PR TITLE
typeanswer: NFC fix & cleanup

### DIFF
--- a/qt/aqt/reviewer.py
+++ b/qt/aqt/reviewer.py
@@ -712,10 +712,10 @@ class Reviewer:
             # get field and cloze position
             clozeIdx = self.card.ord + 1
             fld = fld.split(":")[1]
-        # loop through fields for a match
         if fld.startswith("nc:"):
             self._combining = False
             fld = fld.split(":")[1]
+        # loop through fields for a match
         for f in self.card.note_type()["flds"]:
             if f["name"] == fld:
                 self.typeCorrect = self.card.note()[f["name"]]

--- a/rslib/src/template_filters.rs
+++ b/rslib/src/template_filters.rs
@@ -30,7 +30,7 @@ pub(crate) fn apply_filters<'a>(
 ) -> (Cow<'a, str>, Vec<String>) {
     let mut text: Cow<str> = text.into();
 
-    // type:cloze is handled specially
+    // type:cloze & type:nc are handled specially
     let filters = if filters == ["cloze", "type"] {
         &["type-cloze"]
     } else if filters == ["nc", "type"] {

--- a/rslib/src/text.rs
+++ b/rslib/src/text.rs
@@ -13,7 +13,6 @@ use regex::Regex;
 use unicase::eq as uni_eq;
 use unicode_normalization::char::is_combining_mark;
 use unicode_normalization::is_nfc;
-use unicode_normalization::is_nfkd;
 use unicode_normalization::is_nfkd_quick;
 use unicode_normalization::IsNormalized;
 use unicode_normalization::UnicodeNormalization;
@@ -396,13 +395,6 @@ pub(crate) fn normalize_to_nfc(s: &str) -> Cow<str> {
 pub(crate) fn ensure_string_in_nfc(s: &mut String) {
     if !is_nfc(s) {
         *s = s.chars().nfc().collect()
-    }
-}
-
-pub(crate) fn normalize_to_nfkd(s: &str) -> Cow<str> {
-    match is_nfkd(s) {
-        false => s.chars().nfkd().collect::<String>().into(),
-        true => s.into(),
     }
 }
 


### PR DESCRIPTION
I'm sorry if this is getting annoying as my last PR was already the "final" cleanup, but this should really be it…

No functional changes:

* *DiffNonCombining*'s `new()` used `String` where plain `Vec` is appropriate
* get rid of `normalize_typed` for *DiffTrait* again by pulling code into *DiffNonCombining*'s `new()`
* *DiffNonCombining* testcase
* Typos

Functional change

* Revert to NFC throughout `typeanswer.rs` for now. If it breaks the non-combining comparison for other languages, we can still re-revert only for it to NFKD later. (This time I'd skip `normalize_to_nfkd`/`text.rs` and just go for `nfkd()` directly, it returning an iterator also allows more concise code.)

(Curiously my local nightly `rustfmt` now wants to reformat other testcases in a way that breaks the repo check.)