### PR TITLE
ts/src/app.html: Changed from favicon.png to favicon.ico

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -196,6 +196,7 @@ Kris Cherven <krischerven@gmail.com>
 twwn <github.com/twwn>
 Shirish Pokhrel <singurty@gmail.com>
 Park Hyunwoo <phu54321@naver.com>
+Tomas Fabrizio Orsi <torsi@fi.uba.ar>
 
 ********************
 

--- a/ts/src/app.html
+++ b/ts/src/app.html
@@ -2,7 +2,7 @@
 <html lang="en">
 	<head>
 		<meta charset="utf-8" />
-		<link rel="icon" href="%sveltekit.assets%/favicon.png" />
+		<link rel="icon" href="%sveltekit.assets%/favicon.ico" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		%sveltekit.head%
 	</head>


### PR DESCRIPTION
I was getting the following error when running anki:

```
Not found: favicon.png
```

Looking through anki's file, I wasn't able to find a `favicon.png`. IIANM, [here's](https://github.com/ankitects/anki/blob/main/ts/src/app.html#L5)  the only mention of "favicon.png" (I doubled checked with grep).

However, I did find a `favicon.ico` file. 

Therefore, I changed the ".png" to ".ico" and anki stopped showing that error.

However, I still wasn't able to see the image. I am not sure *where* it should be displayed. Plus (and probably the reason why I'm not seeing it), I'm using the qtile window manager, which shows little to no desktop-app-images.

If the ".ico" file extension is needed, I could  force push a commit where I add the `favicon.ico` file (using ImageMagick).

If that is preferred, let me know.

- Best regards


PS: Thank you very much Anki devs for the wonderful app! I used Anki a whiiiiiile ago. I'm glad it's still getting love :blush:  
