### PR TITLE
Fix broken tag editor in Svelte 5

### DIFF
--- a/ts/lib/tag-editor/TagEditMode.svelte
+++ b/ts/lib/tag-editor/TagEditMode.svelte
@@ -43,9 +43,10 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 >
     <TagDeleteBadge
         class={hoverClass}
-        on:click={() => {
+        on:click={(evt) => {
             if (!selectMode) {
                 deleteTag();
+                evt.stopPropagation();
             }
         }}
     />

--- a/ts/lib/tag-editor/WithAutocomplete.svelte
+++ b/ts/lib/tag-editor/WithAutocomplete.svelte
@@ -76,6 +76,10 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
      * Choose as accepted suggestion
      */
     async function chooseSelected() {
+        if (!suggestionsItems.length) {
+            return;
+        }
+
         active = true;
         dispatch("choose", { chosen: suggestionsItems[selected ?? -1] });
 
@@ -129,7 +133,6 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     keepOnKeyup
     show={$show}
     preferredPlacement="top"
-    portalTarget={document.body}
     let:asReference
     on:close={() => show.set(false)}
 >

--- a/ts/lib/tag-editor/tag-options-button/TagOptionsButton.svelte
+++ b/ts/lib/tag-editor/tag-options-button/TagOptionsButton.svelte
@@ -17,11 +17,13 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     bind:offsetHeight={badgeHeight}
     on:mousedown|preventDefault
 >
-    {#if tagsSelected}
-        <TagsSelectedButton on:tagselectall on:tagcopy on:tagdelete />
-    {:else}
-        <TagAddButton on:tagappend {keyCombination} />
-    {/if}
+    {#key tagsSelected}
+        {#if tagsSelected}
+            <TagsSelectedButton on:tagselectall on:tagcopy on:tagdelete />
+        {:else}
+            <TagAddButton on:tagappend {keyCombination} />
+        {/if}
+    {/key}
 </div>
 
 <style lang="scss">


### PR DESCRIPTION
Fixes #3473

(To be honest, the tag editor code is too complicated for me to fully understand, so I'm not sure if this is a proper fix.)