### PR TITLE
Fix 'Discard changes' dialog appearing even when no changes are made

### DIFF
--- a/qt/aqt/deckoptions.py
+++ b/qt/aqt/deckoptions.py
@@ -69,8 +69,7 @@ class DeckOptionsDialog(QDialog):
 
     def closeEvent(self, evt: QCloseEvent) -> None:
         if self._close_event_has_cleaned_up:
-            evt.accept()
-            return
+            return super().closeEvent(evt)
         evt.ignore()
         self.check_pending_changes()
 

--- a/ts/routes/deck-options/[deckId]/+page.svelte
+++ b/ts/routes/deck-options/[deckId]/+page.svelte
@@ -16,7 +16,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     globalThis.anki.deckOptionsPendingChanges = async (): Promise<void> => {
         await commitEditing();
         if (bridgeCommandsAvailable()) {
-            if (data.state.isModified()) {
+            if (await data.state.isModified()) {
                 bridgeCommand("confirmDiscardChanges");
             } else {
                 bridgeCommand("_close");
@@ -28,6 +28,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         globalThis.$deckOptions = new Promise((resolve, _reject) => {
             resolve(page);
         });
+        data.state.resolveOriginalConfigs();
         if (bridgeCommandsAvailable()) {
             bridgeCommand("deckOptionsReady");
         }

--- a/ts/routes/deck-options/lib.ts
+++ b/ts/routes/deck-options/lib.ts
@@ -11,7 +11,8 @@ import type {
 import { DeckConfig, DeckConfig_Config, DeckConfigsForUpdate_CurrentDeck_Limits } from "@generated/anki/deck_config_pb";
 import { updateDeckConfigs } from "@generated/backend";
 import { localeCompare } from "@tslib/i18n";
-import { cloneDeep, isEqual, pickBy } from "lodash-es";
+import { promiseWithResolver } from "@tslib/promise";
+import { cloneDeep, isEqual } from "lodash-es";
 import { tick } from "svelte";
 import type { Readable, Writable } from "svelte/store";
 import { get, readable, writable } from "svelte/store";
@@ -33,7 +34,7 @@ export interface ConfigListEntry {
     current: boolean;
 }
 
-type Configs =
+type AllConfigs =
     & Required<
         Pick<
             PlainMessage<UpdateDeckConfigsRequest>,
@@ -47,10 +48,6 @@ type Configs =
         >
     >
     & { currentConfig: DeckConfig_Config };
-
-type DeepPartial<T extends object, K extends keyof T> = {
-    [key in keyof T]: key extends K ? Partial<T[key]> : T[key];
-};
 
 export class DeckOptionsState {
     readonly currentConfig: Writable<DeckConfig_Config>;
@@ -68,7 +65,8 @@ export class DeckOptionsState {
     readonly daysSinceLastOptimization: Writable<number>;
     readonly currentPresetName: Writable<string>;
     /** Used to detect if there are any pending changes */
-    readonly originalConfigs: Configs;
+    readonly originalConfigsPromise: Promise<AllConfigs>;
+    readonly originalConfigsResolve: (value: AllConfigs) => void;
 
     private targetDeckId: DeckOptionsId;
     private configs: ConfigWithCount[];
@@ -124,16 +122,9 @@ export class DeckOptionsState {
         this.currentConfig.subscribe((val) => this.onCurrentConfigChanged(val));
         this.currentAuxData.subscribe((val) => this.onCurrentAuxDataChanged(val));
 
-        this.originalConfigs = cloneDeep<Configs>({
-            configs: this.configs.map(c => c.config!),
-            cardStateCustomizer: data.cardStateCustomizer,
-            limits: get(this.deckLimits),
-            newCardsIgnoreReviewLimit: data.newCardsIgnoreReviewLimit,
-            applyAllParentLimits: data.applyAllParentLimits,
-            fsrs: data.fsrs,
-            fsrsReschedule: get(this.fsrsReschedule),
-            currentConfig: get(this.currentConfig),
-        });
+        // Must be resolved after all components are mounted, as some components
+        // may modify the config during their initialization.
+        [this.originalConfigsPromise, this.originalConfigsResolve] = promiseWithResolver<AllConfigs>();
     }
 
     setCurrentIndex(index: number): void {
@@ -326,23 +317,27 @@ export class DeckOptionsState {
         return list;
     }
 
-    isModified(): boolean {
-        const original: DeepPartial<Configs, "limits"> = {
-            ...this.originalConfigs,
-            limits: omitUndefined(this.originalConfigs.limits),
-        };
-        const current: typeof original = {
+    private getAllConfigs(): AllConfigs {
+        return cloneDeep({
             configs: this.configs.map(c => c.config),
             cardStateCustomizer: get(this.cardStateCustomizer),
-            limits: omitUndefined(get(this.deckLimits)),
+            limits: get(this.deckLimits),
             newCardsIgnoreReviewLimit: get(this.newCardsIgnoreReviewLimit),
             applyAllParentLimits: get(this.applyAllParentLimits),
             fsrs: get(this.fsrs),
             fsrsReschedule: get(this.fsrsReschedule),
             currentConfig: get(this.currentConfig),
-        };
+        });
+    }
 
+    async isModified(): Promise<boolean> {
+        const original = await this.originalConfigsPromise;
+        const current = this.getAllConfigs();
         return !isEqual(original, current);
+    }
+
+    resolveOriginalConfigs(): void {
+        this.originalConfigsResolve(this.getAllConfigs());
     }
 }
 
@@ -411,11 +406,6 @@ export class ValueTab {
         this.value = value;
         this.setter(value);
     }
-}
-
-/** Returns a copy of the given object with the properties whose values are 'undefined' omitted */
-function omitUndefined<T extends object>(obj: T): Partial<T> {
-    return pickBy(obj, val => val !== undefined);
 }
 
 /** Ensure blur handler has fired so changes get committed. */


### PR DESCRIPTION
Fixes #3491

> Attaching a repro case provided by a user.
> collection-2024-10-12@10-58-10.zip

I was unable to reproduce the issue using the provided collection or newly created profiles. However, I managed to reproduce it with some of my existing profiles, so I investigated the cause.

> it appears to be the absence of limits.newToday/reviewToday in the current preset vs the original.

Firstly, I don't think the absence of `limits.newToday/reviewToday` should be the cause of the issue.

When working on #3478, I recognized that some of the properties of `limits` could change during the initialization of the `DailyLimits` component. For `DailyLimits`, all missing properties in the orginal config default to `undefined`. Therefore, in #3478, properties with the value `undefined` are excluded when comparing orginal and current to prevent false positives.

After running `git bisect`, I found that the issue has been introduced in #3442.

The issue is caused by the fact that the `EasyDays` component, like `DailyLimits`, may modify the config object during its initialization.

https://github.com/ankitects/anki/blob/f00211df359f8214e9e97688776876a724f59266/ts/routes/deck-options/EasyDays.svelte#L18-L20

#### Approach in this PR

Retrieve the original configs asynchronously after all components are mounted, allowing child components to adjust the config during their initialization phase.

-----------

> Curiously when I hit esc instead of using the x on the window, no confirmation pops up.

From testing, it appears that this only happens if the user never interacts with the webview (e.g., clicking on the webview or pressing a key) from the time the window is opened until the `Esc` key is pressed. In this case, AnkiWebView's `onEsc()` is not called, and DeckOptionsDialog's `reject()` is called directly. As a result, `check_pending_changes()` is not executed.

I don't think this is something that needs to be addressed, because as a practical matter it's impossible for a user to change deck options without interacting with the webview at all, and the expected behavior is for the confirmation dialog not to pop up if no changes have been made.

Apart from the above, I found another issue while investigating.

Since #3410, we use `evt.accept()` instead of `closeEvent()` of the base class when closing the window, but it seems that `evt.accept()` does not trigger `reject()` afterwards. As a result, the cleanup process within `reject()` does not run. You can confirm this issue in Anki 24.10 beta (all of 1, 2, and 3) by the fact that if you close the window without saving the config, the geometry is not saved.

Approach in this PR
Call `closeEvent()` of the base class instead of `evt.accept()`.