### PR TITLE
Fix/only let FSRS take over short-term schedule when steps are empty

### DIFF
--- a/rslib/src/scheduler/fsrs/retention.rs
+++ b/rslib/src/scheduler/fsrs/retention.rs
@@ -63,7 +63,7 @@ impl Collection {
                         .is_ok()
                 },
             )?
-            .clamp(0.75, 0.95))
+            .clamp(0.7, 0.95))
     }
 
     pub fn get_optimal_retention_parameters(

--- a/rslib/src/scheduler/states/learning.rs
+++ b/rslib/src/scheduler/states/learning.rs
@@ -49,7 +49,10 @@ impl LearnState {
         } else {
             let (minimum, maximum) = ctx.min_and_max_review_intervals(1);
             let (interval, short_term) = if let Some(states) = &ctx.fsrs_next_states {
-                (states.again.interval, states.again.interval < 0.5)
+                (
+                    states.again.interval,
+                    ctx.steps.is_empty() && states.again.interval < 0.5,
+                )
             } else {
                 (ctx.graduating_interval_good as f32, false)
             };
@@ -91,7 +94,10 @@ impl LearnState {
         } else {
             let (minimum, maximum) = ctx.min_and_max_review_intervals(1);
             let (interval, short_term) = if let Some(states) = &ctx.fsrs_next_states {
-                (states.hard.interval, states.hard.interval < 0.5)
+                (
+                    states.hard.interval,
+                    ctx.steps.is_empty() && states.hard.interval < 0.5,
+                )
             } else {
                 (ctx.graduating_interval_good as f32, false)
             };
@@ -133,7 +139,10 @@ impl LearnState {
         } else {
             let (minimum, maximum) = ctx.min_and_max_review_intervals(1);
             let (interval, short_term) = if let Some(states) = &ctx.fsrs_next_states {
-                (states.good.interval, states.good.interval < 0.5)
+                (
+                    states.good.interval,
+                    ctx.steps.is_empty() && states.good.interval < 0.5,
+                )
             } else {
                 (ctx.graduating_interval_good as f32, false)
             };

--- a/rslib/src/scheduler/states/relearning.rs
+++ b/rslib/src/scheduler/states/relearning.rs
@@ -68,10 +68,10 @@ impl RelearnState {
                 },
                 review: again_review,
             };
-            if interval > 0.5 {
-                again_review.into()
-            } else {
+            if ctx.relearn_steps.is_empty() && interval < 0.5 {
                 again_relearn.into()
+            } else {
+                again_review.into()
             }
         } else {
             self.review.into()
@@ -112,10 +112,10 @@ impl RelearnState {
                 },
                 review: hard_review,
             };
-            if interval > 0.5 {
-                hard_review.into()
-            } else {
+            if ctx.relearn_steps.is_empty() && interval < 0.5 {
                 hard_relearn.into()
+            } else {
+                hard_review.into()
             }
         } else {
             self.review.into()
@@ -162,10 +162,10 @@ impl RelearnState {
                 },
                 review: good_review,
             };
-            if interval > 0.5 {
-                good_review.into()
-            } else {
+            if ctx.relearn_steps.is_empty() && interval < 0.5 {
                 good_relearn.into()
+            } else {
+                good_review.into()
             }
         } else {
             self.review.into()

--- a/rslib/src/scheduler/states/review.rs
+++ b/rslib/src/scheduler/states/review.rs
@@ -124,7 +124,7 @@ impl ReviewState {
                 review: again_review,
             }
             .into()
-        } else if scheduled_days < 0.5 {
+        } else if ctx.relearn_steps.is_empty() && scheduled_days < 0.5 {
             again_relearn.into()
         } else {
             again_review.into()

--- a/rslib/src/scheduler/states/steps.rs
+++ b/rslib/src/scheduler/states/steps.rs
@@ -83,6 +83,10 @@ impl<'a> LearningSteps<'a> {
     pub(crate) fn remaining_for_failed(self) -> u32 {
         self.steps.len() as u32
     }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.steps.is_empty()
+    }
 }
 
 /// If the given interval in seconds surpasses 1 day, rounds it to a whole


### PR DESCRIPTION
source: https://forums.ankiweb.net/t/fsrs-5-1d-scheduling-and-learning-steps/50242/72?u=l.m.sherlock

In previous implementation #3375, FSRS will take over the scheduling when the (re)learning steps run out, which is unintended.

However, someone wishes for the previous one: https://forums.ankiweb.net/t/fsrs-5-1d-scheduling-and-learning-steps/50242/77?u=l.m.sherlock

Should we add an extra option to support this case?