### PR TITLE
Revert "Fully switch to File::set_times() from utime crate"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,6 +171,7 @@ dependencies = [
  "unic-ucd-category",
  "unicase",
  "unicode-normalization",
+ "utime",
  "windows 0.56.0",
  "wiremock",
  "zip",
@@ -6420,6 +6421,16 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "utime"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91baa0c65eabd12fcbdac8cc35ff16159cab95cae96d0222d6d0271db6193cef"
+dependencies = [
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "uuid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ ninja_gen = { "path" = "build/ninja_gen" }
 
 # pinned
 unicase = "=2.6.0" # any changes could invalidate sqlite indexes
+utime = "=0.3.1" # marked as deprecated, but no native solution for folder mtimes exists
 
 # normal
 ammonia = "4.0.0"

--- a/cargo/licenses.json
+++ b/cargo/licenses.json
@@ -4239,6 +4239,15 @@
     "description": "Incremental, zero-copy UTF-8 decoding with error handling"
   },
   {
+    "name": "utime",
+    "version": "0.3.1",
+    "authors": "Hyeon Kim <simnalamburt@gmail.com>",
+    "repository": "https://github.com/simnalamburt/utime",
+    "license": "Apache-2.0 OR MIT",
+    "license_file": null,
+    "description": "A missing utime function for Rust."
+  },
+  {
     "name": "uuid",
     "version": "1.10.0",
     "authors": "Ashley Mannix<ashleymannix@live.com.au>|Dylan DPC<dylan.dpc@gmail.com>|Hunar Roop Kahlon<hunar.roop@gmail.com>",

--- a/rslib/Cargo.toml
+++ b/rslib/Cargo.toml
@@ -103,6 +103,7 @@ tracing-subscriber.workspace = true
 unic-ucd-category.workspace = true
 unicase.workspace = true
 unicode-normalization.workspace = true
+utime.workspace = true
 zip.workspace = true
 zstd.workspace = true
 

--- a/rslib/io/src/lib.rs
+++ b/rslib/io/src/lib.rs
@@ -53,9 +53,10 @@ pub fn write_file(path: impl AsRef<Path>, contents: impl AsRef<[u8]>) -> Result<
         op: FileOp::Write,
     })
 }
-/// See [File::set_times].
+/// See [File::set_times]. Note that this won't work on folders.
 pub fn set_file_times(path: impl AsRef<Path>, times: FileTimes) -> Result<()> {
-    open_file(&path)?.set_times(times).context(FileIoSnafu {
+    let file = open_file_ext(&path, OpenOptions::new().write(true).to_owned())?;
+    file.set_times(times).context(FileIoSnafu {
         path: path.as_ref(),
         op: FileOp::SetFileTimes,
     })


### PR DESCRIPTION
Reverts ankitects/anki#3501

Looks like this unfortunately does not work on Windows.