### PR TITLE
Fix calculation of daily load

### DIFF
--- a/rslib/src/stats/graphs/future_due.rs
+++ b/rslib/src/stats/graphs/future_due.rs
@@ -26,17 +26,14 @@ impl GraphsContext {
                 due - (self.days_elapsed as i32)
             };
 
+            daily_load += 1.0 / c.interval.max(1) as f32;
+
             // still want to filtered out buried cards that are due today
             if due_day == 0 && matches!(c.queue, CardQueue::UserBuried | CardQueue::SchedBuried) {
                 continue;
             }
             have_backlog |= due_day < 0;
             *due_by_day.entry(due_day).or_default() += 1;
-            if matches!(c.queue, CardQueue::Review | CardQueue::DayLearn) {
-                daily_load += 1.0 / c.interval.max(1) as f32;
-            } else {
-                daily_load += 1.0;
-            }
         }
         FutureDue {
             future_due: due_by_day,

--- a/ts/routes/graphs/future-due.ts
+++ b/ts/routes/graphs/future-due.ts
@@ -145,8 +145,8 @@ export function buildHistogram(
         },
         {
             label: tr.statisticsDailyLoad(),
-            value: tr.statisticsReviews({
-                reviews: sourceData.dailyLoad,
+            value: tr.statisticsReviewsPerDay({
+                count: sourceData.dailyLoad,
             }),
         },
     ];


### PR DESCRIPTION
The previous code caused buried cards to be counted as 1 instead of 1/ivl.
Also, moved the code above because we don't want to exclude the buried cards that are due today.

In the add-on, the only cards that are excluded in the calculation are new cards and suspended cards.

https://github.com/open-spaced-repetition/fsrs4anki-helper/blob/42ec95d9578f35da0ed5908570e9513f93a00820/stats.py#L25