### PR TITLE
template_filters: make {{type:}} forward compatible

### DIFF
--- a/rslib/src/template_filters.rs
+++ b/rslib/src/template_filters.rs
@@ -31,12 +31,12 @@ pub(crate) fn apply_filters<'a>(
     let mut text: Cow<str> = text.into();
 
     // type:cloze & type:nc are handled specially
-    let filters = if filters == ["cloze", "type"] {
-        &["type-cloze"]
-    } else if filters == ["nc", "type"] {
-        &["type-nc"]
-    } else {
-        filters
+    // other type: are passed as the default one
+    let filters = match filters {
+        ["cloze", "type"] => &["type-cloze"],
+        ["nc", "type"] => &["type-nc"],
+        [.., "type"] => &["type"],
+        _ => filters,
     };
 
     for (idx, &filter_name) in filters.iter().enumerate() {
@@ -258,6 +258,10 @@ field</a>
         assert_eq!(
             apply_filters("ignored", &["nc", "type"], "Text", &ctx),
             ("[[type:nc:Text]]".into(), vec![])
+        );
+        assert_eq!(
+            apply_filters("ignored", &["some", "unknown", "type"], "Text", &ctx),
+            ("[[type:Text]]".into(), vec![])
         );
     }
 


### PR DESCRIPTION
Make Anki treat `{{type:unknown:field}}` field replacements as `{{type:field}}` instead of `{{field}}`.

This way users always get to type and especially: The front side will always render as intended.

The previous behavior is seriously inconvenient for further reasons, including:

* Updated clients aren't all released at the same time, causing an unavoidable mismatch period when a new variant is introduced. Now it causes minimum friction.
* Devs can't readily test new in-dev variants without breaking/inconveniencing their own mobile experience.
* Some users will have (potentially perpetually) outdated Anki clients and likely complain, wasting both dev & deck creator time.