### PR TITLE
Fix/buried new cards shouldn't be counted in daily load

### DIFF
--- a/rslib/src/stats/graphs/future_due.rs
+++ b/rslib/src/stats/graphs/future_due.rs
@@ -6,7 +6,7 @@ use std::collections::HashMap;
 use anki_proto::stats::graphs_response::FutureDue;
 
 use super::GraphsContext;
-use crate::card::CardQueue;
+use crate::card::{CardQueue, CardType};
 use crate::scheduler::timing::is_unix_epoch_timestamp;
 
 impl GraphsContext {
@@ -26,7 +26,7 @@ impl GraphsContext {
                 due - (self.days_elapsed as i32)
             };
 
-            if c.memory_state.is_some() {
+            if c.ctype != CardType::New {
                 daily_load += 1.0 / c.interval.max(1) as f32;
             }
 

--- a/rslib/src/stats/graphs/future_due.rs
+++ b/rslib/src/stats/graphs/future_due.rs
@@ -6,7 +6,8 @@ use std::collections::HashMap;
 use anki_proto::stats::graphs_response::FutureDue;
 
 use super::GraphsContext;
-use crate::card::{CardQueue, CardType};
+use crate::card::CardQueue;
+use crate::card::CardType;
 use crate::scheduler::timing::is_unix_epoch_timestamp;
 
 impl GraphsContext {

--- a/rslib/src/stats/graphs/future_due.rs
+++ b/rslib/src/stats/graphs/future_due.rs
@@ -26,7 +26,9 @@ impl GraphsContext {
                 due - (self.days_elapsed as i32)
             };
 
-            daily_load += 1.0 / c.interval.max(1) as f32;
+            if c.memory_state.is_some() {
+                daily_load += 1.0 / c.interval.max(1) as f32;
+            }
 
             // still want to filtered out buried cards that are due today
             if due_day == 0 && matches!(c.queue, CardQueue::UserBuried | CardQueue::SchedBuried) {


### PR DESCRIPTION
fix #3529, https://github.com/open-spaced-repetition/fsrs4anki-helper/issues/480

New cards don't have memory state, so I exclude them in that way. And it's consistent with FSRS helper.