### PR TITLE
Fix flaky tests

### DIFF
--- a/rslib/io/src/lib.rs
+++ b/rslib/io/src/lib.rs
@@ -8,6 +8,7 @@ use std::fs::FileTimes;
 use std::fs::OpenOptions;
 use std::io::Read;
 use std::io::Seek;
+use std::io::Write;
 use std::path::Component;
 use std::path::Path;
 use std::path::PathBuf;
@@ -51,6 +52,21 @@ pub fn write_file(path: impl AsRef<Path>, contents: impl AsRef<[u8]>) -> Result<
     std::fs::write(&path, contents).context(FileIoSnafu {
         path: path.as_ref(),
         op: FileOp::Write,
+    })
+}
+
+pub fn write_file_and_flush(
+    path: impl AsRef<Path> + Clone,
+    contents: impl AsRef<[u8]>,
+) -> Result<()> {
+    let mut file = create_file(path.clone())?;
+    file.write_all(contents.as_ref()).context(FileIoSnafu {
+        path: path.clone().as_ref(),
+        op: FileOp::Write,
+    })?;
+    file.sync_all().context(FileIoSnafu {
+        path: path.as_ref(),
+        op: FileOp::Sync,
     })
 }
 

--- a/rslib/src/media/check.rs
+++ b/rslib/src/media/check.rs
@@ -546,6 +546,7 @@ pub(crate) mod test {
     use anki_io::create_dir;
     use anki_io::read_to_string;
     use anki_io::write_file;
+    use anki_io::write_file_and_flush;
     use tempfile::tempdir;
     use tempfile::TempDir;
 
@@ -696,7 +697,7 @@ Unused: unused.jpg
     fn unicode_normalization() -> Result<()> {
         let (_dir, mgr, mut col) = common_setup()?;
 
-        write_file(mgr.media_folder.join("ぱぱ.jpg"), "nfd encoding")?;
+        write_file_and_flush(mgr.media_folder.join("ぱぱ.jpg"), "nfd encoding")?;
 
         let mut output = {
             let mut checker = col.media_checker()?;

--- a/rslib/src/scheduler/answering/mod.rs
+++ b/rslib/src/scheduler/answering/mod.rs
@@ -644,10 +644,9 @@ mod test {
 
         // new->learning
         let post_answer = col.answer_again();
-        assert_eq!(
-            post_answer.new_state,
-            current_state(&mut col, post_answer.card_id)
-        );
+        let mut current = current_state(&mut col, post_answer.card_id);
+        col.set_elapsed_secs_equal(&post_answer.new_state, &mut current);
+        assert_eq!(post_answer.new_state, current);
         let card = col.storage.get_card(post_answer.card_id)?.unwrap();
         assert_eq!(card.queue, CardQueue::Learn);
         assert_eq!(card.remaining_steps, 2);
@@ -656,10 +655,9 @@ mod test {
         col.storage.db.execute_batch("update cards set due=0")?;
         col.clear_study_queues();
         let post_answer = col.answer_good();
-        assert_eq!(
-            post_answer.new_state,
-            current_state(&mut col, post_answer.card_id)
-        );
+        let mut current = current_state(&mut col, post_answer.card_id);
+        col.set_elapsed_secs_equal(&post_answer.new_state, &mut current);
+        assert_eq!(post_answer.new_state, current);
         let card = col.storage.get_card(post_answer.card_id)?.unwrap();
         assert_eq!(card.queue, CardQueue::Learn);
         assert_eq!(card.remaining_steps, 1);
@@ -672,10 +670,9 @@ mod test {
         if let CardState::Normal(NormalState::Review(state)) = &mut post_answer.new_state {
             state.elapsed_days = 1;
         };
-        assert_eq!(
-            post_answer.new_state,
-            current_state(&mut col, post_answer.card_id)
-        );
+        let mut current = current_state(&mut col, post_answer.card_id);
+        col.set_elapsed_secs_equal(&post_answer.new_state, &mut current);
+        assert_eq!(post_answer.new_state, current);
         let card = col.storage.get_card(post_answer.card_id)?.unwrap();
         assert_eq!(card.queue, CardQueue::Review);
         assert_eq!(card.interval, 1);
@@ -688,10 +685,9 @@ mod test {
         if let CardState::Normal(NormalState::Review(state)) = &mut post_answer.new_state {
             state.elapsed_days = 4;
         };
-        assert_eq!(
-            post_answer.new_state,
-            current_state(&mut col, post_answer.card_id)
-        );
+        let mut current = current_state(&mut col, post_answer.card_id);
+        col.set_elapsed_secs_equal(&post_answer.new_state, &mut current);
+        assert_eq!(post_answer.new_state, current);
         let card = col.storage.get_card(post_answer.card_id)?.unwrap();
         assert_eq!(card.queue, CardQueue::Review);
         assert_eq!(card.interval, 4);
@@ -704,10 +700,9 @@ mod test {
         if let CardState::Normal(NormalState::Relearning(state)) = &mut post_answer.new_state {
             state.review.elapsed_days = 1;
         };
-        assert_eq!(
-            post_answer.new_state,
-            current_state(&mut col, post_answer.card_id)
-        );
+        let mut current = current_state(&mut col, post_answer.card_id);
+        col.set_elapsed_secs_equal(&post_answer.new_state, &mut current);
+        assert_eq!(post_answer.new_state, current);
         let card = col.storage.get_card(post_answer.card_id)?.unwrap();
         assert_eq!(card.queue, CardQueue::Learn);
         assert_eq!(card.ctype, CardType::Relearn);
@@ -722,10 +717,9 @@ mod test {
         if let CardState::Normal(NormalState::Relearning(state)) = &mut post_answer.new_state {
             state.review.elapsed_days = 1;
         };
-        assert_eq!(
-            post_answer.new_state,
-            current_state(&mut col, post_answer.card_id)
-        );
+        let mut current = current_state(&mut col, post_answer.card_id);
+        col.set_elapsed_secs_equal(&post_answer.new_state, &mut current);
+        assert_eq!(post_answer.new_state, current);
         let card = col.storage.get_card(post_answer.card_id)?.unwrap();
         assert_eq!(card.queue, CardQueue::Learn);
         assert_eq!(card.lapses, 1);
@@ -737,10 +731,9 @@ mod test {
         if let CardState::Normal(NormalState::Review(state)) = &mut post_answer.new_state {
             state.elapsed_days = 1;
         };
-        assert_eq!(
-            post_answer.new_state,
-            current_state(&mut col, post_answer.card_id)
-        );
+        let mut current = current_state(&mut col, post_answer.card_id);
+        col.set_elapsed_secs_equal(&post_answer.new_state, &mut current);
+        assert_eq!(post_answer.new_state, current);
         let card = col.storage.get_card(post_answer.card_id)?.unwrap();
         assert_eq!(card.queue, CardQueue::Review);
         assert_eq!(card.interval, 1);


### PR DESCRIPTION
Closes #3353

## state_application

Adding some set_elapsed_secs_equal() calls is a simple solution.

## unicode_normalization

I couldn't reproduce the issue here so unsure about this fix. But the issue does seem to be about filesystem metadata: `ぱぱ.jpg` is missing from MediaCheckOutput. This can only happen if it was not returned by check_media_folder() at all.