### PR TITLE
Update Docs Link in Error Message

### DIFF
--- a/rslib/src/template.rs
+++ b/rslib/src/template.rs
@@ -33,7 +33,7 @@ static TEMPLATE_ERROR_LINK: &str =
 static TEMPLATE_BLANK_LINK: &str =
     "https://docs.ankiweb.net/templates/errors.html#front-of-card-is-blank";
 static TEMPLATE_BLANK_CLOZE_LINK: &str =
-    "https://docs.ankiweb.net/templates/errors.html#no-cloze-filter-on-cloze-notetype";
+    "https://docs.ankiweb.net/templates/errors.html#no-cloze-filter-on-cloze-note-type";
 
 // Lexing
 //----------------------------------------


### PR DESCRIPTION
Done for https://github.com/ankitects/anki-manual/pull/299. 

I suggest we merge these two PRs before a stable release so that people have the correct anchor link.