### PR TITLE
Correct a comment

### DIFF
--- a/rslib/src/scheduler/fsrs/params.rs
+++ b/rslib/src/scheduler/fsrs/params.rs
@@ -343,7 +343,7 @@ pub(crate) fn single_card_revlog_to_items(
     // Filter out unwanted entries
     entries.retain(|entry| {
         !(
-            // set due date or reset
+            // set due date, reset or rescheduled
             (entry.review_kind == RevlogReviewKind::Manual || entry.button_chosen == 0)
             || // cram
             (entry.review_kind == RevlogReviewKind::Filtered && entry.ease_factor == 0)


### PR DESCRIPTION
Because of the `entry.button_chosen == 0` part, it also filters out reschedule entries. Frankly, we don't need the `(entry.review_kind == RevlogReviewKind::Rescheduled)` part, but I didn't remove it yet.