### PR TITLE
Fix/inconsistent retrievability calculations between normal/filtered decks and display/sorting

### DIFF
--- a/rslib/src/browser_table.rs
+++ b/rslib/src/browser_table.rs
@@ -111,7 +111,7 @@ impl Card {
     /// Returns the card's due date as a timestamp if it has one.
     fn due_time(&self, timing: &SchedTimingToday) -> Option<TimestampSecs> {
         if self.queue == CardQueue::Learn {
-            Some(TimestampSecs(self.due as i64))
+            Some(TimestampSecs(self.original_or_current_due() as i64))
         } else if self.is_due_in_days() {
             Some(
                 TimestampSecs::now().adding_secs(
@@ -128,7 +128,10 @@ impl Card {
     /// date' or an add-on has changed the due date, this won't be accurate.
     pub(crate) fn days_since_last_review(&self, timing: &SchedTimingToday) -> Option<u32> {
         if !self.is_due_in_days() {
-            Some((timing.next_day_at.0 as u32).saturating_sub(self.due.max(0) as u32) / 86_400)
+            Some(
+                (timing.next_day_at.0 as u32).saturating_sub(self.original_or_current_due() as u32)
+                    / 86_400,
+            )
         } else {
             self.due_time(timing).map(|due| {
                 (due.adding_secs(-86_400 * self.interval as i64)

--- a/rslib/src/storage/card/filtered.rs
+++ b/rslib/src/storage/card/filtered.rs
@@ -53,7 +53,7 @@ fn build_retrievability_query(
 ) -> String {
     if fsrs {
         format!(
-            "extract_fsrs_relative_retrievability(c.data, due, {today}, ivl, {next_day_at}) {order}"
+            "extract_fsrs_relative_retrievability(c.data, case when c.odue !=0 then c.odue else c.due end, {today}, ivl, {next_day_at}) {order}"
         )
     } else {
         format!(

--- a/rslib/src/storage/card/mod.rs
+++ b/rslib/src/storage/card/mod.rs
@@ -784,7 +784,7 @@ impl fmt::Display for ReviewOrderSubclause {
                 let today = timing.days_elapsed;
                 let next_day_at = timing.next_day_at.0;
                 temp_string =
-                    format!("extract_fsrs_relative_retrievability(data, due, {today}, ivl, {next_day_at}) {order}");
+                    format!("extract_fsrs_relative_retrievability(data, case when odue !=0 then odue else due end, {today}, ivl, {next_day_at}) {order}");
                 &temp_string
             }
             ReviewOrderSubclause::Added => "nid asc, ord asc",

--- a/rslib/src/storage/sqlite.rs
+++ b/rslib/src/storage/sqlite.rs
@@ -314,7 +314,7 @@ fn add_extract_fsrs_retrievability(db: &Connection) -> rusqlite::Result<()> {
                 let Ok(next_day_at) = ctx.get_raw(4).as_i64() else {
                     return Ok(None);
                 };
-                (next_day_at as u32).saturating_sub(due.max(0) as u32) / 86_400
+                (next_day_at).saturating_sub(due) as u32 / 86_400
             } else {
                 let Ok(ivl) = ctx.get_raw(2).as_i64() else {
                     return Ok(None);
@@ -322,8 +322,8 @@ fn add_extract_fsrs_retrievability(db: &Connection) -> rusqlite::Result<()> {
                 let Ok(days_elapsed) = ctx.get_raw(3).as_i64() else {
                     return Ok(None);
                 };
-                let review_day = (due.max(0) as u32).saturating_sub(ivl as u32);
-                (days_elapsed.max(0) as u32).saturating_sub(review_day)
+                let review_day = due.saturating_sub(ivl);
+                days_elapsed.saturating_sub(review_day) as u32
             };
             Ok(card_data.memory_state().map(|state| {
                 FSRS::new(None)
@@ -361,7 +361,7 @@ fn add_extract_fsrs_relative_retrievability(db: &Connection) -> rusqlite::Result
                 let Ok(next_day_at) = ctx.get_raw(4).as_i64() else {
                     return Ok(None);
                 };
-                (next_day_at as u32).saturating_sub(due.max(0) as u32) / 86_400
+                next_day_at.saturating_sub(due) as u32 / 86_400
             } else {
                 let Ok(days_elapsed) = ctx.get_raw(2).as_i64() else {
                     return Ok(None);


### PR DESCRIPTION
source: https://forums.ankiweb.net/t/anki-24-10-release-candidate/51191/120?u=l.m.sherlock

This PR addresses two inconsistencies in retrievability calculations:

1. Fixes the discrepancy in retrievability values between normal decks and filtered decks for the same card by using the original due date (odue) when card belongs to filtered deck.
2. Fixes retrievability calculations between display strings and review sorting to ensure consistent behavior

Changes:
- Modified due date handling to consider original due date (odue) when card belongs to filtered deck.
- Removed unnecessary max(0) operations from due date calculations

These changes ensure that retrievability values are calculated consistently across all contexts where they are used.