### PR TITLE
Fix deck button not clickable in stats screen for smaller screens

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -197,6 +197,7 @@ twwn <github.com/twwn>
 Cy Pokhrel <cy@cy7.sh>
 Park Hyunwoo <phu54321@naver.com>
 Tomas Fabrizio Orsi <torsi@fi.uba.ar>
+Sawan Sunar <sawansunar24072002@gmail.com>
 
 ********************
 

--- a/ts/routes/graphs/RangeBox.svelte
+++ b/ts/routes/graphs/RangeBox.svelte
@@ -144,11 +144,13 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         animation: spin;
         animation-duration: 1s;
         animation-iteration-count: infinite;
+        z-index: -1;
 
         opacity: 0;
 
         &.loading {
             opacity: 0.5;
+            z-index: 1;
             transition: opacity var(--transition-slow);
         }
     }


### PR DESCRIPTION
fix #3595 

Changed the z-index of the spinner element in the stats screen, which caused the spinner to take the click events if the spinner and the radio buttons(deck, collection) were on top of each other, due to insufficient space. I just made it so that it goes behind  if the element is not loading and in front if it is. 