### PR TITLE
Add "No reviews to optimize" message

### DIFF
--- a/ftl/core/deck-config.ftl
+++ b/ftl/core/deck-config.ftl
@@ -452,7 +452,7 @@ deck-config-percent-of-reviews =
 deck-config-optimizing-preset = Optimizing preset { $current_count }/{ $total_count }...
 deck-config-fsrs-must-be-enabled = FSRS must be enabled first.
 deck-config-fsrs-params-optimal = The FSRS parameters currently appear to be optimal.
-deck-config-fsrs-params-no-reviews = No reviews found. Please check that this preset is assigned to all decks you want to optimize and try again.
+deck-config-fsrs-params-no-reviews = No reviews found. Please check that this preset is assigned to all decks you want to optimize (including subdecks) and try again.
 
 deck-config-wait-for-audio = Wait for audio
 deck-config-show-reminder = Show Reminder

--- a/ftl/core/deck-config.ftl
+++ b/ftl/core/deck-config.ftl
@@ -452,6 +452,7 @@ deck-config-percent-of-reviews =
 deck-config-optimizing-preset = Optimizing preset { $current_count }/{ $total_count }...
 deck-config-fsrs-must-be-enabled = FSRS must be enabled first.
 deck-config-fsrs-params-optimal = The FSRS parameters currently appear to be optimal.
+deck-config-fsrs-params-failed = Failed to optimize, Ensure there are sufficient reviews in cards with this preset.
 
 deck-config-wait-for-audio = Wait for audio
 deck-config-show-reminder = Show Reminder

--- a/ftl/core/deck-config.ftl
+++ b/ftl/core/deck-config.ftl
@@ -452,7 +452,7 @@ deck-config-percent-of-reviews =
 deck-config-optimizing-preset = Optimizing preset { $current_count }/{ $total_count }...
 deck-config-fsrs-must-be-enabled = FSRS must be enabled first.
 deck-config-fsrs-params-optimal = The FSRS parameters currently appear to be optimal.
-deck-config-fsrs-params-failed = Failed to optimize, Ensure there are sufficient reviews in cards with this preset.
+deck-config-fsrs-params-no-reviews = There are no reviews on cards with this preset. Please ensure that this preset is assigned to all decks you want to optimize and try again.
 
 deck-config-wait-for-audio = Wait for audio
 deck-config-show-reminder = Show Reminder

--- a/ftl/core/deck-config.ftl
+++ b/ftl/core/deck-config.ftl
@@ -452,7 +452,7 @@ deck-config-percent-of-reviews =
 deck-config-optimizing-preset = Optimizing preset { $current_count }/{ $total_count }...
 deck-config-fsrs-must-be-enabled = FSRS must be enabled first.
 deck-config-fsrs-params-optimal = The FSRS parameters currently appear to be optimal.
-deck-config-fsrs-params-no-reviews = There are no reviews on cards with this preset. Please ensure that this preset is assigned to all decks you want to optimize and try again.
+deck-config-fsrs-params-no-reviews = No reviews found. Please check that this preset is assigned to all decks you want to optimize and try again.
 
 deck-config-wait-for-audio = Wait for audio
 deck-config-show-reminder = Show Reminder

--- a/ts/routes/deck-options/FsrsOptions.svelte
+++ b/ts/routes/deck-options/FsrsOptions.svelte
@@ -148,15 +148,20 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
                         ignoreRevlogsBeforeMs: getIgnoreRevlogsBeforeMs(),
                         currentParams: params,
                     });
-                    if (
-                        params.length &&
-                        params.every(
-                            (n, i) => n.toFixed(4) === resp.params[i].toFixed(4),
-                        )
+
+                    if (!resp.fsrsItems) {
+                        setTimeout(
+                            () => alert(tr.deckConfigFsrsParamsNoReviews()),
+                            200,
+                        );
+                    } else if (
+                        (params.length &&
+                            params.every(
+                                (n, i) => n.toFixed(4) === resp.params[i].toFixed(4),
+                            )) ||
+                        resp.params.length === 0
                     ) {
                         setTimeout(() => alert(tr.deckConfigFsrsParamsOptimal()), 200);
-                    } else if (resp.params.length === 0) {
-                        setTimeout(() => alert(tr.deckConfigFsrsParamsFailed()), 200);
                     } else {
                         $config.fsrsParams5 = resp.params;
                     }

--- a/ts/routes/deck-options/FsrsOptions.svelte
+++ b/ts/routes/deck-options/FsrsOptions.svelte
@@ -157,19 +157,10 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
                         resp.params.length === 0;
 
                     if (already_optimal) {
-                        if (resp.fsrsItems) {
-                            // If there are reviews
-                            setTimeout(
-                                () => alert(tr.deckConfigFsrsParamsOptimal()),
-                                200,
-                            );
-                        } else {
-                            // If the preset is empty
-                            setTimeout(
-                                () => alert(tr.deckConfigFsrsParamsNoReviews()),
-                                200,
-                            );
-                        }
+                        const msg = resp.fsrsItems
+                            ? tr.deckConfigFsrsParamsOptimal()
+                            : tr.deckConfigFsrsParamsNoReviews();
+                        setTimeout(() => alert(msg), 200);
                     } else {
                         $config.fsrsParams5 = resp.params;
                     }

--- a/ts/routes/deck-options/FsrsOptions.svelte
+++ b/ts/routes/deck-options/FsrsOptions.svelte
@@ -149,13 +149,14 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
                         currentParams: params,
                     });
                     if (
-                        (params.length &&
-                            params.every(
-                                (n, i) => n.toFixed(4) === resp.params[i].toFixed(4),
-                            )) ||
-                        resp.params.length === 0
+                        params.length &&
+                        params.every(
+                            (n, i) => n.toFixed(4) === resp.params[i].toFixed(4),
+                        )
                     ) {
                         setTimeout(() => alert(tr.deckConfigFsrsParamsOptimal()), 200);
+                    } else if (resp.params.length === 0) {
+                        setTimeout(() => alert(tr.deckConfigFsrsParamsFailed()), 200);
                     } else {
                         $config.fsrsParams5 = resp.params;
                     }

--- a/ts/routes/deck-options/FsrsOptions.svelte
+++ b/ts/routes/deck-options/FsrsOptions.svelte
@@ -149,19 +149,27 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
                         currentParams: params,
                     });
 
-                    if (!resp.fsrsItems) {
-                        setTimeout(
-                            () => alert(tr.deckConfigFsrsParamsNoReviews()),
-                            200,
-                        );
-                    } else if (
+                    const already_optimal =
                         (params.length &&
                             params.every(
                                 (n, i) => n.toFixed(4) === resp.params[i].toFixed(4),
                             )) ||
-                        resp.params.length === 0
-                    ) {
-                        setTimeout(() => alert(tr.deckConfigFsrsParamsOptimal()), 200);
+                        resp.params.length === 0;
+
+                    if (already_optimal) {
+                        if (resp.fsrsItems) {
+                            // If there are reviews
+                            setTimeout(
+                                () => alert(tr.deckConfigFsrsParamsOptimal()),
+                                200,
+                            );
+                        } else {
+                            // If the preset is empty
+                            setTimeout(
+                                () => alert(tr.deckConfigFsrsParamsNoReviews()),
+                                200,
+                            );
+                        }
                     } else {
                         $config.fsrsParams5 = resp.params;
                     }


### PR DESCRIPTION
Gives a different message when there are no reviews as opposed to when it has already optimal reviews.

![image](https://github.com/user-attachments/assets/5ae04199-95bd-472f-8138-d20fde253ad3)

Related forum post: https://forums.ankiweb.net/t/change-the-parameters-appear-to-be-optimal-message-of-there-are-0-reviews/52729