### PR TITLE
Snap: keep LD_LIBRARY_PATH in snap environment

### DIFF
--- a/qt/aqt/sound.py
+++ b/qt/aqt/sound.py
@@ -245,7 +245,8 @@ av_player = AVPlayer()
 def _packagedCmd(cmd: list[str]) -> tuple[Any, dict[str, str]]:
     cmd = cmd[:]
     env = os.environ.copy()
-    if "LD_LIBRARY_PATH" in env:
+    # lets don't delete LD_LIBRARY_PATH in snap environment
+    if "LD_LIBRARY_PATH" in env and "SNAP" not in env:
         del env["LD_LIBRARY_PATH"]
 
     if is_win:


### PR DESCRIPTION
The mpv player in the snap environment depends on ld to work properly.