### PR TITLE
Snap: keep LD_LIBRARY_PATH when in snap environment

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -198,6 +198,7 @@ Cy Pokhrel <cy@cy7.sh>
 Park Hyunwoo <phu54321@naver.com>
 Tomas Fabrizio Orsi <torsi@fi.uba.ar>
 Sawan Sunar <sawansunar24072002@gmail.com>
+hideo aoyama <https://github.com/boukendesho>
 
 ********************
 

--- a/qt/aqt/sound.py
+++ b/qt/aqt/sound.py
@@ -245,7 +245,8 @@ av_player = AVPlayer()
 def _packagedCmd(cmd: list[str]) -> tuple[Any, dict[str, str]]:
     cmd = cmd[:]
     env = os.environ.copy()
-    if "LD_LIBRARY_PATH" in env:
+    # keep LD_LIBRARY_PATH when in snap environment
+    if "LD_LIBRARY_PATH" in env and "SNAP" not in env:
         del env["LD_LIBRARY_PATH"]
 
     if is_win:


### PR DESCRIPTION
The mpv player in the snap's  isolated environment relies on ld_library_path to work properly.