### PR TITLE
Fix segfault when closing Anki on Linux with "QT_DEBUG_PLUGINS=1"

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -199,6 +199,7 @@ Park Hyunwoo <phu54321@naver.com>
 Tomas Fabrizio Orsi <torsi@fi.uba.ar>
 Sawan Sunar <sawansunar24072002@gmail.com>
 hideo aoyama <https://github.com/boukendesho>
+Ross Brown <rbrownwsws@googlemail.com>
 
 ********************
 

--- a/qt/aqt/__init__.py
+++ b/qt/aqt/__init__.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import atexit
 import logging
 import sys
 from collections.abc import Callable
@@ -525,6 +526,7 @@ def setupGL(pm: aqt.profiles.ProfileManager) -> None:
             print(f"Qt {category}: {msg} {context}")
 
     qInstallMessageHandler(msgHandler)
+    atexit.register(qInstallMessageHandler, None)
 
     if driver == VideoDriver.OpenGL:
         # Leaving QT_OPENGL unset appears to sometimes produce different results


### PR DESCRIPTION
This is a quick and dirty fix for the bug reported on the forum here:

https://forums.ankiweb.net/t/linux-v24-11-segmentation-fault-after-close-event/52852

I think this is how the bug occurs:

[Python thread] - Use `qInstallMessageHandler(...)` to install a logging callback from Qt -> Python
[Python thread] - Start Qt application
[Qt thread] - Do stuff...
...
[User] - Close app
[Python thread] - Terminates
[Qt thread] - Try to call Python logging callback, but Python has already been cleaned up...
SEGFAULT

This seems to work for me but is a bit of a dirty fix because:
1. I'm not forcing any synchronisation so race conditions may cause it to SEGFAULT anyway in some circumstances.
2. The logging format will change back to the Qt default for any final messages sent after Python terminates.

I'm not sure how much this matters though as this issue seems only occur
1. In very niche circumstances (when you have the env var `QT_DEBUG_PLUGINS` set)
2. After all the Python code has finished anyway (nothing to be corrupted by being interrupted by the SEGFAULT?)