### PR TITLE
Remove use of window.location.href in CardInfoDialog

### DIFF
--- a/qt/aqt/browser/card_info.py
+++ b/qt/aqt/browser/card_info.py
@@ -67,11 +67,17 @@ class CardInfoDialog(QDialog):
         self.setLayout(layout)
 
     def update_card(self, card_id: CardId | None) -> None:
+        from aqt.theme import theme_manager
+
         try:
             self.mw.col.get_card(card_id)
         except NotFoundError:
             card_id = None
 
+        if theme_manager.night_mode:
+            extra = "#night"
+        else:
+            extra = ""
         assert self.web is not None
         self.web.eval(
             f"""
@@ -80,6 +86,9 @@ class CardInfoDialog(QDialog):
             if (form) {{
                 form.dataset.id = "{card_id}";
                 form.requestSubmit();
+            }} else {{
+                // fallback to a full reload with window.location
+                window.location.href = '/card-info/{card_id}{extra}';
             }}
         }})();
         """

--- a/qt/aqt/browser/card_info.py
+++ b/qt/aqt/browser/card_info.py
@@ -67,19 +67,13 @@ class CardInfoDialog(QDialog):
         self.setLayout(layout)
 
     def update_card(self, card_id: CardId | None) -> None:
-        from aqt.theme import theme_manager
-
         try:
             self.mw.col.get_card(card_id)
         except NotFoundError:
             card_id = None
 
-        if theme_manager.night_mode:
-            extra = "#night"
-        else:
-            extra = ""
         assert self.web is not None
-        self.web.eval(f"window.location.href = '/card-info/{card_id}{extra}';")
+        self.web.load_sveltekit_page(f'card-info/{card_id}')
 
     def reject(self) -> None:
         if self._on_close:

--- a/qt/aqt/browser/card_info.py
+++ b/qt/aqt/browser/card_info.py
@@ -73,7 +73,17 @@ class CardInfoDialog(QDialog):
             card_id = None
 
         assert self.web is not None
-        self.web.eval(f"window._updateCardId({card_id})")
+        self.web.eval(
+            f"""
+        (function(){{
+            const form = document.querySelector("form#update_card_id");
+            if (form) {{
+                form.dataset.id = "{card_id}";
+                form.requestSubmit();
+            }}
+        }})();
+        """
+        )
 
     def reject(self) -> None:
         if self._on_close:

--- a/qt/aqt/browser/card_info.py
+++ b/qt/aqt/browser/card_info.py
@@ -73,7 +73,7 @@ class CardInfoDialog(QDialog):
             card_id = None
 
         assert self.web is not None
-        self.web.load_sveltekit_page(f"card-info/{card_id}")
+        self.web.eval(f"window._updateCardId({card_id})")
 
     def reject(self) -> None:
         if self._on_close:

--- a/qt/aqt/browser/card_info.py
+++ b/qt/aqt/browser/card_info.py
@@ -73,7 +73,7 @@ class CardInfoDialog(QDialog):
             card_id = None
 
         assert self.web is not None
-        self.web.load_sveltekit_page(f'card-info/{card_id}')
+        self.web.load_sveltekit_page(f"card-info/{card_id}")
 
     def reject(self) -> None:
         if self._on_close:

--- a/qt/aqt/browser/card_info.py
+++ b/qt/aqt/browser/card_info.py
@@ -67,32 +67,13 @@ class CardInfoDialog(QDialog):
         self.setLayout(layout)
 
     def update_card(self, card_id: CardId | None) -> None:
-        from aqt.theme import theme_manager
-
         try:
             self.mw.col.get_card(card_id)
         except NotFoundError:
             card_id = None
 
-        if theme_manager.night_mode:
-            extra = "#night"
-        else:
-            extra = ""
         assert self.web is not None
-        self.web.eval(
-            f"""
-        (function(){{
-            const form = document.querySelector("form#update_card_id");
-            if (form) {{
-                form.dataset.id = "{card_id}";
-                form.requestSubmit();
-            }} else {{
-                // fallback to a full reload with window.location
-                window.location.href = '/card-info/{card_id}{extra}';
-            }}
-        }})();
-        """
-        )
+        self.web.eval(f"window.postMessage('{card_id}');")
 
     def reject(self) -> None:
         if self._on_close:

--- a/ts/routes/card-info/CardInfo.svelte
+++ b/ts/routes/card-info/CardInfo.svelte
@@ -15,8 +15,9 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
     export let stats: CardStatsResponse | null = null;
     export let showRevlog: boolean = true;
-    export let fsrsEnabled: boolean = stats?.memoryState != null;
-    export let desiredRetention: number = stats?.desiredRetention ?? 0.9;
+
+    $: fsrsEnabled = stats?.memoryState != null;
+    $: desiredRetention = stats?.desiredRetention ?? 0.9;
 </script>
 
 <Container breakpoint="md" --gutter-inline="1rem" --gutter-block="0.5rem">

--- a/ts/routes/card-info/ForgettingCurve.svelte
+++ b/ts/routes/card-info/ForgettingCurve.svelte
@@ -31,7 +31,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     let defaultTimeRange = TimeRange.Week;
     const timeRange: Writable<TimeRange> = writable(defaultTimeRange);
 
-    // https://github.com/sveltejs/svelte/issues/13811 
+    // https://github.com/sveltejs/svelte/issues/13811
     // svelte-ignore reactive_declaration_non_reactive_property
     $: if (maxDays > 365) {
         defaultTimeRange = TimeRange.AllTime;

--- a/ts/routes/card-info/ForgettingCurve.svelte
+++ b/ts/routes/card-info/ForgettingCurve.svelte
@@ -8,7 +8,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     import Graph from "../graphs/Graph.svelte";
     import NoDataOverlay from "../graphs/NoDataOverlay.svelte";
     import AxisTicks from "../graphs/AxisTicks.svelte";
-    import { writable } from "svelte/store";
+    import { writable, type Writable } from "svelte/store";
     import InputBox from "../graphs/InputBox.svelte";
     import {
         renderForgettingCurve,
@@ -24,17 +24,24 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     let svg = null as HTMLElement | SVGElement | null;
     const bounds = defaultGraphBounds();
     const title = tr.cardStatsFsrsForgettingCurveTitle();
-    const filteredRevlog = filterRevlog(revlog);
-    const maxDays = calculateMaxDays(filteredRevlog, TimeRange.AllTime);
+
+    $: filteredRevlog = filterRevlog(revlog);
+    $: maxDays = calculateMaxDays(filteredRevlog, TimeRange.AllTime);
+
     let defaultTimeRange = TimeRange.Week;
-    if (maxDays > 365) {
+    const timeRange: Writable<TimeRange> = writable(defaultTimeRange);
+
+    // https://github.com/sveltejs/svelte/issues/13811 
+    // svelte-ignore reactive_declaration_non_reactive_property
+    $: if (maxDays > 365) {
         defaultTimeRange = TimeRange.AllTime;
     } else if (maxDays > 30) {
         defaultTimeRange = TimeRange.Year;
     } else if (maxDays > 7) {
         defaultTimeRange = TimeRange.Month;
     }
-    const timeRange = writable(defaultTimeRange);
+
+    $: $timeRange = defaultTimeRange;
 
     $: renderForgettingCurve(
         filteredRevlog,

--- a/ts/routes/card-info/[cardId]/+page.svelte
+++ b/ts/routes/card-info/[cardId]/+page.svelte
@@ -4,7 +4,6 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 -->
 <script lang="ts">
     import { page } from "$app/stores";
-    import { enhance } from "$app/forms";
 
     import CardInfo from "../CardInfo.svelte";
     import type { PageData } from "./$types";
@@ -13,19 +12,13 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     export let data: PageData;
 
     const showRevlog = $page.url.searchParams.get("revlog") !== "0";
+
+    function updateCardId(evt: MessageEvent) {
+        goto(`/card-info/${evt.data}`);
+    }
 </script>
 
-<CardInfo stats={data.info} {showRevlog} />
-
 <!-- used by CardInfoDialog.update_card -->
-<form
-    id="update_card_id"
-    style="display: none;"
-    method="POST"
-    use:enhance={({ formElement }) => {
-        const id = formElement.dataset?.id;
-        if (id != null) {
-            return async () => goto(`/card-info/${id}`);
-        }
-    }}
-></form>
+<svelte:window on:message={updateCardId} />
+
+<CardInfo stats={data.info} {showRevlog} />

--- a/ts/routes/card-info/[cardId]/+page.svelte
+++ b/ts/routes/card-info/[cardId]/+page.svelte
@@ -4,9 +4,11 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 -->
 <script lang="ts">
     import { page } from "$app/stores";
+    import { enhance } from "$app/forms";
 
     import CardInfo from "../CardInfo.svelte";
     import type { PageData } from "./$types";
+    import { goto } from "$app/navigation";
 
     export let data: PageData;
 
@@ -14,3 +16,16 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 </script>
 
 <CardInfo stats={data.info} {showRevlog} />
+
+<!-- used by CardInfoDialog.update_card -->
+<form
+    id="update_card_id"
+    style="display: none;"
+    method="POST"
+    use:enhance={({ formElement }) => {
+        const id = formElement.dataset?.id;
+        if (id != null) {
+            return async () => goto(`/card-info/${id}`);
+        }
+    }}
+></form>

--- a/ts/routes/card-info/[cardId]/+page.ts
+++ b/ts/routes/card-info/[cardId]/+page.ts
@@ -1,7 +1,5 @@
 // Copyright: Ankitects Pty Ltd and contributors
 // License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
-import { browser } from "$app/environment";
-import { goto } from "$app/navigation";
 import { cardStats } from "@generated/backend";
 
 import type { PageLoad } from "./$types";
@@ -19,12 +17,3 @@ export const load = (async ({ params }) => {
     const info = cid !== null ? await cardStats({ cid }) : null;
     return { info };
 }) satisfies PageLoad;
-
-function _updateCardId(cardId: bigint) {
-    goto(`/card-info/${cardId}`);
-}
-
-if (browser) {
-    // called by CardInfoDialog.update_card in card_info.py
-    window["_updateCardId"] = _updateCardId;
-}

--- a/ts/routes/card-info/[cardId]/+page.ts
+++ b/ts/routes/card-info/[cardId]/+page.ts
@@ -1,6 +1,8 @@
 // Copyright: Ankitects Pty Ltd and contributors
 // License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 import { cardStats } from "@generated/backend";
+import { goto } from "$app/navigation";
+import { browser } from "$app/environment";
 
 import type { PageLoad } from "./$types";
 
@@ -17,3 +19,12 @@ export const load = (async ({ params }) => {
     const info = cid !== null ? await cardStats({ cid }) : null;
     return { info };
 }) satisfies PageLoad;
+
+function _updateCardId(cardId: BigInt) {
+    goto(`/card-info/${cardId}`);
+}
+
+if(browser) {
+    // called by CardInfoDialog.update_card in card_info.py
+    window["_updateCardId"] = _updateCardId;
+}

--- a/ts/routes/card-info/[cardId]/+page.ts
+++ b/ts/routes/card-info/[cardId]/+page.ts
@@ -1,8 +1,8 @@
 // Copyright: Ankitects Pty Ltd and contributors
 // License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
-import { cardStats } from "@generated/backend";
-import { goto } from "$app/navigation";
 import { browser } from "$app/environment";
+import { goto } from "$app/navigation";
+import { cardStats } from "@generated/backend";
 
 import type { PageLoad } from "./$types";
 
@@ -24,7 +24,7 @@ function _updateCardId(cardId: BigInt) {
     goto(`/card-info/${cardId}`);
 }
 
-if(browser) {
+if (browser) {
     // called by CardInfoDialog.update_card in card_info.py
     window["_updateCardId"] = _updateCardId;
 }

--- a/ts/routes/card-info/[cardId]/+page.ts
+++ b/ts/routes/card-info/[cardId]/+page.ts
@@ -20,7 +20,7 @@ export const load = (async ({ params }) => {
     return { info };
 }) satisfies PageLoad;
 
-function _updateCardId(cardId: BigInt) {
+function _updateCardId(cardId: bigint) {
     goto(`/card-info/${cardId}`);
 }
 


### PR DESCRIPTION
This PR proposes to replace the card info dialog's navigation method from setting `window.location.href` via `eval` to using `AnkiWebView.load_sveltekit_page`

This lets addons, like Anki ReColor and Anki Redesign, style the dialog consistently, even when the card is changed/updated, via `gui_hooks.webview_did_inject_style_into_page`