### PR TITLE
[Qt 6.7] Set ForceDarkMode attribute in AnkiWebView

### DIFF
--- a/qt/aqt/webview.py
+++ b/qt/aqt/webview.py
@@ -289,10 +289,6 @@ class AnkiWebView(QWebEngineView):
         self.set_kind(kind)
         if title:
             self.set_title(title)
-        self.settings().setAttribute(
-            QWebEngineSettings.WebAttribute.ForceDarkMode,
-            theme_manager.get_night_mode(),
-        )
         self._page = AnkiWebPage(self._onBridgeCmd)
         # reduce flicker
         self._page.setBackgroundColor(theme_manager.qcolor(colors.CANVAS))
@@ -842,6 +838,12 @@ html {{ {font} }}
     def on_theme_did_change(self) -> None:
         # avoid flashes if page reloaded
         self._page.setBackgroundColor(theme_manager.qcolor(colors.CANVAS))
+        if hasattr(QWebEngineSettings.WebAttribute, "ForceDarkMode"):
+            force_dark_mode = getattr(QWebEngineSettings.WebAttribute, "ForceDarkMode")
+            self._page.settings().setAttribute(
+                force_dark_mode,
+                theme_manager.get_night_mode(),
+            )
         # update night-mode class, and legacy nightMode/night-mode body classes
         self.eval(
             f"""

--- a/qt/aqt/webview.py
+++ b/qt/aqt/webview.py
@@ -289,6 +289,10 @@ class AnkiWebView(QWebEngineView):
         self.set_kind(kind)
         if title:
             self.set_title(title)
+        self.settings().setAttribute(
+            QWebEngineSettings.WebAttribute.ForceDarkMode,
+            theme_manager.get_night_mode(),
+        )
         self._page = AnkiWebPage(self._onBridgeCmd)
         # reduce flicker
         self._page.setBackgroundColor(theme_manager.qcolor(colors.CANVAS))

--- a/qt/aqt/webview.py
+++ b/qt/aqt/webview.py
@@ -840,10 +840,12 @@ html {{ {font} }}
         self._page.setBackgroundColor(theme_manager.qcolor(colors.CANVAS))
         if hasattr(QWebEngineSettings.WebAttribute, "ForceDarkMode"):
             force_dark_mode = getattr(QWebEngineSettings.WebAttribute, "ForceDarkMode")
-            self._page.settings().setAttribute(
-                force_dark_mode,
-                theme_manager.get_night_mode(),
-            )
+            page_settings = self._page.settings()
+            if page_settings is not None:
+                page_settings.setAttribute(
+                    force_dark_mode,
+                    theme_manager.get_night_mode(),
+                )
         # update night-mode class, and legacy nightMode/night-mode body classes
         self.eval(
             f"""


### PR DESCRIPTION
This PR allows using [`prefers-color-scheme`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-color-scheme) in styles. For example:

```css
p {
 color: red;
}

@media (prefers-color-scheme: dark) {
  p {
   color: blue;
  }
}
```

I know the `night-mode` is already added to the HTML root, but since there is now a CSS feature for this I think it is preferred. Also, it will work with external CSS style sheets that are dark mode aware.

Note that this depends on #3342 since `QWebEngineSettings.ForceDarkMode` was [introduced in Qt 6.7](https://doc.qt.io/qtforpython-6/PySide6/QtWebEngineCore/QWebEngineSettings.html#PySide6.QtWebEngineCore.QWebEngineSettings.WebAttribute
), hence this is marked a Draft for now.

https://github.com/user-attachments/assets/137dbf24-2002-48df-91a8-99313cdcd04c
