### PR TITLE
Fix deck options button twitching on hover

### DIFF
--- a/ts/lib/components/HelpModal.svelte
+++ b/ts/lib/components/HelpModal.svelte
@@ -208,7 +208,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         text-align: start;
         min-width: 250px;
         background-color: var(--canvas);
-        border: none;
+        border: 1px solid transparent;
         cursor: pointer;
         border-radius: 0;
         &:hover {

--- a/ts/routes/deck-options/TabbedValue.svelte
+++ b/ts/routes/deck-options/TabbedValue.svelte
@@ -66,7 +66,7 @@
         white-space: nowrap;
         cursor: pointer;
         color: var(--fg-subtle);
-        border: none;
+        border: 1px solid transparent;
         background-color: transparent;
         /* remove default macOS styling */
         box-shadow: none;


### PR DESCRIPTION
In deck options page, hovering on buttons shifts layout in 2 places:
1. Hovering on the tab buttons ('This Deck', 'Today Only') in 'Daily Limits' section makes the button text twitch.
2. In the help modal, hovering on the tab buttons makes the entire page layout shift. (The issue is especially pronounced in the 'Audio' help modal)

The issue is caused by a 1px border being added to the button on hover, where there is no border. This PR fixes the 2 issues.