### PR TITLE
Remove hardcoded note/card colours from switch.py

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -201,6 +201,7 @@ Dongjin Ouyang <1113117424@qq.com>
 Sawan Sunar <sawansunar24072002@gmail.com>
 hideo aoyama <https://github.com/boukendesho>
 Ross Brown <rbrownwsws@googlemail.com>
+🦙 <github.com/iamllama>
 
 ********************
 

--- a/qt/aqt/switch.py
+++ b/qt/aqt/switch.py
@@ -21,8 +21,8 @@ class Switch(QAbstractButton):
         radius: int = 10,
         left_label: str = "",
         right_label: str = "",
-        left_color: dict[str, str] = colors.ACCENT_CARD | {},
-        right_color: dict[str, str] = colors.ACCENT_NOTE | {},
+        left_color: dict[str, str] = {},
+        right_color: dict[str, str] = {},
         parent: QWidget | None = None,
     ) -> None:
         super().__init__(parent=parent)
@@ -31,8 +31,8 @@ class Switch(QAbstractButton):
         self.setSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
         self._left_label = left_label
         self._right_label = right_label
-        self._left_color = left_color
-        self._right_color = right_color
+        self._left_color = left_color if left_color else colors.ACCENT_CARD
+        self._right_color = right_color if right_color else colors.ACCENT_NOTE
         self._path_radius = radius
         self._knob_radius = radius - 2
         self._label_padding = 4

--- a/qt/aqt/switch.py
+++ b/qt/aqt/switch.py
@@ -21,8 +21,8 @@ class Switch(QAbstractButton):
         radius: int = 10,
         left_label: str = "",
         right_label: str = "",
-        left_color: dict[str, str] = {},
-        right_color: dict[str, str] = {},
+        left_color: dict[str, str] | None = None,
+        right_color: dict[str, str] | None = None,
         parent: QWidget | None = None,
     ) -> None:
         super().__init__(parent=parent)


### PR DESCRIPTION
Currently, the ACCENT_CARD and ACCENT_NOTE colours are hardcoded into `Switch.__init__` as default args.

> Default parameter values are evaluated from left to right when the function definition is executed. This means that the expression is evaluated once, when the function is defined, and that the same “pre-computed” value is used for each call.
https://docs.python.org/3/reference/compound_stmts.html#function-definitions

This means that it doesn't use the current colour values after addons (recolor, redesign etc.) have potentially changed them

This PR proposes to have `Switch` look up the colours when it's initialised, and not just when it's first defined

EDIT: not sure why it's failing on rust crate advisories