### PR TITLE
Allow object to move to right edge and bottom edge and allow scroll of note fields when not using IO

### DIFF
--- a/ts/routes/image-occlusion/Toolbar.svelte
+++ b/ts/routes/image-occlusion/Toolbar.svelte
@@ -126,8 +126,8 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
     function onWheel(event: WheelEvent) {
         // allow scroll in fields, when mask editor hidden
-        if(!$ioMaskEditorVisible) {
-            return
+        if (!$ioMaskEditorVisible) {
+            return;
         }
 
         if (event.ctrlKey) {

--- a/ts/routes/image-occlusion/Toolbar.svelte
+++ b/ts/routes/image-occlusion/Toolbar.svelte
@@ -125,6 +125,11 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     }
 
     function onWheel(event: WheelEvent) {
+        // allow scroll in fields, when mask editor hidden
+        if(!$ioMaskEditorVisible) {
+            return
+        }
+
         if (event.ctrlKey) {
             controlClicked = true;
         }

--- a/ts/routes/image-occlusion/tools/lib.ts
+++ b/ts/routes/image-occlusion/tools/lib.ts
@@ -288,9 +288,9 @@ export const makeShapesRemainInCanvas = (canvas: fabric.Canvas, boundingBox: fab
         const left = obj.left!;
 
         const topBound = boundingBox.top!;
-        const bottomBound = topBound + boundingBox.height!;
+        const bottomBound = topBound + boundingBox.height! + 5;
         const leftBound = boundingBox.left!;
-        const rightBound = leftBound + boundingBox.width!;
+        const rightBound = leftBound + boundingBox.width! + 5;
 
         obj.left = Math.min(Math.max(left, leftBound), rightBound - objWidth);
         obj.top = Math.min(Math.max(top, topBound), bottomBound - objHeight);


### PR DESCRIPTION

> Add window: If you toggle the mask editor and navigate to the fields section, you cannot scroll using the mousepad or the mouse scroll wheel. If you attempt to, the "mask editor" will be scrolled instead.

https://github.com/ankitects/anki/issues/3608

> Zoom in as much as possible when making/editing an IO card.
Try to make an occlusion such that its edge is touching the edge of the image itself.
The edge of the occlusion doesn’t touch the edge of the image, there is a gap.

https://github.com/ankitects/anki/issues/3581