### PR TITLE
Fix CardInfoPlaceholder not showing when card id is invalid

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -201,6 +201,7 @@ Dongjin Ouyang <1113117424@qq.com>
 Sawan Sunar <sawansunar24072002@gmail.com>
 hideo aoyama <https://github.com/boukendesho>
 Ross Brown <rbrownwsws@googlemail.com>
+🦙 <github.com/iamllama>
 
 ********************
 

--- a/ts/routes/card-info/[cardId]/+page.ts
+++ b/ts/routes/card-info/[cardId]/+page.ts
@@ -4,7 +4,16 @@ import { cardStats } from "@generated/backend";
 
 import type { PageLoad } from "./$types";
 
+function optionalBigInt(x: any): bigint | null {
+    try {
+        return BigInt(x);
+    } catch (e) {
+        return null;
+    }
+}
+
 export const load = (async ({ params }) => {
-    const info = await cardStats({ cid: BigInt(params.cardId) });
+    const cid = optionalBigInt(params.cardId);
+    const info = cid !== null ? await cardStats({ cid }) : null;
     return { info };
 }) satisfies PageLoad;


### PR DESCRIPTION
When the card info dialog is opened during study (or in the browser), and when study ends (or the browser has 0 results), the card info dialog's card id is set to `None` and shows the error thrown when parsing it as a BigInt.

![image](https://github.com/user-attachments/assets/9a591995-2e66-4ddc-aa87-79c35115883c)


With this pr, the error is caught and an optional is returned by load that's handled by CardInfo, showing the placeholder instead of the thrown error

![image](https://github.com/user-attachments/assets/a8ebecf1-16a9-4887-a25d-981459e84941)

Split out from #3621
