### PR TITLE
Fix "Show in folder" on windows when path has spaces

### DIFF
--- a/qt/aqt/utils.py
+++ b/qt/aqt/utils.py
@@ -959,7 +959,7 @@ def _show_in_folder_win32(path: str) -> None:
             win32gui.ShowWindow(hwnd, win32con.SW_RESTORE)
             win32gui.SetForegroundWindow(hwnd)
 
-    subprocess.run(["explorer", f"/select,{path}"], check=False)
+    subprocess.run(["explorer", "/select,", path], check=False)
     mw.progress.single_shot(500, focus_explorer)
 
 


### PR DESCRIPTION
On windows, "Show in folder" opens the default (Documents) folder when someone with the default ("User 1") profile uses it on an image residing in the media folder

In this case, a typical media path would be `C:\Users\name with spaces\AppData\Roaming\Anki2\User 1\collection.media\img.png`

However,
> Quotation marks are required if the File/Folder object contains spaces or symbols.
https://ss64.com/nt/explorer.html

But adding quotes around `path`, i.e.
```py
subprocess.run(["explorer", f"/select,\"{path}\""], check=False)
```
breaks it for all paths, even those without spaces. I suspect the issue is [improper command line quoting](https://learn.microsoft.com/en-gb/archive/blogs/twistylittlepassagesallalike/everyone-quotes-command-line-arguments-the-wrong-way) with the extra "s

As per https://github.com/microsoft/WSL/issues/7603#issuecomment-2418110077 and [this SO answer](https://stackoverflow.com/questions/13624961/execute-command-with-correctly-escaped-paths/13625225#13625225), spliting off the path into its own arg lets it be quoted properly

NB:
```py
subprocess.run(f"explorer /select,{path}", shell=True)
```
is an alternative, because the above-mentioned limitation doesn't apply to the shell, which correctly handles it regardless of spaces for some reason 😕