### PR TITLE
Fix easy days causing load balancer to disproportionately schedule graduates to the furthest day

### DIFF
--- a/rslib/src/scheduler/states/load_balancer.rs
+++ b/rslib/src/scheduler/states/load_balancer.rs
@@ -222,7 +222,7 @@ impl LoadBalancer {
 
         let easy_days_percentages = self.easy_days_percentages_by_preset.get(&deckconfig_id)?;
         // check if easy days are in effect by seeing if all days have the same
-        // configuration if all days are the same we can skip out on calculating
+        // configuration. If all days are the same, we can skip out on calculating
         // the distribution
         let easy_days_are_all_the_same = easy_days_percentages
             .iter()


### PR DESCRIPTION
In the case where easy days is effectively disabled (all days are set to the same ease), do not call its corresponding routines.

Take this case of graduating intervals:

Here are the intervals with only the load balancer operating
  (format is `interval: cards_due_on_day, normalized_weight (raw_weight)`):
```
   10: 86 0.15 (0.000013520822)
   11: 81 0.15 (0.000013855983)
   12: 76 0.16 (0.000014427517)
   13: 73 0.16 (0.000014434805)
   14: 73 0.15 (0.000013403748)
*  15: 58 0.22 (0.000019817679)
```

However after the easy days logic gets run (but all days are all set to `Normal`), the intervals become 
```
   10: 86 0.00 (0)
   11: 81 0.00 (0)
   12: 76 0.00 (0)
   13: 73 0.06 (0.000021652208)
   14: 73 0.05 (0.000020105623)
*  15: 58 0.89 (0.0003269917)
```

We're effectively back to the old problem of graduates getting disproportionately placed on the furthest day due to the inherent dip that is created at that point.


Interestingly, having at least one day changed does provide a reasonable-enough load balance:
  monday minimal:
```
   10: 86 0.04 (0.000045970817)
   11: 81 0.10 (0.00011639028)
   12: 76 0.16 (0.00019332876)
   13: 73 0.19 (0.00023673082)
   14: 73 0.00 (0)
*  15: 58 0.51 (0.0006222751)
```

  tuesday minimal:
```
   10: 86 0.06 (0.000045970817)
   11: 81 0.14 (0.00011639028)
   12: 76 0.24 (0.00019332876)
   13: 73 0.29 (0.00023673082)
*  14: 73 0.27 (0.0002198215)
   15: 58 0.00 (0)
```