### PR TITLE
Replace use of window.postMessage in card info

### DIFF
--- a/qt/aqt/browser/card_info.py
+++ b/qt/aqt/browser/card_info.py
@@ -73,7 +73,7 @@ class CardInfoDialog(QDialog):
             card_id = None
 
         assert self.web is not None
-        self.web.eval(f"window.postMessage('{card_id}');")
+        self.web.eval(f"anki.updateCard('{card_id}');")
 
     def reject(self) -> None:
         if self._on_close:

--- a/ts/routes/card-info/CardInfoPlaceholder.svelte
+++ b/ts/routes/card-info/CardInfoPlaceholder.svelte
@@ -15,5 +15,6 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         top: 50%;
         left: 50%;
         transform: translate(-50%, -50%);
+        color: grey;
     }
 </style>

--- a/ts/routes/card-info/[cardId]/+page.svelte
+++ b/ts/routes/card-info/[cardId]/+page.svelte
@@ -13,12 +13,13 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
     const showRevlog = $page.url.searchParams.get("revlog") !== "0";
 
-    function updateCardId(evt: MessageEvent) {
-        goto(`/card-info/${evt.data}`);
-    }
+    globalThis.anki ||= {};
+    globalThis.anki.updateCard = async (card_id: string): Promise<void> => {
+        const path = `/card-info/${card_id}`;
+        return goto(path).catch(() => {
+            window.location.href = path;
+        });
+    };
 </script>
-
-<!-- used by CardInfoDialog.update_card -->
-<svelte:window on:message={updateCardId} />
 
 <CardInfo stats={data.info} {showRevlog} />


### PR DESCRIPTION
Sorry for bringing this up again, looked through #3572 and the deck options page and came across existing uses of `globalThis.anki`

~~Using it seems more reliable than `window.postMessage` (from #3621), in that~~ it doesn't need the page to be rendered properly for it to navigate (the `onmessage` listener is currently added via a component, and `cardStats` can still throw when the card doesn't exist) and falls back to `window.location` if `goto` were to fail

Also added the proposed placeholder format change that was missed out from #3631

EDIT: poor choice of words, postMessage isn't intrisically less reliable than a global fn