### PR TITLE
Fix missing buttons on bottom bar when window is narrow

### DIFF
--- a/qt/aqt/toolbar.py
+++ b/qt/aqt/toolbar.py
@@ -246,8 +246,13 @@ class BottomWebView(ToolbarWebView):
 
         self.hidden = False
         if self.mw.state == "review":
-            self.evalWithCallback(
-                "document.documentElement.offsetHeight", self.animate_height
+            # delay to account for reflow
+            self.mw.progress.single_shot(
+                50,
+                lambda: self.evalWithCallback(
+                    "document.documentElement.offsetHeight", self.animate_height
+                ),
+                False,
             )
         else:
             self.adjustHeightToFit()

--- a/qt/aqt/toolbar.py
+++ b/qt/aqt/toolbar.py
@@ -247,10 +247,15 @@ class BottomWebView(ToolbarWebView):
         self.hidden = False
         if self.mw.state == "review":
             # delay to account for reflow
+            def cb(height: int | None):
+                # "When QWebEnginePage is deleted, the callback is triggered with an invalid value"
+                if height is not None:
+                    self.animate_height(height)
+
             self.mw.progress.single_shot(
                 50,
                 lambda: self.evalWithCallback(
-                    "document.documentElement.offsetHeight", self.animate_height
+                    "document.documentElement.offsetHeight", cb
                 ),
                 False,
             )


### PR DESCRIPTION
Potential fix for #3625. Seems like [this media query](https://github.com/ankitects/anki/blob/5637390b501e92a46160557e581f8e1ccd79b1ce/qt/aqt/data/web/css/reviewer-bottom.scss#L40) is causing a reflow that doesn't finish by the time BottomWebView.show is called

4 observations support this: Removing the media query fixes it. Adding a dummy media query to toolbar-bottom.css reproduces the issue in the deckbrowser. Setting [center's](https://github.com/ankitects/anki/blob/5637390b501e92a46160557e581f8e1ccd79b1ce/qt/aqt/reviewer.py#L796) min-height to x, i.e a size hint, causes the returned height to be x+1. getComputedStyle spits out a height of 0.666667px, presumably rounded to 1

With that, the root cause appears to be `self.evalWithCallback("document.documentElement.offsetHeight", ...)` potentially being run during a reflow, returning an invalid height of 1. It's called twice when moving to the review state, in BottomWebView.show (gets 1, starts animating) and adjustHeightToFit (gets 66). Without "reduce motion", the height is [set](https://github.com/ankitects/anki/blob/5637390b501e92a46160557e581f8e1ccd79b1ce/qt/aqt/toolbar.py#L221) to 1 when the anim ends, overriding the 2nd call

The solutions i've come up with so far are:
- Give center a fixed height of 66px (root cause remains)
- Delay in js (ideal soln)
We'd use `requestAnimationFrame` to wait for any ongoing reflow to end before querying height. But that'd involve a fair bit of unjustified refactoring to thread the async result along back to BottomWebView, via bridgeCommand or a post handler
- Delay in python (implemented soln)
Using a singleshot timer to delay the height query to account for reflow is a hacky fix that works. On my machine it also works with a delay of 0 ([on next tick](https://doc.qt.io/qt-6/qtimer.html#interval-prop)), but it's set to 50ms for good measure

Sorry in advance if i've overcomplicated this and there's a simpler fix 😅