### PR TITLE
Fix potential race condition when refreshing the webview during review

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -201,6 +201,7 @@ Dongjin Ouyang <1113117424@qq.com>
 Sawan Sunar <sawansunar24072002@gmail.com>
 hideo aoyama <https://github.com/boukendesho>
 Ross Brown <rbrownwsws@googlemail.com>
+Luca Auer <lolle2000.la@gmail.com>
 🦙 <github.com/iamllama>
 
 ********************


### PR DESCRIPTION
This happens especially when the `refresh_if_needed` gets called in fast succession, allowing `mw.fade_in_webview` to get called concurrently. This causes the webview to, under certain conditions, present a previous or corrupted frame since the underlying call to is `web.eval` not thread safe. This will ensure that the renders happen in order.

More context: Sometimes on different devices, when checking the back of a card, the back does not get shown. Either nothing changes or the previous cards back gets displayed, though manually causing a re-render by selecting text will fix this. This happens especially often with complicated cards, i.e. those that load scrips, display a lot of contents, use more css etc.

I have searched for the cause of this and saw that the affected code seemed to have circumstances where the `web.eval`-function gets called concurrently, causing this bug. The lock around the `refresh_if_needed` fixes this, ensuring the correct order of frames. I am not sure if this fixes the root issue (most likely not), but it does fix the error with the wrong order/false presentation of frames.