### PR TITLE
Place the forgetting curve above the revlog

### DIFF
--- a/ts/routes/card-info/CardInfo.svelte
+++ b/ts/routes/card-info/CardInfo.svelte
@@ -26,14 +26,14 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
             <CardStats {stats} />
         </Row>
 
-        {#if showRevlog}
-            <Row>
-                <Revlog revlog={stats.revlog} {fsrsEnabled} />
-            </Row>
-        {/if}
         {#if fsrsEnabled}
             <Row>
                 <ForgettingCurve revlog={stats.revlog} {desiredRetention} />
+            </Row>
+        {/if}
+        {#if showRevlog}
+            <Row>
+                <Revlog revlog={stats.revlog} {fsrsEnabled} />
             </Row>
         {/if}
     {:else}


### PR DESCRIPTION
## Description
The length of the revlog is variable, which leads to uncertainty about the position of the forgetting curve. Therefore, it may be a better choice to place the forgetting curve above the revlog.