### PR TITLE
Easy days: revisited

### DIFF
--- a/rslib/src/scheduler/states/load_balancer.rs
+++ b/rslib/src/scheduler/states/load_balancer.rs
@@ -25,6 +25,28 @@ const MAX_LOAD_BALANCE_INTERVAL: usize = 90;
 // problems
 const LOAD_BALANCE_DAYS: usize = (MAX_LOAD_BALANCE_INTERVAL as f32 * 1.1) as usize;
 const SIBLING_PENALTY: f32 = 0.001;
+const EASY_DAYS_REDUCED_MODIFIER: f32 = 0.5;
+const EASY_DAYS_NORMAL_LOAD: f32 = 1.0;
+// this is a non-zero value so if all days are minimum, the load balancer will
+// proceed as normal
+const EASY_DAYS_MINIMUM_LOAD: f32 = 0.0001;
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum EasyDay {
+    Minimum,
+    Reduced,
+    Normal,
+}
+
+impl From<f32> for EasyDay {
+    fn from(other: f32) -> EasyDay {
+        match other {
+            1.0 => EasyDay::Normal,
+            0.0 => EasyDay::Minimum,
+            _ => EasyDay::Reduced,
+        }
+    }
+}
 
 #[derive(Debug, Default)]
 struct LoadBalancerDay {
@@ -84,7 +106,7 @@ pub struct LoadBalancer {
     /// Load balancer operates at the preset level, it only counts
     /// cards in the same preset as the card being balanced.
     days_by_preset: HashMap<DeckConfigId, [LoadBalancerDay; LOAD_BALANCE_DAYS]>,
-    easy_days_percentages_by_preset: HashMap<DeckConfigId, [f32; 7]>,
+    easy_days_percentages_by_preset: HashMap<DeckConfigId, [EasyDay; 7]>,
     next_day_at: TimestampSecs,
 }
 
@@ -133,21 +155,26 @@ impl LoadBalancer {
             );
         let configs = storage.get_deck_config_map()?;
 
-        let mut easy_days_percentages_by_preset = HashMap::with_capacity(configs.len());
-        for (dcid, conf) in configs {
-            let easy_days_percentages = if conf.inner.easy_days_percentages.is_empty() {
-                [1.0; 7]
-            } else {
-                conf.inner.easy_days_percentages.try_into().map_err(|_| {
-                    AnkiError::from(InvalidInputError {
-                        message: "expected 7 days".into(),
-                        source: None,
-                        backtrace: None,
-                    })
-                })?
-            };
-            easy_days_percentages_by_preset.insert(dcid, easy_days_percentages);
-        }
+        let easy_days_percentages_by_preset = configs
+            .into_iter()
+            .map(|(dcid, conf)| {
+                let easy_days_percentages: [EasyDay; 7] =
+                    if conf.inner.easy_days_percentages.is_empty() {
+                        [EasyDay::Normal; 7]
+                    } else {
+                        TryInto::<[_; 7]>::try_into(conf.inner.easy_days_percentages)
+                            .map_err(|_| {
+                                AnkiError::from(InvalidInputError {
+                                    message: "expected 7 days".into(),
+                                    source: None,
+                                    backtrace: None,
+                                })
+                            })?
+                            .map(EasyDay::from)
+                    };
+                Ok((dcid, easy_days_percentages))
+            })
+            .collect::<Result<HashMap<_, [EasyDay; 7]>, AnkiError>>()?;
 
         Ok(LoadBalancer {
             days_by_preset,
@@ -220,22 +247,25 @@ impl LoadBalancer {
             })
             .unzip();
 
-        let easy_days_percentages = self.easy_days_percentages_by_preset.get(&deckconfig_id)?;
-        // check if easy days are in effect by seeing if all days have the same
-        // configuration. If all days are the same, we can skip out on calculating
-        // the distribution
-        let easy_days_are_all_the_same = easy_days_percentages
+        let easy_days_load = self.easy_days_percentages_by_preset.get(&deckconfig_id)?;
+        let total_review_count: usize = review_counts.iter().sum();
+        let easy_days_modifier = weekdays
             .iter()
-            .all(|day| easy_days_percentages[0] == *day);
-        let expected_distribution = if easy_days_are_all_the_same {
-            vec![1.0; weekdays.len()]
-        } else {
-            let percentages = weekdays
-                .iter()
-                .map(|&wd| easy_days_percentages[wd])
-                .collect::<Vec<_>>();
-            check_review_distribution(&review_counts, &percentages)
-        };
+            .zip(review_counts.iter())
+            .map(|(&weekday, &review_count)| match easy_days_load[weekday] {
+                EasyDay::Normal => EASY_DAYS_NORMAL_LOAD,
+                EasyDay::Minimum => EASY_DAYS_MINIMUM_LOAD,
+                EasyDay::Reduced => {
+                    let other_days_total = total_review_count - review_count;
+                    let other_days_avg = other_days_total / (review_counts.len() - 1);
+                    if review_count as f32 > other_days_avg as f32 * EASY_DAYS_REDUCED_MODIFIER {
+                        EASY_DAYS_MINIMUM_LOAD
+                    } else {
+                        EASY_DAYS_NORMAL_LOAD
+                    }
+                }
+            })
+            .collect::<Vec<_>>();
 
         // calculate params for each day
         let intervals_and_params = interval_days
@@ -259,14 +289,14 @@ impl LoadBalancer {
                         let card_count_weight = (1.0 / card_count as f32).powi(2);
                         let card_interval_weight = 1.0 / target_interval as f32;
 
-                        card_count_weight * card_interval_weight * sibling_multiplier
+                        card_count_weight
+                            * card_interval_weight
+                            * sibling_multiplier
+                            * easy_days_modifier[interval_index]
                     }
                 };
 
-                (
-                    target_interval,
-                    weight * expected_distribution[interval_index],
-                )
+                (target_interval, weight)
             })
             .collect::<Vec<_>>();
 
@@ -302,20 +332,4 @@ fn interval_to_weekday(interval: u32, next_day_at: TimestampSecs) -> usize {
         .local_datetime()
         .unwrap();
     target_datetime.weekday().num_days_from_monday() as usize
-}
-
-fn check_review_distribution(actual_reviews: &[usize], percentages: &[f32]) -> Vec<f32> {
-    if percentages.iter().sum::<f32>() == 0.0 {
-        return vec![1.0; actual_reviews.len()];
-    }
-    let total_actual = actual_reviews.iter().sum::<usize>() as f32;
-    let expected_distribution: Vec<f32> = percentages
-        .iter()
-        .map(|&p| p * (total_actual / percentages.iter().sum::<f32>()))
-        .collect();
-    expected_distribution
-        .iter()
-        .zip(actual_reviews.iter())
-        .map(|(&e, &a)| (e - a as f32).max(0.0))
-        .collect()
 }


### PR DESCRIPTION
https://github.com/ankitects/anki/pull/3643 was something of a temporary fix. However, having a feature be effectively disabled and it still affecting scheduling to that degree hinted at a more fundamental problem.

I found that the existing system has two problems: it biases cards to the furthest day, and removes many reasonable days from the list of possible days to schedule to.

format for scheduler examples:
```
interval: cards_due_on_day, load_balancer_percent (raw_lb_weight) => after_easy_days_percent (raw_ed_weight)
```
---

Take the (fixed by the above PR, but kept for illustration of the issue) case where all days were set to normal:

good -> good graduating interval
```
   11: 92 0.16 (0.000010740678) => 0.00 (0)
   12: 84 0.18 (0.00001181028) => 0.00 (0)
   13: 76 0.20 (0.000013317708) => 0.04 (0.00001598121)
   14: 73 0.20 (0.000013403748) => 0.16 (0.000056295703)
   15: 61 0.27 (0.00001791633) => 0.80 (0.0002902445)
```

good -> easy graduating interval
```
   21: 56 0.14 (0.000015184647) => 0.00 (0)
   22: 55 0.14 (0.000015026295) => 0.00 (0)
   23: 55 0.13 (0.000014372978) => 0.00 (0)
   24: 48 0.16 (0.000018084493) => 0.32 (0.000064587504)
   25: 52 0.13 (0.0000147929) => 0.00 (0)
   26: 48 0.15 (0.000016693379) => 0.30 (0.000059619237)
   27: 47 0.15 (0.000016766426) => 0.38 (0.000076646545)
```

In the first case, the latest day is heavily biased. And in the second, days that would be entirely reasonable to schedule to are zeroed out.

---

The case with a day marked as reduced fares similarly.

good -> good graduating interval
```
   11: 92 0.16 (0.000010740678) => 0.00 (0)
   12: 84 0.18 (0.00001181028) => 0.04 (0.000020996064)
   13: 76 0.20 (0.000013317708) => 0.22 (0.0001302176)
   14: 73 0.20 (0.000013403748) => 0.00 (0) # reduced day
   15: 61 0.27 (0.00001791633) => 0.75 (0.00044392687)
```

good -> easy graduating interval
```
   21: 56 0.14 (0.000015184647) => 0.00 (0) # reduced day
   22: 55 0.14 (0.000015026295) => 0.02 (0.000008091056)
   23: 55 0.13 (0.000014372978) => 0.02 (0.000007739271)
   24: 48 0.16 (0.000018084493) => 0.29 (0.00013632922)
   25: 52 0.13 (0.0000147929) => 0.11 (0.000052344083)
   26: 48 0.15 (0.000016693379) => 0.27 (0.00012584236)
   27: 47 0.15 (0.000016766426) => 0.30 (0.00014315946)
```

When there is at least one day set as reduced it fares a bit better, but it still overpowers the existing fuzz by putting a very heavy bias on days with less cards (the existing load balancer already does this (though in a gentler manner) so fuzzing ends up being overbiased by this particular data point). For a feature that is about scheduling fewer cards on certain days it sure does a lot more than that.

-----

In this PR I have a different approach. The easy days modifers are either 0.0 or 1.0. This effectively turns that day on or off as a possible day to schedule to.

Naturally, minimum is always a 0.0 and normal is always a 1.0. The issue is how to toggle between 0.0 and 1.0 for reduced days. Here I use a simple method:
If the amount of cards due on a reduced day is below half the mean of all other days in the fuzz range, it is 1.0. Otherwise it is 0.0.

(note: in practice, the minimum modifier will be a small value such as 0.0001 to make it a rare occurance and remove the need to add a variety of special cases in the implementation)
  (also note: half the mean is flexible, I can see it make more sense in practice for it to be 0.4 instead)



Lets look at the same cases above, but with this new approach.

With all days as normal:

good -> good graduating interval
```
   11: 92 0.16 (0.000010740678) => 0.16 (0.000010740678)
   12: 84 0.18 (0.00001181028) => 0.18 (0.00001181028)
   13: 76 0.20 (0.000013317708) => 0.20 (0.000013317708)
   14: 73 0.20 (0.000013403748) => 0.20 (0.000013403748)
   15: 61 0.27 (0.00001791633) => 0.27 (0.00001791633)
```

good -> easy graduating interval
```
   21: 56 0.14 (0.000015184647) => 0.14 (0.000015184647)
   22: 55 0.14 (0.000015026295) => 0.14 (0.000015026295)
   23: 55 0.13 (0.000014372978) => 0.13 (0.000014372978)
   24: 48 0.16 (0.000018084493) => 0.16 (0.000018084493)
   25: 52 0.13 (0.0000147929) => 0.13 (0.0000147929)
   26: 48 0.15 (0.000016693379) => 0.15 (0.000016693379)
   27: 47 0.15 (0.000016766426) => 0.15 (0.000016766426)
```

nothing changes, as it should be.

---

And with a single day reduced:


good -> good graduating interval
```
   11: 92 0.16 (0.000010740678) => 0.20 (0.000010740678)
   12: 84 0.18 (0.00001181028) => 0.22 (0.00001181028)
   13: 76 0.20 (0.000013317708) => 0.25 (0.000013317708)
   14: 73 0.20 (0.000013403748) => 0.00 (0.0000000013403748) # reduced day
   15: 61 0.27 (0.00001791633) => 0.33 (0.00001791633)
```

good -> easy graduating interval
```
   21: 56 0.14 (0.000015184647) => 0.00 (0.0000000015184647) # reduced day
   22: 55 0.14 (0.000015026295) => 0.16 (0.000015026295)
   23: 55 0.13 (0.000014372978) => 0.15 (0.000014372978)
   24: 48 0.16 (0.000018084493) => 0.19 (0.000018084493)
   25: 52 0.13 (0.0000147929) => 0.15 (0.0000147929)
   26: 48 0.15 (0.000016693379) => 0.17 (0.000016693379)
   27: 47 0.15 (0.000016766426) => 0.18 (0.000016766426)
```

The first case favored the day with fewer cards scheduled to it, but not exessively so. The second day has a fairly even distribution which is expected as the amount of cards due is fairly even.

---

Other cases/contrived examples!

all days are minimum: the easy day factor is constant for all of them so fuzzing occurs as normal
all days are reduced: days under the threshold will be 1.0 with higher load days being 0.0, if they are all close it will have the minimum load factor for all of them so normal balancing occurs.

a case where two days are reduced:
```
normal  1: 60 cards
reduced 2: 35 cards
normal  3: 40 cards
reduced 4: 20 cards
normal  5: 30 cards
```
in this case, the threshold of reduced 2 is <span title="(sum([60, 35, 40, 20, 30]) - 35)/4*0.5">18.75</span> and reduced 4 is <span title="(sum([60, 35, 40, 20, 30]) - 20)/4*0.5">20.625</span>. reduced 2 is above the threshold but reduced 4 is below, so the easy days modifier is is: `[1.0, 0.0, 1.0, 1.0, 1.0]`



all reduced days:
```
reduced 1: 45 cards
reduced 2: 40 cards
reduced 3: 35 cards
```

```
day 1 => (120-45)/2*0.5 = 18.75 (45: over)
day 2 => (120-40)/2*0.5 = 20 (40: over)
day 3 => (120-35)/2*0.5 = 21.25 (35: over)
```

resulting modifier: `[0.0, 0.0, 0.0]`

But since the `0.0` is actually `0.0001`, the fuzzing can proceed as normal .

If we add a normal day with 100 cards, we can see it will only schedule to the normal day.

```
day 1 => (220-45)/3*0.5 = 29.16  (45: over)
day 2 => (220-40)/3*0.5 = 30 (40: over)
day 3 => (220-35)/3*0.5 = 30.83 (35: over)
day 4 => the normal one
```

resulting modifier: `[0.0, 0.0, 0.0, 1.0]`

In this particular case, day4 would need 126 cards scheduled before a reduced day would even have the option of being scheduled to.


<br/><br/>

I would also like to convert the underlying configuration from being a series of floats to a series of enumerations of (`Normal`/`Reduced`/`Minimal`), but I am unsure it is worth the effort.
