### PR TITLE
Add support for html comments to template syntax

### DIFF
--- a/qt/aqt/clayout.py
+++ b/qt/aqt/clayout.py
@@ -157,7 +157,8 @@ class CardLayout(QDialog):
         )
 
     def _fieldsOnTemplate(self, fmt: str) -> str:
-        matches = re.findall("{{[^#/}]+?}}", fmt)
+        fmt_without_comments = re.sub("<!--.*?-->", "", fmt)
+        matches = re.findall("{{[^#/}]+?}}", fmt_without_comments)
         chars_allowed = 30
         field_names: list[str] = []
         for m in matches:


### PR DESCRIPTION
From https://forums.ankiweb.net/t/conditional-brackets-are-still-recognized-inside-html-comments/2207 and https://forums.ankiweb.net/t/is-it-possible-to-add-comment-in-template-that-is-not-displayed-in-review-mode/19962

This PR proposes adding support for html comments (`<!-- -->`) to the template syntax, e.g.
```
{{#A}}
    <!-- {{B}} -->
    {{C}}
    <!--
    {{#Image}}
        {{#Image}}
        {{#Caption}}
    {{/Image}}
    -->
{{\A}}
```
where brackets inside closed comment blocks are treated as text

Just as styling allows comments in it, it can be handy to keep old/useful snippets around without having to make another note/card type or stash it somewhere else. Since templates are html, html comments are used instead of something like `/* */`

Couldn't find a suitable parser combination that could pass current tests *and* avoid allocations, hence the mess 😅
Extra relevant tests have been added as well. Unclosed comments aren't treated as errors, since ankidroid still lacks a wysiwyg field editor (desktop enforces closed comments).

Breakage:

- Legacy mode is left alone, as i assumed it to be under feature-freeze

- The following would no longer cause card generation, despite currently not rendering anything:
```
<!--
{{#A}}
    {{#B}}
{{/A}}
-->
```
This seems like the most concerning one, but it can be fixed by moving the comments inside the {{#A}} scope instead of around

- This would no longer be valid:
```
<!-- {{#A}} -->
    {{#B}}
{{/A}}
```

Given the breakages and the lack of issues requesting this for quite some time, this might not be well received, so i'd just like to put this out here to gather feedback. Happy holidays!
