### PR TITLE
Stop audio playback on editor close

### DIFF
--- a/qt/aqt/addcards.py
+++ b/qt/aqt/addcards.py
@@ -341,7 +341,6 @@ class AddCards(QMainWindow):
         evt.ignore()
 
     def _close(self) -> None:
-        av_player.stop_and_clear_queue()
         self.editor.cleanup()
         self.notetype_chooser.cleanup()
         self.deck_chooser.cleanup()

--- a/qt/aqt/browser/browser.py
+++ b/qt/aqt/browser/browser.py
@@ -401,6 +401,7 @@ class Browser(QMainWindow):
     def _closeWindow(self) -> None:
         assert self.editor is not None
 
+        av_player.stop_and_clear_queue()
         self._cleanup_preview()
         self._card_info.close()
         self.editor.cleanup()

--- a/qt/aqt/browser/browser.py
+++ b/qt/aqt/browser/browser.py
@@ -401,7 +401,6 @@ class Browser(QMainWindow):
     def _closeWindow(self) -> None:
         assert self.editor is not None
 
-        av_player.stop_and_clear_queue()
         self._cleanup_preview()
         self._card_info.close()
         self.editor.cleanup()

--- a/qt/aqt/editor.py
+++ b/qt/aqt/editor.py
@@ -700,6 +700,7 @@ require("anki/ui").loaded.then(() => require("anki/NoteEditor").instances[0].too
         return True
 
     def cleanup(self) -> None:
+        av_player.stop_and_clear_queue_if_caller(self.editorMode)
         self.set_note(None)
         # prevent any remaining evalWithCallback() events from firing after C++ object deleted
         if self.web:
@@ -850,7 +851,7 @@ require("anki/ui").loaded.then(() => require("anki/NoteEditor").instances[0].too
             name = urllib.parse.quote(fname.encode("utf8"))
             return f'<img src="{name}">'
         else:
-            av_player.play_file(fname)
+            av_player.play_file_with_caller(fname, self.editorMode)
             return f"[sound:{html.escape(fname, quote=False)}]"
 
     def urlToFile(self, url: str) -> str | None:


### PR DESCRIPTION
Fixes #3664

~~EDIT: This stops all playback when the browser is closed, i.e even during study. I don't think that's the intended effect~~

The editor now stops its own autoplay (if any) when it's closed, and is specific to its current mode (add, edit or in the browser)

Also fixes the bug where closing the add window stops review audio playback