### PR TITLE
replace localhost with 127.0.0.1 in syncserver Dockerfile

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -203,6 +203,7 @@ hideo aoyama <https://github.com/boukendesho>
 Ross Brown <rbrownwsws@googlemail.com>
 🦙 <github.com/iamllama>
 Lukas Sommer <sommerluk@gmail.com>
+Omar Kohl <omarkohl@posteo.net>
 
 ********************
 

--- a/docs/syncserver/Dockerfile
+++ b/docs/syncserver/Dockerfile
@@ -29,6 +29,6 @@ CMD ["anki-sync-server"]
 # This health check will work for Anki versions 24.08.x and newer.
 # For older versions, it may incorrectly report an unhealthy status, which should not be the case.
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
-    CMD wget -qO- http://localhost:${SYNC_PORT}/health || exit 1
+    CMD wget -qO- http://127.0.0.1:${SYNC_PORT}/health || exit 1
 
 LABEL maintainer="Jean Khawand <jk@jeankhawand.com>"


### PR DESCRIPTION
The healthcheck was failing, presumably because localhost was resolving to ::1 (IPv6), as detailed in this issue: https://github.com/maildev/maildev/pull/500