### PR TITLE
Ensure data is stored in a volume in anki-sync-server Docker image

### DIFF
--- a/docs/syncserver/Dockerfile
+++ b/docs/syncserver/Dockerfile
@@ -15,6 +15,8 @@ ARG SYNC_PORT=8080
 
 RUN adduser -D -h /home/anki anki
 
+RUN mkdir -p /anki_data && chown -R anki /anki_data
+
 COPY --from=builder /anki-server/bin/anki-sync-server /usr/local/bin/anki-sync-server
 
 
@@ -24,6 +26,8 @@ USER anki
 
 ENV SYNC_PORT=${SYNC_PORT}
 
+ENV SYNC_BASE=/anki_data
+
 EXPOSE ${SYNC_PORT}
 
 CMD ["anki-sync-server"]
@@ -32,5 +36,7 @@ CMD ["anki-sync-server"]
 # For older versions, it may incorrectly report an unhealthy status, which should not be the case.
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
     CMD wget -qO- http://127.0.0.1:${SYNC_PORT}/health || exit 1
+
+VOLUME /anki_data
 
 LABEL maintainer="Jean Khawand <jk@jeankhawand.com>"

--- a/docs/syncserver/Dockerfile.distroless
+++ b/docs/syncserver/Dockerfile.distroless
@@ -17,6 +17,8 @@ COPY --from=builder /anki-server/bin/anki-sync-server /usr/bin/anki-sync-server
 
 ENV SYNC_PORT=${SYNC_PORT}
 
+ENV SYNC_BASE=/anki_data
+
 EXPOSE ${SYNC_PORT}
 
 CMD ["anki-sync-server"]
@@ -25,5 +27,7 @@ CMD ["anki-sync-server"]
 # For older versions, it may incorrectly report an unhealthy status, which should not be the case.
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
 CMD ["anki-sync-server", "--healthcheck"]
+
+VOLUME /anki_data
 
 LABEL maintainer="Jean Khawand <jk@jeankhawand.com>"

--- a/docs/syncserver/README.md
+++ b/docs/syncserver/README.md
@@ -38,14 +38,27 @@ Once done with build, you can proceed with running this image with the following
 
 ```bash
 # this will create anki server
-docker run -d  -e "SYNC_USER1=admin:admin" -p 8080:8080 --name anki-sync-server anki-sync-server
+docker run -d \
+    -e "SYNC_USER1=admin:admin" \
+    -p 8080:8080 \
+    --mount type=volume,src=anki-sync-server-data,dst=/anki_data \
+    --name anki-sync-server \
+    anki-sync-server
 ```
 
 However, if you want to have multiple users, you have to use the following approach:
 
 ```bash
 # this will create anki server with multiple users
-docker run -d -e "SYNC_USER1=test:test" -e "SYNC_USER2=test2:test2" -p 8080:8080 --name anki-sync-server anki-sync-server
+docker run -d \
+    -e "SYNC_USER1=admin:admin" \
+    -e "SYNC_USER2=admin2:admin2" \
+    -p 8080:8080 \
+    --mount type=volume,src=anki-sync-server-data,dst=/anki_data \
+    --name anki-sync-server \
+    anki-sync-server
 ```
 
-Moreover, you can pass additional env vars mentioned [here](https://docs.ankiweb.net/sync-server.html)
+Moreover, you can pass additional env vars mentioned
+[here](https://docs.ankiweb.net/sync-server.html). Note that you should **not**
+override SYNC_BASE because you risk data loss.


### PR DESCRIPTION
Otherwise data would be lost by default when removing (or re-creating) a
container.

It would be possible to expose the default directory (e.g.
/home/anki/.syncserver) but it would be different for the two Dockerfiles and
less convenient for users of the Docker container to specify such a long path
when naming their volumes.

Setting the permissions is necessary since anki will be running with 'anki'
user permissions inside the container.