### PR TITLE
avoid warning by setting SYNC_PORT as ARG in Dockerfile

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -203,6 +203,7 @@ hideo aoyama <https://github.com/boukendesho>
 Ross Brown <rbrownwsws@googlemail.com>
 🦙 <github.com/iamllama>
 Lukas Sommer <sommerluk@gmail.com>
+Omar Kohl <omarkohl@posteo.net>
 
 ********************
 

--- a/docs/syncserver/Dockerfile
+++ b/docs/syncserver/Dockerfile
@@ -11,6 +11,8 @@ anki-sync-server
 
 FROM alpine:3.20.2
 
+ARG SYNC_PORT=8080
+
 RUN adduser -D -h /home/anki anki
 
 COPY --from=builder /anki-server/bin/anki-sync-server /usr/local/bin/anki-sync-server
@@ -20,7 +22,7 @@ RUN apk update && apk add --no-cache bash && rm -rf /var/cache/apk/*
 
 USER anki
 
-ENV SYNC_PORT=${SYNC_PORT:-"8080"}
+ENV SYNC_PORT=${SYNC_PORT}
 
 EXPOSE ${SYNC_PORT}
 

--- a/docs/syncserver/Dockerfile.distroless
+++ b/docs/syncserver/Dockerfile.distroless
@@ -11,9 +11,11 @@ anki-sync-server
 
 FROM gcr.io/distroless/cc-debian12
 
+ARG SYNC_PORT=8080
+
 COPY --from=builder /anki-server/bin/anki-sync-server /usr/bin/anki-sync-server
 
-ENV SYNC_PORT=${SYNC_PORT:-"8080"}
+ENV SYNC_PORT=${SYNC_PORT}
 
 EXPOSE ${SYNC_PORT}
 


### PR DESCRIPTION
>    1 warning found (use docker --debug to expand):
>    UndefinedVar: Usage of undefined variable '$SYNC_PORT'