### PR TITLE
Tweak how the True Retention stats table displays numbers

### DIFF
--- a/ftl/core/statistics.ftl
+++ b/ftl/core/statistics.ftl
@@ -106,6 +106,7 @@ statistics-true-retention-week = Last week
 statistics-true-retention-month = Last month
 statistics-true-retention-year = Last year
 statistics-true-retention-all-time = All time
+statistics-true-retention-not-applicable = N/A
 statistics-range-all-time = all
 statistics-range-1-year-history = last 12 months
 statistics-range-all-history = all history

--- a/ts/lib/tslib/i18n/utils.ts
+++ b/ts/lib/tslib/i18n/utils.ts
@@ -55,6 +55,10 @@ export function localizedNumber(n: number, precision = 2): string {
     return rounded.toLocaleString(langs);
 }
 
+export function createLocaleNumberFormat(options?: Intl.NumberFormatOptions): Intl.NumberFormat {
+    return new Intl.NumberFormat(langs, options);
+}
+
 export function localeCompare(
     first: string,
     second: string,

--- a/ts/routes/graphs/true-retention.ts
+++ b/ts/routes/graphs/true-retention.ts
@@ -112,12 +112,11 @@ export function calculateRetentionPercentageString(
         return tr.statisticsTrueRetentionNotApplicable();
     }
 
-    const percentage = (passed / total) * 100;
-
     const numberFormat = createLocaleNumberFormat({
         minimumFractionDigits: 1,
         maximumFractionDigits: 1,
+        style: "percent",
     });
 
-    return numberFormat.format(percentage) + "%";
+    return numberFormat.format(passed / total);
 }

--- a/ts/routes/graphs/true-retention.ts
+++ b/ts/routes/graphs/true-retention.ts
@@ -1,7 +1,7 @@
 // Copyright: Ankitects Pty Ltd and contributors
 // License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 import * as tr from "@generated/ftl";
-import { localizedNumber } from "@tslib/i18n";
+import { createLocaleNumberFormat } from "@tslib/i18n";
 import { assertUnreachable } from "@tslib/typing";
 import { RevlogRange } from "./graph-helpers";
 
@@ -106,12 +106,18 @@ export function calculateRetentionPercentageString(
     passed: number,
     failed: number,
 ): string {
-    let percentage = 0;
     const total = passed + failed;
 
-    if (total !== 0) {
-        percentage = (passed / total) * 100;
+    if (total === 0) {
+        return tr.statisticsTrueRetentionNotApplicable();
     }
 
-    return localizedNumber(percentage, 1) + "%";
+    const percentage = (passed / total) * 100;
+
+    const numberFormat = createLocaleNumberFormat({
+        minimumFractionDigits: 1,
+        maximumFractionDigits: 1,
+    });
+
+    return numberFormat.format(percentage) + "%";
 }


### PR DESCRIPTION
- Always show fractional parts of numbers even if they are 0 (91.0% not 91%).
  > This makes the numbers line up nicer across rows.
- Show "N/A" for percentages instead of 0% when there are 0 total reviews.
  > I feel showing 0% in this case can be a bit misleading.
  >
  > e.g.
  > You have not reviewed any mature cards today.
  > You look at the "all" table and see it shows 0% for mature today.
  > You might assume that you saw mature cards but failed all of them.

<table>
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tf>
</thead>

<tbody>
<tr>
<td>
<img src="https://github.com/user-attachments/assets/feb03329-8a0d-4132-a985-d4495bd10448" />
</td>

<td>
<img src="https://github.com/user-attachments/assets/24e678c8-144f-4b13-9bb0-5b5a2f3359ab" />
</td>
</tr>
</tbody>
</table>
