### PR TITLE
Add percentage to FSRS spinner

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -32,8 +32,8 @@ AMBOSS MD Inc. <https://www.amboss.com/>
 Aristotelis P.  <https://glutanimate.com/contact>
 Erez Volk <erez.volk@gmail.com>
 zjosua <zjosua@hotmail.com>
-Arthur Milchior <arthur@milchior.fr>
 Yngve Hoiseth <yngve@hoiseth.net>
+Arthur Milchior <arthur@milchior.fr>
 Ijgnd
 Yoonchae Lee <bluegreenmagick@gmail.com>
 Evandro Coan <github.com/evandrocoan>

--- a/ftl/core/deck-config.ftl
+++ b/ftl/core/deck-config.ftl
@@ -385,7 +385,7 @@ deck-config-fsrs-tooltip =
     more material in the same amount of time. This setting is shared by all presets.
 
 deck-config-desired-retention-tooltip =
-    The default value of 0.9 schedules cards so that you have a 90% chance of remembering them when
+    By default, Anki schedules cards so that you have a 90% chance of remembering them when
     they come up for review again. If you increase this value, Anki will show cards more frequently
     to increase the chances of you remembering them. If you decrease the value, Anki will show cards
     less frequently, and you will forget more of them. Be conservative when adjusting this - higher

--- a/ts/lib/components/SpinBox.svelte
+++ b/ts/lib/components/SpinBox.svelte
@@ -111,9 +111,6 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         on:focusin={() => (focused = true)}
         on:focusout={() => (focused = false)}
     />
-    {#if percentage}
-        <div>%</div>
-    {/if}
     {#if isDesktop()}
         <!-- svelte-ignore a11y-click-events-have-key-events -->
         <div

--- a/ts/routes/deck-options/AdvancedOptions.svelte
+++ b/ts/routes/deck-options/AdvancedOptions.svelte
@@ -212,6 +212,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
                 defaultValue={defaults.historicalRetention}
                 min={0.5}
                 max={1.0}
+                percentage={true}
             >
                 <SettingTitle
                     on:click={() =>

--- a/ts/routes/deck-options/FsrsOptions.svelte
+++ b/ts/routes/deck-options/FsrsOptions.svelte
@@ -377,6 +377,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     defaultValue={defaults.desiredRetention}
     min={0.7}
     max={0.99}
+    percentage={true}
 >
     <SettingTitle on:click={() => openHelpModal("desiredRetention")}>
         {tr.deckConfigDesiredRetention()}

--- a/ts/routes/deck-options/SpinBoxFloatRow.svelte
+++ b/ts/routes/deck-options/SpinBoxFloatRow.svelte
@@ -14,6 +14,7 @@
     export let min = 0;
     export let max = 9999;
     export let step = 0.01;
+    export let percentage = false;
 </script>
 
 <Row --cols={13}>
@@ -22,7 +23,7 @@
     </Col>
     <Col --col-size={6} breakpoint="xs">
         <ConfigInput>
-            <SpinBox bind:value {min} {max} {step} />
+            <SpinBox bind:value {min} {max} {step} {percentage} />
             <RevertButton slot="revert" bind:value {defaultValue} />
         </ConfigInput>
     </Col>


### PR DESCRIPTION
This commit add a percentage option in SpinBox and SpinBoxFloatRow, set to False by default.

If it's true, a percent symbol is added at the end of the line before the increase/decrease button.

While the value is represented as a percentage without decimal places, the internal representation is not changed. Which mean that a multiplier must used to compute the string value, indicate to the input field the min, max and step, and when updating the result.

Currently result is as this 
![image](https://github.com/user-attachments/assets/bcd68f03-52a6-4e4d-8b46-86072372c806)


I was able to obtain 
![image](https://github.com/user-attachments/assets/2bf8dfa6-50c9-49f2-8e81-2b7247071ab1)
 but not to let it be very close to the number, nor to put it outside of the box on the left of the reset value.

If anyone knows their CSS well, that could be helpful here. At least the data part is correctly ported