### PR TITLE
Fix/issue 3659 wrong window closes command w

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -187,7 +187,7 @@ Christian Donat <https://github.com/cdonat2>
 Asuka Minato <https://asukaminato.eu.org>
 Dillon Baldwin <https://github.com/DillBal>
 Voczi <https://github.com/voczi>
-Ben Nguyen <105088397+bpnguyen107@users.noreply.github.com>     
+Ben Nguyen <105088397+bpnguyen107@users.noreply.github.com>
 Themis Demetriades <themis100@outlook.com>
 Luke Bartholomew <lukesbart@icloud.com>
 Gregory Abrasaldo <degeemon@gmail.com>
@@ -203,6 +203,7 @@ hideo aoyama <https://github.com/boukendesho>
 Ross Brown <rbrownwsws@googlemail.com>
 🦙 <github.com/iamllama>
 Lukas Sommer <sommerluk@gmail.com>
+Tom Ampuero <tom.ampuero.c@gmail.com>
 
 ********************
 

--- a/qt/aqt/browser/browser.py
+++ b/qt/aqt/browser/browser.py
@@ -385,7 +385,6 @@ class Browser(QMainWindow):
         else:
             f.actionClose.setVisible(True)
 
-
     def _editor_web_view(self) -> EditorWebView:
         assert self.editor is not None
         editor_web_view = self.editor.web
@@ -399,13 +398,12 @@ class Browser(QMainWindow):
             evt.accept()
             return
 
+        assert self.editor is not None
         if current_window() == self:
             self.editor.call_after_note_saved(self._closeWindow)
             evt.accept()
         else:
             evt.ignore()
-
-        assert self.editor is not None
 
     def _closeWindow(self) -> None:
         assert self.editor is not None

--- a/qt/aqt/browser/browser.py
+++ b/qt/aqt/browser/browser.py
@@ -380,6 +380,12 @@ class Browser(QMainWindow):
         add_ellipsis_to_action_label(f.actionCopy)
         add_ellipsis_to_action_label(f.action_forget)
 
+        if isinstance(self, AddCards):
+            f.actionClose.setVisible(False)
+        else:
+            f.actionClose.setVisible(True)
+
+
     def _editor_web_view(self) -> EditorWebView:
         assert self.editor is not None
         editor_web_view = self.editor.web
@@ -393,10 +399,13 @@ class Browser(QMainWindow):
             evt.accept()
             return
 
-        assert self.editor is not None
+        if current_window() == self:
+            self.editor.call_after_note_saved(self._closeWindow)
+            evt.accept()
+        else:
+            evt.ignore()
 
-        self.editor.call_after_note_saved(self._closeWindow)
-        evt.ignore()
+        assert self.editor is not None
 
     def _closeWindow(self) -> None:
         assert self.editor is not None


### PR DESCRIPTION
Fixes #3659
Prevents closing the browser window unless it’s the active window.