### PR TITLE
Fix card info failing to load with qt5

### DIFF
--- a/ts/routes/card-info/forgetting-curve.ts
+++ b/ts/routes/card-info/forgetting-curve.ts
@@ -73,7 +73,8 @@ export function prepareData(revlog: RevlogEntry[], maxDays: number) {
     let daysSinceFirstLearn = 0;
 
     revlog
-        .toReversed()
+        .slice()
+        .reverse()
         .forEach((entry, index) => {
             const reviewTime = Number(entry.time);
             if (index === 0) {


### PR DESCRIPTION
Fixes issues ~~2~~ and 4 of #3614 

~~Issue 2:~~
> Going into deck options > FSRS simulator, the simulation chart area is completely black:

~~Could reproduce, seems to be caused by [NoDataOverlay's `<rect>`](https://github.com/ankitects/anki/blob/9d1be9a4132533ffd0baa2afa330c0cfc6896cb4/ts/routes/graphs/NoDataOverlay.svelte#L16C5-L16C69) behaving differently in qt5's chromium. Removing it doesn't produce any visible change in qt6, and fixes the issue for qt5.14 and qt5.15~~

~~EDIT: Given the existing `.no-data rect` style, I've double-checked against main on qt6, 5.15 and 5.14, found no visual difference caused by it, and have removed it~~

Nope, I triaged it wrongly. The svelte styles aren't even being applied to the svg elements. Reverted for now, since it's still functional unlike the card info dialog

Issue 4:
> Going to card browser > right click > stats the window stays completely empty, meaning the stats are completely unusable.

Could reproduce as well, and is caused by [this use of `toReversed`](https://github.com/ankitects/anki/blob/9d1be9a4132533ffd0baa2afa330c0cfc6896cb4/ts/routes/card-info/forgetting-curve.ts#L76) being [too new](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/toReversed) (chromium 110 and up) for [qt5's chromium](https://wiki.qt.io/QtWebEngine/ChromiumVersions) (<88). Replaced it with `.slice().reverse()` which is functionally equivalent in qt6 and supported by qt5.14 and qt5.15
