### PR TITLE
Show menu bar in full screen

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -203,6 +203,7 @@ hideo aoyama <https://github.com/boukendesho>
 Ross Brown <rbrownwsws@googlemail.com>
 🦙 <github.com/iamllama>
 Lukas Sommer <sommerluk@gmail.com>
+Kartik Sharma <github.com/KartikSharma0>
 
 ********************
 

--- a/qt/aqt/main.py
+++ b/qt/aqt/main.py
@@ -163,6 +163,15 @@ class MainWebView(AnkiWebView):
             self.mw.toolbarWeb.hide_timer.start()
             self.mw.bottomWeb.hide_timer.start()
             return True
+        
+        if evt.type() == QEvent.Type.MouseMove:
+            if self.mw.fullscreen and not is_mac:
+                cursor_pos = self.mapFromGlobal(QCursor.pos())
+                if cursor_pos.y() < 1:
+                    self.mw.show_menubar()
+                else:
+                    self.mw.hide_menubar()
+            return True
 
         return False
 
@@ -1433,11 +1442,12 @@ title="{}" {}>{}</button>""".format(
                 window.windowState() ^ Qt.WindowState.WindowFullScreen
             )
 
-        self.show_menubar()
         if window.windowState() & Qt.WindowState.WindowFullScreen and not is_mac:
             self.fullscreen = True
+            self.hide_menubar()
         else:
             self.fullscreen = False
+            self.show_menubar()
 
         # Update Toolbar states
         self.toolbarWeb.hide_if_allowed()

--- a/qt/aqt/main.py
+++ b/qt/aqt/main.py
@@ -1433,14 +1433,12 @@ title="{}" {}>{}</button>""".format(
                 window.windowState() ^ Qt.WindowState.WindowFullScreen
             )
 
-        # Hide Menubar on Windows and Linux
+        self.show_menubar()
         if window.windowState() & Qt.WindowState.WindowFullScreen and not is_mac:
             self.fullscreen = True
-            self.hide_menubar()
         else:
             self.fullscreen = False
-            self.show_menubar()
-
+            
         # Update Toolbar states
         self.toolbarWeb.hide_if_allowed()
         self.bottomWeb.hide_if_allowed()

--- a/qt/aqt/main.py
+++ b/qt/aqt/main.py
@@ -1438,7 +1438,7 @@ title="{}" {}>{}</button>""".format(
             self.fullscreen = True
         else:
             self.fullscreen = False
-            
+
         # Update Toolbar states
         self.toolbarWeb.hide_if_allowed()
         self.bottomWeb.hide_if_allowed()

--- a/qt/aqt/main.py
+++ b/qt/aqt/main.py
@@ -163,7 +163,7 @@ class MainWebView(AnkiWebView):
             self.mw.toolbarWeb.hide_timer.start()
             self.mw.bottomWeb.hide_timer.start()
             return True
-        
+
         if evt.type() == QEvent.Type.MouseMove:
             if self.mw.fullscreen and not is_mac:
                 cursor_pos = self.mapFromGlobal(QCursor.pos())


### PR DESCRIPTION
Fix: #3647 
EDIT: The menu bar will be visible to users in full screen when the cursor hovers near the top of the screen.
1. Added a mouse movement event to detect changes in the cursor's position.
2. When the cursor's height (y value) is near 1 (top of the screen) the menu bar becomes visible. 

~1. Removed ``hide_menubar`` function when full screen is toggled on Windows and non-mac systems.~
~3. Added the ``show_menubar`` function in the ``on_toggle_full_screen`` function without conditional statement.~

Added my name in CONTRIBUTORS as this is my first PR for this project.