### PR TITLE
Remove broken editor image menu when on qt5

### DIFF
--- a/qt/aqt/editor.py
+++ b/qt/aqt/editor.py
@@ -1472,6 +1472,8 @@ class EditorWebView(AnkiWebView):
         self.triggerPageAction(QWebEnginePage.WebAction.CopyImageToClipboard)
 
     def _opened_context_menu_on_image(self) -> bool:
+        if not hasattr(self, "lastContextMenuRequest"):
+            return False
         context_menu_request = self.lastContextMenuRequest()
         assert context_menu_request is not None
         return (


### PR DESCRIPTION
Relevant post: https://forums.ankiweb.net/t/right-click-paste-error/53835

When on qt5, right-clicking in the editor throws. This is due to [`lastContextMenuRequest`](https://doc.qt.io/qt-6/qwebengineview.html#lastContextMenuRequest) only having been introduced in qt 6.2.

Until such time as someone manages to find an appropriate workaround for qt5, this pr proposes to remove that feature when on qt5 to make the editor's context menu functional again at least.