### PR TITLE
Allow choosing filtered decks in stats

### DIFF
--- a/qt/aqt/deckchooser.py
+++ b/qt/aqt/deckchooser.py
@@ -21,10 +21,12 @@ class DeckChooser(QHBoxLayout):
         label: bool = True,
         starting_deck_id: DeckId | None = None,
         on_deck_changed: Callable[[int], None] | None = None,
+        dyn: bool = False,
     ) -> None:
         QHBoxLayout.__init__(self)
         self._widget = widget  # type: ignore
         self.mw = mw
+        self.dyn = dyn
         self._setup_ui(show_label=label)
 
         self._selected_deck_id = DeckId(0)
@@ -78,7 +80,7 @@ class DeckChooser(QHBoxLayout):
 
     def _ensure_selected_deck_valid(self) -> None:
         deck = self.mw.col.decks.get(self._selected_deck_id, default=False)
-        if not deck or deck["dyn"]:
+        if not deck or (not self.dyn and deck["dyn"]):
             self.selected_deck_id = DEFAULT_DECK_ID
 
     def _update_button_label(self) -> None:
@@ -117,6 +119,7 @@ class DeckChooser(QHBoxLayout):
             parent=self._widget,
             geomKey="selectDeck",
             callback=callback,
+            dyn=self.dyn,
         )
 
     def on_operation_did_execute(

--- a/qt/aqt/stats.py
+++ b/qt/aqt/stats.py
@@ -56,6 +56,7 @@ class NewDeckStats(QDialog):
             self.mw,
             f.deckArea,
             on_deck_changed=self.on_deck_changed,
+            dyn=True,  # include filtered decks
         )
 
         b = f.buttonBox.addButton(


### PR DESCRIPTION
Fixes #3600

`StudyDeck` is already able to include filtered decks. As suggested, this change adds an optional passthru param to `DeckChooser` that lets `NewDeckStats` tell `StudyDeck` to include them

Since it's already possible to open the stats window when a filtered deck is selected, this behaviour seems sensible

Also fixes the bug where if the stats window is opened while a filtered deck is selected, the deck chooser button shows `Default` instead