### PR TITLE
Fix csv columns potentially being numbered wrongly in the header when exporting

### DIFF
--- a/rslib/src/import_export/text/csv/export.rs
+++ b/rslib/src/import_export/text/csv/export.rs
@@ -222,13 +222,23 @@ impl NoteContext {
     }
 
     fn deck_column(&self) -> Option<usize> {
-        self.with_deck
-            .then(|| 1 + self.notetype_column().unwrap_or_default())
+        self.with_deck.then(|| {
+            1 + self
+                .notetype_column()
+                .or_else(|| self.guid_column())
+                .unwrap_or_default()
+        })
     }
 
     fn tags_column(&self) -> Option<usize> {
-        self.with_tags
-            .then(|| 1 + self.deck_column().unwrap_or_default() + self.field_columns)
+        self.with_tags.then(|| {
+            1 + self
+                .deck_column()
+                .or_else(|| self.notetype_column())
+                .or_else(|| self.guid_column())
+                .unwrap_or_default()
+                + self.field_columns
+        })
     }
 
     fn record<'c, 's: 'c, 'n: 'c>(&'s self, note: &'n Note) -> impl Iterator<Item = Cow<'c, [u8]>> {


### PR DESCRIPTION
Originally reported by @brishtibheja in https://forums.ankiweb.net/t/bug-guid-column-is-marked-as-deck-column/53924

With the way [csv columns are currently numbered](https://github.com/ankitects/anki/blob/f1a5808d83e809b41d1299d2245ca9f8a7ddb5b7/rslib/src/import_export/text/csv/export.rs#L219) when exporting, a column selection that isn't a contiguous subsequence of `guid, notetype, deck, tags*` causes them to be numbered wrongly in the csv output.

By contiguous, e.g.
Fine: `guid, notetype, deck` or `notetype, deck` or `deck` etc.
Not fine: `guid, deck` or `notetype, tags` or `guid, notetype, tags` etc.

*the field(s) before `tags` don't affect this