### PR TITLE
Fix EasyDays not applying defaults correctly in deck options

### DIFF
--- a/ts/routes/deck-options/EasyDays.svelte
+++ b/ts/routes/deck-options/EasyDays.svelte
@@ -16,7 +16,6 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     const config = state.currentConfig;
     const defaults = state.defaults;
 
-    // svelte-ignore reactive_declaration_non_reactive_property
     $: if ($config.easyDaysPercentages.length !== 7) {
         $config.easyDaysPercentages = defaults.easyDaysPercentages.slice();
     }

--- a/ts/routes/deck-options/EasyDays.svelte
+++ b/ts/routes/deck-options/EasyDays.svelte
@@ -18,7 +18,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
     // svelte-ignore reactive_declaration_non_reactive_property
     $: if ($config.easyDaysPercentages.length !== 7) {
-        $config.easyDaysPercentages = defaults.easyDaysPercentages;
+        $config.easyDaysPercentages = defaults.easyDaysPercentages.slice();
     }
 
     $: noNormalDay = $config.easyDaysPercentages.some((p) => p === 1.0)


### PR DESCRIPTION
Steps to reproduce:
1) Open deck options and switch to a preset without easy day settings (if not already on one)
2) Switch to another such preset (repeat as many times as you wish)
3) Modify the easy day settings in any one of those presets
4) Note that the rest of those presets all reflect the same changes

`default.easyDaysPercentages` needs to be cloned, otherwise all the presets with applied default easy day settings share the same copy
