### PR TITLE
Fix newer notes incorrectly being skipped when importing successive exports

### DIFF
--- a/rslib/src/import_export/package/apkg/import/notes.rs
+++ b/rslib/src/import_export/package/apkg/import/notes.rs
@@ -15,6 +15,7 @@ use crate::import_export::package::UpdateCondition;
 use crate::import_export::ImportError;
 use crate::import_export::ImportProgress;
 use crate::import_export::NoteLog;
+use crate::notes::UpdateNoteInnerWithoutCardsArgs;
 use crate::notetype::ChangeNotetypeInput;
 use crate::prelude::*;
 use crate::progress::ThrottlingProgressHandler;
@@ -463,15 +464,16 @@ impl<'n> NoteContext<'n> {
         self.munge_media(&mut note)?;
         let original = self.get_expected_note(note.id)?;
         let notetype = self.get_expected_notetype(note.notetype_id)?;
-        self.target_col.update_note_inner_without_cards(
-            &mut note,
-            &original,
-            &notetype,
-            self.usn,
-            true,
-            self.normalize_notes,
-            true,
-        )?;
+        self.target_col
+            .update_note_inner_without_cards(UpdateNoteInnerWithoutCardsArgs {
+                note: &mut note,
+                original: &original,
+                notetype: &notetype,
+                usn: self.usn,
+                mark_note_modified: true,
+                normalize_text: self.normalize_notes,
+                update_tags: true,
+            })?;
         self.imports.log_updated(note, source_id);
         Ok(())
     }

--- a/rslib/src/import_export/package/apkg/import/notes.rs
+++ b/rslib/src/import_export/package/apkg/import/notes.rs
@@ -464,16 +464,21 @@ impl<'n> NoteContext<'n> {
         self.munge_media(&mut note)?;
         let original = self.get_expected_note(note.id)?;
         let notetype = self.get_expected_notetype(note.notetype_id)?;
+        // Preserve the incoming note's mtime to allow imports of successive exports
+        let incoming_mtime = note.mtime;
         self.target_col
-            .update_note_inner_without_cards(UpdateNoteInnerWithoutCardsArgs {
-                note: &mut note,
-                original: &original,
-                notetype: &notetype,
-                usn: self.usn,
-                mark_note_modified: true,
-                normalize_text: self.normalize_notes,
-                update_tags: true,
-            })?;
+            .update_note_inner_without_cards_using_mtime(
+                UpdateNoteInnerWithoutCardsArgs {
+                    note: &mut note,
+                    original: &original,
+                    notetype: &notetype,
+                    usn: self.usn,
+                    mark_note_modified: true,
+                    normalize_text: self.normalize_notes,
+                    update_tags: true,
+                },
+                Some(incoming_mtime),
+            )?;
         self.imports.log_updated(note, source_id);
         Ok(())
     }

--- a/rslib/src/notes/mod.rs
+++ b/rslib/src/notes/mod.rs
@@ -220,9 +220,14 @@ impl Note {
         Ok(())
     }
 
-    pub(crate) fn set_modified(&mut self, usn: Usn) {
-        self.mtime = TimestampSecs::now();
+    #[inline]
+    pub(crate) fn set_modified_with_mtime(&mut self, usn: Usn, mtime: TimestampSecs) {
+        self.mtime = mtime;
         self.usn = usn;
+    }
+
+    pub(crate) fn set_modified(&mut self, usn: Usn) {
+        self.set_modified_with_mtime(usn, TimestampSecs::now())
     }
 
     pub(crate) fn nonempty_fields<'a>(&self, fields: &'a [NoteField]) -> HashSet<&'a str> {

--- a/rslib/src/notes/mod.rs
+++ b/rslib/src/notes/mod.rs
@@ -451,29 +451,29 @@ impl Collection {
         normalize_text: bool,
         update_tags: bool,
     ) -> Result<()> {
-        self.update_note_inner_without_cards(
+        self.update_note_inner_without_cards(UpdateNoteInnerWithoutCardsArgs {
             note,
             original,
-            ctx.notetype,
-            ctx.usn,
+            notetype: ctx.notetype,
+            usn: ctx.usn,
             mark_note_modified,
             normalize_text,
             update_tags,
-        )?;
+        })?;
         self.generate_cards_for_existing_note(ctx, note)
     }
 
-    // TODO: refactor into struct
-    #[allow(clippy::too_many_arguments)]
     pub(crate) fn update_note_inner_without_cards(
         &mut self,
-        note: &mut Note,
-        original: &Note,
-        notetype: &Notetype,
-        usn: Usn,
-        mark_note_modified: bool,
-        normalize_text: bool,
-        update_tags: bool,
+        UpdateNoteInnerWithoutCardsArgs {
+            note,
+            original,
+            notetype,
+            usn,
+            mark_note_modified,
+            normalize_text,
+            update_tags,
+        }: UpdateNoteInnerWithoutCardsArgs,
     ) -> Result<()> {
         if update_tags {
             self.canonify_note_tags(note, usn)?;
@@ -559,15 +559,15 @@ impl Collection {
                         out.update_tags,
                     )?;
                 } else {
-                    self.update_note_inner_without_cards(
-                        &mut note,
-                        &original,
-                        &nt,
+                    self.update_note_inner_without_cards(UpdateNoteInnerWithoutCardsArgs {
+                        note: &mut note,
+                        original: &original,
+                        notetype: &nt,
                         usn,
-                        out.mark_modified,
-                        norm,
-                        out.update_tags,
-                    )?;
+                        mark_note_modified: out.mark_modified,
+                        normalize_text: norm,
+                        update_tags: out.update_tags,
+                    })?;
                 }
 
                 changed_notes += 1;

--- a/rslib/src/notes/mod.rs
+++ b/rslib/src/notes/mod.rs
@@ -351,6 +351,18 @@ fn invalid_char_for_field(c: char) -> bool {
     c.is_ascii_control() && c != '\n' && c != '\t'
 }
 
+/// Used when calling [Collection::update_note_inner_without_cards] and
+/// [Collection::update_note_inner_without_cards_using_mtime]
+pub(crate) struct UpdateNoteInnerWithoutCardsArgs<'a> {
+    pub(crate) note: &'a mut Note,
+    pub(crate) original: &'a Note,
+    pub(crate) notetype: &'a Notetype,
+    pub(crate) usn: Usn,
+    pub(crate) mark_note_modified: bool,
+    pub(crate) normalize_text: bool,
+    pub(crate) update_tags: bool,
+}
+
 impl Collection {
     pub(crate) fn canonify_note_tags(&mut self, note: &mut Note, usn: Usn) -> Result<()> {
         if !note.tags.is_empty() {

--- a/rslib/src/notetype/schemachange.rs
+++ b/rslib/src/notetype/schemachange.rs
@@ -9,6 +9,7 @@ use std::mem;
 use super::CardGenContext;
 use super::CardTemplate;
 use super::Notetype;
+use crate::notes::UpdateNoteInnerWithoutCardsArgs;
 use crate::prelude::*;
 use crate::search::JoinSearches;
 use crate::search::TemplateKind;
@@ -80,15 +81,15 @@ impl Collection {
                 for nid in nids {
                     let mut note = self.storage.get_note(nid)?.unwrap();
                     let original = note.clone();
-                    self.update_note_inner_without_cards(
-                        &mut note,
-                        &original,
-                        nt,
+                    self.update_note_inner_without_cards(UpdateNoteInnerWithoutCardsArgs {
+                        note: &mut note,
+                        original: &original,
+                        notetype: nt,
                         usn,
-                        true,
+                        mark_note_modified: true,
                         normalize_text,
-                        false,
-                    )?;
+                        update_tags: false,
+                    })?;
                 }
             } else {
                 // nothing to do
@@ -104,15 +105,15 @@ impl Collection {
             let mut note = self.storage.get_note(nid)?.unwrap();
             let original = note.clone();
             note.reorder_fields(&ords);
-            self.update_note_inner_without_cards(
-                &mut note,
-                &original,
-                nt,
+            self.update_note_inner_without_cards(UpdateNoteInnerWithoutCardsArgs {
+                note: &mut note,
+                original: &original,
+                notetype: nt,
                 usn,
-                true,
+                mark_note_modified: true,
                 normalize_text,
-                false,
-            )?;
+                update_tags: false,
+            })?;
         }
         Ok(())
     }


### PR DESCRIPTION
> Related? https://forums.ankiweb.net/t/update-notes-if-newer-only-works-one-time/52064

Fixes the "skipped notes when importing" issue in #3589

Let's say someone exports a deck X as an apkg (1), modifies it, exports it again (2), modifies it, exports it again (3)
And on a new profile: imports apkg 1, imports apkg 2, and tries to import apkg 3

Currently, when **existing** notes are updated while importing an apkg (2), the mtime is set to the *time of the import*.

This means that the notes in apkg 3 are now considered to be older than existing notes, and are skipped when trying to import it.

This is incorrect behaviour, since the user didn't manually modify any notes after each import.

With this change, the incoming note's mtime is preserved to allow importing successive exports