### PR TITLE
Issue 2563 - remove mhchem

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -205,7 +205,7 @@ Ross Brown <rbrownwsws@googlemail.com>
 Lukas Sommer <sommerluk@gmail.com>
 Niclas Heinz <nheinz@hpost.net>
 Omar Kohl <omarkohl@posteo.net>
-
+David Elizalde <david.elizalde.r.a@gmail.com>
 ********************
 
 The text of the 3 clause BSD license follows:

--- a/ts/mathjax/index.ts
+++ b/ts/mathjax/index.ts
@@ -3,7 +3,7 @@
 
 /// <reference types="./mathjax-types" />
 
-const packages = ["noerrors", "mathtools", "mhchem"];
+const packages = ["noerrors", "mathtools"];
 
 function packagesForLoading(packages: string[]): string[] {
     return packages.map((value: string): string => `[tex]/${value}`);


### PR DESCRIPTION
As per issue [2563](https://github.com/ankitects/anki/issues/2563) looks like it is safe to remove "mhchem" from the packages that MathJax is loading.