### PR TITLE
Fix image field not being saved if a mask is created too quickly

### DIFF
--- a/ts/editor/NoteEditor.svelte
+++ b/ts/editor/NoteEditor.svelte
@@ -431,6 +431,9 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         imageOcclusionMode = options.mode;
         if (options.mode.kind === "add") {
             fieldStores[ioFields.image].set(options.html);
+            // the image field is set programmatically and does not need debouncing
+            // commit immediately to avoid a race condition with the occlusions field
+            fieldSave.fireImmediately();
 
             // new image is being added
             if (isIOImageLoaded) {

--- a/ts/editor/NoteEditor.svelte
+++ b/ts/editor/NoteEditor.svelte
@@ -433,7 +433,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
             fieldStores[ioFields.image].set(options.html);
             // the image field is set programmatically and does not need debouncing
             // commit immediately to avoid a race condition with the occlusions field
-            fieldSave.fireImmediately();
+            saveFieldNow();
 
             // new image is being added
             if (isIOImageLoaded) {


### PR DESCRIPTION
Closes #3700

Was able to reproduce it (rather reliably) by following @GithubAnon0000's steps. Turns out the note's image field wasn't getting saved.

The issue is that field saves caused by changing `fieldStores` go through a *single* debouncer (`fieldSave`), with a delay of 600ms:
https://github.com/ankitects/anki/blob/769f302ea8f17e9d30104235cf9411a02394daf1/ts/editor/NoteEditor.svelte#L291-L299
where calling `ChangeTimer.schedule` cancels any previously scheduled action (even if it was for a different field).

In IO mode, the [image field's save](https://github.com/ankitects/anki/blob/769f302ea8f17e9d30104235cf9411a02394daf1/ts/editor/NoteEditor.svelte#L433) in `setupMaskEditor` can be cancelled by the [occlusions field's save](https://github.com/ankitects/anki/blob/769f302ea8f17e9d30104235cf9411a02394daf1/ts/editor/NoteEditor.svelte#L462) if a mask is made within the debounce delay (600ms), which is ridiculously easy to do with a mouse alone.

Contrast with non-IO mode, where fields are committed immediately (without debouncing) [on focusout](https://github.com/ankitects/anki/blob/769f302ea8f17e9d30104235cf9411a02394daf1/ts/editor/NoteEditor.svelte#L671) and so aren't affected by this sort of issue.

The fix implemented in this pr is to commit the image field immediately after setting it without debouncing to avoid racing with saving the occlusions field