### PR TITLE
Fix IO editor always starting in "hide all, guess one" mode

### DIFF
--- a/proto/anki/image_occlusion.proto
+++ b/proto/anki/image_occlusion.proto
@@ -76,6 +76,7 @@ message GetImageOcclusionNoteResponse {
     string back_extra = 4;
     repeated string tags = 5;
     string image_file_name = 6;
+    bool occlude_inactive = 7;
   }
 
   oneof value {

--- a/rslib/src/image_occlusion/imagedata.rs
+++ b/rslib/src/image_occlusion/imagedata.rs
@@ -97,6 +97,14 @@ impl Collection {
         let idxs = nt.get_io_field_indexes()?;
 
         cloze_note.occlusions = parse_image_occlusions(fields[idxs.occlusions as usize].as_str());
+        cloze_note.occlude_inactive = cloze_note.occlusions.iter().any(|oc| {
+            oc.shapes.iter().any(|sh| {
+                sh.properties
+                    .iter()
+                    .find(|p| p.name == "oi")
+                    .is_some_and(|p| p.value == "1")
+            })
+        });
         cloze_note.header.clone_from(&fields[idxs.header as usize]);
         cloze_note
             .back_extra

--- a/ts/editor/NoteEditor.svelte
+++ b/ts/editor/NoteEditor.svelte
@@ -442,13 +442,6 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
                     ),
                 );
             }
-        } else {
-            const clozeNote = get(fieldStores[ioFields.occlusions]);
-            if (clozeNote.includes("oi=1")) {
-                $hideAllGuessOne = true;
-            } else {
-                $hideAllGuessOne = false;
-            }
         }
 
         isIOImageLoaded = true;

--- a/ts/routes/image-occlusion/mask-editor.ts
+++ b/ts/routes/image-occlusion/mask-editor.ts
@@ -8,7 +8,7 @@ import { fabric } from "fabric";
 import { get } from "svelte/store";
 
 import { optimumCssSizeForCanvas } from "./canvas-scale";
-import { notesDataStore, saveNeededStore, tagsWritable, textEditingState } from "./store";
+import { hideAllGuessOne, notesDataStore, saveNeededStore, tagsWritable, textEditingState } from "./store";
 import Toast from "./Toast.svelte";
 import { addShapesToCanvasFromCloze } from "./tools/add-from-cloze";
 import { enableSelectable, makeShapesRemainInCanvas, moveShapeToCanvasBoundaries } from "./tools/lib";
@@ -62,6 +62,8 @@ export const setupMaskEditorForEdit = async (
 
     const clozeNote = clozeNoteResponse.value.value;
     const canvas = initCanvas();
+
+    hideAllGuessOne.set(clozeNote.occludeInactive);
 
     // get image width and height
     const image = document.getElementById("image") as HTMLImageElement;


### PR DESCRIPTION
Closes #3703

There's only two places where hideAllGuessOne is set:
- on init (set to `true`)
- in NoteEditor's setupMaskEditor when in IO edit mode (searches for "oi=1" in occlusions)

The latter is called by the desktop editor, but not by ankidroid (nor ankimobile, i assume), so it always starts out in "hide all, guess one" mode regardless of the note

The fix proposed here is to move the write from NoteEditor's setupMaskEditor to MaskEditor's setupMaskEditorForEdit, which is called on all platforms