### PR TITLE
Fix mpv loadfile syntax change 2

### DIFF
--- a/qt/aqt/mpv.py
+++ b/qt/aqt/mpv.py
@@ -88,7 +88,6 @@ class MPVBase:
         "--keep-open=no",
         "--autoload-files=no",
         "--gapless-audio=no",
-        "--reset-on-next-file=pause",
     ]
 
     if is_win:

--- a/qt/aqt/sound.py
+++ b/qt/aqt/sound.py
@@ -427,6 +427,12 @@ class MpvManager(MPV, SoundOrVideoPlayer):
         if self._on_done:
             self._on_done()
 
+        m = re.search(r"(\d+)\.(\d+)\.(\d+)", self.get_property("mpv-version"))
+        if m:
+            self.mpv_version = (int(m[1]), int(m[2]), int(m[3]))
+        else:
+            self.mpv_version = None
+
         try:
             self.command("keybind", "q", "stop")
             self.command("keybind", "Q", "stop")
@@ -442,7 +448,10 @@ class MpvManager(MPV, SoundOrVideoPlayer):
         filename = hooks.media_file_filter(tag.filename)
         path = os.path.join(self.media_folder, filename)
 
-        self.command("loadfile", path, "replace", "pause=no")
+        if self.mpv_version is None or self.mpv_version >= (0, 38, 0):
+            self.command("loadfile", path, "replace", -1, "pause=no")
+        else:
+            self.command("loadfile", path, "replace", "pause=no")
         gui_hooks.av_player_did_begin_playing(self, tag)
 
     def stop(self) -> None:

--- a/qt/aqt/sound.py
+++ b/qt/aqt/sound.py
@@ -442,7 +442,7 @@ class MpvManager(MPV, SoundOrVideoPlayer):
         filename = hooks.media_file_filter(tag.filename)
         path = os.path.join(self.media_folder, filename)
 
-        self.command("loadfile", path, "replace")
+        self.command("loadfile", path, "replace", "pause=no")
         gui_hooks.av_player_did_begin_playing(self, tag)
 
     def stop(self) -> None:


### PR DESCRIPTION
Unfortunately, the changes introduced by my previous pull request weren't equivalent and reintroduced the issue with the "pause" button being pressed near the end of the audio file and resulting in no sound, that was previously fixed.

The issue can be reproduced by running the following code in the debug console.

```
from aqt.sound import mpvManager
mpvManager.command("stop")
mpvManager.set_property("pause", "yes")
```

I'm not sure, if it was a correct way to fix it that won't backfire later, but it seems to work fine with `mpv 0.34.0` and `mpv v0.39.0-597-g996e58a7` on Windows.

For reference:
- <https://forums.ankiweb.net/t/since-update-24-11-cards-stop-producing-sound/53262>
- <https://github.com/ankitects/anki/pull/3105>
- <https://github.com/ankitects/anki/pull/1221>
- <https://mpv.io/manual/master/#command-interface-[%3Coptions%3E]]]>

> `loadfile <url> [<flags> [<index> [<options>]]]`
> 
> Warning
> 
> Since mpv 0.38.0, an insertion index argument is added as the third argument. This breaks all existing uses of this command which make use of the argument to include the list of options to be set while the file is playing. To address this problem, the third argument now needs to be set to -1 if the fourth argument needs to be used.