### PR TITLE
Ignore SYNC_PORT and SYNC_BASE in syncserver Dockerfile

### DIFF
--- a/docs/syncserver/Dockerfile
+++ b/docs/syncserver/Dockerfile
@@ -11,8 +11,6 @@ anki-sync-server
 
 FROM alpine:3.21.0
 
-ARG SYNC_PORT=8080
-
 # Default PUID and PGID values (can be overridden at runtime). Use these to
 # ensure the files on the volume have the permissions you need.
 ENV PUID=1000
@@ -22,11 +20,8 @@ COPY --from=builder /anki-server/bin/anki-sync-server /usr/local/bin/anki-sync-s
 
 RUN apk update && apk add --no-cache bash su-exec && rm -rf /var/cache/apk/*
 
-ENV SYNC_PORT=${SYNC_PORT}
 
-ENV SYNC_BASE=/anki_data
-
-EXPOSE ${SYNC_PORT}
+EXPOSE 8080
 
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
@@ -37,7 +32,7 @@ CMD ["anki-sync-server"]
 # This health check will work for Anki versions 24.08.x and newer.
 # For older versions, it may incorrectly report an unhealthy status, which should not be the case.
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
-    CMD wget -qO- http://127.0.0.1:${SYNC_PORT}/health || exit 1
+    CMD wget -qO- http://127.0.0.1:8080/health || exit 1
 
 VOLUME /anki_data
 

--- a/docs/syncserver/Dockerfile.distroless
+++ b/docs/syncserver/Dockerfile.distroless
@@ -11,12 +11,11 @@ anki-sync-server
 
 FROM gcr.io/distroless/cc-debian12
 
-ARG SYNC_PORT=8080
-
 COPY --from=builder /anki-server/bin/anki-sync-server /usr/bin/anki-sync-server
 
-ENV SYNC_PORT=${SYNC_PORT}
-
+# Note that as a user of the container you should NOT overwrite these values
+# for safety and simplicity reasons
+ENV SYNC_PORT=8080
 ENV SYNC_BASE=/anki_data
 
 EXPOSE ${SYNC_PORT}

--- a/docs/syncserver/README.md
+++ b/docs/syncserver/README.md
@@ -71,5 +71,25 @@ docker run -d \
 ```
 
 Moreover, you can pass additional env vars mentioned
-[here](https://docs.ankiweb.net/sync-server.html). Note that you should **not**
-override SYNC_BASE because you risk data loss.
+[here](https://docs.ankiweb.net/sync-server.html). Note that `SYNC_BASE` and
+`SYNC_PORT` will be ignored. In the first case for safety reasons, to avoid
+accidentally placing data outside the volume and the second for simplicity
+since the internal port of the container does not matter given that you can
+change the external one.
+
+# Upgrading
+
+If your image was built after January 2025 then you can just build a new image
+and start a new container with the same configuration as the previous
+container. Everything should work as expected.
+
+If the image you were running was built **before January 2025** then it did not
+contain a volume, meaning all syncserver data was stored inside the container.
+If you discard the container, for example because you want to build a new
+container using an updated image, then your syncserver data will be lost.
+
+The easiest way of working around this is by ensuring at least one of your
+devices is fully in sync with your syncserver before upgrading the Docker
+container. Then after upgrading the container when you try to sync your device
+it will tell you that the server has no data. You will then be given the option
+of uploading all local data from the device to syncserver.

--- a/docs/syncserver/entrypoint.sh
+++ b/docs/syncserver/entrypoint.sh
@@ -7,6 +7,11 @@ set -o pipefail
 export PUID=${PUID:-1000}
 export PGID=${PGID:-1000}
 
+# These values are fixed and cannot be overwritten from the outside for
+# convenience and safety reasons
+export SYNC_PORT=8080
+export SYNC_BASE=/anki_data
+
 # Check if group exists, create if not
 if ! getent group anki-group > /dev/null 2>&1; then
     addgroup -g "$PGID" anki-group


### PR DESCRIPTION
**Note**: I recommend reviewing only the last commit of this PR since the first one is a separate PR #3714 and the second one also is #3715  . I will rebase things as needed. (a.k.a. stacked diffs).

Hardcode them to:

    SYNC_PORT=8080
    SYNC_BASE=/anki_data

If these env variables are passed into the container with different values,
they are ignored.

The reasons is if the user modifies SYNC_BASE they risk data loss since
anki-sync-server will no longer write data into the volume. If they change
SYNC_PORT they need to also change it when mapping this internal port to the
external port of the container, which could be confusing plus it has no benefit
to allow this since it's always possible to change the external port even if
the internal port is fixed to 8080 (e.g. `-p 1234:8080`).

In both cases there is no benefit to making these values configurable and there
are risks associated.

Unfortunately there is no easy way of implementing this for the
Dockerfile.distroless so it's up to the user not to modify these values.