### PR TITLE
Fix "Note Types" dialog moving down each time it is opened

### DIFF
--- a/qt/aqt/models.py
+++ b/qt/aqt/models.py
@@ -61,13 +61,13 @@ class Models(QDialog):
         )
         self.models: Sequence[NotetypeNameIdUseCount] = []
         self.setupModels()
-        restoreGeom(self, "models")
 
         self.setWindowFlags(
             self.windowFlags()
             | Qt.WindowType.WindowMaximizeButtonHint
             | Qt.WindowType.WindowMinimizeButtonHint
         )
+        restoreGeom(self, "models")
 
         self.show()
 


### PR DESCRIPTION
Fixes this bug:

https://forums.ankiweb.net/t/bug-note-types-window-moves-down-every-time-it-is-opened/54248

Setting window flags seem to make the window move down by the title bar height, so you have to restore geometry after setting them.

N.B. There may be similar bugs elsewhere, I have not checked all dialogs.