### PR TITLE
Fix flaky tests

### DIFF
--- a/rslib/src/tests.rs
+++ b/rslib/src/tests.rs
@@ -27,6 +27,7 @@ pub(crate) fn open_test_collection_with_learning_card() -> Collection {
     let mut col = Collection::new();
     NoteAdder::basic(&mut col).add(&mut col);
     col.answer_again();
+    col.clear_study_queues();
     col
 }
 
@@ -40,6 +41,7 @@ pub(crate) fn open_test_collection_with_relearning_card() -> Collection {
         .unwrap();
     col.clear_study_queues();
     col.answer_again();
+    col.clear_study_queues();
     col
 }
 


### PR DESCRIPTION
Closes #3619

This fixes an issue with two tests: `should_keep_at_least_one_remaining_relearning_step` and `should_keep_remaining_relearning_steps_if_passed_relearning_step_added`.

