### PR TITLE
Use platform-native button layout in dialogs and messageboxes

### DIFF
--- a/qt/aqt/stylesheets.py
+++ b/qt/aqt/stylesheets.py
@@ -1,7 +1,7 @@
 # Copyright: Ankitects Pty Ltd and contributors
 # License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
-from anki.utils import is_win, is_mac
+from anki.utils import is_mac, is_win
 from aqt import colors, props
 from aqt.theme import ThemeManager
 

--- a/qt/aqt/stylesheets.py
+++ b/qt/aqt/stylesheets.py
@@ -1,7 +1,7 @@
 # Copyright: Ankitects Pty Ltd and contributors
 # License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
-from anki.utils import is_win
+from anki.utils import is_win, is_mac
 from aqt import colors, props
 from aqt.theme import ThemeManager
 
@@ -26,6 +26,16 @@ qlineargradient(
     stop:1 {shadow}
 );
     """
+
+
+def button_layout():
+    # https://doc.qt.io/qt-6/stylesheet-reference.html#button-layout
+    if is_win:
+        return 0
+    elif is_mac:
+        return 1
+    # fallback to GnomeLayout
+    return 3
 
 
 class CustomStyles:
@@ -201,6 +211,9 @@ class CustomStyles:
     }}
     QPushButton:flat {{
         border: none;
+    }}
+    QDialogButtonBox {{
+        button-layout: {button_layout()};
     }}
         """
 

--- a/qt/aqt/stylesheets.py
+++ b/qt/aqt/stylesheets.py
@@ -28,12 +28,15 @@ qlineargradient(
     """
 
 
-def button_layout():
+def button_layout(tm: ThemeManager):
     # https://doc.qt.io/qt-6/stylesheet-reference.html#button-layout
     if is_win:
         return 0
     elif is_mac:
         return 1
+    # on linux, use non-default layout if available
+    if tm._default_button_layout:
+        return tm._default_button_layout
     # fallback to GnomeLayout
     return 3
 
@@ -213,7 +216,7 @@ class CustomStyles:
         border: none;
     }}
     QDialogButtonBox {{
-        button-layout: {button_layout()};
+        button-layout: {button_layout(tm)};
     }}
         """
 

--- a/qt/aqt/theme.py
+++ b/qt/aqt/theme.py
@@ -21,6 +21,7 @@ from aqt.qt import (
     QPainter,
     QPalette,
     QPixmap,
+    QStyle,
     QStyleFactory,
     Qt,
     qtmajor,
@@ -62,6 +63,7 @@ class ThemeManager:
     _dark_mode_available: bool | None = None
     _default_style: str | None = None
     _current_widget_style: WidgetStyle | None = None
+    _default_button_layout: int | None = None
 
     def rtl(self) -> bool:
         return is_rtl(anki.lang.current_lang)
@@ -234,6 +236,9 @@ class ThemeManager:
             style = app.style()
             assert style is not None
             self._default_style = style.objectName()
+            self._default_button_layout = style.styleHint(
+                QStyle.StyleHint.SH_DialogButtonLayout
+            )
         self._apply_palette(app)
         self._apply_style(app)
         gui_hooks.theme_did_change()


### PR DESCRIPTION
Relevant to #3720

Qt 5 and 6 provide a `button-layout` [stylesheet prop](https://doc.qt.io/qt-6/stylesheet-reference.html#button-layout) to specify which platform's layout should be used in `QDialogButtonBox`, which is also implicitly used in messageboxes. This pr proposes to use that prop

On win, this is a no-op (i suspect the same is true on macs). On linux (my machine at least), it seems that the qt fusion theme's `QStyle::SH_DialogButtonLayout` style hint defaults to 0, i.e the win layout. According to [this doc comment](https://github.com/qt/qtbase/blob/6.8.1/src/widgets/widgets/qdialogbuttonbox.cpp#L574), it doesn't seem to be consistently set automatically.

EDIT: It's correctly set to 3 (gnome) when in a ubuntu vm, meaning it's a no-op there as well. This pr's only real outward-facing change might be on enforcing the gnome layout on linux systems that don't set it, since qt already uses the platform-native layout in other cases

On linux, I opted to default to gnome's layout instead of kde's to avoid the problem of desktop env detection (unless someone knows how 👀)

Comparing the addcards and fields dialogs on linux:

Before (same as win):
![image](https://github.com/user-attachments/assets/78e541c5-68a9-44c4-b416-5d927692f905)
![image](https://github.com/user-attachments/assets/1302bce9-d20f-4e47-ac85-510fae75cccb)

After:
![image](https://github.com/user-attachments/assets/da8b7721-217a-4495-8f60-2ab72e0c39f1)
![image](https://github.com/user-attachments/assets/6c1b8a25-07fa-4bee-961d-96147e232e90)

Unfortunately, i don't think this will help the [forum post](https://forums.ankiweb.net/t/add-on-required-to-interchange-the-add-and-close-buttons/54196)'s OP in any way.

Here's how qt6 decides platform-native button ordering: https://github.com/qt/qtbase/blob/6.8.1/src/gui/kernel/qplatformdialoghelper.cpp#L58, tldr:
```
Win:   Accept - Destructive - Action - Reject - Help
Mac:   Help - Action - Destructive - Reject - Accept
Gnome: Help - Action - Destructive - Reject - Accept
Kde:   Help - Action - Accept - Destructive - Reject
```
where the "Add" button is `Action`, "Discard" is `Destructive`, "Close" and "Keep editing" are `Reject`

In all cases, "Discard" comes before "Keep editing", so that's already in line with all native behaviours, unless we rethink what roles to assign those buttons (should "Discard" be given the `Destructive` role in a modal asking for confirmation to discard?)

Likewise, "Add" is always to left of "Close"