### PR TITLE
set media folder mtime on sync

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -208,6 +208,7 @@ Omar Kohl <omarkohl@posteo.net>
 David Elizalde <david.elizalde.r.a@gmail.com>
 Yuki <https://github.com/YukiNagat0>
 wackbyte <wackbyte@protonmail.com>
+Joonas Rajamäki <jormki@gmail.com>
 
 ********************
 

--- a/qt/aqt/main.py
+++ b/qt/aqt/main.py
@@ -1108,6 +1108,9 @@ title="{}" {}>{}</button>""".format(
             after_sync()
 
         gui_hooks.sync_will_start()
+        media_folder = os.path.join(self.pm.profileFolder(), "collection.media")
+        os.utime(media_folder, None)
+
         sync_collection(self, on_done=on_collection_sync_finished)
 
     def maybe_auto_sync_on_open_close(self, after_sync: Callable[[bool], None]) -> None:


### PR DESCRIPTION
Related to https://forums.ankiweb.net/t/edited-media-files-auto-sync/54293/2?u=jhhr

Since it's so easy to enable this, wouldn't it make sense to make this default sync behaviour? I couldn't find one right now, but I recall there's been a thread or two on the forums with users wondering why their edits to media files didn't get synced. So, users probably expect syncing to work this way.