### PR TITLE
Don't treat manually scheduled cards with no reps as new cards

### DIFF
--- a/rslib/src/scheduler/fsrs/memory_state.rs
+++ b/rslib/src/scheduler/fsrs/memory_state.rs
@@ -189,7 +189,7 @@ impl Card {
     ) -> Result<()> {
         let memory_state = if let Some(i) = item {
             Some(fsrs.memory_state(i.item, i.starting_state)?)
-        } else if self.ctype == CardType::New || self.interval == 0 || self.reps == 0 {
+        } else if self.ctype == CardType::New || self.interval == 0 {
             None
         } else {
             // no valid revlog entries; infer state from current card state


### PR DESCRIPTION
Complements the change in https://github.com/ankitects/anki/pull/3639, ensuring that scheduler and rescheduling produce the same results.

To be more precise, it complements the removal of the following code in #3639

```rs
    if !revlogs_complete {
        revlogs_complete = matches!(
            entries.first(),
            Some(RevlogEntry {
                review_kind: RevlogReviewKind::Manual,
                ..
            }) | Some(RevlogEntry {
                review_kind: RevlogReviewKind::Rescheduled,
                ..
            })
        );
    }
```