### PR TITLE
Fix issue in regex for underscored CSS imports

### DIFF
--- a/rslib/src/text.rs
+++ b/rslib/src/text.rs
@@ -649,8 +649,17 @@ mod test {
                 "URL(\"_bar.css\")\n",
                 "@import url('_baz.css')\n",
                 "url('nope.css')\n",
+                "url(_foo.woff2) format('woff2')",
             )),
-            vec!["_foo.css", "_bar.css", "_baz.css", "_foo.css", "_bar.css", "_baz.css",]
+            vec![
+                "_foo.css",
+                "_bar.css",
+                "_baz.css",
+                "_foo.css",
+                "_bar.css",
+                "_baz.css",
+                "_foo.woff2"
+            ]
         );
         assert_eq!(
             extract_underscored_references(concat!(

--- a/rslib/src/text.rs
+++ b/rslib/src/text.rs
@@ -186,7 +186,7 @@ static UNDERSCORED_CSS_IMPORTS: LazyLock<Regex> = LazyLock::new(|| {
                 |                   # or
                 '(_[^']+)'          # single quoted
                 |                   # or
-                (_.+)               # unquoted filename
+                (_.+?)              # unquoted filename
             \s*\))
     "#,
     )


### PR DESCRIPTION
A minor tweak to fix the issue reported here: https://forums.ankiweb.net/t/it-seems-fonts-are-not-included-in-exported-in-anki-deck/54238



