### PR TITLE
Fix "Create copy" for IO notes

### DIFF
--- a/pylib/anki/collection.py
+++ b/pylib/anki/collection.py
@@ -53,6 +53,7 @@ TtsVoice = card_rendering_pb2.AllTtsVoicesResponse.TtsVoice
 GetImageForOcclusionResponse = image_occlusion_pb2.GetImageForOcclusionResponse
 AddImageOcclusionNoteRequest = image_occlusion_pb2.AddImageOcclusionNoteRequest
 GetImageOcclusionNoteResponse = image_occlusion_pb2.GetImageOcclusionNoteResponse
+ImageOcclusionFieldIndexes = image_occlusion_pb2.ImageOcclusionFieldIndexes
 AddonInfo = ankiweb_pb2.AddonInfo
 CheckForUpdateResponse = ankiweb_pb2.CheckForUpdateResponse
 MediaSyncStatus = sync_pb2.MediaSyncStatusResponse
@@ -457,6 +458,11 @@ class Collection(DeprecatedNamesMixin):
         self, note_id: int | None
     ) -> GetImageOcclusionNoteResponse:
         return self._backend.get_image_occlusion_note(note_id=note_id)
+
+    def get_image_occlusion_fields(
+        self, notetype_id: NotetypeId
+    ) -> ImageOcclusionFieldIndexes:
+        return self._backend.get_image_occlusion_fields(notetype_id)
 
     def update_image_occlusion_note(
         self,

--- a/pylib/anki/collection.py
+++ b/pylib/anki/collection.py
@@ -53,7 +53,6 @@ TtsVoice = card_rendering_pb2.AllTtsVoicesResponse.TtsVoice
 GetImageForOcclusionResponse = image_occlusion_pb2.GetImageForOcclusionResponse
 AddImageOcclusionNoteRequest = image_occlusion_pb2.AddImageOcclusionNoteRequest
 GetImageOcclusionNoteResponse = image_occlusion_pb2.GetImageOcclusionNoteResponse
-ImageOcclusionFieldIndexes = image_occlusion_pb2.ImageOcclusionFieldIndexes
 AddonInfo = ankiweb_pb2.AddonInfo
 CheckForUpdateResponse = ankiweb_pb2.CheckForUpdateResponse
 MediaSyncStatus = sync_pb2.MediaSyncStatusResponse
@@ -458,11 +457,6 @@ class Collection(DeprecatedNamesMixin):
         self, note_id: int | None
     ) -> GetImageOcclusionNoteResponse:
         return self._backend.get_image_occlusion_note(note_id=note_id)
-
-    def get_image_occlusion_fields(
-        self, notetype_id: NotetypeId
-    ) -> ImageOcclusionFieldIndexes:
-        return self._backend.get_image_occlusion_fields(notetype_id)
 
     def update_image_occlusion_note(
         self,

--- a/qt/aqt/addcards.py
+++ b/qt/aqt/addcards.py
@@ -78,7 +78,7 @@ class AddCards(QMainWindow):
         new_note.fields = note.fields[:]
         new_note.tags = note.tags[:]
 
-        self.setAndFocusNote(new_note)
+        self.setAndFocusNote(new_note, orig_note_id=note.id)
 
     def setupEditor(self) -> None:
         self.editor = aqt.editor.Editor(
@@ -143,8 +143,8 @@ class AddCards(QMainWindow):
         b.setEnabled(False)
         self.historyButton = b
 
-    def setAndFocusNote(self, note: Note) -> None:
-        self.editor.set_note(note, focusTo=0)
+    def setAndFocusNote(self, note: Note, orig_note_id: NoteId | None = None) -> None:
+        self.editor.set_note(note, focusTo=0, orig_note_id=orig_note_id)
 
     def show_notetype_selector(self) -> None:
         self.editor.call_after_note_saved(self.notetype_chooser.choose_notetype)

--- a/qt/aqt/editor.py
+++ b/qt/aqt/editor.py
@@ -596,26 +596,12 @@ require("anki/ui").loaded.then(() => require("anki/NoteEditor").instances[0].too
             sticky = [field["sticky"] for field in self.note_type()["flds"]]
             js += " setSticky(%s);" % json.dumps(sticky)
 
-        if self.current_notetype_is_image_occlusion():
-            if self.editorMode is EditorMode.ADD_CARDS:
-                mid = self.note.mid
-                io_fields = self.mw.col.get_image_occlusion_fields(mid)
-                media = self.mw.col.media
-                if (
-                    (image_field := self.note.fields[io_fields.image])
-                    and (images := media.files_in_str(mid, image_field))
-                    and (media.have(images[0]))
-                ):
-                    image_path = os.path.join(media.dir(), images[0])
-                    io_options = self._create_add_io_options(
-                        image_path=image_path,
-                        image_field_html=image_field,
-                        notetype_id=mid,
-                    )
-                    js += " setupMaskEditor(%s);" % json.dumps(io_options)
-            else:
-                io_options = self._create_edit_io_options(note_id=self.note.id)
-                js += " setupMaskEditor(%s);" % json.dumps(io_options)
+        if (
+            self.editorMode != EditorMode.ADD_CARDS
+            and self.current_notetype_is_image_occlusion()
+        ):
+            io_options = self._create_edit_io_options(note_id=self.note.id)
+            js += " setupMaskEditor(%s);" % json.dumps(io_options)
 
         js = gui_hooks.editor_will_load_note(js, self.note, self)
         self.web.evalWithCallback(

--- a/qt/aqt/editor.py
+++ b/qt/aqt/editor.py
@@ -602,12 +602,13 @@ require("anki/ui").loaded.then(() => require("anki/NoteEditor").instances[0].too
             sticky = [field["sticky"] for field in self.note_type()["flds"]]
             js += " setSticky(%s);" % json.dumps(sticky)
 
-        if (
-            self.editorMode != EditorMode.ADD_CARDS
-            and self.current_notetype_is_image_occlusion()
-        ):
-            io_options = self._create_edit_io_options(note_id=self.note.id)
-            js += " setupMaskEditor(%s);" % json.dumps(io_options)
+        if self.current_notetype_is_image_occlusion():
+            if self.editorMode is not EditorMode.ADD_CARDS:
+                io_options = self._create_edit_io_options(note_id=self.note.id)
+                js += " setupMaskEditor(%s);" % json.dumps(io_options)
+            elif orig_note_id:
+                io_options = self._create_clone_io_options(cloned_note_id=orig_note_id)
+                js += " setupMaskEditor(%s);" % json.dumps(io_options)
 
         js = gui_hooks.editor_will_load_note(js, self.note, self)
         self.web.evalWithCallback(
@@ -1165,6 +1166,12 @@ require("anki/ui").loaded.then(() => require("anki/NoteEditor").instances[0].too
         return {
             "mode": {"kind": "add", "imagePath": image_path, "notetypeId": notetype_id},
             "html": image_field_html,
+        }
+
+    @staticmethod
+    def _create_clone_io_options(cloned_note_id: NoteId) -> dict:
+        return {
+            "mode": {"kind": "add", "clonedNoteId": cloned_note_id},
         }
 
     @staticmethod

--- a/qt/aqt/editor.py
+++ b/qt/aqt/editor.py
@@ -524,20 +524,26 @@ require("anki/ui").loaded.then(() => require("anki/NoteEditor").instances[0].too
     ######################################################################
 
     def set_note(
-        self, note: Note | None, hide: bool = True, focusTo: int | None = None
+        self,
+        note: Note | None,
+        hide: bool = True,
+        focusTo: int | None = None,
+        orig_note_id: NoteId | None = None,
     ) -> None:
         "Make NOTE the current note."
         self.note = note
         self.currentField = None
         if self.note:
-            self.loadNote(focusTo=focusTo)
+            self.loadNote(focusTo=focusTo, orig_note_id=orig_note_id)
         elif hide:
             self.widget.hide()
 
     def loadNoteKeepingFocus(self) -> None:
         self.loadNote(self.currentField)
 
-    def loadNote(self, focusTo: int | None = None) -> None:
+    def loadNote(
+        self, focusTo: int | None = None, orig_note_id: NoteId | None = None
+    ) -> None:
         if not self.note:
             return
 

--- a/ts/editor/NoteEditor.svelte
+++ b/ts/editor/NoteEditor.svelte
@@ -431,7 +431,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         imageOcclusionMode = undefined;
         await tick();
         imageOcclusionMode = options.mode;
-        if (options.mode.kind === "add") {
+        if (options.mode.kind === "add" && !("clonedNoteId" in options.mode)) {
             fieldStores[ioFields.image].set(options.html);
             // the image field is set programmatically and does not need debouncing
             // commit immediately to avoid a race condition with the occlusions field

--- a/ts/routes/image-occlusion/MaskEditor.svelte
+++ b/ts/routes/image-occlusion/MaskEditor.svelte
@@ -44,10 +44,19 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
     function init(_node: HTMLDivElement) {
         if (mode.kind == "add") {
-            // Editing occlusions on a new note through the "Add" window
-            setupMaskEditor(mode.imagePath, onImageLoaded).then((canvas1) => {
-                canvas = canvas1;
-            });
+            if ("clonedNoteId" in mode) {
+                // Editing occlusions on a new note cloned from an existing note via "Create copy"
+                setupMaskEditorForEdit(mode.clonedNoteId, onImageLoaded).then(
+                    (canvas1) => {
+                        canvas = canvas1;
+                    },
+                );
+            } else {
+                // Editing occlusions on a new note through the "Add" window
+                setupMaskEditor(mode.imagePath, onImageLoaded).then((canvas1) => {
+                    canvas = canvas1;
+                });
+            }
         } else {
             // Editing occlusions on an existing note through the "Browser" window
             setupMaskEditorForEdit(mode.noteId, onImageLoaded).then((canvas1) => {

--- a/ts/routes/image-occlusion/add-or-update-note.svelte.ts
+++ b/ts/routes/image-occlusion/add-or-update-note.svelte.ts
@@ -7,7 +7,7 @@ import * as tr from "@generated/ftl";
 import { get } from "svelte/store";
 
 import { mount } from "svelte";
-import type { IOMode } from "./lib";
+import type { IOAddingMode, IOMode } from "./lib";
 import { exportShapesToClozeDeletions } from "./shapes/to-cloze";
 import { notesDataStore, tagsWritable } from "./store";
 import Toast from "./Toast.svelte";
@@ -40,8 +40,9 @@ export const addOrUpdateNote = async function(
         showResult(mode.noteId, result, noteCount);
     } else {
         const result = await addImageOcclusionNote({
-            notetypeId: BigInt(mode.notetypeId),
-            imagePath: mode.imagePath,
+            // IOCloningMode is not used on mobile
+            notetypeId: BigInt((<IOAddingMode> mode).notetypeId),
+            imagePath: (<IOAddingMode> mode).imagePath,
             occlusions: occlusionCloze,
             header,
             backExtra,

--- a/ts/routes/image-occlusion/lib.ts
+++ b/ts/routes/image-occlusion/lib.ts
@@ -7,9 +7,14 @@ export interface IOAddingMode {
     imagePath: string;
 }
 
+export interface IOCloningMode {
+    kind: "add";
+    clonedNoteId: number;
+}
+
 export interface IOEditingMode {
     kind: "edit";
     noteId: number;
 }
 
-export type IOMode = IOAddingMode | IOEditingMode;
+export type IOMode = IOAddingMode | IOEditingMode | IOCloningMode;


### PR DESCRIPTION
Closes #3247

~~The mask editor is now provided with the copied note's image if it exists (which should almost always be the case)~~

The copied note's image and occlusions now carry over to the new note, along with its tags, occlusion mode, misc. fields etc