### PR TITLE
FSRS: ignore initial reviews until first longer break

### DIFF
--- a/rslib/src/scheduler/fsrs/params.rs
+++ b/rslib/src/scheduler/fsrs/params.rs
@@ -331,6 +331,12 @@ pub(crate) fn reviews_for_fsrs(
         if idx > 0 {
             entries.drain(..idx);
         }
+        for i in 1..entries.len() {
+            if entries[i].id.0 - entries[i - 1].id.0 >= 2*60*60*1000 { //TODO: make the 2h offset configurable via deck options
+                entries.drain(..i);
+                break;
+            }
+        }
     } else if training {
         // when training, we ignore cards that don't have any learning steps
         return None;


### PR DESCRIPTION
I'm dealing with a deck where I practically don't know any of the new cards that show up (It's a Kanji-Learning-Deck).
So that results in practically all first ratings to be "Again", which results in relatively poor performance of FSRS for that deck for me.
It consistently thinks I'm much better than I actually am, resulting in lower retention than the configured desired value.

I also initially did some mistakes in my learning process(while still using SM2), and hit "Good" as initial rating on cards I learned on the Sibling Card minutes prior, which should actually have been "Again".

I have however consistently had a 3h learning step, so I got the idea that this patch implements:
Ignore all ratings until after that first 3h break. That way FSRS won't see just a wall of Again (and my faulty early Good-Reviews), but actually a pretty well balanced mix, with Good being the by far most common, but also quite a few Hard and some Again ratings.

Here's the resulting parameters of optimizing that deck, once with a cutoff of 1.1.2024, and once the full collection with all the broken early reviews:

```
with patch(2024+): 0.9740, 1.3670, 5.4289, 13.6145, 6.7360, 0.9580, 3.7119, 0.0010, 1.4519, 0.4317, 1.0705, 2.0221, 0.0013, 0.3570, 2.4720, 0.0738, 2.9898, 0.2773, 0.6563
with patch(full): 1.9143, 2.3422, 6.2829, 12.1299, 5.9645, 0.8355, 3.9036, 0.0010, 1.3884, 0.2687, 1.0849, 2.3507, 0.0036, 0.3997, 3.0904, 0.0083, 5.9993, 0.1425, 0.0225
no patch(2024+): 2.2672, 13.6816, 16.2068, 18.1442, 5.8833, 0.8862, 3.6219, 0.0010, 1.5006, 0.3336, 1.0599, 2.1953, 0.0113, 0.3936, 2.6687, 0.0007, 2.9898, 0.2133, 0.2458
no patch(full): 2.8489, 9.1171, 19.3318, 31.9068, 5.7983, 0.8792, 3.7462, 0.0013, 1.3907, 0.1841, 1.0353, 2.4633, 0.0029, 0.3701, 3.1397, 0.0000, 6.0000, 0.1994, 0.1922
```

As demonstrated by the initial stabilities, this has pretty much solved the issue of a way too high stability for Cards initially rated "Good", which mostly affects ~1000 cards from my early reviews.

But even without such a mistake in a lot of review histories, I think this approach is worthwhile.
Specially when learning completely new material via a deck, all initial ratings will be Again. The first rating after the first break will almost certainly be more varied.

Obviously the code is not ready like this. It at the very least needs to be configurable via an option. Just looking for opinions here.
I also found no obvious way how to access the deck setting from that place. Looks like it'll have to be passed on as a parameter for quite a while.