### PR TITLE
Revert Editor.set_note's signature change with an alternative approach for #3730

### DIFF
--- a/pylib/anki/notes.py
+++ b/pylib/anki/notes.py
@@ -32,6 +32,8 @@ class Note(DeprecatedNamesMixin):
     data = ""
     id: NoteId
     mid: NotetypeId
+    # used when creating a copy of an existing note
+    orig_note_id: NoteId | None = None
 
     def __init__(
         self,

--- a/pylib/anki/notes.py
+++ b/pylib/anki/notes.py
@@ -32,8 +32,6 @@ class Note(DeprecatedNamesMixin):
     data = ""
     id: NoteId
     mid: NotetypeId
-    # used when creating a copy of an existing note
-    orig_note_id: NoteId | None = None
 
     def __init__(
         self,

--- a/qt/aqt/addcards.py
+++ b/qt/aqt/addcards.py
@@ -77,6 +77,7 @@ class AddCards(QMainWindow):
         new_note = self._new_note()
         new_note.fields = note.fields[:]
         new_note.tags = note.tags[:]
+        new_note.orig_note_id = note.id
 
         self.setAndFocusNote(new_note)
 

--- a/qt/aqt/addcards.py
+++ b/qt/aqt/addcards.py
@@ -77,8 +77,8 @@ class AddCards(QMainWindow):
         new_note = self._new_note()
         new_note.fields = note.fields[:]
         new_note.tags = note.tags[:]
-        new_note.orig_note_id = note.id
 
+        self.editor.orig_note_id = note.id
         self.setAndFocusNote(new_note)
 
     def setupEditor(self) -> None:

--- a/qt/aqt/addcards.py
+++ b/qt/aqt/addcards.py
@@ -78,7 +78,7 @@ class AddCards(QMainWindow):
         new_note.fields = note.fields[:]
         new_note.tags = note.tags[:]
 
-        self.setAndFocusNote(new_note, orig_note_id=note.id)
+        self.setAndFocusNote(new_note)
 
     def setupEditor(self) -> None:
         self.editor = aqt.editor.Editor(
@@ -143,8 +143,8 @@ class AddCards(QMainWindow):
         b.setEnabled(False)
         self.historyButton = b
 
-    def setAndFocusNote(self, note: Note, orig_note_id: NoteId | None = None) -> None:
-        self.editor.set_note(note, focusTo=0, orig_note_id=orig_note_id)
+    def setAndFocusNote(self, note: Note) -> None:
+        self.editor.set_note(note, focusTo=0)
 
     def show_notetype_selector(self) -> None:
         self.editor.call_after_note_saved(self.notetype_chooser.choose_notetype)

--- a/qt/aqt/editor.py
+++ b/qt/aqt/editor.py
@@ -603,8 +603,8 @@ require("anki/ui").loaded.then(() => require("anki/NoteEditor").instances[0].too
             if self.editorMode is not EditorMode.ADD_CARDS:
                 io_options = self._create_edit_io_options(note_id=self.note.id)
                 js += " setupMaskEditor(%s);" % json.dumps(io_options)
-            elif orig_note_id:
-                io_options = self._create_clone_io_options(cloned_note_id=orig_note_id)
+            elif orig_note_id := self.note.orig_note_id:
+                io_options = self._create_clone_io_options(orig_note_id)
                 js += " setupMaskEditor(%s);" % json.dumps(io_options)
 
         js = gui_hooks.editor_will_load_note(js, self.note, self)
@@ -1166,9 +1166,9 @@ require("anki/ui").loaded.then(() => require("anki/NoteEditor").instances[0].too
         }
 
     @staticmethod
-    def _create_clone_io_options(cloned_note_id: NoteId) -> dict:
+    def _create_clone_io_options(orig_note_id: NoteId) -> dict:
         return {
-            "mode": {"kind": "add", "clonedNoteId": cloned_note_id},
+            "mode": {"kind": "add", "clonedNoteId": orig_note_id},
         }
 
     @staticmethod

--- a/qt/aqt/editor.py
+++ b/qt/aqt/editor.py
@@ -528,22 +528,19 @@ require("anki/ui").loaded.then(() => require("anki/NoteEditor").instances[0].too
         note: Note | None,
         hide: bool = True,
         focusTo: int | None = None,
-        orig_note_id: NoteId | None = None,
     ) -> None:
         "Make NOTE the current note."
         self.note = note
         self.currentField = None
         if self.note:
-            self.loadNote(focusTo=focusTo, orig_note_id=orig_note_id)
+            self.loadNote(focusTo=focusTo)
         elif hide:
             self.widget.hide()
 
     def loadNoteKeepingFocus(self) -> None:
         self.loadNote(self.currentField)
 
-    def loadNote(
-        self, focusTo: int | None = None, orig_note_id: NoteId | None = None
-    ) -> None:
+    def loadNote(self, focusTo: int | None = None) -> None:
         if not self.note:
             return
 

--- a/qt/aqt/editor.py
+++ b/qt/aqt/editor.py
@@ -139,6 +139,8 @@ class Editor:
         # Similar to currentField, but not set to None on a blur. May be
         # outside the bounds of the current notetype.
         self.last_field_index: int | None = None
+        # used when creating a copy of an existing note
+        self.orig_note_id: NoteId | None = None
         # current card, for card layout
         self.card: Card | None = None
         self.state: EditorState = EditorState.INITIAL
@@ -603,7 +605,8 @@ require("anki/ui").loaded.then(() => require("anki/NoteEditor").instances[0].too
             if self.editorMode is not EditorMode.ADD_CARDS:
                 io_options = self._create_edit_io_options(note_id=self.note.id)
                 js += " setupMaskEditor(%s);" % json.dumps(io_options)
-            elif orig_note_id := self.note.orig_note_id:
+            elif orig_note_id := self.orig_note_id:
+                self.orig_note_id = None
                 io_options = self._create_clone_io_options(orig_note_id)
                 js += " setupMaskEditor(%s);" % json.dumps(io_options)
 


### PR DESCRIPTION
Reported in https://discord.com/channels/368267295601983490/368267296046841857/1330000729582211185

Changing the signature of `Editor.set_note` in #3730 broke the [Cloze (Hide All)](https://ankiweb.net/shared/info/1709973686) addon, and it might not be the only one :/

This pr proposes adding a field to `Note` to keep track of the original note it was copied from (if any), which doesn't get [passed to the backend](https://github.com/ankitects/anki/blob/7ba143bad8cfd60bf865c1274c1fc3e6c3d3886a/pylib/anki/notes.py#L72), and using that instead of drilling it through to `Editor.loadNote`