### PR TITLE
Increase font size in debug console

### DIFF
--- a/qt/aqt/debug_console.py
+++ b/qt/aqt/debug_console.py
@@ -75,7 +75,7 @@ class DebugConsole(QDialog):
         font = QFont("Consolas")
         if not font.exactMatch():
             font = QFontDatabase.systemFont(QFontDatabase.SystemFont.FixedFont)
-        font.setPointSize(self._text.font().pointSize())
+        font.setPointSize(self._text.font().pointSize() + 1)
         self._text.setFont(font)
         self._log.setFont(font)
 


### PR DESCRIPTION
In 25.01 beta, the font size in debug console looked small. So, I increased it back. I have tested the changes and the font size looks better to me now.