### PR TITLE
Add translation strings for True Retention table

### DIFF
--- a/ftl/core/statistics.ftl
+++ b/ftl/core/statistics.ftl
@@ -103,14 +103,25 @@ statistics-counts-separate-suspended-buried-cards = Separate suspended/buried ca
 ## comparison to the "desired retention" parameter of FSRS, which forecasts
 ## future retention. True Retention is the percentage of all reviewed cards
 ## that were marked as "Hard," "Good," or "Easy" within a specific time period.
+##
+## Most of these strings are used as column / row headings in a table.
+## (Excluding -title and -subtitle)
+## It is important to keep these translations short so that they do not make
+## the table too large to display on a single stats card.
+##
+## N.B. Stats cards may be very small on mobile devices and when the Stats
+##      window is certain sizes.
 
 statistics-true-retention-title = True Retention
 statistics-true-retention-subtitle = Pass rate of cards with an interval ≥ 1 day.
 statistics-true-retention-range = Range
 statistics-true-retention-pass = Pass
 statistics-true-retention-fail = Fail
+statistics-true-retention-total = { statistics-counts-total-cards }
 statistics-true-retention-count = Count
 statistics-true-retention-retention = Retention
+statistics-true-retention-young = { statistics-counts-young-cards }
+statistics-true-retention-mature = { statistics-counts-mature-cards }
 statistics-true-retention-all = All
 statistics-true-retention-today = Today
 statistics-true-retention-yesterday = Yesterday

--- a/ftl/core/statistics.ftl
+++ b/ftl/core/statistics.ftl
@@ -117,11 +117,14 @@ statistics-true-retention-subtitle = Pass rate of cards with an interval ≥ 1 d
 statistics-true-retention-range = Range
 statistics-true-retention-pass = Pass
 statistics-true-retention-fail = Fail
-statistics-true-retention-total = { statistics-counts-total-cards }
+# This will usually be the same as statistics-counts-total-cards
+statistics-true-retention-total = Total
 statistics-true-retention-count = Count
 statistics-true-retention-retention = Retention
-statistics-true-retention-young = { statistics-counts-young-cards }
-statistics-true-retention-mature = { statistics-counts-mature-cards }
+# This will usually be the same as statistics-counts-young-cards
+statistics-true-retention-young = Young
+# This will usually be the same as statistics-counts-mature-cards
+statistics-true-retention-mature = Mature
 statistics-true-retention-all = All
 statistics-true-retention-today = Today
 statistics-true-retention-yesterday = Yesterday

--- a/ts/routes/graphs/TrueRetention.svelte
+++ b/ts/routes/graphs/TrueRetention.svelte
@@ -41,12 +41,12 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     <InputBox>
         <label>
             <input type="radio" bind:group={mode} value={DisplayMode.Young} />
-            {tr.statisticsCountsYoungCards()}
+            {tr.statisticsTrueRetentionYoung()}
         </label>
 
         <label>
             <input type="radio" bind:group={mode} value={DisplayMode.Mature} />
-            {tr.statisticsCountsMatureCards()}
+            {tr.statisticsTrueRetentionMature()}
         </label>
 
         <label>

--- a/ts/routes/graphs/TrueRetentionCombined.svelte
+++ b/ts/routes/graphs/TrueRetentionCombined.svelte
@@ -29,13 +29,13 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         <tr>
             <td></td>
             <th scope="col" class="col-header young">
-                {tr.statisticsCountsYoungCards()}
+                {tr.statisticsTrueRetentionYoung()}
             </th>
             <th scope="col" class="col-header mature">
-                {tr.statisticsCountsMatureCards()}
+                {tr.statisticsTrueRetentionMature()}
             </th>
             <th scope="col" class="col-header total">
-                {tr.statisticsCountsTotalCards()}
+                {tr.statisticsTrueRetentionTotal()}
             </th>
             <th scope="col" class="col-header count">
                 {tr.statisticsTrueRetentionCount()}


### PR DESCRIPTION
Based on this discussion on the forum: https://forums.ankiweb.net/t/anki-25-01-beta/54490/5

I reused translation strings from the Cards Counts chart in the redesign of the True Retention table as it meant less translation work was required.

Unfortunately in some languages these translations are quite long, which can make the table overflow and need scroll bars if the card is small:

![image](https://github.com/user-attachments/assets/a82db4cf-a80c-4ba3-a6a6-495775aa6d9e)

This PR adds new translation strings specific to the True Retention table so you can do something like this:

```
statistics-counts-young-cards = Junge Karten
statistics-true-retention-young = Jung
```

so you can be verbose where you have plenty of space, and terse where you do not.

An unfortunate downside of this is it requires new translations to be added for all languages, which will often be identical to the ones from Card Counts and mean less maintained languages may not get a translation for a while.

**This should probably not be merged without input from people more involved in the translation of Anki.**