### PR TITLE
Add workflow to publish syncserver docker images on tag creation

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,64 @@
+name: Docker
+
+on:
+  push:
+    tags: [ '*' ]
+
+env:
+  # Use docker.io for Docker Hub if empty
+  REGISTRY: ghcr.io
+
+jobs:
+  extract-version:
+    name: extract version
+    runs-on: ubuntu-latest
+    steps:
+      - name: Extract version
+        run: echo "VERSION=$(echo ${GITHUB_REF#refs/tags/})" >> $GITHUB_OUTPUT
+        id: extract_version
+    outputs:
+      VERSION: ${{ steps.extract_version.outputs.VERSION }}
+
+  publish-sync-server-docker-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      # This is used to complete the identity challenge
+      # with sigstore/fulcio when running outside of PRs.
+      id-token: write
+
+    needs: extract-version
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log into registry ${{ env.REGISTRY }}
+        uses: docker/login-action@v3.0.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@5
+        with:
+          images: ${{ env.REGISTRY }}/${{ github.repository }}-syncserver
+
+      - name: Build and push Docker image
+        id: build-and-push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docs/syncserver/Dockerfile
+          no-cache: true
+          build-args:
+            - ANKI_VERSION=${{ needs.extract-version.outputs.VERSION }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -210,6 +210,7 @@ Omar Kohl <omarkohl@posteo.net>
 David Elizalde <david.elizalde.r.a@gmail.com>
 Yuki <https://github.com/YukiNagat0>
 wackbyte <wackbyte@protonmail.com>
+KolbyML <kolbyml@protonmail.com>
 
 ********************
 
@@ -223,11 +224,11 @@ modification, are permitted provided that the following conditions are met:
 1. Redistributions of source code must retain the above copyright notice, this
 list of conditions and the following disclaimer.
 
-2. Redistributions in binary form must reproduce the above copyright notice,
+1. Redistributions in binary form must reproduce the above copyright notice,
 this list of conditions and the following disclaimer in the documentation
 and/or other materials provided with the distribution.
 
-3. Neither the name of the copyright holder nor the names of its contributors
+1. Neither the name of the copyright holder nor the names of its contributors
 may be used to endorse or promote products derived from this software without
 specific prior written permission.
 


### PR DESCRIPTION
This workflow will publish docker images on tag creation and publish to the anki repo's package hub.

It will publish the docker images under `ghcr.io/ankitects/anki-syncserver:<tag>` and `ghcr.io/ankitects/anki-syncserver:latest`. `ghcr.io/ankitects/anki-syncserver:latest` will always point to the latest git tag.

I want to make this PR as it will make it easier for people who do self hosting, I want to setup automated deployments with anisble

```
- name: Pull an image
  community.docker.docker_image_pull:
    name: ghcr.io/ankitects/anki-syncserver:latest

- name: Start a container with a command
  community.docker.docker_container:
    name: anki-syncserver
    image: ghcr.io/ankitects/anki-syncserver:latest
    state: started
    restart_policy: always
    network_mode: host
    volumes: 
      - ${HOME}/.syncserver:${HOME}/.syncserver
    env:
      - MAX_SYNC_PAYLOAD_MEGS=50000
      - SYNC_PORT=${SYNC_PORT:-8080}
      - SYNC_USER1=${SYNC_USER1?anki-sync-server Requires a username and password in "SYNC_USER1=user:pass" format}
```

Here is an example of an ansible task to deploy this