### PR TITLE
Fix numeric deck and notetype names being treated as ids when importing csv

### DIFF
--- a/rslib/src/import_export/text/csv/metadata.rs
+++ b/rslib/src/import_export/text/csv/metadata.rs
@@ -688,6 +688,35 @@ pub(in crate::import_export) mod test {
     }
 
     #[test]
+    fn should_fallback_to_parsing_deck_ids_as_deck_names() {
+        let mut col = Collection::new();
+        let numeric_deck_id = col.get_or_create_normal_deck("123456789").unwrap().id.0;
+        let numeric_deck_2_id = col
+            .get_or_create_normal_deck(&numeric_deck_id.to_string())
+            .unwrap()
+            .id
+            .0;
+
+        assert_eq!(
+            metadata!(col, "#deck:123456789\n").unwrap_deck_id(),
+            numeric_deck_id
+        );
+        // parsed as id first, fallback to name after
+        assert_eq!(
+            metadata!(col, format!("#deck:{numeric_deck_id}\n")).unwrap_deck_id(),
+            numeric_deck_id
+        );
+        assert_eq!(
+            metadata!(col, format!("#deck:{numeric_deck_2_id}\n")).unwrap_deck_id(),
+            numeric_deck_2_id
+        );
+        assert_eq!(
+            metadata!(col, format!("#deck:1234\n")).unwrap_deck_id(),
+            1 // default deck
+        );
+    }
+
+    #[test]
     fn should_detect_valid_delimiters() {
         let mut col = Collection::new();
         assert_eq!(

--- a/rslib/src/import_export/text/import.rs
+++ b/rslib/src/import_export/text/import.rs
@@ -167,7 +167,12 @@ impl DeckIdsByNameOrId {
     fn get(&self, name_or_id: &NameOrId) -> Option<DeckId> {
         match name_or_id {
             _ if *name_or_id == NameOrId::default() => self.default,
-            NameOrId::Id(id) => self.ids.get(&DeckId(*id)).copied(),
+            NameOrId::Id(id) => self
+                .ids
+                .get(&DeckId(*id))
+                // try treating it as a numeric deck name
+                .or_else(|| self.names.get(&UniCase::new(id.to_string())))
+                .copied(),
             NameOrId::Name(name) => self.names.get(&UniCase::new(name.to_string())).copied(),
         }
     }
@@ -504,7 +509,13 @@ impl Note {
 impl Collection {
     pub(super) fn deck_id_by_name_or_id(&mut self, deck: &NameOrId) -> Result<Option<DeckId>> {
         match deck {
-            NameOrId::Id(id) => Ok(self.get_deck(DeckId(*id))?.map(|_| DeckId(*id))),
+            NameOrId::Id(id) => Ok({
+                match self.get_deck(DeckId(*id))?.map(|d| d.id) {
+                    did @ Some(_) => did,
+                    // try treating it as a numeric deck name
+                    _ => self.get_deck_id(&id.to_string())?,
+                }
+            }),
             NameOrId::Name(name) => self.get_deck_id(name),
         }
     }
@@ -514,7 +525,13 @@ impl Collection {
         notetype: &NameOrId,
     ) -> Result<Option<Arc<Notetype>>> {
         match notetype {
-            NameOrId::Id(id) => self.get_notetype(NotetypeId(*id)),
+            NameOrId::Id(id) => Ok({
+                match self.get_notetype(NotetypeId(*id))? {
+                    nt @ Some(_) => nt,
+                    // try treating it as a numeric notetype name
+                    _ => self.get_notetype_by_name(&id.to_string())?,
+                }
+            }),
             NameOrId::Name(name) => self.get_notetype_by_name(name),
         }
     }


### PR DESCRIPTION
Reported in https://forums.ankiweb.net/t/import-problem-deck-field-is-ignored-since-version-24-11

Fixes numeric deck and notetype names being treated as ids in `#deck:...`, or in the specified deck/notetype column

`DeckIdsByNameOrId::get`, `Collection::deck_id_by_name_or_id` and `Collection::notetype_by_name_or_id` are modified to fallback to treating ids as names if said deck/notetype id is nonexistent

Modifying `Collection.deck_id_by_name_or_id` may seem redundant, as the metadata deck [goes through DeckIdsByNameOrId::get anyway](https://github.com/ankitects/anki/blob/1be94a8b0461defcbf2a2d39e5a1f316446b0169/rslib/src/import_export/text/import.rs#L162), but since its used by the import options page, it's kept for consistency when dealing with `#deck:<numeric>`

The only breakage I can think of is when an exporter exports notes from a deck with a name that's the same as one of the importer's decks' ids, in which case the deck with that id would be used instead of making a new deck with the id as the name. But this seems highly pathological, and is identical to existing behaviour regardless.
