### PR TITLE
Fix: Simulator Ignores New Cards Already Introduced

### DIFF
--- a/rslib/src/scheduler/fsrs/simulator.rs
+++ b/rslib/src/scheduler/fsrs/simulator.rs
@@ -26,7 +26,7 @@ impl Collection {
         let days_elapsed = self.timing_today().unwrap().days_elapsed as i32;
         let new_cards = cards
             .iter()
-            .filter(|c| c.memory_state == None || c.queue == CardQueue::New)
+            .filter(|c| c.memory_state.is_none() || c.queue == CardQueue::New)
             .count()
             + req.deck_size as usize;
         let mut converted_cards = cards

--- a/rslib/src/scheduler/fsrs/simulator.rs
+++ b/rslib/src/scheduler/fsrs/simulator.rs
@@ -32,15 +32,13 @@ impl Collection {
         let introduced_today_count = self.search_cards(&format!("{} introduced:1", &req.search), SortMode::NoOrder)?.len();
         if req.new_limit > 0 {
             let new_cards = (introduced_today_count..(req.deck_size as usize + introduced_today_count)).map(|i| fsrs::Card {
-                difficulty: f32::NEG_INFINITY,
-                stability: 1e-8, // Hack to get around the filter
-                last_date: f32::NEG_INFINITY,
-                due: 1. + (i / req.new_limit as usize) as f32,
+                difficulty: 0.,
+                stability: 0., // Not filtered by fsrs-rs
+                last_date: f32::NEG_INFINITY, // Treated as a new card in simulation
+                due: (i / req.new_limit as usize) as f32,
             });
-            dbg!(introduced_today_count, req.deck_size as usize, converted_cards.len(), new_cards.clone().collect_vec());
             converted_cards.extend(new_cards);
         }
-        dbg!(&converted_cards);
         let p = self.get_optimal_retention_parameters(revlogs)?;
         let config = SimulatorConfig {
             deck_size: converted_cards.len(),

--- a/rslib/src/scheduler/fsrs/simulator.rs
+++ b/rslib/src/scheduler/fsrs/simulator.rs
@@ -26,11 +26,7 @@ impl Collection {
         let days_elapsed = self.timing_today().unwrap().days_elapsed as i32;
         let mut converted_cards = cards
             .into_iter()
-            .filter(|c| {
-                c.queue != CardQueue::Suspended
-                    && c.queue != CardQueue::PreviewRepeat
-                    && c.queue != CardQueue::New
-            })
+            .filter(|c| c.queue != CardQueue::Suspended && c.queue != CardQueue::PreviewRepeat)
             .filter_map(|c| Card::convert(c, days_elapsed, req.days_to_simulate))
             .collect_vec();
         let introduced_today_count = self

--- a/rslib/src/scheduler/fsrs/simulator.rs
+++ b/rslib/src/scheduler/fsrs/simulator.rs
@@ -24,7 +24,11 @@ impl Collection {
         let cards = guard.col.storage.all_searched_cards()?;
         drop(guard);
         let days_elapsed = self.timing_today().unwrap().days_elapsed as i32;
-        let new_cards = cards.iter().filter(|c| c.memory_state == None || c.queue == CardQueue::New).count() + req.deck_size as usize;
+        let new_cards = cards
+            .iter()
+            .filter(|c| c.memory_state == None || c.queue == CardQueue::New)
+            .count()
+            + req.deck_size as usize;
         let mut converted_cards = cards
             .into_iter()
             .filter(|c| c.queue != CardQueue::Suspended && c.queue != CardQueue::PreviewRepeat)

--- a/rslib/src/scheduler/fsrs/simulator.rs
+++ b/rslib/src/scheduler/fsrs/simulator.rs
@@ -31,11 +31,11 @@ impl Collection {
             .collect_vec();
         let introduced_today_count = self.search_cards(&format!("{} introduced:1", &req.search), SortMode::NoOrder)?.len();
         if req.new_limit > 0 {
-            let new_cards = (introduced_today_count..(req.deck_size as usize + introduced_today_count)).map(|i| fsrs::Card {
-                difficulty: 0.,
-                stability: 0., // Not filtered by fsrs-rs
+            let new_cards = (0..req.deck_size as usize).map(|i| fsrs::Card {
+                difficulty: f32::NEG_INFINITY,
+                stability: 1e-8, // Not filtered by fsrs-rs
                 last_date: f32::NEG_INFINITY, // Treated as a new card in simulation
-                due: (i / req.new_limit as usize) as f32,
+                due: ((introduced_today_count + i) / req.new_limit as usize) as f32,
             });
             converted_cards.extend(new_cards);
         }

--- a/rslib/src/scheduler/fsrs/simulator.rs
+++ b/rslib/src/scheduler/fsrs/simulator.rs
@@ -36,7 +36,8 @@ impl Collection {
             .collect_vec();
         let introduced_today_count = self
             .search_cards(&format!("{} introduced:1", &req.search), SortMode::NoOrder)?
-            .len();
+            .len()
+            .min(req.new_limit as usize);
         if req.new_limit > 0 {
             let new_cards = (0..new_cards).map(|i| fsrs::Card {
                 difficulty: f32::NEG_INFINITY,

--- a/rslib/src/scheduler/fsrs/simulator.rs
+++ b/rslib/src/scheduler/fsrs/simulator.rs
@@ -26,14 +26,20 @@ impl Collection {
         let days_elapsed = self.timing_today().unwrap().days_elapsed as i32;
         let mut converted_cards = cards
             .into_iter()
-            .filter(|c| c.queue != CardQueue::Suspended && c.queue != CardQueue::PreviewRepeat && c.queue != CardQueue::New)
+            .filter(|c| {
+                c.queue != CardQueue::Suspended
+                    && c.queue != CardQueue::PreviewRepeat
+                    && c.queue != CardQueue::New
+            })
             .filter_map(|c| Card::convert(c, days_elapsed, req.days_to_simulate))
             .collect_vec();
-        let introduced_today_count = self.search_cards(&format!("{} introduced:1", &req.search), SortMode::NoOrder)?.len();
+        let introduced_today_count = self
+            .search_cards(&format!("{} introduced:1", &req.search), SortMode::NoOrder)?
+            .len();
         if req.new_limit > 0 {
             let new_cards = (0..req.deck_size as usize).map(|i| fsrs::Card {
                 difficulty: f32::NEG_INFINITY,
-                stability: 1e-8, // Not filtered by fsrs-rs
+                stability: 1e-8,              // Not filtered by fsrs-rs
                 last_date: f32::NEG_INFINITY, // Treated as a new card in simulation
                 due: ((introduced_today_count + i) / req.new_limit as usize) as f32,
             });

--- a/rslib/src/scheduler/fsrs/simulator.rs
+++ b/rslib/src/scheduler/fsrs/simulator.rs
@@ -32,7 +32,7 @@ impl Collection {
         let mut converted_cards = cards
             .into_iter()
             .filter(|c| c.queue != CardQueue::Suspended && c.queue != CardQueue::PreviewRepeat)
-            .filter_map(|c| Card::convert(c, days_elapsed, req.days_to_simulate))
+            .filter_map(|c| Card::convert(c, days_elapsed))
             .collect_vec();
         let introduced_today_count = self
             .search_cards(&format!("{} introduced:1", &req.search), SortMode::NoOrder)?
@@ -91,7 +91,7 @@ impl Collection {
 }
 
 impl Card {
-    fn convert(card: Card, days_elapsed: i32, day_to_simulate: u32) -> Option<fsrs::Card> {
+    fn convert(card: Card, days_elapsed: i32) -> Option<fsrs::Card> {
         match card.memory_state {
             Some(state) => match card.queue {
                 CardQueue::DayLearn | CardQueue::Review => {


### PR DESCRIPTION
fixes #3708

Where you have reviewed 4 cards today:
![image](https://github.com/user-attachments/assets/88c036bd-5ac7-49d2-937b-963a8482f231)

Is there a better way than using `introduced:1` which doesn't include cards which have been forgotten and then re-introduced?