### PR TITLE
Fix changes to tags not being reflected when editing in IO mode

### DIFF
--- a/ts/editor/NoteEditor.svelte
+++ b/ts/editor/NoteEditor.svelte
@@ -277,8 +277,10 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         hidden: hideFieldInOcclusionType(index, ioFields),
     })) as FieldData[];
 
+    let lastSavedTags: string[] | null = null;
     function saveTags({ detail }: CustomEvent): void {
         tagAmount = detail.tags.filter((tag: string) => tag != "").length;
+        lastSavedTags = detail.tags;
         bridgeCommand(`saveTags:${JSON.stringify(detail.tags)}`);
     }
 
@@ -534,6 +536,11 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         isIOImageLoaded,
         imageOcclusionMode,
     );
+
+    $: if (isImageOcclusion && $ioMaskEditorVisible && lastSavedTags) {
+        setTags(lastSavedTags);
+        lastSavedTags = null;
+    }
 
     onMount(() => {
         function wrap(before: string, after: string): void {


### PR DESCRIPTION
Resolves the latter half of #3608. This issue is also present when editing in the browser as well.

`TagEditor` derives its initial internal state from the `tags` store, which is only ever set by eval-ing `setTags` [from python](https://github.com/ankitects/anki/blob/28ba578fc7b6986096b78cf53eae09d8ef52239b/qt/aqt/editor.py#L592). When a user edits tags, the internal state is changed, and the `saveTags` bridge command is invoked, but `tags` itself isn't updated

When toggling the mask editor on and off, `TagEditor` is remounted and re-inited with the stale `tags`. Contrast with non-IO mode, where it isn't remounted, and retains its internal state in between `setTags` evals, and so isn't affected

The fix proposed here is to manually set `tags` when turning on the mask editor after having edited tags

Just calling `setTags` in `NoteEditor.saveTags` might seem simpler but it causes the tag editor to (waste)fully rerender and lose focus after each edit

