### PR TITLE
Use the term Retrievability consistently

### DIFF
--- a/ftl/core/card-stats.ftl
+++ b/ftl/core/card-stats.ftl
@@ -35,7 +35,7 @@ card-stats-fsrs-forgetting-curve-first-week = First Week
 card-stats-fsrs-forgetting-curve-first-month = First Month
 card-stats-fsrs-forgetting-curve-first-year = First Year
 card-stats-fsrs-forgetting-curve-all-time = All Time
-card-stats-fsrs-forgetting-curve-probability-of-recalling = Probability of Recall
+card-stats-fsrs-forgetting-curve-probability-of-recalling = Retrievability
 card-stats-fsrs-forgetting-curve-desired-retention = Desired Retention
 
 ## Window Titles


### PR DESCRIPTION
#3604 introduced the string “Probability of Recall” as description of the y-axis in the card stats diagram. I suppose it means the same as “Retrievability”, which is used yet in various other contexts in Anki, and also in the very same card statistics dialog, above in the list of data. Therefore, I suggest changing it to “Retrievability” for greater consistency.