### PR TITLE
Fix copying pasted images when adding IO being broken if filename has reserved chars

### DIFF
--- a/qt/aqt/editor.py
+++ b/qt/aqt/editor.py
@@ -1105,7 +1105,8 @@ require("anki/ui").loaded.then(() => require("anki/NoteEditor").instances[0].too
         # with allowed_suffixes=pics, all non-pics will be rendered as <a>s and won't be included here
         if not (images := self.mw.col.media.files_in_str(self.note.mid, html)):
             return None
-        return os.path.join(self.mw.col.media.dir(), images[0])
+        image_path = urllib.parse.unquote(images[0])
+        return os.path.join(self.mw.col.media.dir(), image_path)
 
     def select_image_from_clipboard_and_occlude(self) -> None:
         """Set up the mask editor for the image in the clipboard."""


### PR DESCRIPTION
#3733 has a bug that i've only just found, unfortunately, where image filenames with spaces or other reserved characters cause it to break

The issue is that the image path obtained from the processed html is url-encoded (`image%20%281%29.jpg`) , which has to be decoded (`image (1).jpg`) before being passed to the backend, otherwise it tries to open and read from a file that doesn't exist

This wasn't a problem before, because the only possible filenames when pasting image bitmaps didn't contain reserved chars:
https://github.com/ankitects/anki/blob/b65fa693dacbd92c0bdd2a8c3800d0827432d108/qt/aqt/editor.py#L908-L910
and when selecting, the html is derived from the path, not the other way around