### PR TITLE
Add drag/drop support when adding IO images

### DIFF
--- a/qt/aqt/editor.py
+++ b/qt/aqt/editor.py
@@ -1559,7 +1559,7 @@ class EditorWebView(AnkiWebView):
             and (html := self._processUrls(mime, allowed_suffixes=pics))
             and (path := self.editor.extract_img_path_from_html(html))
         ):
-            self.editor.setup_mask_editor_for_new_note(path)
+            self.editor.setup_mask_editor(path)
             return
 
         evt_pos = evt.position()

--- a/qt/aqt/editor.py
+++ b/qt/aqt/editor.py
@@ -1552,6 +1552,15 @@ class EditorWebView(AnkiWebView):
         extended = self._wantsExtendedPaste()
         mime = evt.mimeData()
         assert mime is not None
+
+        if (
+            self.editor.state is EditorState.IO_PICKER
+            and (html := self._processUrls(mime, allowed_suffixes=pics))
+            and (path := self.editor.extract_img_path_from_html(html))
+        ):
+            self.editor.setup_mask_editor_for_new_note(path)
+            return
+
         evt_pos = evt.position()
         cursor_pos = QPoint(int(evt_pos.x()), int(evt_pos.y()))
 


### PR DESCRIPTION
Relevant forum topic: https://forums.ankiweb.net/t/image-occlusion-not-working-jan-2025

With this pr, images can now be now dragged and dropped onto the IO picker screen instead of having to be selected or copied and pasted. Tested on ubuntu 24 and win 10

NB: this suffers from the bug brought up in and fixed by:
- #3775