### PR TITLE
Added: SpinnerBox percentage symbol.

### DIFF
--- a/ftl/core/deck-config.ftl
+++ b/ftl/core/deck-config.ftl
@@ -449,6 +449,7 @@ deck-config-percent-of-reviews =
         [one] { $pct }% of { $reviews } review
        *[other] { $pct }% of { $reviews } reviews
     }
+deck-config-percent-input = { $pct }%
 deck-config-optimizing-preset = Optimizing preset { $current_count }/{ $total_count }...
 deck-config-fsrs-must-be-enabled = FSRS must be enabled first.
 deck-config-fsrs-params-optimal = The FSRS parameters currently appear to be optimal.

--- a/ts/lib/components/SpinBox.svelte
+++ b/ts/lib/components/SpinBox.svelte
@@ -11,8 +11,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
     import Icon from "./Icon.svelte";
     import IconConstrain from "./IconConstrain.svelte";
-    import type { GraphsResponse_TrueRetentionStats } from "@generated/anki/stats_pb";
-
+    
     export let value: number;
     export let step = 1;
     export let min = 1;

--- a/ts/lib/components/SpinBox.svelte
+++ b/ts/lib/components/SpinBox.svelte
@@ -222,6 +222,11 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
             white-space: pre;
             left: 0.5em;
             top: 1px;
+
+            @supports (-webkit-touch-callout: none) {
+                /* CSS specific to iOS devices */ 
+                top: 3.5px;
+            }
         }
 
         .invisible {

--- a/ts/lib/components/SpinBox.svelte
+++ b/ts/lib/components/SpinBox.svelte
@@ -97,7 +97,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     }
 
     function updatePercentageText(value: string) {
-        // Separate the % from the padding text
+        // Separate the % from the padding text.
         percentage_text = tr
             .deckConfigPercentInput({ pct: value })
             .replaceAll("%", "-%-")
@@ -108,10 +108,10 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         updatePercentageText(input.value);
     }
 
-    // Invisible, used to shift the % sign the correct amount
+    // Invisible, used to shift the % sign the correct amount.
     let percentage_text: string[];
     $: updatePercentageText(stringValue);
-    // If the input box should be moved right for the
+    // If the input box should be moved right for leading percentage symbol.
     $: percentage_padding = percentage && !percentage_text[0] ? "1.5em" : undefined;
 
     let pressed = false;

--- a/ts/lib/components/SpinBox.svelte
+++ b/ts/lib/components/SpinBox.svelte
@@ -108,7 +108,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     let percentage_text: string[];
     $: updatePercentageText(stringValue);
     // If the input box should be moved right for leading percentage symbol.
-    $: percentage_padding = percentage && !percentage_text[0] ? "1.5em" : undefined;
+    $: percentage_padding = percentage && !percentage_text[0] ? "2.2ch" : undefined;
 
     let pressed = false;
     let timeout: number;

--- a/ts/lib/components/SpinBox.svelte
+++ b/ts/lib/components/SpinBox.svelte
@@ -224,7 +224,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
             top: 1px;
 
             @supports (-webkit-touch-callout: none) {
-                /* CSS specific to iOS devices */ 
+                /* CSS specific to iOS devices */
                 top: 3.5px;
             }
         }

--- a/ts/lib/components/SpinBox.svelte
+++ b/ts/lib/components/SpinBox.svelte
@@ -11,6 +11,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
     import Icon from "./Icon.svelte";
     import IconConstrain from "./IconConstrain.svelte";
+    import type { GraphsResponse_TrueRetentionStats } from "@generated/anki/stats_pb";
 
     export let value: number;
     export let step = 1;
@@ -57,12 +58,8 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         return Math.max(0, displayedPlace);
     }
 
-    function toStringValue(value: number) {
-        return (value * multiplier).toFixed(decimalPlaces(step));
-    }
-
     let stringValue: string;
-    $: stringValue = toStringValue(value);
+    $: stringValue = (value * multiplier).toFixed(decimalPlaces(step));
 
     function update(this: HTMLInputElement): void {
         updateValue(parseFloat(this.value) / multiplier);

--- a/ts/lib/components/SpinBox.svelte
+++ b/ts/lib/components/SpinBox.svelte
@@ -218,7 +218,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
             pointer-events: none;
             white-space: pre;
             left: 0.5em;
-            top: 2%;
+            top: 1px;
         }
 
         .invisible {

--- a/ts/lib/components/SpinBox.svelte
+++ b/ts/lib/components/SpinBox.svelte
@@ -92,6 +92,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         }
     }
 
+    let percentage_text = "       %"
     let pressed = false;
     let timeout: number;
     let pressTimer: any;
@@ -110,7 +111,11 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         on:blur={update}
         on:focusin={() => (focused = true)}
         on:focusout={() => (focused = false)}
+        style:padding-left={percentage && percentage_text == "%" ? "1.5em" : undefined}
     />
+    {#if percentage}
+        <span class="suffix">{percentage_text}</span>
+    {/if}
     {#if isDesktop()}
         <!-- svelte-ignore a11y-click-events-have-key-events -->
         <div
@@ -181,6 +186,14 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         position: relative;
         display: flex;
         justify-content: space-between;
+
+        .suffix {
+            position: absolute;
+            white-space: pre;
+            left: 0.5em;
+            top: 2%;
+            pointer-events: none;
+        }
 
         input {
             flex-grow: 1;

--- a/ts/lib/components/SpinBox.svelte
+++ b/ts/lib/components/SpinBox.svelte
@@ -11,7 +11,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
     import Icon from "./Icon.svelte";
     import IconConstrain from "./IconConstrain.svelte";
-    
+
     export let value: number;
     export let step = 1;
     export let min = 1;
@@ -135,7 +135,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         <span class="suffix">
             {#each percentage_text as str}
                 {#if str == "%"}
-                    <span style:pointer-events="none">%</span>
+                    %
                 {:else}
                     <span class="invisible">{str}</span>
                 {/if}
@@ -215,6 +215,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
         .suffix {
             position: absolute;
+            pointer-events: none;
             white-space: pre;
             left: 0.5em;
             top: 2%;

--- a/ts/lib/components/SpinBox.svelte
+++ b/ts/lib/components/SpinBox.svelte
@@ -41,8 +41,8 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         // changed, and will skip the UI update. So we manually update the DOM to ensure it stays
         // in sync.
         tick().then(() => {
-            input.value = stringValue
-            updatePercentageText(stringValue)
+            input.value = stringValue;
+            updatePercentageText(stringValue);
         });
     }
 

--- a/ts/lib/components/SpinBox.svelte
+++ b/ts/lib/components/SpinBox.svelte
@@ -62,7 +62,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     }
 
     let stringValue: string;
-    $: stringValue = toStringValue(value)
+    $: stringValue = toStringValue(value);
 
     function update(this: HTMLInputElement): void {
         updateValue(parseFloat(this.value) / multiplier);
@@ -98,7 +98,10 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
     function updatePercentageText(value: string) {
         // Separate the % from the padding text
-        percentage_text = tr.deckConfigPercentInput({pct: value}).replaceAll("%", "-%-").split("-")
+        percentage_text = tr
+            .deckConfigPercentInput({ pct: value })
+            .replaceAll("%", "-%-")
+            .split("-");
     }
 
     function onInput() {
@@ -106,10 +109,10 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     }
 
     // Invisible, used to shift the % sign the correct amount
-    let percentage_text: string[]
-    $: updatePercentageText(stringValue)
-    // If the input box should be moved right for the 
-    $: percentage_padding = percentage && !percentage_text[0] ? "1.5em" : undefined
+    let percentage_text: string[];
+    $: updatePercentageText(stringValue);
+    // If the input box should be moved right for the
+    $: percentage_padding = percentage && !percentage_text[0] ? "1.5em" : undefined;
 
     let pressed = false;
     let timeout: number;
@@ -133,15 +136,15 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         style:padding-left={percentage_padding}
     />
     {#if percentage}
-    <span class="suffix">
-        {#each percentage_text as str}
-            {#if str == "%"}
-                <span style:pointer-events="none">%</span>
-            {:else}
-                <span class="invisible">{str}</span>
-            {/if}
-        {/each}
-    </span>
+        <span class="suffix">
+            {#each percentage_text as str}
+                {#if str == "%"}
+                    <span style:pointer-events="none">%</span>
+                {:else}
+                    <span class="invisible">{str}</span>
+                {/if}
+            {/each}
+        </span>
     {/if}
     {#if isDesktop()}
         <!-- svelte-ignore a11y-click-events-have-key-events -->
@@ -220,7 +223,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
             left: 0.5em;
             top: 2%;
         }
-        
+
         .invisible {
             color: transparent;
             pointer-events: none;

--- a/ts/lib/components/SpinBox.svelte
+++ b/ts/lib/components/SpinBox.svelte
@@ -40,7 +40,10 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         // enters '0', if the value gets clamped back to '1', Svelte will think the value hasn't
         // changed, and will skip the UI update. So we manually update the DOM to ensure it stays
         // in sync.
-        tick().then(() => (input.value = stringValue));
+        tick().then(() => {
+            input.value = stringValue
+            updatePercentageText(stringValue)
+        });
     }
 
     /**


### PR DESCRIPTION
Adds the trailing % as referenced in #3679

Displays a percentage directly following the percentage values in the deck config.

![percentage](https://github.com/user-attachments/assets/cacec0fb-9f38-4e1c-aa1d-3cf667be6a32)

Supports i18n:
```deck-config-percent-input = %{ $pct }```
![image](https://github.com/user-attachments/assets/34b1f5e2-c220-4710-afc8-e17941859edc)
```deck-config-percent-input = { $pct } %```
![image](https://github.com/user-attachments/assets/2761f277-86e5-41d4-b621-59edb6618d53)

Known issue: The percentage sign flies off the right hand side of the box if the user fills the input to the extent where it gets horizontal scroll.

Sorry if doing it using invisible characters is a little hacky, I couldn't think of a better way.