### PR TITLE
Fix error when right-clicking empty space in update addons dialog

### DIFF
--- a/qt/aqt/addons.py
+++ b/qt/aqt/addons.py
@@ -1369,7 +1369,8 @@ class ChooseAddonsToUpdateList(QListWidget):
             self.header_checked(self.bool_to_check(not checked))
 
     def on_context_menu(self, point: QPoint) -> None:
-        item = self.itemAt(point)
+        if not (item := self.itemAt(point)):
+            return
         addon_id = item.data(self.ADDON_ID_ROLE)
         m = QMenu()
         a = m.addAction(tr.addons_view_addon_page())


### PR DESCRIPTION
Fixes the tiny bug when right clicking on empty space in the "update addons" dialog

```
Traceback (most recent call last):
  File "aqt.addons", line 1373, in on_context_menu
AttributeError: 'NoneType' object has no attribute 'data'
```