### PR TITLE
Fix discard changes randomly being a noop on certain linux systems

### DIFF
--- a/qt/aqt/mediasrv.py
+++ b/qt/aqt/mediasrv.py
@@ -581,7 +581,9 @@ def deck_options_require_close() -> bytes:
         if isinstance(window, DeckOptionsDialog):
             window.require_close()
 
-    aqt.mw.taskman.run_on_main(handle_on_main)
+    # on certain linux systems, askUser's QMessageBox.question unsets the active window
+    # so we wait for the next event loop before querying the next current active window
+    aqt.mw.taskman.run_on_main(lambda: QTimer.singleShot(0, handle_on_main))
     return b""
 
 

--- a/qt/aqt/utils.py
+++ b/qt/aqt/utils.py
@@ -429,6 +429,11 @@ def askUser(
             openHelp(help)
         else:
             break
+    # https://doc.qt.io/qt-6/qapplication.html#activeWindow
+    # on some systems, qt unsets the active window when this messagebox causes the previous window to lose focus
+    # to handle that case, this hack sets the previously active window (parent) as the current active window anew
+    if parent and not parent.isActiveWindow():
+        parent.activateWindow()
     return r == QMessageBox.StandardButton.Yes
 
 

--- a/qt/aqt/utils.py
+++ b/qt/aqt/utils.py
@@ -432,8 +432,10 @@ def askUser(
     # https://doc.qt.io/qt-6/qapplication.html#activeWindow
     # on some systems, qt unsets the active window when this messagebox causes the previous window to lose focus
     # to handle that case, this hack sets the previously active window (parent) as the current active window anew
+    # QApplication.setActiveWindow was deprecated in 6.5, but its recommended alternative (QWidget.activateWindow)
+    # doesn't work, for some reason
     if parent and not parent.isActiveWindow():
-        parent.activateWindow()
+        aqt.mw.app.setActiveWindow(parent)
     return r == QMessageBox.StandardButton.Yes
 
 

--- a/qt/aqt/utils.py
+++ b/qt/aqt/utils.py
@@ -429,13 +429,6 @@ def askUser(
             openHelp(help)
         else:
             break
-    # https://doc.qt.io/qt-6/qapplication.html#activeWindow
-    # on some systems, qt unsets the active window when this messagebox causes the previous window to lose focus
-    # to handle that case, this hack sets the previously active window (parent) as the current active window anew
-    # QApplication.setActiveWindow was deprecated in 6.5, but its recommended alternative (QWidget.activateWindow)
-    # doesn't work, for some reason
-    if parent and not parent.isActiveWindow():
-        aqt.mw.app.setActiveWindow(parent)
     return r == QMessageBox.StandardButton.Yes
 
 


### PR DESCRIPTION
> Does anyone have problem with discarding changes of presets?
Linux - Using linux archive in github release
1- Open preset
2- Modify the settings
3- Try to close the preset settings page
4- Ask for discard and click yes
5- It doesn’t close the preset window
https://forums.ankiweb.net/t/anki-25-01-beta/54490/57
https://github.com/ankitects/anki/pull/3571#issuecomment-2615433625

Was able to reproduce this on an ubuntu 24 vm and wsl (ubuntu 24), but not on win 10

According to the docs for `QApplication::activeWindow`
> Returns the application top-level window that has the keyboard input focus, or nullptr if no application window has the focus

The latter seems to be happening on my 2 linux systems, and on least one other person's. Not sure what the common thread is, whether it's a ubuntu issue or possibly a wayland one

The fix proposed here is to explicitly restore the active window at the end of `askUser`, if it was unset

Can confirm that this makes "discard changes" work reliably, and on win 10 the branch isn't taken

EDIT: this issue becomes much rarer when switching to the software video driver

~~Setting as draft because the issue just reappeared out of nowhere again~~ Turns out there was a difference in behaviour between the deprecated [QApplication.setActiveWindow](https://doc.qt.io/qt-6/qapplication-obsolete.html#setActiveWindow) and the recommended alternative [QWidget.activateWindow](https://doc.qt.io/qt-6/qwidget.html#activateWindow). Using the former seems to have fixed the issue for good