### PR TITLE
Cap preview cols to prevent stall when csv is parsed with the wrong delimiter

### DIFF
--- a/ftl/core/importing.ftl
+++ b/ftl/core/importing.ftl
@@ -67,6 +67,12 @@ importing-packaged-anki-deckcollection-apkg-colpkg-zip = Packaged Anki Deck/Coll
 importing-pauker-18-lesson-paugz = Pauker 1.8 Lesson (*.pau.gz)
 # the '|' character
 importing-pipe = Pipe
+# Warning displayed when the csv import preview table is clipped (some columns were hidden)
+importing-preview-truncated =
+    { $count ->
+        [one] Only the first column is shown. If this doesn't seem right, try changing the field separator.
+        *[other] Only the first { $count } columns are shown. If this doesn't seem right, try changing the field separator.
+    }
 importing-rows-had-num1d-fields-expected-num2d = '{ $row }' had { $found } fields, expected { $expected }
 importing-selected-file-was-not-in-utf8 = Selected file was not in UTF-8 format. Please see the importing section of the manual.
 importing-semicolon = Semicolon

--- a/ftl/core/importing.ftl
+++ b/ftl/core/importing.ftl
@@ -68,9 +68,9 @@ importing-pauker-18-lesson-paugz = Pauker 1.8 Lesson (*.pau.gz)
 # the '|' character
 importing-pipe = Pipe
 # Warning displayed when the csv import preview table is clipped (some columns were hidden)
+# $count is intended to be a large number (1000 and above)
 importing-preview-truncated =
     { $count ->
-        [one] Only the first column is shown. If this doesn't seem right, try changing the field separator.
         *[other] Only the first { $count } columns are shown. If this doesn't seem right, try changing the field separator.
     }
 importing-rows-had-num1d-fields-expected-num2d = '{ $row }' had { $found } fields, expected { $expected }

--- a/ts/routes/import-csv/Preview.svelte
+++ b/ts/routes/import-csv/Preview.svelte
@@ -6,9 +6,27 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     import { type ImportCsvState } from "./lib";
 
     export let state: ImportCsvState;
+    export let maxColumns = 1000;
 
     const metadata = state.metadata;
     const columnOptions = state.columnOptions;
+
+    let rows: string[][];
+    let truncated = false;
+
+    function sanitisePreview(preview: typeof $metadata.preview) {
+        let truncated = false;
+        const rows = preview.map((x) => {
+            if (x.vals.length > maxColumns) {
+                truncated = true;
+                return x.vals.slice(0, maxColumns);
+            }
+            return x.vals;
+        });
+        return { rows, truncated };
+    }
+
+    $: ({ rows, truncated } = sanitisePreview($metadata.preview));
 </script>
 
 <div class="outer">
@@ -23,9 +41,9 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
             </tr>
         </thead>
         <tbody>
-            {#each $metadata.preview as row}
+            {#each rows as row}
                 <tr>
-                    {#each row.vals as cell}
+                    {#each row as cell}
                         <td>{cell}</td>
                     {/each}
                 </tr>

--- a/ts/routes/import-csv/Preview.svelte
+++ b/ts/routes/import-csv/Preview.svelte
@@ -3,7 +3,9 @@ Copyright: Ankitects Pty Ltd and contributors
 License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 -->
 <script lang="ts">
+    import Warning from "../deck-options/Warning.svelte";
     import { type ImportCsvState } from "./lib";
+    import * as _tr from "@generated/ftl";
 
     export let state: ImportCsvState;
     export let maxColumns = 1000;
@@ -27,6 +29,8 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     }
 
     $: ({ rows, truncated } = sanitisePreview($metadata.preview));
+
+    $: warning = truncated ? _tr.importingPreviewTruncated({ count: maxColumns }) : "";
 </script>
 
 <div class="outer">
@@ -51,10 +55,12 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         </tbody>
     </table>
 </div>
+<Warning {warning} />
 
 <style lang="scss">
     .outer {
         overflow: auto;
+        margin-bottom: 0.5rem;
     }
 
     .preview {

--- a/ts/routes/import-csv/Preview.svelte
+++ b/ts/routes/import-csv/Preview.svelte
@@ -5,7 +5,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 <script lang="ts">
     import Warning from "../deck-options/Warning.svelte";
     import { type ImportCsvState } from "./lib";
-    import * as _tr from "@generated/ftl";
+    import * as tr from "@generated/ftl";
 
     export let state: ImportCsvState;
     export let maxColumns = 1000;
@@ -30,7 +30,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
     $: ({ rows, truncated } = sanitisePreview($metadata.preview));
 
-    $: warning = truncated ? _tr.importingPreviewTruncated({ count: maxColumns }) : "";
+    $: warning = truncated ? tr.importingPreviewTruncated({ count: maxColumns }) : "";
 </script>
 
 <div class="outer">


### PR DESCRIPTION
Resolves #3588

> Sure, [here is an example](https://www.dropbox.com/scl/fi/yorxjlwzszwd6j7a0e9u2/Cities-of-Your-Country-First-4000.csv?rlkey=yvtuelr9xl9a0raf3dx0p93rz&st=xf6wywo7&dl=0) which takes 25 seconds to load for my pc.

Looking at what passes for the [csv spec](https://datatracker.ietf.org/doc/html/rfc4180#page-2), the example is considered **invalid** csv when pipe-delimited. But python's csv.reader parses it in the same way as the crate. I can't speak to how they handle quirks, but my guess is that the last pipe in each row having one unclosed quote after it causes the record terminator to be quoted and ignored, and the file ends up as being 1 header and 1 record long

The stall doesn't seem to be happening on the backend (which parses and responds in ~100ms), but on the webpage itself. Profiling on firefox confirms that it's choking on rendering ~40000 columns in the preview table

This pr proposes to cap the preview table's columns at 1000, a number small enough that it should render reasonably quickly (~1s, prev ~20s), and ludicrously large enough that exceeding it almost certainly means wrong delimiter and/or invalid csv (who has notetypes with >1000 fields?)

This'll allow the user to quickly recover from a wrong guess by the delimiter heuristic, rather than have to wait ~20 seconds for the page to load

A warning is shown when columns have been clipped:
![image](https://github.com/user-attachments/assets/53ed9118-af12-40aa-a854-eea177e14e38)

EDIT: failing on an openssl advisory 👀
