### PR TITLE
Fix ∷ in tags not being converted to :: when cut

### DIFF
--- a/ts/lib/tag-editor/TagInput.svelte
+++ b/ts/lib/tag-editor/TagInput.svelte
@@ -213,6 +213,18 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         );
     }
 
+    async function onCut(event: ClipboardEvent): Promise<void> {
+        onCopy(event);
+
+        const s = input.selectionStart!;
+        const e = input.selectionEnd!;
+        name = name.slice(0, s) + name.slice(e);
+
+        await tick();
+        setPosition(s);
+        dispatch("taginput");
+    }
+
     function onPaste(event: ClipboardEvent): void {
         if (!event.clipboardData) {
             return;
@@ -283,6 +295,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     on:keyup
     on:input={() => dispatch("taginput")}
     on:copy|preventDefault={onCopy}
+    on:cut|preventDefault={onCut}
     on:paste|preventDefault={onPaste}
     use:updateCurrent
 />


### PR DESCRIPTION
Resolves part of #3062

The tag editor displays `::` as `∷` to simplify(?) hierarchical tag editing (https://github.com/ankitects/anki/pull/1264#issuecomment-915254400)

The conversion back to `::` is handled when copying, but not when cutting, which this pr aims to rectify

Omitting `setPosition` moves the caret to the end
Omitting `dispatch` means not opening autocomplete or updating it if already open (existing behaviour)

Didn't notice any regressions with this, but the editor code in general is very confusing and i might've missed something 👀