### PR TITLE
Fix "discard changes" appearing even after resetting IO note

### DIFF
--- a/ts/editor/NoteEditor.svelte
+++ b/ts/editor/NoteEditor.svelte
@@ -471,6 +471,11 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         isIOImageLoaded = false;
         globalThis.canvas.clear();
         globalThis.canvas = undefined;
+        if (imageOcclusionMode?.kind === "add") {
+            // canvas.clear indirectly calls saveOcclusions
+            saveFieldNow();
+            fieldStores[ioFields.image].set("");
+        }
         const page = document.querySelector(".image-occlusion");
         if (page) {
             page.remove();


### PR DESCRIPTION
In the add window, when resetting image occlusion, the occlusions field is cleared* (by way of `canvas.clear`), but the image field isn't. This causes "discard changes" to appear when trying to close the window, even though there's seemingly nothing to discard

The fix proposed is to clear it when resetting in add mode. Edit mode is left alone since the note is still editable afterwards and new masks can be added over the same image

*which is why `saveFieldNow` is needed again to avoid a race