### PR TITLE
Update reviewer.py to prevent custom scheduler js from commenting out py code

### DIFF
--- a/qt/aqt/reviewer.py
+++ b/qt/aqt/reviewer.py
@@ -289,13 +289,6 @@ class Reviewer:
 
         if js := self._state_mutation_js:
             self._states_mutated = False
-            # if the last element is a comment, then the RUN_STATE_MUTATION code
-            # breaks due to the comment wrongly commenting out python code.
-            # To prevent this we check whether the last line is a comment and
-            # append a new line if true.
-            tmp_js = js.rsplit("\n", 1)
-            if tmp_js[len(tmp_js) - 1].startswith("//"):
-                js += "\n"
             self.web.evalWithCallback(
                 RUN_STATE_MUTATION.format(key=self._state_mutation_key, js=js),
                 on_eval,
@@ -1222,7 +1215,11 @@ timerStopped = false;
     setFlag = set_flag_on_current_card
 
 
+# if the last element is a comment, then the RUN_STATE_MUTATION code
+# breaks due to the comment wrongly commenting out python code.
+# To prevent this we put the js code on a separate line
 RUN_STATE_MUTATION = """
-anki.mutateNextCardStates('{key}', async (states, customData, ctx) => {{ {js} }})
-    .finally(() => bridgeCommand('statesMutated'));
+anki.mutateNextCardStates('{key}', async (states, customData, ctx) => {{
+    {js}
+    }}).finally(() => bridgeCommand('statesMutated'));
 """

--- a/qt/aqt/reviewer.py
+++ b/qt/aqt/reviewer.py
@@ -289,6 +289,13 @@ class Reviewer:
 
         if js := self._state_mutation_js:
             self._states_mutated = False
+            # if the last element is a comment, then the RUN_STATE_MUTATION code
+            # breaks due to the comment wrongly commenting out python code.
+            # To prevent this we check whether the last line is a comment and
+            # append a new line if true.
+            tmp_js = js.rsplit("\n", 1)
+            if tmp_js[len(tmp_js) - 1].startswith("//"):
+                js += "\n"
             self.web.evalWithCallback(
                 RUN_STATE_MUTATION.format(key=self._state_mutation_key, js=js),
                 on_eval,


### PR DESCRIPTION
Fixes: https://forums.ankiweb.net/t/custom-scheduler-comment-bug/55483?u=anon_0000


This commit adds a new line to the js code, if the last line of the code is  a comment. Tested with:
```js
console.log(JSON.stringify(states, null, 4));
console.log(JSON.stringify(states, null, 2));
//console.log(JSON.stringify(states, null, 2));
```