### PR TITLE
Only update notetype/deck when reopening add window if no changes to discard

### DIFF
--- a/qt/aqt/addcards.py
+++ b/qt/aqt/addcards.py
@@ -110,6 +110,9 @@ class AddCards(QMainWindow):
         )
 
     def reopen(self, mw: AnkiQt) -> None:
+        if not self.editor.fieldsAreBlank():
+            return
+
         defaults = self.col.defaults_for_adding(
             current_review_card=self.mw.reviewer.card
         )


### PR DESCRIPTION
Relevant post: https://forums.ankiweb.net/t/anki-25-01-02-beta-rc/54490/75

#3756 introduced new behaviour when reopening the add cards window - updating the notetype and deck

Someone pointed out on the forums that silently changing notetypes when reopening without switching decks should warrant a "discard changes" confirmation, which makes sense. Currently, changing notetypes in the add window doesn't warn about the loss of field data either, but that's an explicit action by the user, as opposed to them expecting to raise the window without anything being changed

The fix proposed is to just raise the window (and not change notetype/deck) if there are nonempty fields (i.e. if there's data to discard)