### PR TITLE
Hide forgetting curve radio buttons when theres only one option

### DIFF
--- a/ts/routes/card-info/ForgettingCurve.svelte
+++ b/ts/routes/card-info/ForgettingCurve.svelte
@@ -51,9 +51,9 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 </script>
 
 <div class="forgetting-curve">
-    <InputBox>
-        <div class="time-range-selector">
-            {#if maxDays > 0}
+    {#if maxDays > 7}
+        <InputBox>
+            <div class="time-range-selector">
                 <label>
                     <input
                         type="radio"
@@ -62,8 +62,6 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
                     />
                     {tr.cardStatsFsrsForgettingCurveFirstWeek()}
                 </label>
-            {/if}
-            {#if maxDays > 7}
                 <label>
                     <input
                         type="radio"
@@ -72,29 +70,29 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
                     />
                     {tr.cardStatsFsrsForgettingCurveFirstMonth()}
                 </label>
-            {/if}
-            {#if maxDays > 30}
-                <label>
-                    <input
-                        type="radio"
-                        bind:group={$timeRange}
-                        value={TimeRange.Year}
-                    />
-                    {tr.cardStatsFsrsForgettingCurveFirstYear()}
-                </label>
-            {/if}
-            {#if maxDays > 365}
-                <label>
-                    <input
-                        type="radio"
-                        bind:group={$timeRange}
-                        value={TimeRange.AllTime}
-                    />
-                    {tr.cardStatsFsrsForgettingCurveAllTime()}
-                </label>
-            {/if}
-        </div>
-    </InputBox>
+                {#if maxDays > 30}
+                    <label>
+                        <input
+                            type="radio"
+                            bind:group={$timeRange}
+                            value={TimeRange.Year}
+                        />
+                        {tr.cardStatsFsrsForgettingCurveFirstYear()}
+                    </label>
+                {/if}
+                {#if maxDays > 365}
+                    <label>
+                        <input
+                            type="radio"
+                            bind:group={$timeRange}
+                            value={TimeRange.AllTime}
+                        />
+                        {tr.cardStatsFsrsForgettingCurveAllTime()}
+                    </label>
+                {/if}
+            </div>
+        </InputBox>
+    {/if}
     <Graph {title}>
         <svg bind:this={svg} viewBox={`0 0 ${bounds.width} ${bounds.height}`}>
             <AxisTicks {bounds} />


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/c41d1b05-8ba1-4b88-8438-359cff92f7eb)
After:
![image](https://github.com/user-attachments/assets/23797ff3-810a-454e-91b8-4de840bd4cc5)
