### PR TITLE
Add margin to the bottom of forgetting curve

### DIFF
--- a/ts/routes/card-info/ForgettingCurve.svelte
+++ b/ts/routes/card-info/ForgettingCurve.svelte
@@ -106,6 +106,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     .forgetting-curve {
         width: 100%;
         max-width: 50em;
+        margin-bottom: 10em;
     }
 
     .time-range-selector {


### PR DESCRIPTION
It could avoid the jitter when displaying the tooltip.

Before:

![20250210-111648](https://github.com/user-attachments/assets/f682fe22-e29c-49a5-b666-1101d704b629)

After:

![20250210-111606](https://github.com/user-attachments/assets/fafae739-d5c6-4107-92c2-c466352e36b7)

may fix #3607, test is wanted.
