### PR TITLE
Fix card layout editor crash when editing while reviewing 

### DIFF
--- a/qt/aqt/editcurrent.py
+++ b/qt/aqt/editcurrent.py
@@ -67,6 +67,7 @@ class EditCurrent(QMainWindow):
 
     def reopen(self, mw: aqt.AnkiQt) -> None:
         if card := self.mw.reviewer.card:
+            self.editor.card = card
             self.editor.set_note(card.note())
 
     def closeEvent(self, evt: QCloseEvent | None) -> None:


### PR DESCRIPTION
Closes #3808

When reviewing, the editor's card and note are set on initial-open, but on reopen, only the note is set. This causes the old (initial) card's ord to be used when opening the card layout editor, which can at best cause the wrong card to be selected and shown, and at worse, throw if the current note doesn't have that many cards/templates

The fix proposed is to set the editor's card when reopening