### PR TITLE
x86_64-unknown-linux-gnu has issues with 1.84.0 toolchain for some reason

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 # older versions may fail to compile; newer versions may fail the clippy tests
-channel = "1.84.0"
+channel = "1.84.1"


### PR DESCRIPTION
There might be some issues with 1.84.0 on linux systems? Attempting to do anything with cargo leads to `error: Missing manifest in toolchain '1.84.0-x86_64-unknown-linux-gnu'`

bumping to 1.84.1 appears to have fixed the issue. I believe that since it is a minor version bump that this should not cause any sort of issues?
