### PR TITLE
add hook for day rollover

### DIFF
--- a/qt/aqt/main.py
+++ b/qt/aqt/main.py
@@ -554,6 +554,8 @@ class AnkiQt(QMainWindow):
                 last_day_cutoff = self.col.sched.day_cutoff
                 self.reviewer._refresh_needed = RefreshNeeded.QUEUES
                 self.reviewer.refresh_if_needed()
+            if last_day_cutoff != current_cutoff:
+                gui_hooks.rollover()
 
             # schedule another check
             secs_until_cutoff = current_cutoff - int_time()

--- a/qt/aqt/main.py
+++ b/qt/aqt/main.py
@@ -555,7 +555,7 @@ class AnkiQt(QMainWindow):
                 self.reviewer._refresh_needed = RefreshNeeded.QUEUES
                 self.reviewer.refresh_if_needed()
             if last_day_cutoff != current_cutoff:
-                gui_hooks.rollover()
+                gui_hooks.day_did_change()
 
             # schedule another check
             secs_until_cutoff = current_cutoff - int_time()

--- a/qt/tools/genhooks_gui.py
+++ b/qt/tools/genhooks_gui.py
@@ -898,7 +898,7 @@ gui_hooks.webview_did_inject_style_into_page.append(mytest)
 
         `output` provides access to the unused/missing file lists and the text output that will be shown in the Check Media screen.""",
     ),
-    Hook(name="rollover", doc="""Called when Anki moves to the next day."""),
+    Hook(name="day_did_change", doc="""Called when Anki moves to the next day."""),
     # Importing/exporting data
     ###################
     Hook(

--- a/qt/tools/genhooks_gui.py
+++ b/qt/tools/genhooks_gui.py
@@ -898,6 +898,7 @@ gui_hooks.webview_did_inject_style_into_page.append(mytest)
 
         `output` provides access to the unused/missing file lists and the text output that will be shown in the Check Media screen.""",
     ),
+    Hook(name="rollover", doc="""Called when Anki moves to the next day."""),
     # Importing/exporting data
     ###################
     Hook(


### PR DESCRIPTION
I was looking in anki to see how day rollover is managed so I can run code around when it triggers for an addon I am working on and saw that it was trivial to add a hook for it! I get that I can hook the `main_window_did_init` and then duplicate this logic in my addon, but this seems like a nice thing to have a hook for.

The use case for me is for it to be used in conjunction with cases I'd hook `profile_did_open` for, but to also handle cases where I left anki on overnight and would like the logic to still run without having to close and reopen anki.

My feelings on this aren't particuarly strong so feel free to close this PR if this is not desired.