### PR TITLE
Update NoteEditor.svelte to swap sticky pin and html view.

### DIFF
--- a/ts/editor/NoteEditor.svelte
+++ b/ts/editor/NoteEditor.svelte
@@ -710,6 +710,13 @@ the AddCards dialog) should be implemented in the user of this component.
                                 {#if cols[index] === "dupe"}
                                     <DuplicateLink />
                                 {/if}
+                                <slot
+                                    name="field-state"
+                                    {field}
+                                    {index}
+                                    show={fields[index] === $hoveredField ||
+                                        fields[index] === $focusedField}
+                                />
                                 {#if plainTextDefaults[index]}
                                     <RichTextBadge
                                         show={!fieldsCollapsed[index] &&
@@ -727,13 +734,6 @@ the AddCards dialog) should be implemented in the user of this component.
                                         on:toggle={() => togglePlainTextInput(index)}
                                     />
                                 {/if}
-                                <slot
-                                    name="field-state"
-                                    {field}
-                                    {index}
-                                    show={fields[index] === $hoveredField ||
-                                        fields[index] === $focusedField}
-                                />
                             </FieldState>
                         </LabelContainer>
                     </svelte:fragment>


### PR DESCRIPTION
Fixes: https://forums.ankiweb.net/t/if-the-user-completely-erases-a-sticky-field-that-should-automatically-unstickify-it/38177/16?u=anon_0000

@dae wanted to see the swapped icons in situ, so here's a PR.

The goal from OP was to reduce accidental misclicks on the pin icon when the user actually wanted to scroll. This lead to confused users a couple of times that thought that anki was somehow suddenly broken.

The proposed icon change isn't implemented here as I do not understand where the icon is generated from. I can open a follow-up PR if somehow can help me with finding the old icon / where the new icon would have to go to.

# What it looks like after the change:
![anki](https://github.com/user-attachments/assets/08f5125b-c890-403f-a2b7-b8e61e5f698d)
