### PR TITLE
Update FsrsOptions.svelte to add margin / gap between simulator buttons

### DIFF
--- a/ts/routes/deck-options/FsrsOptions.svelte
+++ b/ts/routes/deck-options/FsrsOptions.svelte
@@ -644,6 +644,6 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     }
 
     .btn {
-        margin-bottom: .375rem;
+        margin-bottom: 0.375rem;
     }
 </style>

--- a/ts/routes/deck-options/FsrsOptions.svelte
+++ b/ts/routes/deck-options/FsrsOptions.svelte
@@ -642,4 +642,8 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     div.radio-group {
         margin: 0.5em;
     }
+
+    .btn {
+        margin-bottom: .375rem;
+    }
 </style>


### PR DESCRIPTION
Fixes: #3807 

After the change it looks like this:
![anki](https://github.com/user-attachments/assets/72a8954b-59a3-4850-8296-eed1e47d3510)
