### PR TITLE
Cache rendered mathjax to avoid stalling when editing plaintext

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
         "jquery": "^3.5.1",
         "jquery-ui-dist": "^1.12.1",
         "lodash-es": "^4.17.21",
+        "lru-cache": "^10.2.0",
         "marked": "^5.1.0",
         "mathjax": "^3.1.2"
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2033,6 +2033,7 @@ __metadata:
     jquery-ui-dist: "npm:^1.12.1"
     license-checker-rseidelsohn: "npm:=4.3.0"
     lodash-es: "npm:^4.17.21"
+    lru-cache: "npm:^10.2.0"
     marked: "npm:^5.1.0"
     mathjax: "npm:^3.1.2"
     prettier: "npm:^3.4.2"


### PR DESCRIPTION
#3827 deals with stalling when editing in the richtext editor's mathjax overlay editor. But when the plaintext editor is changed, all the mathjax custom element components are recreated* and thus rerendered on each change.

This can be much slower since now all the mathjax expressions in the field are re-rendered even if none of them were changed

The fix proposed here is to add and use lru-cache (an existing indirect dep) to cache the rendered svg. A max cache size of 10 is chosen to limit memory use, and should account for most normal usecases with <10 mathjax exprs per field

*this seems to have been noted already in https://github.com/ankitects/anki/pull/1502#issuecomment-976590300. it's also why the debouncing within the component has no effect here
