### PR TITLE
Increase font size in mathjax preview for accessibility

### DIFF
--- a/ts/editor/mathjax-overlay/MathjaxEditor.svelte
+++ b/ts/editor/mathjax-overlay/MathjaxEditor.svelte
@@ -144,7 +144,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
         :global(.CodeMirror-placeholder) {
             font-family: sans-serif;
-            font-size: 55%;
+            font-size: max(12px, 55%);
             text-align: center;
             color: var(--fg-subtle);
         }


### PR DESCRIPTION
Apparently no font size should be lower than 12px, see https://www.boia.org/blog/accessibility-tips-let-users-control-font-size.

With the current 55%, I get a computed font size of 8.25px though. Considering the text shows the helpful message "Press ⁨Enter⁩ to accept, ⁨Shift+Enter⁩ for new line.", I think we should add a minimum font size.

For reference. This is the 55% size:
![anki](https://github.com/user-attachments/assets/59f3da6f-c072-4516-8a3e-d3a68f964e1d)

And this is the size with the change from this PR:
![anki](https://github.com/user-attachments/assets/10c38d83-1ba6-4f04-96e9-5da4b5df2597)
