### PR TITLE
Update uninstall.sh to give feedback to the user

### DIFF
--- a/qt/bundle/lin/uninstall.sh
+++ b/qt/bundle/lin/uninstall.sh
@@ -6,6 +6,7 @@ if [ "$PREFIX" = "" ]; then
 	PREFIX=/usr/local
 fi
 
+echo "Uninstalling Anki..."
 xdg-mime uninstall "$PREFIX"/share/anki/anki.xml || true
 
 rm -rf "$PREFIX"/share/anki


### PR DESCRIPTION
The uninstall script runs `xdg-mime uninstall` which takes >5 seconds to process.

There is no indication to the user though that the script is actually running. Adding an `echo` info message solves that.

Additionally we could `rm -rfv` to make it more verbose (the install script is verbose too). But the main thing that needs time to process is the `xdg-mime uninstall` part of the script.

The reason why I didn't make `rm -rf` verbose, too, is that the output text is greater than the buffer that the terminal provides – meaning you cannot view it from the beginning. And since `rm` is very fast even on old systems with slow hardware I didn't really see a reason to make it verbose here.