### PR TITLE
Changed keyboard shortcut for indent/outdent

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -213,6 +213,7 @@ wackbyte <wackbyte@protonmail.com>
 GithubAnon0000 <GithubAnon0000@users.noreply.github.com>
 Mike Hardy <github@mikehardy.net>
 Danika_Dakika <https://github.com/Danika-Dakika>
+Thomas Lenz <bf4ktommy@gmail.com>
 
 ********************
 

--- a/qt/aqt/about.py
+++ b/qt/aqt/about.py
@@ -213,6 +213,7 @@ def show(mw: aqt.AnkiQt) -> QDialog:
             "Eros Cardoso",
             "Gregory Abrasaldo",
             "Danika_Dakika",
+            "Thomas Lenz",
         )
     )
 

--- a/ts/editor/editor-toolbar/BlockButtons.svelte
+++ b/ts/editor/editor-toolbar/BlockButtons.svelte
@@ -40,7 +40,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
     export let api = {};
 
-    const outdentKeyCombination = "Control+Shift+,";
+    const outdentKeyCombination = "Shift+Tab";
     function outdentListItem() {
         if (getListItem(document.activeElement!.shadowRoot!)) {
             execCommand("outdent");
@@ -49,7 +49,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         }
     }
 
-    const indentKeyCombination = "Control+Shift+.";
+    const indentKeyCombination = "Tab";
     function indentListItem() {
         if (getListItem(document.activeElement!.shadowRoot!)) {
             execCommand("indent");


### PR DESCRIPTION
**tl;dr:** Indent/outdent shortcuts did not work on macOS. Switching from `Control + Shift + .` to `Tab` for indent, and `Control + Shift + ,` for outdent. Tests did pass.

As discussed in [this Anki forum thread](https://forums.ankiweb.net/t/wrong-shortcut-for-indentation-on-german-keyboard-still-not-fixed/53250), and many other older forum threads, shortcuts are not working for all systems or keyboard layouts. As Anki is widely used among language learners from different countries, the app is prone to the problem of users having switched their keyboard layout by adjusting system settings (e.g., I am switching between German, English US and Unicode Hex on my MacBook by pressing the `fn` button). Yet, even with default settings, not all keyboard shortcuts that are displayed as tooltips in the Anki app work. See the thread linked above for a non-exhaustive list of **more than ten shortcuts not working** on the up-to-date Anki version on macOS for other than standard English keyboard layouts, as the shortcuts are asking for keyboard combinations not possible on those keyboards.

Example: Indent is tool tipped as `Control + Shift + .`, which works using a standard English keyboard layout. Yet, the`.` (period) key is a so called *writing system key* [as per W3C](https://www.w3.org/TR/uievents-code/#key-alphanumeric-writing-system), and as such, the result a key press yields is different based on the keyboard layout a users is using: For standard English layout users, the key will yield a period irrespective of `Shift` being pressed. For German users, pressing the period system key will yield a period only if `Shift` is not pressed simultaneously. When pressing `Shift` as well, it will yield a colon. As such, **the tool-tipped shortcut cannot be typed** using some layouts, amongst them the German keyboard layout. (See more examples for this on the W3C proposed recommendation document linked at the beginning of this paragraph.)

While we are working out the best solution (uniform shortcuts for all keyboard layouts? customisable shortcuts? let users select a locale in the settings? …), I thought it would not hurt to already fix the shortcut for indent/outdent.

Using `Tab` and `Shift + Tab` seemed to be natural options to me, as they are used for the mechanic in apps widely known, like Word, Pages, or Obsidian. Those keys are considered so called *functional keys* by the W3C (cf [here](https://www.w3.org/TR/uievents-code/#key-alphanumeric-functional)), and as such will work on nearly all layouts. Adjusting shortcuts for other buttons is as easy—I successfully tried this with superscript by replacing `Control + Shift + =` with some other combination, e.g., `Control + O`–if we were to agree on which combinations the shortcuts should have. In my opinion, the [thread](https://forums.ankiweb.net/t/wrong-shortcut-for-indentation-on-german-keyboard-still-not-fixed/53250) seems to be the right place to do that. As for this quick fix, `./ninja checks` did pass for me on macOS.

This is my first contribution to Anki code and the first thread in the forums I am taking part in. I am happy for feedback and advice. It would be an honour to contribute to this app that I have been a user of for many years, and no doubt will be for many more to come.