### PR TITLE
feat: add title to some of the sync dialogs

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -98,7 +98,7 @@ gnnoh <gerongfenh@gmail.com>
 Sachin Govind <sachin.govind.too@gmail.com>
 Bruce Harris <github.com/bruceharris>
 Patric Cunha <patricc@agap2.pt>
-Brayan Oliveira <github.com/BrayanDSO>
+Brayan Oliveira <github.com/brayandso>
 Luka Warren <github.com/lukawarren>
 wisherhxl <wisherhxl@gmail.com>
 dobefore <1432338032@qq.com>

--- a/qt/aqt/progress.py
+++ b/qt/aqt/progress.py
@@ -139,7 +139,7 @@ class ProgressManager:
         label: str | None = None,
         parent: QWidget | None = None,
         immediate: bool = False,
-        title: str = "Anki"
+        title: str = "Anki",
     ) -> ProgressDialog | None:
         self._levels += 1
         if self._levels > 1:

--- a/qt/aqt/progress.py
+++ b/qt/aqt/progress.py
@@ -139,6 +139,7 @@ class ProgressManager:
         label: str | None = None,
         parent: QWidget | None = None,
         immediate: bool = False,
+        title: str = "Anki"
     ) -> ProgressDialog | None:
         self._levels += 1
         if self._levels > 1:
@@ -154,7 +155,7 @@ class ProgressManager:
         self._win.form.progressBar.setMaximum(max)
         self._win.form.progressBar.setTextVisible(False)
         self._win.form.label.setText(label)
-        self._win.setWindowTitle("Anki")
+        self._win.setWindowTitle(title)
         self._win.setWindowModality(Qt.WindowModality.ApplicationModal)
         self._win.setMinimumWidth(300)
         self._busy_cursor_timer = QTimer(self.mw)

--- a/qt/aqt/sync.py
+++ b/qt/aqt/sync.py
@@ -131,6 +131,7 @@ def sync_collection(mw: aqt.main.AnkiQt, on_done: Callable[[], None]) -> None:
         on_future_done,
         label=tr.sync_checking(),
         immediate=True,
+        title=tr.sync_checking()
     )
 
 

--- a/qt/aqt/sync.py
+++ b/qt/aqt/sync.py
@@ -131,7 +131,7 @@ def sync_collection(mw: aqt.main.AnkiQt, on_done: Callable[[], None]) -> None:
         on_future_done,
         label=tr.sync_checking(),
         immediate=True,
-        title=tr.sync_checking()
+        title=tr.sync_checking(),
     )
 
 
@@ -165,7 +165,7 @@ def full_sync(
             default_button=2,
             parent=mw,
             textFormat=Qt.TextFormat.MarkdownText,
-            title=tr.qt_misc_sync()
+            title=tr.qt_misc_sync(),
         )
 
 

--- a/qt/aqt/sync.py
+++ b/qt/aqt/sync.py
@@ -344,7 +344,7 @@ def get_id_and_pass_from_user(
     password: str = "",
 ) -> None:
     diag = QDialog(mw)
-    diag.setWindowTitle("Anki")
+    diag.setWindowTitle(tr.qt_misc_sync())
     disable_help_button(diag)
     diag.setWindowModality(Qt.WindowModality.WindowModal)
     vbox = QVBoxLayout()

--- a/qt/aqt/sync.py
+++ b/qt/aqt/sync.py
@@ -165,6 +165,7 @@ def full_sync(
             default_button=2,
             parent=mw,
             textFormat=Qt.TextFormat.MarkdownText,
+            title=tr.qt_misc_sync()
         )
 
 

--- a/qt/aqt/taskman.py
+++ b/qt/aqt/taskman.py
@@ -101,7 +101,9 @@ class TaskManager(QObject):
         title: str = "Anki",
     ) -> None:
         "Use QueryOp()/CollectionOp() in new code."
-        self.mw.progress.start(parent=parent, label=label, immediate=immediate, title=title)
+        self.mw.progress.start(
+            parent=parent, label=label, immediate=immediate, title=title
+        )
 
         def wrapped_done(fut: Future) -> None:
             self.mw.progress.finish()

--- a/qt/aqt/taskman.py
+++ b/qt/aqt/taskman.py
@@ -98,9 +98,10 @@ class TaskManager(QObject):
         label: str | None = None,
         immediate: bool = False,
         uses_collection=True,
+        title: str = "Anki",
     ) -> None:
         "Use QueryOp()/CollectionOp() in new code."
-        self.mw.progress.start(parent=parent, label=label, immediate=immediate)
+        self.mw.progress.start(parent=parent, label=label, immediate=immediate, title=title)
 
         def wrapped_done(fut: Future) -> None:
             self.mw.progress.finish()

--- a/qt/aqt/utils.py
+++ b/qt/aqt/utils.py
@@ -217,6 +217,7 @@ def ask_user_dialog(
     ) = None,
     default_button: int = 1,
     parent: QWidget | None = None,
+    title: str = "Anki",
     **kwargs: Any,
 ) -> MessageBox:
     "Shows a question to the user, passes the index of the button clicked to the callback."
@@ -229,6 +230,7 @@ def ask_user_dialog(
         buttons=buttons,
         default_button=default_button,
         parent=parent,
+        title=title,
         **kwargs,
     )
 


### PR DESCRIPTION
Context: I use Windows 11 and [komorebi](https://github.com/LGUG2Z/komorebi) as my window manager. It can differentiate windows by executable, window class, and window title. The issue is that many Anki windows spawn with `Anki` as title and change it later, so the program can't differentiate them when they spawn. Also, there are dialogs/windows without a proper title, like the sync conflict dialog.

So I propose changing the title of some of the sync dialogs. Despite of my original reason, I think that the titles should be improved anyway.

The changes are described in the commits



