### PR TITLE
fix: Task manager exception handling

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -213,6 +213,7 @@ GithubAnon0000 <GithubAnon0000@users.noreply.github.com>
 Mike Hardy <github@mikehardy.net>
 Danika_Dakika <https://github.com/Danika-Dakika>
 Mumtaz Hajjo Alrifai <mumtazrifai@protonmail.com>
+Jakub Fidler <jakub.fidler@protonmail.com>
 
 ********************
 

--- a/qt/aqt/taskman.py
+++ b/qt/aqt/taskman.py
@@ -68,14 +68,7 @@ class TaskManager(QObject):
         # background task starts, and it takes out a long-running lock on the database,
         # the UI thread will hang until the end of the op.
         if current_thread() is main_thread():
-            try:
-                self._on_closures_pending()
-            except Exception as e:
-                # We need to raise the exception from the closure, but we don't want it to disrupt the current call stack.
-                def raise_exception() -> None:
-                    raise e
-
-                self.run_on_main(raise_exception)
+            self._on_closures_pending()
         else:
             print("bug: run_in_background not called from main thread")
             traceback.print_stack()

--- a/qt/aqt/taskman.py
+++ b/qt/aqt/taskman.py
@@ -141,4 +141,11 @@ class TaskManager(QObject):
             self._closures = []
 
         for closure in closures:
-            closure()
+            try:
+                closure()
+            except Exception as e:
+
+                def raise_exception(exception=e) -> None:
+                    raise exception
+
+                QTimer.singleShot(0, raise_exception)


### PR DESCRIPTION
This fixes some issues with `aqt.taskman.TaskManager`:
- `TaskManager.run_in_background()` can raise an exception if there was an exception in a (possibly unrelated) background task that was just completed. When this happens, the new background task is not run and the exception bubbles up to the code that called `run_in_background()`.
  - This can lead to confusing issues. For example, we encountered an [issue](https://github.com/AnkiHubSoftware/ankihub_addon/pull/1098) where the central exception handler of the AnkiHub add-on was raising an exception after trying to start a background task (for uploading logs). As a fix, we wrapped the `run_in_background()` calls in the exception handler with `run_on_main()`. We encountered similar issues with this before.
- When there are multiple closures in `TaskManager._closures`, and one of the closures raises an exception, the other closures are not called at all

## Proposed changes
- In `TaskManager._on_closures_pending()`, catch exceptions and re-raise them using `QTimer.singleShot` with a delay of 0 instead of allowing them to bubble up immediately.
  - Effects:
    - All closures are run
    - The caller of `run_in_background()` is not interrupted by exceptions frogm closures the and the new background task is scheduled successfully
    - All exceptions from closures are raised


## Risks
- Maybe some code relies on the current taskman exception-handling behavior?
  - If making this change is too risky, it could be adjusted. However, it would be good to prevent exceptions from bubbling up to the caller of `run_in_background()`, or at least document that this can happen.