### PR TITLE
Prevent accidental dragging of audio playback buttons and hint links

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -207,6 +207,7 @@ Luca Auer <lolle2000.la@gmail.com>
 Niclas Heinz <nheinz@hpost.net>
 Omar Kohl <omarkohl@posteo.net>
 David Elizalde <david.elizalde.r.a@gmail.com>
+beyondcompute <beyondcompute@gmail.com>
 Yuki <https://github.com/YukiNagat0>
 wackbyte <wackbyte@protonmail.com>
 GithubAnon0000 <GithubAnon0000@users.noreply.github.com>

--- a/qt/aqt/sound.py
+++ b/qt/aqt/sound.py
@@ -845,7 +845,7 @@ def av_refs_to_play_icons(text: str) -> str:
 
     def repl(match: re.Match) -> str:
         return f"""
-<a class="replay-button soundLink" href=# onclick="pycmd('{match.group(1)}'); return false;">
+<a class="replay-button soundLink" href=# onclick="pycmd('{match.group(1)}'); return false;" draggable="false">
     <svg class="playImage" viewBox="0 0 64 64" version="1.1">
         <circle cx="32" cy="32" r="29" />
         <path d="M56.502,32.301l-37.502,20.101l0.329,-40.804l37.173,20.703Z" />

--- a/rslib/src/template_filters.rs
+++ b/rslib/src/template_filters.rs
@@ -192,7 +192,7 @@ fn hint_filter<'a>(text: &'a str, field_name: &str) -> Cow<'a, str> {
 <a class=hint href="#"
 onclick="this.style.display='none';
 document.getElementById('hint{}').style.display='block';
-return false;">
+return false;" draggable=false>
 {}</a>
 <div id="hint{}" class=hint style="display: none">{}</div>
 "##,
@@ -232,7 +232,7 @@ mod test {
 <a class=hint href="#"
 onclick="this.style.display='none';
 document.getElementById('hint83fe48607f0f3a66').style.display='block';
-return false;">
+return false;" draggable=false>
 field</a>
 <div id="hint83fe48607f0f3a66" class=hint style="display: none">foo</div>
 "##


### PR DESCRIPTION
Currently if a user drags slightly (happens to me often unintentionally) upon clicking an audio play button or a hint link, the action does not happen.

#### Some videos that demonstrate the issue below.

_I first click the button successfully but then twice I click it with dragging slightly after `mousedown` (this video also contains an audio track):_

https://github.com/user-attachments/assets/6ac02a5c-a459-4bcc-89f6-ea22d0812ca8

_An example with a hint link:_

https://github.com/user-attachments/assets/147f142d-39da-40fd-b3a9-99debae33903

#### After the attempted fix:

https://github.com/user-attachments/assets/8470fd6f-26df-4c38-bde3-e769ff88e370

<img width="819" alt="hint_inspection" src="https://github.com/user-attachments/assets/0d5910f6-b3ca-467a-8a0f-8e751bfce1e7" />

-------

Hopefully that will be good from the accessibility standpoint.

Thank you!