### PR TITLE
feat: add translation string to FSRS evaluation message

### DIFF
--- a/ftl/core/deck-config.ftl
+++ b/ftl/core/deck-config.ftl
@@ -400,6 +400,8 @@ deck-config-evaluate-button = Evaluate
 deck-config-desired-retention = Desired retention
 deck-config-historical-retention = Historical retention
 deck-config-smaller-is-better = Smaller numbers indicate a better fit to your review history.
+# Mathematical values describing the FSRS algorithm's performance
+deck-config-smaller-is-better-fsrs-values = Log loss : { $logLoss }, RMSE(bins): { $rmse }%.
 deck-config-steps-too-large-for-fsrs = When FSRS is enabled, steps of 1 day or more are not recommended.
 deck-config-get-params = Get Params
 deck-config-predicted-minimum-recommended-retention = Minimum recommended retention: { $num }

--- a/ts/routes/deck-options/FsrsOptions.svelte
+++ b/ts/routes/deck-options/FsrsOptions.svelte
@@ -212,9 +212,10 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
                     setTimeout(
                         () =>
                             alert(
-                                `Log loss: ${resp.logLoss.toFixed(4)}, RMSE(bins): ${(
-                                    resp.rmseBins * 100
-                                ).toFixed(2)}%. ${tr.deckConfigSmallerIsBetter()}`,
+                                `${tr.deckConfigSmallerIsBetterFsrsValues({
+                                    logLoss: resp.logLoss.toFixed(4),
+                                    rmse: (resp.rmseBins * 100).toFixed(2),
+                                })} ${tr.deckConfigSmallerIsBetter()}`,
                             ),
                         200,
                     );


### PR DESCRIPTION
(see issue #3845)

I think that translating those terms gives better insight into the FSRS algorithm, however they are not easy to translate since they're mathematical/algorithmic terms