### PR TITLE
Don't recalculate remaining steps, conditionally

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -213,6 +213,7 @@ GithubAnon0000 <GithubAnon0000@users.noreply.github.com>
 Mike Hardy <github@mikehardy.net>
 Danika_Dakika <https://github.com/Danika-Dakika>
 Mumtaz Hajjo Alrifai <mumtazrifai@protonmail.com>
+Thomas Graves <fate@hey.com>
 
 ********************
 

--- a/rslib/src/card/mod.rs
+++ b/rslib/src/card/mod.rs
@@ -242,18 +242,18 @@ impl Card {
             remaining
         } else {
             old_steps
-            .len()
-            .checked_sub(remaining as usize + 1)
-            .and_then(|last_index| {
-                new_steps
-                    .iter()
-                    .rev()
-                    .position(|&step| step <= old_steps[last_index])
-            })
-            // no last delay or last delay is less than all new steps → all steps remain
-            .unwrap_or(new_steps.len())
-            // (re)learning card must have at least 1 step remaining
-            .max(1) as u32
+                .len()
+                .checked_sub(remaining as usize + 1)
+                .and_then(|last_index| {
+                    new_steps
+                        .iter()
+                        .rev()
+                        .position(|&step| step <= old_steps[last_index])
+                })
+                // no last delay or last delay is less than all new steps → all steps remain
+                .unwrap_or(new_steps.len())
+                // (re)learning card must have at least 1 step remaining
+                .max(1) as u32
         };
 
         (remaining != new_remaining).then_some(new_remaining)
@@ -496,12 +496,12 @@ impl From<MemoryState> for FsrsMemoryState {
 
 #[cfg(test)]
 mod test {
+    use crate::prelude::AnkiError;
+    use crate::prelude::Collection;
+    use crate::prelude::DeckId;
     use crate::tests::open_test_collection_with_learning_card;
     use crate::tests::open_test_collection_with_relearning_card;
     use crate::tests::DeckAdder;
-    use crate::prelude::Collection;
-    use crate::prelude::DeckId;
-    use crate::prelude::AnkiError;
 
     #[test]
     fn should_increase_remaining_learning_steps_if_new_deck_has_more_unpassed_ones() {
@@ -524,7 +524,7 @@ mod test {
         col.set_deck(&[card_id], deck.id).unwrap();
         assert_eq!(col.get_first_card().remaining_steps, 2);
     }
-    
+
     #[test]
     fn should_not_recalculate_remaining_steps_if_there_are_no_old_steps() -> Result<(), AnkiError> {
         let mut col = Collection::new();

--- a/rslib/src/card/mod.rs
+++ b/rslib/src/card/mod.rs
@@ -238,7 +238,7 @@ impl Card {
     fn new_remaining_steps(&self, new_steps: &[f32], old_steps: &[f32]) -> Option<u32> {
         let remaining = self.remaining_steps();
 
-        let new_remaining = if old_steps.len() == 0 {
+        let new_remaining = if old_steps.is_empty() {
             remaining
         } else {
             old_steps

--- a/rslib/src/card/mod.rs
+++ b/rslib/src/card/mod.rs
@@ -496,9 +496,7 @@ impl From<MemoryState> for FsrsMemoryState {
 
 #[cfg(test)]
 mod test {
-    use crate::prelude::AnkiError;
-    use crate::prelude::Collection;
-    use crate::prelude::DeckId;
+    use crate::prelude::*;
     use crate::tests::open_test_collection_with_learning_card;
     use crate::tests::open_test_collection_with_relearning_card;
     use crate::tests::DeckAdder;


### PR DESCRIPTION
This PR fixes a bug reported on the forums.

Steps to reproduce the bug.

1. Create a new profile so that everything is set to default.
2. Create a new card.
3. Click Good.
4. Open deck options and empty learning steps. Save.
5. No go back and put 1m 10m as LS.
6. Go back to the card and it should show 10m on the Good button.

### Changes

Add a condition to check if `old_steps` is empty and if it is use the `remaining` steps as the `new_remaining` steps. Add a test.

### Evidence

https://github.com/user-attachments/assets/8e2f7427-dc38-49f6-95b0-afcc9232b06e

close #3699 

