### PR TITLE
Automatically select decks created in the deck browser

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -213,6 +213,7 @@ GithubAnon0000 <GithubAnon0000@users.noreply.github.com>
 Mike Hardy <github@mikehardy.net>
 Danika_Dakika <https://github.com/Danika-Dakika>
 Mumtaz Hajjo Alrifai <mumtazrifai@protonmail.com>
+Marcus Low <mlow16@outlook.com>
 
 ********************
 

--- a/qt/aqt/deckbrowser.py
+++ b/qt/aqt/deckbrowser.py
@@ -398,7 +398,7 @@ class DeckBrowser:
 
     def _on_create(self) -> None:
         def select_deck(changes: OpChangesWithId):
-            for parent in self.mw.col.decks.parents(changes.id):
+            for parent in self.mw.col.decks.parents(DeckId(changes.id)):
                 if parent["collapsed"]:
                     set_deck_collapsed(
                         parent=self.mw,
@@ -406,7 +406,9 @@ class DeckBrowser:
                         collapsed=False,
                         scope=DeckCollapseScope.REVIEWER,
                     ).run_in_background(initiator=self)
-            set_current_deck(parent=self.mw, deck_id=DeckId(changes.id)).run_in_background()
+            set_current_deck(
+                parent=self.mw, deck_id=DeckId(changes.id)
+            ).run_in_background()
 
         if op := add_deck_dialog(
             parent=self.mw, default_text=self.mw.col.decks.current()["name"]


### PR DESCRIPTION
When a new deck is created in the deck browser, it is now automatically selected so that cards can be added immediately without having to search for the deck in the list.