### PR TITLE
Add hooks for comparing answers

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -217,6 +217,7 @@ Mumtaz Hajjo Alrifai <mumtazrifai@protonmail.com>
 Thomas Graves <fate@hey.com>
 Jakub Fidler <jakub.fidler@protonmail.com>
 Valerie Enfys <val@unidentified.systems>
+Julien Chol <https://github.com/chel-ou>
 
 ********************
 

--- a/qt/aqt/reviewer.py
+++ b/qt/aqt/reviewer.py
@@ -749,6 +749,8 @@ class Reviewer:
     def typeAnsAnswerFilter(self, buf: str) -> str:
         if not self.typeCorrect:
             return re.sub(self.typeAnsPat, "", buf)
+        m = re.search(self.typeAnsPat, buf)
+        type_pattern = m.group(1) if m else ""
         orig = buf
         origSize = len(buf)
         buf = buf.replace("<hr id=answer>", "")
@@ -756,7 +758,7 @@ class Reviewer:
         initial_expected = self.typeCorrect
         initial_provided = self.typedAnswer
         expected, provided = gui_hooks.reviewer_will_compare_answer(
-            (initial_expected, initial_provided)
+            (initial_expected, initial_provided), type_pattern
         )
 
         output = self.mw.col.compare_answer(expected, provided, self._combining)
@@ -764,6 +766,7 @@ class Reviewer:
             output,
             initial_expected,
             initial_provided,
+            type_pattern,
         )
 
         # and update the type answer area

--- a/qt/aqt/reviewer.py
+++ b/qt/aqt/reviewer.py
@@ -753,9 +753,18 @@ class Reviewer:
         origSize = len(buf)
         buf = buf.replace("<hr id=answer>", "")
         hadHR = len(buf) != origSize
-        expected = self.typeCorrect
-        provided = self.typedAnswer
+        initial_expected = self.typeCorrect
+        initial_provided = self.typedAnswer
+        expected, provided = gui_hooks.reviewer_will_compare_answer(
+            (initial_expected, initial_provided)
+        )
+
         output = self.mw.col.compare_answer(expected, provided, self._combining)
+        output = gui_hooks.reviewer_will_render_compared_answer(
+            output,
+            initial_expected,
+            initial_provided,
+        )
 
         # and update the type answer area
         def repl(match: Match) -> str:

--- a/qt/tools/genhooks_gui.py
+++ b/qt/tools/genhooks_gui.py
@@ -102,13 +102,17 @@ hooks = [
     ),
     Hook(
         name="reviewer_will_compare_answer",
-        args=["expected_provided_tuple: tuple[str, str]"],
+        args=[
+            "expected_provided_tuple: tuple[str, str]",
+            "type_pattern: str",
+        ],
         return_type="tuple[str, str]",
         doc="""Modify expected answer and provided answer before comparing
 
         expected_provided_tuple is a tuple composed of:
         - expected answer
         - provided answer
+        type_pattern is the detail of the type tag on the card
 
         Return a tuple composed of:
         - modified expected answer
@@ -121,6 +125,7 @@ hooks = [
             "output: str",
             "initial_expected: str",
             "initial_provided: str",
+            "type_pattern: str",
         ],
         return_type="str",
         doc="""Modify the output of default compare answer feature
@@ -128,6 +133,7 @@ hooks = [
         output is the result of default compare answer function
         initial_expected is the expected answer from the card
         initial_provided is the answer provided during review
+        type_pattern is the detail of the type tag on the card
 
         Return a string comparing expected and provided answers
         """,

--- a/qt/tools/genhooks_gui.py
+++ b/qt/tools/genhooks_gui.py
@@ -101,6 +101,38 @@ hooks = [
         legacy_no_args=True,
     ),
     Hook(
+        name="reviewer_will_compare_answer",
+        args=["expected_provided_tuple: tuple[str, str]"],
+        return_type="tuple[str, str]",
+        doc="""Modify expected answer and provided answer before comparing
+
+        expected_provided_tuple is a tuple composed of:
+        - expected answer
+        - provided answer
+
+        Return a tuple composed of:
+        - modified expected answer
+        - modified provided answer
+        """,
+    ),
+    Hook(
+        name="reviewer_will_render_compared_answer",
+        args=[
+            "output: str",
+            "initial_expected: str",
+            "initial_provided: str",
+        ],
+        return_type="str",
+        doc="""Modify the output of default compare answer feature
+
+        output is the result of default compare answer function
+        initial_expected is the expected answer from the card
+        initial_provided is the answer provided during review
+
+        Return a string comparing expected and provided answers
+        """,
+    ),
+    Hook(
         name="reviewer_did_show_answer",
         args=["card: Card"],
         legacy_hook="showAnswer",
@@ -846,7 +878,7 @@ gui_hooks.webview_did_inject_style_into_page.append(mytest)
         'content' is a list of HTML strings added by add-ons which you can append your
         own components or elements to. To equip your components with logic and styling
         please see `webview_will_set_content` and `webview_did_receive_js_message`.
-        
+
         Please note that Anki's main screen is due to undergo a significant refactor
         in the future and, as a result, add-ons subscribing to this hook will likely
         require changes to continue working.
@@ -861,7 +893,7 @@ gui_hooks.webview_did_inject_style_into_page.append(mytest)
         'content' is a list of HTML strings added by add-ons which you can append your
         own components or elements to. To equip your components with logic and styling
         please see `webview_will_set_content` and `webview_did_receive_js_message`.
-        
+
         Please note that Anki's main screen is due to undergo a significant refactor
         in the future and, as a result, add-ons subscribing to this hook will likely
         require changes to continue working.
@@ -1161,7 +1193,7 @@ gui_hooks.webview_did_inject_style_into_page.append(mytest)
         args=["editor: aqt.editor.Editor", "path_or_nid: str | anki.notes.NoteId"],
         doc="""Called when the image occlusion mask editor has completed
         loading an image.
-        
+
         When adding new notes `path_or_nid` will be the path to the image file.
         When editing existing notes `path_or_nid` will be the note id.""",
     ),
@@ -1250,7 +1282,7 @@ gui_hooks.webview_did_inject_style_into_page.append(mytest)
         name="addon_manager_will_install_addon",
         args=["manager: aqt.addons.AddonManager", "module: str"],
         doc="""Called before installing or updating an addon.
-        
+
         Can be used to release DB connections or open files that
         would prevent an update from succeeding.""",
     ),
@@ -1258,7 +1290,7 @@ gui_hooks.webview_did_inject_style_into_page.append(mytest)
         name="addon_manager_did_install_addon",
         args=["manager: aqt.addons.AddonManager", "module: str"],
         doc="""Called after installing or updating an addon.
-        
+
         Can be used to restore DB connections or open files after
         an add-on has been updated.""",
     ),


### PR DESCRIPTION
Following the suggestion made on the forum [Hook for Collection.compare_answer](https://forums.ankiweb.net/t/hook-for-collection-compare-answer/50278) and welcomed by @dae, this PR creates filter hooks associated with the compare answer feature.

The use case has been discussed in [issue #40 of answerset add-on](https://github.com/scott2000/answerset/issues/40#issuecomment-2708994547).

Two filter hooks would be created with different scopes:
- `reviewer_will_compare_answer(expected_provided_tuple: tuple[str, str])`, updates expected and provided. This would enable simple modifications of the answers, while letting anki process the comparison. Examples use cases could be: reformatting the provided answer, shuffling the order of the expected answers...
- `reviewer_will_render_compared_answer(output: str, expected_initial: str, provided_initial: str)`, enables an update or a complete rewrite of the default `compare_answer`.

While `answerset` will mainly use `reviewer_will_render_compared_answer`, `reviewer_will_compare_answer` will enable more simple use cases.

As these new hooks would enable add-ons to provide changes to the `compare_answer` feature across all cards, I feel that this could also let the add-ons enabled only for specific cards, for example by having type patterns like `type:UseMyAddonFieldName` or  `type:MyAddon:FieldName`. The former would just require users to rename their fields, while the latter is not possible right now because `MyAddon` would be filtered out.

As this may be a less critical feature, I added `type_pattern` to the hooks as an "optional" commit.