### PR TITLE
Fix cargo ignoring lockfile when building syncserver image

### DIFF
--- a/docs/syncserver/Dockerfile
+++ b/docs/syncserver/Dockerfile
@@ -7,6 +7,7 @@ RUN apk update && apk add --no-cache build-base protobuf && rm -rf /var/cache/ap
 RUN cargo install --git https://github.com/ankitects/anki.git \
 --tag ${ANKI_VERSION} \
 --root /anki-server  \
+--locked \
 anki-sync-server
 
 FROM alpine:3.21.0

--- a/docs/syncserver/Dockerfile.distroless
+++ b/docs/syncserver/Dockerfile.distroless
@@ -7,6 +7,7 @@ RUN apt-get update && apt-get install -y build-essential protobuf-compiler && ap
 RUN cargo install --git https://github.com/ankitects/anki.git \
 --tag ${ANKI_VERSION} \
 --root /anki-server  \
+--locked \
 anki-sync-server
 
 FROM gcr.io/distroless/cc-debian12


### PR DESCRIPTION
Fixes #3854

Was able to reproduce. fsrs-rs' indirect dep priority-queue bumped its edition from 2021 to 2024 in a patch version recently, and although anki's lockfile has it pinned to 2.1.1, cargo [ignores](https://doc.rust-lang.org/cargo/commands/cargo-install.html#dealing-with-the-lockfile) the lockfile when installing if the `--locked` flag isn't passed to it

When building the sync server image, `2.1.1` in fsrs-rs' Cargo.toml is [equivalent](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#caret-requirements) to `^2.1.1`, so cargo pulls 2.2.2, which it can't handle yet (on 1.83)

The fix proposed is to pass the `--locked` flag to cargo in the dockerfile
