### PR TITLE
Fix/incorrect initialization of SchedTimingToday in graphs/retrievability.rs

### DIFF
--- a/rslib/src/stats/graphs/retrievability.rs
+++ b/rslib/src/stats/graphs/retrievability.rs
@@ -4,6 +4,7 @@
 use anki_proto::stats::graphs_response::Retrievability;
 use fsrs::FSRS;
 
+use crate::prelude::TimestampSecs;
 use crate::scheduler::timing::SchedTimingToday;
 use crate::stats::graphs::eases::percent_to_bin;
 use crate::stats::graphs::GraphsContext;
@@ -15,8 +16,8 @@ impl GraphsContext {
         let mut card_with_retrievability_count: usize = 0;
         let timing = SchedTimingToday {
             days_elapsed: self.days_elapsed,
-            now: Default::default(),
-            next_day_at: Default::default(),
+            now: TimestampSecs::now(),
+            next_day_at: self.next_day_start,
         };
         let fsrs = FSRS::new(None).unwrap();
         // note id -> (sum, count)


### PR DESCRIPTION
Found in https://forums.ankiweb.net/t/bug-retrievability-in-browser-doesnt-match-retrievability-in-stats-histogram/56547/5?u=l.m.sherlock

The `next_day_at` is used here:

https://github.com/ankitects/anki/blob/9b5da546be49f37c8d6c286e09c86074b2f0c278/rslib/src/browser_table.rs#L129-L134