### PR TITLE
tools/minilints: Fix contributor detection

### DIFF
--- a/tools/minilints/src/main.rs
+++ b/tools/minilints/src/main.rs
@@ -153,9 +153,9 @@ impl LintContext {
                 .args(["rev-parse", "--show-toplevel"])
                 .output()?
                 .stdout,
-        )?;
-
-        let root_dir = root_dir.trim_end();
+        )?
+        .trim_end()
+        .to_string();
 
         let file = File::open(format!("{}/CONTRIBUTORS", root_dir))?;
         let mut contributors: Vec<String> = Vec::new();
@@ -170,7 +170,7 @@ impl LintContext {
                     continue;
                 }
                 if inside_name_section {
-                    contributors.push(line.clone());
+                    contributors.push(line);
                 }
             }
         }


### PR DESCRIPTION
Contributor detection seems to fail with email addresses that do not end in `@users.noreply.github.com` due to a discrepancy between the email in the commit history and the email in the CONTRIBUTORS file. Right now, the email I have in CONTRIBUTORS that passed previous CI pipelines fails on any new PR.

I'm not sure if this is the right solution, but it fixes CI