### PR TITLE
Return a copy of note type in ModelManager.get()

### DIFF
--- a/pylib/anki/models.py
+++ b/pylib/anki/models.py
@@ -151,7 +151,10 @@ class ModelManager(DeprecatedNamesMixin):
             return None
 
     def get(self, id: NotetypeId) -> NotetypeDict | None:
-        "Get model with ID, or None."
+        """Get model with ID, or None.
+
+        This returns a reference to a cached dict. Copy the returned model before modifying it if you're not calling .update_dict() afterward.
+        """
         # deal with various legacy input types
         if id is None:
             return None

--- a/pylib/anki/models.py
+++ b/pylib/anki/models.py
@@ -165,7 +165,7 @@ class ModelManager(DeprecatedNamesMixin):
                 self._update_cache(notetype)
             except NotFoundError:
                 return None
-        return notetype
+        return copy.deepcopy(notetype)
 
     def all(self) -> list[NotetypeDict]:
         "Get all models."

--- a/pylib/anki/models.py
+++ b/pylib/anki/models.py
@@ -165,7 +165,7 @@ class ModelManager(DeprecatedNamesMixin):
                 self._update_cache(notetype)
             except NotFoundError:
                 return None
-        return copy.deepcopy(notetype)
+        return notetype
 
     def all(self) -> list[NotetypeDict]:
         "Get all models."

--- a/pylib/tests/test_decks.py
+++ b/pylib/tests/test_decks.py
@@ -48,7 +48,9 @@ def test_remove():
     deck1 = col.decks.id("deck1")
     note = col.newNote()
     note["Front"] = "1"
-    note.note_type()["did"] = deck1
+    note_type = note.note_type()
+    note_type["did"] = deck1
+    col.models.update_dict(note_type)
     col.addNote(note)
     c = note.cards()[0]
     assert c.did == deck1

--- a/pylib/tests/test_exporting.py
+++ b/pylib/tests/test_exporting.py
@@ -35,7 +35,9 @@ def setup1():
     note = col.newNote()
     note["Front"] = "baz"
     note["Back"] = "qux"
-    note.note_type()["did"] = col.decks.id("new col")
+    note_type = note.note_type()
+    note_type["did"] = col.decks.id("new col")
+    col.models.update_dict(note_type)
     col.addNote(note)
 
 

--- a/pylib/tests/test_schedv3.py
+++ b/pylib/tests/test_schedv3.py
@@ -85,7 +85,9 @@ def test_newLimits():
         note = col.newNote()
         note["Front"] = str(i)
         if i > 4:
-            note.note_type()["did"] = deck2
+            note_type = note.note_type()
+            note_type["did"] = deck2
+            col.models.update_dict(note_type)
         col.addNote(note)
     # give the child deck a different configuration
     c2 = col.decks.add_config_returning_id("new conf")
@@ -936,7 +938,9 @@ def test_deckDue():
     # and one that's a child
     note = col.newNote()
     note["Front"] = "two"
-    default1 = note.note_type()["did"] = col.decks.id("Default::1")
+    note_type = note.note_type()
+    default1 = note_type["did"] = col.decks.id("Default::1")
+    col.models.update_dict(note_type)
     col.addNote(note)
     # make it a review card
     c = note.cards()[0]
@@ -946,12 +950,16 @@ def test_deckDue():
     # add one more with a new deck
     note = col.newNote()
     note["Front"] = "two"
-    note.note_type()["did"] = col.decks.id("foo::bar")
+    note_type = note.note_type()
+    note_type["did"] = col.decks.id("foo::bar")
+    col.models.update_dict(note_type)
     col.addNote(note)
     # and one that's a sibling
     note = col.newNote()
     note["Front"] = "three"
-    note.note_type()["did"] = col.decks.id("foo::baz")
+    note_type = note.note_type()
+    note_type["did"] = col.decks.id("foo::baz")
+    col.models.update_dict(note_type)
     col.addNote(note)
     assert len(col.decks.all_names_and_ids()) == 5
     tree = col.sched.deck_due_tree().children
@@ -991,12 +999,16 @@ def test_deckFlow():
     # and one that's a child
     note = col.newNote()
     note["Front"] = "two"
-    note.note_type()["did"] = col.decks.id("Default::2")
+    note_type = note.note_type()
+    note_type["did"] = col.decks.id("Default::2")
+    col.models.update_dict(note_type)
     col.addNote(note)
     # and another that's higher up
     note = col.newNote()
     note["Front"] = "three"
-    default1 = note.note_type()["did"] = col.decks.id("Default::1")
+    note_type = note.note_type()
+    default1 = note_type["did"] = col.decks.id("Default::1")
+    col.models.update_dict(note_type)
     col.addNote(note)
     assert col.sched.counts() == (3, 0, 0)
     # should get top level one first, then ::1, then ::2


### PR DESCRIPTION
## Proposed Changes

Make ModelManager.get() return a deep copy of the fetched note type.

## Rationale

Any modifications done by one caller will be reflected to other callers due to caching. This is undocumented and can be unexpected in some cases (e.g. https://github.com/AnkiHubSoftware/ankihub_addon/pull/1090#discussion_r1959702689)

## Sidenote

@dae do you have a recent zip of all add-ons? (probably not very useful here but would be nice anyway).