### PR TITLE
Control autoplay order from card layout

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -218,6 +218,7 @@ Thomas Graves <fate@hey.com>
 Jakub Fidler <jakub.fidler@protonmail.com>
 Valerie Enfys <val@unidentified.systems>
 Julien Chol <https://github.com/chel-ou>
+Xavi Arnal <xavi.aclm@gmail.com>
 
 ********************
 

--- a/qt/aqt/browser/previewer.py
+++ b/qt/aqt/browser/previewer.py
@@ -157,8 +157,14 @@ class Previewer(QDialog):
         if cmd.startswith("play:"):
             card = self.card()
             assert card is not None
-
             play_clicked_audio(cmd, card)
+
+        elif cmd.startswith("autoplay:"):
+            card = self.card()
+            assert card is not None
+            if card.autoplay():
+                self._web.setPlaybackRequiresGesture(False)
+                play_clicked_audio(cmd, card)
 
     def _update_flag_and_mark_icons(self, card: Card | None) -> None:
         if card:

--- a/qt/aqt/browser/previewer.py
+++ b/qt/aqt/browser/previewer.py
@@ -162,6 +162,7 @@ class Previewer(QDialog):
         elif cmd.startswith("autoplay:"):
             card = self.card()
             assert card is not None
+            assert self._web is not None
             if card.autoplay():
                 self._web.setPlaybackRequiresGesture(False)
                 play_clicked_audio(cmd, card)

--- a/qt/aqt/clayout.py
+++ b/qt/aqt/clayout.py
@@ -435,6 +435,10 @@ class CardLayout(QDialog):
     def _on_bridge_cmd(self, cmd: str) -> Any:
         if cmd.startswith("play:"):
             play_clicked_audio(cmd, self.rendered_card)
+        if cmd.startswith("autoplay:"):
+            if self.rendered_card.autoplay():
+                self.preview_web.setPlaybackRequiresGesture(False)
+                play_clicked_audio(cmd, self.rendered_card)
 
     def note_has_empty_field(self) -> bool:
         for field in self.note.fields:

--- a/qt/aqt/reviewer.py
+++ b/qt/aqt/reviewer.py
@@ -681,6 +681,10 @@ class Reviewer:
             self.showContextMenu()
         elif url.startswith("play:"):
             play_clicked_audio(url, self.card)
+        elif url.startswith("autoplay:"):
+            if self.card.autoplay():
+                self.web.setPlaybackRequiresGesture(False)
+                play_clicked_audio(url, self.card)
         elif url.startswith("updateToolbar"):
             self.mw.toolbarWeb.update_background_image()
         elif url == "statesMutated":

--- a/qt/aqt/sound.py
+++ b/qt/aqt/sound.py
@@ -856,14 +856,19 @@ def av_refs_to_play_icons(text: str) -> str:
 
 
 def play_clicked_audio(pycmd: str, card: Card) -> None:
-    """eg. if pycmd is 'play:q:0', play the first audio on the question side."""
+    """
+    eg. if pycmd is...
+    'play:q:0', play the first audio on the question side.
+    'autoplay:q:0,4,1', play the first, then fifth, then second audio on the question side.
+    """
     play, context, str_idx = pycmd.split(":")
-    idx = int(str_idx)
+    idxs = [int(idx) for idx in str_idx.split(",")]
     if context == "q":
         tags = card.question_av_tags()
     else:
         tags = card.answer_av_tags()
-    av_player.play_tags([tags[idx]])
+    selected_tags = [tags[idx] for idx in idxs]
+    av_player.play_tags(selected_tags)
 
 
 # Init defaults


### PR DESCRIPTION
## Changes

Modified `aqt.sound.play_clicked_audio` such that pycmd calls to play can take multiple arguments, e.g. `pycmd('play:q:2,4,17')` will play the third, fifth and eighteenth audio in a card's question side in succession.

You can connect this to a button fine, but the intended use is to control autoplay from within a script block in card html (s.t. modifications to autoplay can be embedded into decks). For this reason `aqt.reviewer.Reviewer`, `aqt.clayout.CardLayout`, and `aqt.browser.previewer.Previewer` were also modified, extending their bridge to cmd with a new command 'autoplay' - this does the same as 'play', but only if the current card (deck) has autoplay enabled.

## Rationale

The purpose of this is to allow finer control of playback from script blocks, in particular such that the new behaviour can be exported with the deck. This is a rather minoritary issue (indeed, using js at all in your cards is recommended against), but it has come up a couple of times in the forums.

I imagine this pr may be rejected on the grounds of pycmd not being intended as a public interface - if so, I would appreciate some insight on what might be a better way to present this functionality to the user. On this subject I note that it is easy to imagine some less invasive options to enable control of autoplay from the layout, e.g. a static hidden html element to describe autoplay order. This is fine and probably a decent idea, but this pr is oriented towards cards where the autoplay order may depend on state from a script block - in this setting, a message must be passed from js to python in _some_ way, albeit I'm not sure if there are better options than pycmd. If a more pared-down approach to this were preferable, it'd also be possible to add a bridge command that ended up going to some function enqueue_clicked_audio -> AVPlayer.append_tags, though this loses the ability to condition itself on whether card autoplay is enabled.

## Notes

Fine control of autoplay is strictly speaking already possible, but if you want to do this while also having the standard play buttons, as far as I'm aware the only option is to include every audio twice in the fields - once as a [sound:...], for the buttons, and once as just the audio file, to through javascript generate a series of hidden <audio> elements with their ending events chained in sequence.

The changes in CardLayout do not interact with self.have_autoplayed because pycmd autoplay is meant to override non-pycmd autoplay (and moreover will always execute _after_ the non-pycmd autoplay call).