### PR TITLE
Add-ons Dialog: disable View Config/Page/Files buttons when clicking them would not lead to useful result

### DIFF
--- a/qt/aqt/addons.py
+++ b/qt/aqt/addons.py
@@ -948,7 +948,7 @@ class AddonsDialog(QDialog):
             openLink(page)
 
     def onViewFiles(self) -> None:
-        # if nothing selected, open top level folder
+        # if nothing selected, open top-level folder
         selected = self.selectedAddons()
         if not selected:
             openFolder(self.mgr.addonsFolder())

--- a/qt/aqt/addons.py
+++ b/qt/aqt/addons.py
@@ -43,7 +43,6 @@ from aqt.utils import (
     askUser,
     disable_help_button,
     getFile,
-    is_win,
     openFolder,
     openLink,
     restoreGeom,

--- a/qt/aqt/addons.py
+++ b/qt/aqt/addons.py
@@ -40,6 +40,7 @@ from aqt import gui_hooks
 from aqt.log import ADDON_LOGGER_PREFIX, find_addon_logger, get_addon_logs_folder
 from aqt.qt import *
 from aqt.utils import (
+    addCloseShortcut,
     askUser,
     disable_help_button,
     getFile,
@@ -828,6 +829,7 @@ class AddonsDialog(QDialog):
         self.setAcceptDrops(True)
         self.redrawAddons()
         restoreGeom(self, "addons")
+        addCloseShortcut(self)
         gui_hooks.addons_dialog_will_show(self)
         self._onAddonSelectionChanged()
         self.show()

--- a/qt/aqt/addons.py
+++ b/qt/aqt/addons.py
@@ -820,12 +820,16 @@ class AddonsDialog(QDialog):
         qconnect(f.config.clicked, self.onConfig)
         qconnect(self.form.addonList.itemDoubleClicked, self.onConfig)
         qconnect(self.form.addonList.currentRowChanged, self._onAddonItemSelected)
+        qconnect(
+            self.form.addonList.itemSelectionChanged, self._onAddonSelectionChanged
+        )
         self.setWindowTitle(tr.addons_window_title())
         disable_help_button(self)
         self.setAcceptDrops(True)
         self.redrawAddons()
         restoreGeom(self, "addons")
         gui_hooks.addons_dialog_will_show(self)
+        self._onAddonSelectionChanged()
         self.show()
 
     def dragEnterEvent(self, event: QDragEnterEvent) -> None:
@@ -901,18 +905,33 @@ class AddonsDialog(QDialog):
 
         addonList.reset()
 
+    def _onAddonSelectionChanged(self) -> None:
+        self.form.viewFiles.setEnabled(False)
+        self.form.viewPage.setEnabled(False)
+        self.form.config.setEnabled(False)
+
+        selected_count = len(self.selectedAddons())
+        if selected_count == 0:
+            # View Files button shows top-level add-ons directory when nothing is selected
+            self.form.viewFiles.setEnabled(True)
+        elif selected_count == 1:
+            addon = self.addons[self.form.addonList.currentRow()]
+
+            self.form.viewFiles.setEnabled(True)
+            self.form.viewPage.setEnabled(addon.page() is not None)
+            self.form.config.setEnabled(
+                bool(
+                    self.mgr.getConfig(addon.dir_name)
+                    or self.mgr.configAction(addon.dir_name)
+                )
+            )
+        return
+
     def _onAddonItemSelected(self, row_int: int) -> None:
         try:
             addon = self.addons[row_int]
         except IndexError:
             return
-        self.form.viewPage.setEnabled(addon.page() is not None)
-        self.form.config.setEnabled(
-            bool(
-                self.mgr.getConfig(addon.dir_name)
-                or self.mgr.configAction(addon.dir_name)
-            )
-        )
         gui_hooks.addons_dialog_did_change_selected_addon(self, addon)
         return
 


### PR DESCRIPTION
#### Why

I was getting confused while working with add-on configs, files, etc. often clicking the buttons without having any add-ons selected, and getting the `please_select_a_single_addon_first` pop-up. Perhaps this could improve the usability of the dialog, if buttons were only clickable when clicking them would lead to a useful action.

#### How

1. Added `itemSelectionChanged` handler because it is also triggered on empty selection, etc.
2. Left `currentRowChanged` handler to preserve the hook’s behavior. But moved the button-disabling logic to the new handler.
3. Upon selection state change, disabling the 3 buttons, enabling “View Files” for empty selection, and enabling all 3 buttons when only 1 add-on is selected (still checking if the add-on has Page and Config).

Note that now it would theoretically be possible to remove the [`onlyOneSelected`](https://github.com/ankitects/anki/blob/14dc979e448dbf1c18c63fca64a37cce66689503/qt/aqt/addons.py#L924) function. 📝

I hope, my code is not too sloppy (and I am sorry for doing multiple things, like adding the Cmd+W shortcut, in the same PR). Big thanks to the Anki team for all their effort! 🙌


#### Before:

_Note that when multiple add-ons are selected, the state of Page and Config buttons depends on which add-on is the first among the selected ones._

https://github.com/user-attachments/assets/24fa4af3-3e43-48f7-8749-dffa25cdad02

#### After:

https://github.com/user-attachments/assets/a8f5cf07-1752-4dfc-a02c-55601b4bae32
