### PR TITLE
Fix/index out of bounds exception in Card Stats Data

### DIFF
--- a/ts/routes/card-info/forgetting-curve.ts
+++ b/ts/routes/card-info/forgetting-curve.ts
@@ -56,7 +56,10 @@ export function filterRevlogEntryByReviewKind(entry: RevlogEntry): boolean {
 export function filterRevlog(revlog: RevlogEntry[]): RevlogEntry[] {
     const result: RevlogEntry[] = [];
     for (const entry of revlog) {
-        if (entry.reviewKind === RevlogEntry_ReviewKind.MANUAL && entry.ease === 0) {
+        if (
+            (entry.reviewKind === RevlogEntry_ReviewKind.MANUAL && entry.ease === 0)
+            || entry.memoryState === undefined
+        ) {
             break;
         }
         result.push(entry);


### PR DESCRIPTION
This PR fixes an issue where viewing card statistics for some cards would cause an index out of bounds panic in the Rust backend.

This bug is introduced in:
- #3866

## Problem

The panic happens when there are review logs that don't have corresponding memory states, typically when the removed review logs appear at the end of the review history.

For example:

<img width="745" alt="image" src="https://github.com/user-attachments/assets/7bd5d456-f1d5-486f-9af7-0dd201b4a8d1" />

## Solution

The solution involves two key changes:

1. In `rslib/src/stats/card.rs`:
   - Added boundary checks for the memory states array
   - Properly handle cases when the removed review log appears at different positions
   - Make the memory state optional to handle cases where no appropriate state exists

2. In `ts/routes/card-info/forgetting-curve.ts`:
   - Update the filtering logic to break when encountering entries with undefined memory states

## Code Changes Explained

The main issue in the code is that when processing card review logs, some log entries might not have corresponding memory states. The original code assumed that each log entry has a corresponding memory state, but in reality, this mapping might be incomplete, especially when log entries are filtered or removed.

In the Rust part, we've added handling for several edge cases:
1. When the removed review log is at the end of the log, we use the last memory state
2. When the removed review log is at the beginning of the log, we set the memory state to None (as there's no prior state available)
3. When the removed review log is in the middle of the log, we use the memory state for the previous review entry

In the TypeScript part for forgetting curve, we updated the filtering logic to detect and handle entries that don't have defined memory states.

For example:

<img width="747" alt="image" src="https://github.com/user-attachments/assets/80169ac8-6190-4852-b078-eaf85b0c12b0" />

These changes eliminate the boundary check issues and enable the system to correctly handle card statistics data in all scenarios.