### PR TITLE
Move TR table upwards

### DIFF
--- a/ts/routes/graphs/+page.svelte
+++ b/ts/routes/graphs/+page.svelte
@@ -32,9 +32,9 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         DifficultyGraph,
         RetrievabilityGraph,
         HourGraph,
+        TrueRetention,
         ButtonsGraph,
         AddedGraph,
-        TrueRetention,
     ];
 </script>
 

--- a/ts/routes/graphs/+page.svelte
+++ b/ts/routes/graphs/+page.svelte
@@ -31,8 +31,8 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         EaseGraph,
         DifficultyGraph,
         RetrievabilityGraph,
-        HourGraph,
         TrueRetention,
+        HourGraph,
         ButtonsGraph,
         AddedGraph,
     ];


### PR DESCRIPTION
This moves the TR table upwards, before the buttons graph.

![anki](https://github.com/user-attachments/assets/af25a27c-5d99-486c-879b-514b220b706f)


Also see: https://forums.ankiweb.net/t/let-s-remove-the-answer-buttons-chart-from-stats/56170/26?u=anon_0000

**Edit:** Moved TR above hourly breakdown graph. Also see: https://forums.ankiweb.net/t/let-s-remove-the-answer-buttons-chart-from-stats/56170/32?u=anon_0000