### PR TITLE
Fix syncserver docker image build by bumping Dockerfile rust version

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -218,6 +218,7 @@ Thomas Graves <fate@hey.com>
 Jakub Fidler <jakub.fidler@protonmail.com>
 Valerie Enfys <val@unidentified.systems>
 Julien Chol <https://github.com/chel-ou>
+KolbyML <https://github.com/KolbyML>
 
 ********************
 

--- a/docs/syncserver/Dockerfile
+++ b/docs/syncserver/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.83.0-alpine3.20 AS builder
+FROM rust:1.85.0-alpine3.20 AS builder
 
 ARG ANKI_VERSION
 

--- a/docs/syncserver/Dockerfile
+++ b/docs/syncserver/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.85.0-alpine3.20 AS builder
+FROM rust:alpine3.20 AS builder
 
 ARG ANKI_VERSION
 

--- a/docs/syncserver/Dockerfile.distroless
+++ b/docs/syncserver/Dockerfile.distroless
@@ -1,4 +1,4 @@
-FROM rust:1.85.0 AS builder
+FROM rust:latest AS builder
 
 ARG ANKI_VERSION
 

--- a/docs/syncserver/Dockerfile.distroless
+++ b/docs/syncserver/Dockerfile.distroless
@@ -1,4 +1,4 @@
-FROM rust:1.83.0 AS builder
+FROM rust:1.85.0 AS builder
 
 ARG ANKI_VERSION
 


### PR DESCRIPTION
Currently when I try and build the syncserver docker image it fails because a library uses the new addition of Rust, so I bumped the rust version and it fixes the problem


I set the Dockerfiles to always use the latest Rust Version, to prevent this problem from happening again in the future!



```rust
#12 13.98   Downloaded priority-queue v2.3.0
#12 14.10 error: failed to compile `anki-sync-server v0.0.0 (https://github.com/ankitects/anki.git?tag=25.02#038d85b1)`, intermediate artifacts can be found at `/tmp/cargo-install7AMd5c`.
#12 14.10 To reuse those artifacts with a future compilation, set the environment variable `CARGO_TARGET_DIR` to that path.
#12 14.10 
#12 14.10 Caused by:
#12 14.10   failed to parse manifest at `/usr/local/cargo/registry/src/index.crates.io-6f17d22bba15001f/priority-queue-2.3.0/Cargo.toml`
#12 14.10 
#12 14.10 Caused by:
#12 14.10   feature `edition2024` is required
#12 14.10 
#12 14.10   The package requires the Cargo feature called `edition2024`, but that feature is not stabilized in this version of Cargo (1.83.0 (5ffbef321 2024-10-29)).
#12 14.10   Consider trying a newer version of Cargo (this may require the nightly release).
#12 14.10   See https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#edition-2024 for more information about the status of this feature.
#12 ERROR: process "/bin/sh -c cargo install --git https://github.com/ankitects/anki.git --tag ${ANKI_VERSION} --root /anki-server  anki-sync-server" did not complete successfully: exit code: 101
------
 > [builder 3/3] RUN cargo install --git https://github.com/ankitects/anki.git --tag 25.02 --root /anki-server  anki-sync-server:
14.10 
14.10 Caused by:
14.10   failed to parse manifest at `/usr/local/cargo/registry/src/index.crates.io-6f17d22bba15001f/priority-queue-2.3.0/Cargo.toml`
14.10 
14.10 Caused by:
14.10   feature `edition2024` is required
14.10 
14.10   The package requires the Cargo feature called `edition2024`, but that feature is not stabilized in this version of Cargo (1.83.0 (5ffbef321 2024-10-29)).
14.10   Consider trying a newer version of Cargo (this may require the nightly release).
14.10   See https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#edition-2024 for more information about the status of this feature.
------
Dockerfile:7
--------------------
   6 |     
   7 | >>> RUN cargo install --git https://github.com/ankitects/anki.git \
   8 | >>> --tag ${ANKI_VERSION} \
   9 | >>> --root /anki-server  \
  10 | >>> anki-sync-server
  11 |     
--------------------
ERROR: failed to solve: process "/bin/sh -c cargo install --git https://github.com/ankitects/anki.git --tag ${ANKI_VERSION} --root /anki-server  anki-sync-server" did not complete successfully: exit code: 101

```