### PR TITLE
Fix panic when clearing today limits on the day collection was made

### DIFF
--- a/rslib/src/deckconfig/update.rs
+++ b/rslib/src/deckconfig/update.rs
@@ -414,7 +414,8 @@ fn update_day_limit(day_limit: &mut Option<DayLimit>, new_limit: Option<u32>, to
     } else {
         // if the collection was created today, the
         // "preserve last value" hack below won't work
-        day_limit.take_if(|limit| limit.today == 0);
+        // clear "future" limits as well (from imports)
+        day_limit.take_if(|limit| limit.today == 0 || limit.today > today);
         if let Some(limit) = day_limit {
             // instead of setting to None, only make sure today is in the past,
             // thus preserving last used value

--- a/rslib/src/deckconfig/update.rs
+++ b/rslib/src/deckconfig/update.rs
@@ -411,10 +411,15 @@ fn update_deck_limits(deck: &mut NormalDeck, limits: &Limits, today: u32) {
 fn update_day_limit(day_limit: &mut Option<DayLimit>, new_limit: Option<u32>, today: u32) {
     if let Some(limit) = new_limit {
         day_limit.replace(DayLimit { limit, today });
-    } else if let Some(limit) = day_limit {
-        // instead of setting to None, only make sure today is in the past,
-        // thus preserving last used value
-        limit.today = limit.today.min(today - 1);
+    } else {
+        // if the collection was created today, the
+        // "preserve last value" hack below won't work
+        day_limit.take_if(|limit| limit.today == 0);
+        if let Some(limit) = day_limit {
+            // instead of setting to None, only make sure today is in the past,
+            // thus preserving last used value
+            limit.today = limit.today.min(today - 1);
+        }
     }
 }
 

--- a/rslib/src/deckconfig/update.rs
+++ b/rslib/src/deckconfig/update.rs
@@ -418,7 +418,7 @@ fn update_day_limit(day_limit: &mut Option<DayLimit>, new_limit: Option<u32>, to
         if let Some(limit) = day_limit {
             // instead of setting to None, only make sure today is in the past,
             // thus preserving last used value
-            limit.today = limit.today.min(today - 1);
+            limit.today = limit.today.min(today.saturating_sub(1));
         }
     }
 }


### PR DESCRIPTION
Fixes #3875 

See https://github.com/ankitects/anki/issues/3875#issuecomment-2745211077 for context on the problem

This pr proposes to fix the panic by extending the hack to account for the edge case when the collection was created on the day itself, rather than changing the deck schema to account for this one day 

No new inconsistency is introduced, and it having gone unnoticed till now by a dev suggests that users are unlikely to complain about the last today limit not being preserved on day 0 🤔