### PR TITLE
Fix deck day limits incorrectly being carried over when importing

### DIFF
--- a/rslib/src/decks/mod.rs
+++ b/rslib/src/decks/mod.rs
@@ -20,6 +20,7 @@ use std::sync::Arc;
 pub use anki_proto::decks::deck::filtered::search_term::Order as FilteredSearchOrder;
 pub use anki_proto::decks::deck::filtered::SearchTerm as FilteredSearchTerm;
 pub use anki_proto::decks::deck::kind_container::Kind as DeckKind;
+pub use anki_proto::decks::deck::normal::DayLimit as NormalDeckDayLimit;
 pub use anki_proto::decks::deck::Common as DeckCommon;
 pub use anki_proto::decks::deck::Filtered as FilteredDeck;
 pub use anki_proto::decks::deck::KindContainer as DeckKindContainer;

--- a/rslib/src/import_export/package/apkg/import/decks.rs
+++ b/rslib/src/import_export/package/apkg/import/decks.rs
@@ -88,9 +88,8 @@ impl DeckContext<'_> {
     }
 
     fn maybe_correct_day_limits(&mut self, deck: &mut Deck) -> Result<()> {
-        if let DeckKind::Normal(ref mut normal) = deck.kind {
+        if let Ok(normal) = deck.normal_mut() {
             let target_col_today = self.target_col.timing_today()?.days_elapsed;
-
             let op = |mut limit: NormalDeckDayLimit| {
                 if limit.today == self.source_col_today {
                     // imported deck has an active today limit, map it to target col
@@ -105,7 +104,6 @@ impl DeckContext<'_> {
                     None
                 }
             };
-
             normal.new_limit_today = normal.new_limit_today.and_then(op);
             normal.review_limit_today = normal.review_limit_today.and_then(op);
         }

--- a/rslib/src/import_export/package/apkg/import/decks.rs
+++ b/rslib/src/import_export/package/apkg/import/decks.rs
@@ -211,7 +211,7 @@ mod test {
         DeckAdder::new("filtered").filtered(true).add(&mut col);
         DeckAdder::new("PARENT").add(&mut col);
 
-        let mut ctx = DeckContext::new(&mut col, Usn(1));
+        let mut ctx = DeckContext::new(&mut col, Usn(1), 0);
         ctx.unique_suffix = "★".to_string();
 
         let imports = vec![

--- a/rslib/src/import_export/package/apkg/import/decks.rs
+++ b/rslib/src/import_export/package/apkg/import/decks.rs
@@ -90,16 +90,15 @@ impl DeckContext<'_> {
     fn maybe_correct_day_limits(&mut self, deck: &mut Deck) -> Result<()> {
         if let DeckKind::Normal(ref mut normal) = deck.kind {
             let target_col_today = self.target_col.timing_today()?.days_elapsed;
-            let source_col_today = self.source_col_today;
 
             let op = |mut limit: NormalDeckDayLimit| {
-                if limit.today == source_col_today {
-                    // imported deck has a valid today limit, map it to target col
+                if limit.today == self.source_col_today {
+                    // imported deck has an active today limit, map it to target col
                     limit.today = target_col_today;
                     Some(limit)
                 } else if target_col_today > 0 {
-                    // imported deck's today limit was in the past
-                    limit.today = target_col_today.saturating_sub(1);
+                    // imported deck's today limit was not active
+                    limit.today = limit.today.min(target_col_today - 1);
                     Some(limit)
                 } else {
                     // edge case where target collection is new (day 0), clear saved limit


### PR DESCRIPTION
For [ergonomics](https://github.com/ankitects/anki/pull/1955#discussion_r922768204), day limits aren't cleared* when not used. Instead, a hack is used whereby its set as if it were in the past and thus not applicable on the current day

This is problematic when importing because the current day depends on the collection's age, and so an imported deck's "past" day limit might fall within the importing collection's "future" if the importing col is newer

This means that the imported deck's today limit might turn itself on in the future, even if it was considered to be a past value when the deck was exported. Or, more commonly, when importing a deck that has a valid today limit in the orig col, it isn't applied because the importing col has a different today.

This pr proposes to fix that by ~~shifting~~ correcting the day limit dates ~~back~~ accordingly** when importing, or removing them if the situation described in #3877 would occur. ~~Sorry in advance if i've screwed up the math, it's a bit confusing~~ EDIT: used a simpler approach that should also be more consistent

*changed in #3877, but the problem described here remains
**analogous to ~~shifting back~~ correcting imported cards' due dates
