### PR TITLE
Cloze button get disabled outside of cloze field

### DIFF
--- a/proto/anki/notetypes.proto
+++ b/proto/anki/notetypes.proto
@@ -33,6 +33,7 @@ service NotetypesService {
   rpc GetFieldNames(NotetypeId) returns (generic.StringList);
   rpc RestoreNotetypeToStock(RestoreNotetypeToStockRequest)
       returns (collection.OpChanges);
+  rpc GetClozeFieldOrds(NotetypeId) returns (GetClozeFieldOrdsResponse);
 }
 
 // Implicitly includes any of the above methods that are not listed in the
@@ -241,4 +242,8 @@ enum ImageOcclusionField {
 enum ClozeField {
   CLOZE_FIELD_TEXT = 0;
   CLOZE_FIELD_BACK_EXTRA = 1;
+}
+
+message GetClozeFieldOrdsResponse {
+  repeated uint32 ords = 1;
 }

--- a/pylib/anki/models.py
+++ b/pylib/anki/models.py
@@ -278,6 +278,10 @@ class ModelManager(DeprecatedNamesMixin):
     def sort_idx(self, notetype: NotetypeDict) -> int:
         return notetype["sortf"]
 
+    def cloze_fields(self, mid: NotetypeId) -> list[int]:
+        """The list of index of fields that are used by cloze deletion in the note type with id `mid`."""
+        return self.col._backend.get_cloze_field_ords(mid)
+
     # Adding & changing fields
     ##################################################
 

--- a/qt/aqt/editor.py
+++ b/qt/aqt/editor.py
@@ -556,6 +556,8 @@ require("anki/ui").loaded.then(() => require("anki/NoteEditor").instances[0].too
         note_type = self.note_type()
         flds = note_type["flds"]
         collapsed = [fld["collapsed"] for fld in flds]
+        cloze_fields_ords = self.mw.col.models.cloze_fields(self.note.mid)
+        cloze_fields = [ord in cloze_fields_ords for ord in range(len(flds))]
         plain_texts = [fld.get("plainText", False) for fld in flds]
         descriptions = [fld.get("description", "") for fld in flds]
         notetype_meta = {"id": self.note.mid, "modTime": note_type["mod"]}
@@ -585,6 +587,7 @@ require("anki/ui").loaded.then(() => require("anki/NoteEditor").instances[0].too
             setIsImageOcclusion({json.dumps(self.current_notetype_is_image_occlusion())});
             setNotetypeMeta({json.dumps(notetype_meta)});
             setCollapsed({json.dumps(collapsed)});
+            setClozeFields({json.dumps(cloze_fields)});
             setPlainTexts({json.dumps(plain_texts)});
             setDescriptions({json.dumps(descriptions)});
             setFonts({json.dumps(self.fonts())});

--- a/rslib/src/findreplace.rs
+++ b/rslib/src/findreplace.rs
@@ -74,7 +74,7 @@ impl Collection {
                     None => FieldForNotetype::Any,
                     Some(name) => match nt.get_field_ord(name) {
                         None => FieldForNotetype::None,
-                        Some(ord) => FieldForNotetype::Index(ord),
+                        Some(ord) => FieldForNotetype::Index(ord as usize),
                     },
                 };
                 last_ntid = Some(nt.id);

--- a/rslib/src/notetype/service.rs
+++ b/rslib/src/notetype/service.rs
@@ -212,6 +212,21 @@ impl crate::services::NotetypesService for Collection {
         )
         .map(Into::into)
     }
+
+    fn get_cloze_field_ords(
+        &mut self,
+        input: anki_proto::notetypes::NotetypeId,
+    ) -> error::Result<anki_proto::notetypes::GetClozeFieldOrdsResponse> {
+        Ok(anki_proto::notetypes::GetClozeFieldOrdsResponse {
+            ords: self
+                .get_notetype(input.into())?
+                .unwrap()
+                .cloze_fields()
+                .iter()
+                .map(|ord| (*ord) as u32)
+                .collect(),
+        })
+    }
 }
 
 impl From<anki_proto::notetypes::Notetype> for Notetype {

--- a/ts/editor/EditorField.svelte
+++ b/ts/editor/EditorField.svelte
@@ -16,6 +16,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         description: string;
         collapsed: boolean;
         hidden: boolean;
+        isClozeField: boolean;
     }
 
     export interface EditorFieldAPI {
@@ -81,6 +82,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         element,
         direction: directionStore,
         editingArea: editingArea as EditingAreaAPI,
+        isClozeField: field.isClozeField,
     });
 
     setContextProperty(api);

--- a/ts/editor/NoteEditor.svelte
+++ b/ts/editor/NoteEditor.svelte
@@ -143,6 +143,10 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         fieldsCollapsed =
             sessionOptions[notetypeMeta?.id]?.fieldsCollapsed ?? defaultCollapsed;
     }
+    let clozeFields: boolean[] = [];
+    export function setClozeFields(defaultClozeFields: boolean[]): void {
+        clozeFields = defaultClozeFields;
+    }
 
     let richTextsHidden: boolean[] = [];
     let plainTextsHidden: boolean[] = [];
@@ -275,6 +279,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         direction: fonts[index][2] ? "rtl" : "ltr",
         collapsed: fieldsCollapsed[index],
         hidden: hideFieldInOcclusionType(index, ioFields),
+        isClozeField: clozeFields[index],
     })) as FieldData[];
 
     let lastSavedTags: string[] | null = null;
@@ -562,6 +567,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
             saveSession,
             setFields,
             setCollapsed,
+            setClozeFields,
             setPlainTexts,
             setDescriptions,
             setFonts,
@@ -750,6 +756,7 @@ the AddCards dialog) should be implemented in the user of this component.
                                     $focusedInput = null;
                                 }}
                                 bind:this={richTextInputs[index]}
+                                isClozeField={field.isClozeField}
                             />
                         </Collapsible>
                     </svelte:fragment>

--- a/ts/editor/editor-toolbar/RichTextClozeButtons.svelte
+++ b/ts/editor/editor-toolbar/RichTextClozeButtons.svelte
@@ -3,6 +3,7 @@ Copyright: Ankitects Pty Ltd and contributors
 License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 -->
 <script lang="ts">
+    import * as tr from "@generated/ftl";
     import { wrapInternal } from "@tslib/wrap";
 
     import ClozeButtons from "../ClozeButtons.svelte";
@@ -14,6 +15,10 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     $: richTextAPI = $focusedInput as RichTextInputAPI;
 
     async function onSurround({ detail }): Promise<void> {
+        if (!richTextAPI.isClozeField) {
+            alert(tr.addingClozeOutsideClozeField());
+            return;
+        }
         const richText = await richTextAPI.element;
         const { prefix, suffix } = detail;
 

--- a/ts/editor/mathjax-overlay/MathjaxButtons.svelte
+++ b/ts/editor/mathjax-overlay/MathjaxButtons.svelte
@@ -15,6 +15,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     import ClozeButtons from "../ClozeButtons.svelte";
 
     export let isBlock: boolean;
+    export let isClozeField: boolean;
 
     const dispatch = createEventDispatcher();
 </script>
@@ -40,7 +41,9 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         </IconButton>
     </ButtonGroup>
 
-    <ClozeButtons on:surround alwaysEnabled={true} />
+    {#if isClozeField}
+        <ClozeButtons on:surround alwaysEnabled={true} />
+    {/if}
 
     <ButtonGroup>
         <IconButton

--- a/ts/editor/mathjax-overlay/MathjaxOverlay.svelte
+++ b/ts/editor/mathjax-overlay/MathjaxOverlay.svelte
@@ -34,6 +34,8 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     let cleanup: Callback;
     let richTextInput: RichTextInputAPI | null = null;
     let allowPromise = Promise.resolve();
+    // Whether the last focused input field corresponds to a cloze field.
+    let isClozeField: boolean = true;
 
     async function initialize(input: EditingInputAPI | null): Promise<void> {
         cleanup?.();
@@ -50,6 +52,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
                 on(container, "movecaretafter" as any, showOnAutofocus),
                 on(container, "selectall" as any, showSelectAll),
             );
+            isClozeField = input.isClozeField;
         }
 
         // Wait if the mathjax overlay is still active
@@ -242,6 +245,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
                         <MathjaxButtons
                             {isBlock}
+                            {isClozeField}
                             on:setinline={async () => {
                                 isBlock = false;
                                 await updateBlockAttribute();

--- a/ts/editor/rich-text-input/RichTextInput.svelte
+++ b/ts/editor/rich-text-input/RichTextInput.svelte
@@ -22,6 +22,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         /** The API exposed by the editable component */
         editable: ContentEditableAPI;
         customStyles: Promise<Record<string, any>>;
+        isClozeField: boolean;
     }
 
     function editingInputIsRichText(
@@ -84,6 +85,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
     export let hidden = false;
     export const focusFlag = new Flag();
+    export let isClozeField: boolean;
 
     const { focusedInput } = noteEditorContext.get();
     const { content, editingInputs } = editingAreaContext.get();
@@ -156,6 +158,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         inputHandler,
         editable: {} as ContentEditableAPI,
         customStyles,
+        isClozeField,
     };
 
     const allContexts = getAllContexts();


### PR DESCRIPTION
If the user tries to add a cloze in a field that is not a cloze type, the user gets an alert message.

I could have removed the buttons or disabled them, as it's done when the note type is not a cloze deletion, but I think it's better to avoid changes in the buttons. And anyway, the alert would still be useful if the user tried to use the shortcut to add the cloze.

In order to do this, I added a back-end method (that I expect we may reuse in ankidroid) to get the index of the fields used in cloze. This set is sent to the note editor, which propagates it where needed.

In mathjax, the cloze symbol is removed when the selected field is not a cloze field

I would appreciate help, as the alert message is not properly displayed, instead it shows

> missing key: adding-cloze-outside-cloze-field