### PR TITLE
Move smooth button above simulate graph.

### DIFF
--- a/ts/routes/deck-options/SimulatorModal.svelte
+++ b/ts/routes/deck-options/SimulatorModal.svelte
@@ -292,14 +292,6 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
                         </SettingTitle>
                     </SwitchRow>
 
-                    <SwitchRow bind:value={smooth} defaultValue={true}>
-                        <SettingTitle
-                            on:click={() => openHelpModal("simulateFsrsReview")}
-                        >
-                            {"Smooth Graph"}
-                        </SettingTitle>
-                    </SwitchRow>
-
                     <SwitchRow
                         bind:value={suspendLeeches}
                         defaultValue={$config.leechAction ==
@@ -371,6 +363,16 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
                     {tr.actionsProcessing()}
                 {/if}
 
+                <div class="short">
+                    <SwitchRow bind:value={smooth} defaultValue={true}>
+                        <SettingTitle
+                            on:click={() => openHelpModal("simulateFsrsReview")}
+                        >
+                            {"Smooth Graph"}
+                        </SettingTitle>
+                    </SwitchRow>
+                </div>
+
                 <Graph>
                     <div class="radio-group">
                         <InputBox>
@@ -421,6 +423,10 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 </div>
 
 <style>
+    .short :global(.col) {
+        flex: inherit;
+    }
+
     .modal {
         background-color: rgba(0, 0, 0, 0.5);
         --bs-modal-margin: 0;


### PR DESCRIPTION
@Expertium wanted to make it clearer to the user that the smooth button had no effect on the simulation.

I am personally ambivalent to this change, especially if it runs into issues with scrolling on mac.

![image](https://github.com/user-attachments/assets/c259ebe6-d817-4c53-9b01-c82e61dbe575)
