### PR TITLE
Center align rows in FSRS simulator

### DIFF
--- a/ts/lib/components/Row.svelte
+++ b/ts/lib/components/Row.svelte
@@ -17,5 +17,6 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         flex-flow: row wrap;
         align-content: stretch;
         padding: var(--gutter-block, 0) 0;
+        align-items: center;
     }
 </style>


### PR DESCRIPTION
I confused two rows with each other in the simulator because the option name and option toggle / textfields are quite some distance apart on my screen. My eyes followed the wrong imaginary line between name and toggle.

This PR centers the row strings. That way, the option name and option toggle / textfields are better aligned. The change is small but helps me a tiny bit.

Before:
![anki](https://github.com/user-attachments/assets/c51ec9f4-ccfe-4960-b806-3ebc5b96e9d8)

After:
![anki](https://github.com/user-attachments/assets/314930e5-73de-44f5-ad59-436b7b9c3dc5)


Yes, one can barely see the difference. I'd prefer having a better distinction between rows or some way to make it more obvious which row elements belong to each other. But I don't know how to achieve that, while still having some aesthetics.