### PR TITLE
Fix #3335: Implement shared menu bar for macOS

### DIFF
--- a/qt/aqt/addcards.py
+++ b/qt/aqt/addcards.py
@@ -57,12 +57,11 @@ class AddCards(QMainWindow):
         gui_hooks.operation_did_execute.append(self.on_operation_did_execute)
         restoreGeom(self, "add")
         gui_hooks.add_cards_did_init(self)
-        if not is_mac:
+        if is_mac:
+            self.setMenuBar(mw.shared_menubar)
+        else:
             self.setMenuBar(None)
         self.show()
-
-    def set_deck(self, deck_id: DeckId) -> None:
-        self.deck_chooser.selected_deck_id = deck_id
 
     def set_note_type(self, note_type_id: NotetypeId) -> None:
         self.notetype_chooser.selected_notetype_id = note_type_id

--- a/qt/aqt/main.py
+++ b/qt/aqt/main.py
@@ -16,6 +16,8 @@ from collections.abc import Callable, Sequence
 from concurrent.futures import Future
 from typing import Any, Literal, TypeVar, cast
 
+import PyQt6.QtWidgets as QtWidgets
+
 import anki
 import anki.cards
 import anki.sound
@@ -92,7 +94,7 @@ from aqt.utils import (
     showWarning,
     tooltip,
     tr,
-)
+    )
 from aqt.webview import AnkiWebView, AnkiWebViewKind
 
 install_pylib_legacy()
@@ -983,6 +985,24 @@ title="{}" {}>{}</button>""".format(
                 webview.force_load_hack()
 
         gui_hooks.card_review_webview_did_init(self.web, AnkiWebViewKind.MAIN)
+
+        if is_mac:
+            designed_menubar = self.menuBar()
+            self.shared_menubar = QtWidgets.QMenuBar(None)
+
+            # Copy all menus and actions
+            for action in designed_menubar.actions():
+                if action.menu():  # If it's a menu
+                    new_menu = self.shared_menubar.addMenu(action.text())
+                    # Copy all actions in this menu
+                    for sub_action in action.menu().actions():
+                        new_menu.addAction(sub_action)
+                else:  # If it's a direct action
+                    self.shared_menubar.addAction(action)
+
+            self.setMenuBar(self.shared_menubar)
+
+        self.setMenuBar(self.shared_menubar)
 
     def closeAllWindows(self, onsuccess: Callable) -> None:
         aqt.dialogs.closeAll(onsuccess)


### PR DESCRIPTION
This commit addresses issue #3335 by implementing a shared menu bar for macOS:

- Create a shared menu bar in the main window that can be used by child windows
- Change Add Cards dialog to use the shared menu bar on macOS

As menus in Qt also control keyboard shortcuts we can also use cmd+z now to undo from the add cards dialog