### PR TITLE
Improve performance of card rendering parser

### DIFF
--- a/rslib/src/card_rendering/mod.rs
+++ b/rslib/src/card_rendering/mod.rs
@@ -33,24 +33,24 @@ pub fn prettify_av_tags<S: Into<String> + AsRef<str>>(txt: S) -> String {
 }
 
 /// Parse `txt` into [CardNodes] and return the result,
-/// or [None] if it is only a text node.
+/// or [None] if it only contains text nodes.
 fn nodes_or_text_only(txt: &str) -> Option<CardNodes> {
     let nodes = CardNodes::parse(txt);
-    match nodes.0[..] {
-        [Node::Text(_)] => None,
-        _ => Some(nodes),
-    }
+    (!nodes.text_only).then_some(nodes)
 }
 
 #[derive(Debug, PartialEq)]
-struct CardNodes<'a>(Vec<Node<'a>>);
+struct CardNodes<'a> {
+    nodes: Vec<Node<'a>>,
+    text_only: bool,
+}
 
 impl<'iter, 'nodes> IntoIterator for &'iter CardNodes<'nodes> {
     type Item = &'iter Node<'nodes>;
     type IntoIter = std::slice::Iter<'iter, Node<'nodes>>;
 
     fn into_iter(self) -> Self::IntoIter {
-        self.0.iter()
+        self.nodes.iter()
     }
 }
 

--- a/rslib/src/card_rendering/parser.rs
+++ b/rslib/src/card_rendering/parser.rs
@@ -34,12 +34,14 @@ type IResult<'a, O> = nom::IResult<&'a str, O>;
 impl<'a> CardNodes<'a> {
     pub(super) fn parse(mut txt: &'a str) -> Self {
         let mut nodes = Vec::new();
+        let mut text_only = true;
         while let Ok((remaining, node)) = node(txt) {
+            text_only &= matches!(node, Node::Text(_));
             txt = remaining;
             nodes.push(node);
         }
 
-        Self(nodes)
+        Self { nodes, text_only }
     }
 }
 

--- a/rslib/src/card_rendering/parser.rs
+++ b/rslib/src/card_rendering/parser.rs
@@ -217,6 +217,15 @@ mod test {
             Text("[anki:foo]"),
             Text("[/anki:bar]")
         );
+        assert_parsed_nodes!(
+            "abc[anki:foo]def[/anki:bar]ghi][[anki:bar][",
+            Text("abc"),
+            Text("[anki:foo]def"),
+            Text("[/anki:bar]ghi]"),
+            Text("["),
+            Text("[anki:bar]"),
+            Text("[")
+        );
 
         // sound
         assert_parsed_nodes!("[sound:foo]", SoundOrVideo("foo"));
@@ -238,6 +247,14 @@ mod test {
             Directive(super::Directive::Other(OtherDirective {
                 name: "foo",
                 content: "bar",
+                options: HashMap::new()
+            }))
+        );
+        assert_parsed_nodes!(
+            "[anki:foo]]bar[[/anki:foo]",
+            Directive(super::Directive::Other(OtherDirective {
+                name: "foo",
+                content: "]bar[",
                 options: HashMap::new()
             }))
         );

--- a/rslib/src/card_rendering/parser.rs
+++ b/rslib/src/card_rendering/parser.rs
@@ -196,7 +196,7 @@ mod test {
 
     macro_rules! assert_parsed_nodes {
         ($txt:expr $(, $node:expr)*) => {
-            assert_eq!(CardNodes::parse($txt), CardNodes(vec![$($node),*]));
+            assert_eq!(CardNodes::parse($txt).nodes, vec![$($node),*]);
         }
     }
 
@@ -211,8 +211,12 @@ mod test {
         assert_parsed_nodes!("foo", Text("foo"));
         // broken sound/tags are just text as well
         assert_parsed_nodes!("[sound:]", Text("[sound:]"));
-        assert_parsed_nodes!("[anki:][/anki:]", Text("[anki:][/anki:]"));
-        assert_parsed_nodes!("[anki:foo][/anki:bar]", Text("[anki:foo][/anki:bar]"));
+        assert_parsed_nodes!("[anki:][/anki:]", Text("[anki:]"), Text("[/anki:]"));
+        assert_parsed_nodes!(
+            "[anki:foo][/anki:bar]",
+            Text("[anki:foo]"),
+            Text("[/anki:bar]")
+        );
 
         // sound
         assert_parsed_nodes!("[sound:foo]", SoundOrVideo("foo"));

--- a/rslib/src/cloze.rs
+++ b/rslib/src/cloze.rs
@@ -159,7 +159,7 @@ fn parse_text_with_clozes(text: &str) -> Vec<TextOrCloze<'_>> {
     for token in tokenize(text) {
         match token {
             Token::OpenCloze(ordinal) => {
-                if open_clozes.len() < 8 {
+                if open_clozes.len() < 10 {
                     open_clozes.push(ExtractedCloze {
                         ordinal,
                         nodes: Vec::with_capacity(1), // common case


### PR DESCRIPTION
> This huge html chunk slowes down extract_av_tags to a crawl and crashes anki.
#3189

Looked into why this was happening, seems to be the `recognize(manyX(pair(not(<parser>)), anychar)))` pattern, which calls `<parser>` on every single character. This was fine in 2021, but after #1968 and #2141, cards with deeply nested clozes commonly result in extremely bloated* inputs that it can't handle fast enough

The speedup is mainly realised by making use of memchr to skip ahead to occurences of `[`, a prefix of tags. Also, when nested within `recognize`, `manyX` needlessly allocates a vec, populates it per character and then throws it away. This pr removes that from `text_node` and `closing_parser` as well

Benchmarking with `rslib/bench.sh`, using the [deeply nested malformed cloze example](https://forums.ankiweb.net/t/memory-leak-when-search-specific-kanji-japanese-hieroglyph/44394/2)**, before and after:
```:
anki_tag_parse          time:   [85.267 µs 85.434 µs 85.645 µs]

anki_tag_parse          time:   [345.20 ns 346.54 ns 348.72 ns]
                        change: [-99.596% -99.594% -99.591%] (p = 0.00 < 0.05)
                        Performance has improved.
```
Where this appears to shine: was able to raise the nested cloze limit from 8 to 10 and open up the preview of the abovementioned malformed example without anki complaining of a blocked main thread (pre-pr: ~3.5s stall on my machine, a >94% speedup)

I can't see any breakage resulting from this. Only the internal representation was changed, i.e. consecutive text nodes are now possible, which shouldn't result in changes to the syntax this parser admits. Tested with decks that use sound and tts tags

*the mentioned malformed example gets blown up to 3mb when passed to the parser
**before (nested) cloze metadata gets added to it