### PR TITLE
Modify card rendering output to specify if rendered card is empty

### DIFF
--- a/proto/anki/card_rendering.proto
+++ b/proto/anki/card_rendering.proto
@@ -127,6 +127,7 @@ message RenderCardResponse {
   repeated RenderedTemplateNode answer_nodes = 2;
   string css = 3;
   bool latex_svg = 4;
+  bool is_empty = 5;
 }
 
 message RenderedTemplateNode {

--- a/pylib/anki/template.py
+++ b/pylib/anki/template.py
@@ -60,6 +60,7 @@ class PartiallyRenderedCard:
     anodes: TemplateReplacementList
     css: str
     latex_svg: bool
+    is_empty: bool
 
     @classmethod
     def from_proto(
@@ -68,7 +69,9 @@ class PartiallyRenderedCard:
         qnodes = cls.nodes_from_proto(out.question_nodes)
         anodes = cls.nodes_from_proto(out.answer_nodes)
 
-        return PartiallyRenderedCard(qnodes, anodes, out.css, out.latex_svg)
+        return PartiallyRenderedCard(
+            qnodes, anodes, out.css, out.latex_svg, out.is_empty
+        )
 
     @staticmethod
     def nodes_from_proto(

--- a/rslib/src/card_rendering/service.rs
+++ b/rslib/src/card_rendering/service.rs
@@ -219,6 +219,7 @@ impl From<RenderCardOutput> for anki_proto::card_rendering::RenderCardResponse {
             answer_nodes: rendered_nodes_to_proto(o.anodes),
             css: o.css,
             latex_svg: o.latex_svg,
+            is_empty: o.is_empty,
         }
     }
 }

--- a/rslib/src/notetype/render.rs
+++ b/rslib/src/notetype/render.rs
@@ -20,6 +20,7 @@ pub struct RenderCardOutput {
     pub anodes: Vec<RenderedNode>,
     pub css: String,
     pub latex_svg: bool,
+    pub is_empty: bool,
 }
 
 impl RenderCardOutput {
@@ -136,7 +137,7 @@ impl Collection {
             )
         };
 
-        let (qnodes, anodes) = render_card(RenderCardRequest {
+        let (qnodes, anodes, is_empty) = render_card(RenderCardRequest {
             qfmt,
             afmt,
             field_map: &field_map,
@@ -151,6 +152,7 @@ impl Collection {
             anodes,
             css: nt.config.css.clone(),
             latex_svg: nt.config.latex_svg,
+            is_empty,
         })
     }
 

--- a/rslib/src/notetype/render.rs
+++ b/rslib/src/notetype/render.rs
@@ -137,7 +137,7 @@ impl Collection {
             )
         };
 
-        let (qnodes, anodes, is_empty) = render_card(RenderCardRequest {
+        let response = render_card(RenderCardRequest {
             qfmt,
             afmt,
             field_map: &field_map,
@@ -148,11 +148,11 @@ impl Collection {
             partial_render,
         })?;
         Ok(RenderCardOutput {
-            qnodes,
-            anodes,
+            qnodes: response.qnodes,
+            anodes: response.anodes,
             css: nt.config.css.clone(),
             latex_svg: nt.config.latex_svg,
-            is_empty,
+            is_empty: response.is_empty,
         })
     }
 

--- a/rslib/src/template.rs
+++ b/rslib/src/template.rs
@@ -1339,13 +1339,14 @@ mod test {
             tr: &tr,
             partial_render: true,
         };
-        let qnodes = super::render_card(req.clone()).unwrap().0;
+        let (qnodes, _, is_empty) = super::render_card(req.clone()).unwrap();
         assert_eq!(
             qnodes[0],
             FN::Text {
                 text: "test".into()
             }
         );
+        assert!(is_empty);
         if let FN::Text { ref text } = qnodes[1] {
             assert!(text.contains("card is blank"));
         } else {
@@ -1355,7 +1356,7 @@ mod test {
         // a popular card template expects {{FrontSide}} to resolve to an empty
         // string on the front side :-(
         req.qfmt = "{{FrontSide}}{{N}}";
-        let qnodes = super::render_card(req.clone()).unwrap().0;
+        let (qnodes, _, is_empty) = super::render_card(req.clone()).unwrap();
         assert_eq!(
             &qnodes,
             &[
@@ -1367,8 +1368,10 @@ mod test {
                 FN::Text { text: "N".into() }
             ]
         );
+        assert!(!is_empty);
         req.partial_render = false;
-        let qnodes = super::render_card(req.clone()).unwrap().0;
+        let (qnodes, _, is_empty) = super::render_card(req.clone()).unwrap();
         assert_eq!(&qnodes, &[FN::Text { text: "N".into() }]);
+        assert!(!is_empty);
     }
 }

--- a/rslib/src/template.rs
+++ b/rslib/src/template.rs
@@ -592,6 +592,7 @@ pub struct RenderCardRequest<'a> {
     pub partial_render: bool,
 }
 
+/// Returns `(qnodes, anodes, is_empty)`
 pub fn render_card(
     RenderCardRequest {
         qfmt,
@@ -603,7 +604,7 @@ pub fn render_card(
         tr,
         partial_render: partial_for_python,
     }: RenderCardRequest<'_>,
-) -> Result<(Vec<RenderedNode>, Vec<RenderedNode>)> {
+) -> Result<(Vec<RenderedNode>, Vec<RenderedNode>, bool)> {
     // prepare context
     let mut context = RenderContext {
         fields: field_map,
@@ -638,7 +639,7 @@ pub fn render_card(
     };
     if let Some(text) = empty_message {
         qnodes.push(RenderedNode::Text { text: text.clone() });
-        return Ok((qnodes, vec![RenderedNode::Text { text }]));
+        return Ok((qnodes, vec![RenderedNode::Text { text }], true));
     }
 
     // answer side
@@ -654,7 +655,7 @@ pub fn render_card(
         .and_then(|tmpl| tmpl.render(&context, tr))
         .map_err(|e| template_error_to_anki_error(e, false, browser, tr))?;
 
-    Ok((qnodes, anodes))
+    Ok((qnodes, anodes, false))
 }
 
 fn cloze_is_empty(field_map: &HashMap<&str, Cow<str>>, card_ord: u16) -> bool {


### PR DESCRIPTION
Closes #3889

There currently isn't an easy and accurate way to tell if a rendered card is empty. In rslib, a test checks for the "card is blank" substring, whereas in ankidroid:
> An AnkiDroid feature that marks previewer tabs with a warning badge if they are empty is therefore forced to check for the presence of the doc page link in the rendered card text, which is kind of a hacky frontend fix

This pr proposes to modify the card rendering output to return a flag indicating if the card was empty (missing cloze or empty front), replacing the need for flaky substring matching

Breakage: 
- Mobile clients
They may need to account for the extra field in `RenderCardResponse`. Similar to c731c77c12cd8f268091effde472555544252a3f, ankidroid might have to update https://github.com/ankidroid/Anki-Android/blob/5726c433ba269dbde5a9caa93cac0c0174c0d37b/AnkiDroid/src/main/java/com/ichi2/libanki/TemplateManager.kt#L61 to begin to make use of it
- Addons
c731c77c12cd8f268091effde472555544252a3f changes the `PartiallyRenderedCard` class by adding a field. As it stands i'm not sure if this would break any existing addons, but it does not seem likely