### PR TITLE
style: add shadow to graph tooltip

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -218,6 +218,7 @@ Thomas Graves <fate@hey.com>
 Jakub Fidler <jakub.fidler@protonmail.com>
 Valerie Enfys <val@unidentified.systems>
 Julien Chol <https://github.com/chel-ou>
+ikkz <ylei.mk@gmail.com>
 
 ********************
 

--- a/ts/routes/graphs/Tooltip.svelte
+++ b/ts/routes/graphs/Tooltip.svelte
@@ -53,6 +53,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         transition: opacity var(--transition);
         color: var(--fg);
         background: var(--canvas-overlay);
+        box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
 
         :global(table) {
             border-spacing: 1em 0;


### PR DESCRIPTION
This pr add shadow to graph tooltip to improve ui

### Before
<img width="293" alt="截屏2025-03-28 14 05 18" src="https://github.com/user-attachments/assets/efa7dd8b-c7b3-4739-a758-6d7b04570c56" />

### After
<img width="334" alt="截屏2025-03-28 14 04 28" src="https://github.com/user-attachments/assets/04127393-31cf-4c9b-bf59-7d3d6a6265ea" />
<img width="341" alt="截屏2025-03-28 14 03 49" src="https://github.com/user-attachments/assets/c5a9fa2e-3633-4937-b1b7-e72e0c718dfd" />
