### PR TITLE
style: use consistent input styles in deck options

### DIFF
--- a/ts/routes/deck-options/DateInput.svelte
+++ b/ts/routes/deck-options/DateInput.svelte
@@ -29,6 +29,10 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         width: 100%;
         -webkit-appearance: none;
         appearance: none;
-        height: 1.5em;
+        background: var(--canvas-inset);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
+        padding: 1px 0.5em;
+        outline: none !important;
     }
 </style>


### PR DESCRIPTION
### Before:
<img width="1262" alt="截屏2025-03-31 21 06 43" src="https://github.com/user-attachments/assets/7d733e2a-8c16-446d-9ede-bcefc9e633f2" />

### After
<img width="1233" alt="截屏2025-03-31 21 05 55" src="https://github.com/user-attachments/assets/57d23420-dca8-4a8e-b218-2602594c9f15" />
<img width="1235" alt="截屏2025-03-31 21 06 09" src="https://github.com/user-attachments/assets/e5fc86e1-460c-47e1-8248-9ee2a0370e55" />
