### PR TITLE
Fix coloring of table cells

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -219,6 +219,7 @@ Jakub Fidler <jakub.fidler@protonmail.com>
 Valerie Enfys <val@unidentified.systems>
 Julien Chol <https://github.com/chel-ou>
 ikkz <ylei.mk@gmail.com>
+bilbofroggins <pjcfifa@gmail.com>
 
 ********************
 

--- a/ts/lib/domlib/surround/flat-range.ts
+++ b/ts/lib/domlib/surround/flat-range.ts
@@ -66,13 +66,19 @@ export class FlatRange {
         range.setStart(this.parent, this.startIndex);
         range.setEnd(this.parent, this.endIndex);
 
-        if (range.collapsed) {
-            // If the range is collapsed to a single element, move the range inside the element.
-            // This prevents putting the surround above the base element.
-            const selected = range.commonAncestorContainer.childNodes[range.startOffset];
+        // If the range encompasses exactly one child node
+        if (this.endIndex - this.startIndex === 1) {
+            const selected = this.parent.childNodes[this.startIndex];
 
             if (nodeIsElement(selected)) {
-                range.selectNode(selected);
+                if (selected.textContent && selected.textContent.trim().length > 0) {
+                    range.selectNodeContents(selected);
+                    return range;
+                }
+
+                if (range.collapsed) {
+                    range.selectNode(selected);
+                }
             }
         }
 


### PR DESCRIPTION
To fix issue: https://github.com/ankitects/anki/issues/3073

- Improve text selection and highlighting in table cells by correctly handling range selection for nodes with content.
- Fix an issue where surroundContents() would not properly handle table cells with text content.
- There is still an issue that selecting the entire table or entire rows will put the empty span before the table but that seems like you'd need special code for table handling

Testing:

- Selection works correctly in table cells
- Empty selections still work
- Non table text and div/p tags still work