### PR TITLE
Changed minimum value of DR

### DIFF
--- a/rslib/src/deckconfig/mod.rs
+++ b/rslib/src/deckconfig/mod.rs
@@ -293,14 +293,14 @@ pub(crate) fn ensure_deck_config_values_valid(config: &mut DeckConfigInner) {
     ensure_f32_valid(
         &mut config.desired_retention,
         default.desired_retention,
-        0.7,
+        0.75,
         0.99,
     );
     ensure_f32_valid(
         &mut config.historical_retention,
         default.historical_retention,
-        0.7,
-        0.97,
+        0.5,
+        0.99,
     )
 }
 

--- a/ts/routes/deck-options/FsrsOptions.svelte
+++ b/ts/routes/deck-options/FsrsOptions.svelte
@@ -103,9 +103,9 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     }
 
     function getRetentionWarningClass(retention: number): string {
-        if (retention < 0.7 || retention > 0.97) {
+        if (retention < 0.75 || retention > 0.97) {
             return "alert-danger";
-        } else if (retention < 0.8 || retention > 0.95) {
+        } else if (retention < 0.85 || retention > 0.95) {
             return "alert-warning";
         } else {
             return "alert-info";
@@ -309,7 +309,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 <SpinBoxFloatRow
     bind:value={$config.desiredRetention}
     defaultValue={defaults.desiredRetention}
-    min={0.7}
+    min={0.75}
     max={0.99}
     percentage={true}
 >

--- a/ts/routes/deck-options/SimulatorModal.svelte
+++ b/ts/routes/deck-options/SimulatorModal.svelte
@@ -214,7 +214,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
                 <SpinBoxFloatRow
                     bind:value={simulateFsrsRequest.desiredRetention}
                     defaultValue={$config.desiredRetention}
-                    min={0.7}
+                    min={0.75}
                     max={0.99}
                     percentage={true}
                 >


### PR DESCRIPTION
And also of historical retention, it was too limited for some reason.

In [FSRS-6](https://github.com/open-spaced-repetition/fsrs-optimizer/pull/169/commits/c1f2402c2dc8952da4ff8d33a07319de571755a4) the curve will become flatter. Again. This is the last time this happens, we promise 😅.
Anyway, flatter curve means longer intervals. So in order to make sure that users don't run away from FSRS after being scared by long intervals, I think it's worth it to increase minimum DR. With the new curve, the intervals at DR=75.5% roughly correspond to intervals at DR=70% with the old curve, so I raised the minimum to 75%. This way the intervals in the new version of Anki with FSRS-6 won't be longer than before.

Slightly unrelated, but Dae, I want you to take a look at this idea regarding the UI and how we convey what DR does: https://forums.ankiweb.net/t/desired-retention-ui-overhaul/57678/33?u=expertium

And the proposal to change _default_ DR to 95%: https://forums.ankiweb.net/t/thoughts-on-changing-default-desired-retention-to-95/58273?u=expertium

@L-M-Sherlock 