### PR TITLE
Improve natural unit conversion for a time b/w 360 to 365 days

### DIFF
--- a/pylib/tests/test_schedv3.py
+++ b/pylib/tests/test_schedv3.py
@@ -537,7 +537,7 @@ def test_nextIvl():
     assert ni(c, 3) == 21600000
     # (* 100 2.5 1.3 86400)28080000.0
     assert ni(c, 4) == 28080000
-    assert without_unicode_isolation(col.sched.nextIvlStr(c, 4)) == "10.8mo"
+    assert without_unicode_isolation(col.sched.nextIvlStr(c, 4)) == "10.7mo"
 
 
 def test_bury():

--- a/rslib/src/scheduler/timespan.rs
+++ b/rslib/src/scheduler/timespan.rs
@@ -151,7 +151,7 @@ impl Timespan {
             TimespanUnit::Hours
         } else if secs < MONTH {
             TimespanUnit::Days
-        } else if secs < YEAR {
+        } else if secs < 12.0 * MONTH {
             TimespanUnit::Months
         } else {
             TimespanUnit::Years
@@ -188,6 +188,8 @@ mod test {
         assert_eq!(time_span(30.3, &tr, true), "30.3 seconds");
         assert_eq!(time_span(90.0, &tr, false), "1.5 minutes");
         assert_eq!(time_span(45.0 * 86_400.0, &tr, false), "1.5 months");
+        assert_eq!(time_span(360.0 * 86_400.0, &tr, false), "1 year");
+        assert_eq!(time_span(365.0 * 86_400.0, &tr, false), "1 year");
         assert_eq!(time_span(365.0 * 86_400.0 * 1.5, &tr, false), "1.5 years");
     }
 }

--- a/rslib/src/scheduler/timespan.rs
+++ b/rslib/src/scheduler/timespan.rs
@@ -57,7 +57,7 @@ const SECOND: f32 = 1.0;
 const MINUTE: f32 = 60.0 * SECOND;
 const HOUR: f32 = 60.0 * MINUTE;
 const DAY: f32 = 24.0 * HOUR;
-const MONTH: f32 = 30.0 * DAY;
+const MONTH: f32 = 30.417 * DAY; // 365/12 ≈ 30.417
 const YEAR: f32 = 365.0 * DAY;
 
 #[derive(Clone, Copy)]
@@ -151,7 +151,7 @@ impl Timespan {
             TimespanUnit::Hours
         } else if secs < MONTH {
             TimespanUnit::Days
-        } else if secs < 12.0 * MONTH {
+        } else if secs < YEAR {
             TimespanUnit::Months
         } else {
             TimespanUnit::Years
@@ -188,8 +188,9 @@ mod test {
         assert_eq!(time_span(30.3, &tr, true), "30.3 seconds");
         assert_eq!(time_span(90.0, &tr, false), "1.5 minutes");
         assert_eq!(time_span(45.0 * 86_400.0, &tr, false), "1.5 months");
-        assert_eq!(time_span(360.0 * 86_400.0, &tr, false), "1 year");
-        assert_eq!(time_span(363.0 * 86_400.0, &tr, false), "1 year");
+        assert_eq!(time_span(364.0 * 86_400.0, &tr, false), "12 months");
+        assert_eq!(time_span(364.0 * 86_400.0, &tr, true), "11.97 months");
+        assert_eq!(time_span(365.0 * 86_400.0, &tr, false), "1 year");
         assert_eq!(time_span(365.0 * 86_400.0, &tr, true), "1 year");
         assert_eq!(time_span(365.0 * 86_400.0 * 1.5, &tr, false), "1.5 years");
     }

--- a/rslib/src/scheduler/timespan.rs
+++ b/rslib/src/scheduler/timespan.rs
@@ -189,7 +189,7 @@ mod test {
         assert_eq!(time_span(90.0, &tr, false), "1.5 minutes");
         assert_eq!(time_span(45.0 * 86_400.0, &tr, false), "1.5 months");
         assert_eq!(time_span(360.0 * 86_400.0, &tr, false), "1 year");
-        assert_eq!(time_span(365.0 * 86_400.0, &tr, false), "1 year");
+        assert_eq!(time_span(365.0 * 86_400.0, &tr, true), "1 year");
         assert_eq!(time_span(365.0 * 86_400.0 * 1.5, &tr, false), "1.5 years");
     }
 }

--- a/rslib/src/scheduler/timespan.rs
+++ b/rslib/src/scheduler/timespan.rs
@@ -189,6 +189,7 @@ mod test {
         assert_eq!(time_span(90.0, &tr, false), "1.5 minutes");
         assert_eq!(time_span(45.0 * 86_400.0, &tr, false), "1.5 months");
         assert_eq!(time_span(360.0 * 86_400.0, &tr, false), "1 year");
+        assert_eq!(time_span(363.0 * 86_400.0, &tr, false), "1 year");
         assert_eq!(time_span(365.0 * 86_400.0, &tr, true), "1 year");
         assert_eq!(time_span(365.0 * 86_400.0 * 1.5, &tr, false), "1.5 years");
     }

--- a/ts/lib/tslib/time.test.ts
+++ b/ts/lib/tslib/time.test.ts
@@ -12,7 +12,7 @@ test("natural unit", () => {
     expect(naturalUnit(60 * 60 - 1)).toBe(TimespanUnit.Minutes);
     expect(naturalUnit(60 * 60)).toBe(TimespanUnit.Hours);
     expect(naturalUnit(60 * 60 * 24)).toBe(TimespanUnit.Days);
-    expect(naturalUnit(60 * 60 * 24 * 30)).toBe(TimespanUnit.Months);
+    expect(naturalUnit(60 * 60 * 24 * 31)).toBe(TimespanUnit.Months);
 });
 
 test("natural whole unit", () => {

--- a/ts/lib/tslib/time.ts
+++ b/ts/lib/tslib/time.ts
@@ -7,7 +7,7 @@ export const SECOND = 1.0;
 export const MINUTE = 60.0 * SECOND;
 export const HOUR = 60.0 * MINUTE;
 export const DAY = 24.0 * HOUR;
-export const MONTH = 30.0 * DAY;
+export const MONTH = 30.417 * DAY; // 365/12 ≈ 30.417
 export const YEAR = 365.0 * DAY;
 
 export enum TimespanUnit {
@@ -46,7 +46,7 @@ export function naturalUnit(secs: number): TimespanUnit {
         return TimespanUnit.Hours;
     } else if (secs < MONTH) {
         return TimespanUnit.Days;
-    } else if (secs < 12.0 * MONTH) {
+    } else if (secs < YEAR) {
         return TimespanUnit.Months;
     } else {
         return TimespanUnit.Years;

--- a/ts/lib/tslib/time.ts
+++ b/ts/lib/tslib/time.ts
@@ -8,7 +8,7 @@ export const MINUTE = 60.0 * SECOND;
 export const HOUR = 60.0 * MINUTE;
 export const DAY = 24.0 * HOUR;
 export const MONTH = 30.0 * DAY;
-export const YEAR = 12.0 * MONTH;
+export const YEAR = 365.0 * DAY;
 
 export enum TimespanUnit {
     Seconds,
@@ -46,7 +46,7 @@ export function naturalUnit(secs: number): TimespanUnit {
         return TimespanUnit.Hours;
     } else if (secs < MONTH) {
         return TimespanUnit.Days;
-    } else if (secs < YEAR) {
+    } else if (secs < 12.0 * MONTH) {
         return TimespanUnit.Months;
     } else {
         return TimespanUnit.Years;


### PR DESCRIPTION
Previously, 363 days would be converted to 12.1 months, which is quite confusing because
- a user would think that if the value is more than 12 months, why it isn't displayed in years
- the value is actually less than a year, which is counterintuitive as 12.1 m suggests a value more than a year.