### PR TITLE
Allow drag-dropping into plaintext editor

### DIFF
--- a/ts/editor/EditorField.svelte
+++ b/ts/editor/EditorField.svelte
@@ -60,6 +60,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     export let collapsed = false;
     export let flipInputs = false;
     export let dupe = false;
+    export let index;
 
     const directionStore = writable<"ltr" | "rtl">();
     setContext(directionKey, directionStore);
@@ -95,6 +96,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     on:mouseenter
     on:mouseleave
     role="presentation"
+    data-index={index}
 >
     <slot name="field-label" />
 

--- a/ts/editor/NoteEditor.svelte
+++ b/ts/editor/NoteEditor.svelte
@@ -45,6 +45,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     import { bridgeCommand } from "@tslib/bridgecommand";
     import { onMount, tick } from "svelte";
     import { get, writable } from "svelte/store";
+    import { nodeIsCommonElement } from "@tslib/dom";
 
     import Absolute from "$lib/components/Absolute.svelte";
     import Badge from "$lib/components/Badge.svelte";
@@ -322,15 +323,25 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
     export function focusIfField(x: number, y: number): boolean {
         const elements = document.elementsFromPoint(x, y);
-        const first = elements[0];
+        const first = elements[0].closest(".field-container");
 
-        if (first.shadowRoot) {
-            const richTextInput = first.shadowRoot.lastElementChild! as HTMLElement;
-            richTextInput.focus();
-            return true;
+        if (!first || !nodeIsCommonElement(first)) {
+            return false;
         }
 
-        return false;
+        const index = parseInt(first.dataset?.index ?? "");
+
+        if (Number.isNaN(index) || !fields[index] || fieldsCollapsed[index]) {
+            return false;
+        }
+
+        if (richTextsHidden[index]) {
+            toggleRichTextInput(index);
+        } else {
+            richTextInputs[index].api.refocus();
+        }
+
+        return true;
     }
 
     let richTextInputs: RichTextInput[] = [];

--- a/ts/editor/NoteEditor.svelte
+++ b/ts/editor/NoteEditor.svelte
@@ -668,6 +668,7 @@ the AddCards dialog) should be implemented in the user of this component.
                 <EditorField
                     {field}
                     {content}
+                    {index}
                     flipInputs={plainTextDefaults[index]}
                     api={fields[index]}
                     on:focusin={() => {


### PR DESCRIPTION
It's not currently possible to drag/drop anything into a field's plaintext editor, text or otherwise, which is inconvenient for several reasons:
- When the field is set to "Use HTML editor by default", users have to manually uncollapse the richtext editor and only then drag/drop into that instead
- When the field's editing font size causes the richtext editor to be dwarfed by its plaintext counterpart, there's little leeway when aiming
- When (fellow 😅) anki recolor users set it up in such a way that it's hard to see where the richtext editor ends and the plaintext one begins

This pr proposes to allow dragging and dropping over a field's container, instead of just the richtext editor. This impl has several quirks:
1. The field containers extend beyond the inputs, which seems like a plus given that one of the gripes is it needing to be overly precise
![430796580-5c4014c5-0684-4555-99da-79a1b13b626b](https://github.com/user-attachments/assets/04a64438-fe5d-43d6-93f1-568934009f55)
2. When the field uses the plaintext editor by default, this impl uncollapses and focusses the richtext editor to allow the content to be inserted
This is necessary given the way [`pasteHTML`](https://github.com/ankitects/anki/blob/ccab18b7ba624d888f3d881e14f04c830e3eaa44/ts/editor/old-editor-adapter.ts#L17) currently works. Considering the happy path being drag/dropping multimedia elements, showing the richtext editor doesn't seem too cumbersome. It *could* be seen as annoying when text is drag/dropped, but as mentioned, users currently need to manually uncollapse the richtext editor as it is