### PR TITLE
Add Cmd+W close shortcut (on Mac) to more dialogs

### DIFF
--- a/qt/aqt/addons.py
+++ b/qt/aqt/addons.py
@@ -40,7 +40,7 @@ from aqt import gui_hooks
 from aqt.log import ADDON_LOGGER_PREFIX, find_addon_logger, get_addon_logs_folder
 from aqt.qt import *
 from aqt.utils import (
-    addCloseShortcut,
+    add_close_shortcut,
     askUser,
     disable_help_button,
     getFile,
@@ -829,7 +829,7 @@ class AddonsDialog(QDialog):
         self.setAcceptDrops(True)
         self.redrawAddons()
         restoreGeom(self, "addons")
-        addCloseShortcut(self)
+        add_close_shortcut(self)
         gui_hooks.addons_dialog_will_show(self)
         self._onAddonSelectionChanged()
         self.show()

--- a/qt/aqt/browser/browser.py
+++ b/qt/aqt/browser/browser.py
@@ -58,6 +58,7 @@ from aqt.utils import (
     HelpPage,
     KeyboardModifiersPressed,
     add_ellipsis_to_action_label,
+    addCloseShortcut,
     current_window,
     ensure_editor_saved,
     getTag,
@@ -1092,6 +1093,7 @@ class Browser(QMainWindow):
         dialog.setWindowTitle(tr.actions_grade_now())
         layout = QHBoxLayout()
         dialog.setLayout(layout)
+        addCloseShortcut(dialog)
 
         # Add grade buttons
         for ease, label in [

--- a/qt/aqt/browser/browser.py
+++ b/qt/aqt/browser/browser.py
@@ -57,8 +57,8 @@ from aqt.undo import UndoActionsInfo
 from aqt.utils import (
     HelpPage,
     KeyboardModifiersPressed,
+    add_close_shortcut,
     add_ellipsis_to_action_label,
-    addCloseShortcut,
     current_window,
     ensure_editor_saved,
     getTag,
@@ -1093,7 +1093,7 @@ class Browser(QMainWindow):
         dialog.setWindowTitle(tr.actions_grade_now())
         layout = QHBoxLayout()
         dialog.setLayout(layout)
-        addCloseShortcut(dialog)
+        add_close_shortcut(dialog)
 
         # Add grade buttons
         for ease, label in [

--- a/qt/aqt/browser/card_info.py
+++ b/qt/aqt/browser/card_info.py
@@ -14,7 +14,7 @@ from anki.errors import NotFoundError
 from anki.lang import without_unicode_isolation
 from aqt.qt import *
 from aqt.utils import (
-    addCloseShortcut,
+    add_close_shortcut,
     disable_help_button,
     qconnect,
     restoreGeom,
@@ -53,7 +53,7 @@ class CardInfoDialog(QDialog):
         self.mw.garbage_collect_on_dialog_finish(self)
         disable_help_button(self)
         restoreGeom(self, self.GEOMETRY_KEY, default_size=(800, 800))
-        addCloseShortcut(self)
+        add_close_shortcut(self)
         setWindowIcon(self)
 
         self.web: AnkiWebView | None = AnkiWebView(

--- a/qt/aqt/changenotetype.py
+++ b/qt/aqt/changenotetype.py
@@ -15,7 +15,7 @@ from anki.notes import NoteId
 from aqt.operations.notetype import change_notetype_of_notes
 from aqt.qt import *
 from aqt.utils import (
-    addCloseShortcut,
+    add_close_shortcut,
     disable_help_button,
     restoreGeom,
     saveGeom,
@@ -49,7 +49,7 @@ class ChangeNotetypeDialog(QDialog):
         self.setMinimumSize(400, 300)
         disable_help_button(self)
         restoreGeom(self, self.TITLE, default_size=(800, 800))
-        addCloseShortcut(self)
+        add_close_shortcut(self)
 
         self.web = AnkiWebView(kind=AnkiWebViewKind.CHANGE_NOTETYPE)
         self.web.setVisible(False)

--- a/qt/aqt/clayout.py
+++ b/qt/aqt/clayout.py
@@ -27,6 +27,7 @@ from aqt.sound import av_player, play_clicked_audio
 from aqt.theme import theme_manager
 from aqt.utils import (
     HelpPage,
+    addCloseShortcut,
     ask_user_dialog,
     askUser,
     disable_help_button,
@@ -90,6 +91,7 @@ class CardLayout(QDialog):
         gui_hooks.card_layout_will_show(self)
         self.redraw_everything()
         restoreGeom(self, "CardLayout")
+        addCloseShortcut(self)
         restoreSplitter(self.mainArea, "CardLayoutMainArea")
         self.setWindowModality(Qt.WindowModality.ApplicationModal)
         self.show()

--- a/qt/aqt/clayout.py
+++ b/qt/aqt/clayout.py
@@ -27,7 +27,7 @@ from aqt.sound import av_player, play_clicked_audio
 from aqt.theme import theme_manager
 from aqt.utils import (
     HelpPage,
-    addCloseShortcut,
+    add_close_shortcut,
     ask_user_dialog,
     askUser,
     disable_help_button,
@@ -91,7 +91,7 @@ class CardLayout(QDialog):
         gui_hooks.card_layout_will_show(self)
         self.redraw_everything()
         restoreGeom(self, "CardLayout")
-        addCloseShortcut(self)
+        add_close_shortcut(self)
         restoreSplitter(self.mainArea, "CardLayoutMainArea")
         self.setWindowModality(Qt.WindowModality.ApplicationModal)
         self.show()

--- a/qt/aqt/customstudy.py
+++ b/qt/aqt/customstudy.py
@@ -15,7 +15,7 @@ from aqt.operations import QueryOp
 from aqt.operations.scheduling import custom_study
 from aqt.qt import *
 from aqt.taglimit import TagLimit
-from aqt.utils import addCloseShortcut, disable_help_button, tr
+from aqt.utils import add_close_shortcut, disable_help_button, tr
 
 RADIO_NEW = 1
 RADIO_REV = 2
@@ -63,7 +63,7 @@ class CustomStudy(QDialog):
         self.form.setupUi(self)
         disable_help_button(self)
         self.setupSignals()
-        addCloseShortcut(self)
+        add_close_shortcut(self)
         self.form.radioNew.click()
         self.open()
 

--- a/qt/aqt/customstudy.py
+++ b/qt/aqt/customstudy.py
@@ -15,7 +15,7 @@ from aqt.operations import QueryOp
 from aqt.operations.scheduling import custom_study
 from aqt.qt import *
 from aqt.taglimit import TagLimit
-from aqt.utils import disable_help_button, tr
+from aqt.utils import addCloseShortcut, disable_help_button, tr
 
 RADIO_NEW = 1
 RADIO_REV = 2
@@ -63,6 +63,7 @@ class CustomStudy(QDialog):
         self.form.setupUi(self)
         disable_help_button(self)
         self.setupSignals()
+        addCloseShortcut(self)
         self.form.radioNew.click()
         self.open()
 

--- a/qt/aqt/deckdescription.py
+++ b/qt/aqt/deckdescription.py
@@ -10,7 +10,7 @@ from anki.decks import DeckDict
 from aqt.operations import QueryOp
 from aqt.operations.deck import update_deck_dict
 from aqt.qt import *
-from aqt.utils import addCloseShortcut, disable_help_button, restoreGeom, saveGeom, tr
+from aqt.utils import add_close_shortcut, disable_help_button, restoreGeom, saveGeom, tr
 
 
 class DeckDescriptionDialog(QDialog):
@@ -45,7 +45,7 @@ class DeckDescriptionDialog(QDialog):
         self.setMinimumWidth(400)
         disable_help_button(self)
         restoreGeom(self, self.TITLE)
-        addCloseShortcut(self)
+        add_close_shortcut(self)
 
         box = QVBoxLayout()
 

--- a/qt/aqt/deckoptions.py
+++ b/qt/aqt/deckoptions.py
@@ -13,7 +13,7 @@ from aqt import gui_hooks
 from aqt.qt import *
 from aqt.utils import (
     KeyboardModifiersPressed,
-    addCloseShortcut,
+    add_close_shortcut,
     disable_help_button,
     restoreGeom,
     saveGeom,
@@ -42,7 +42,7 @@ class DeckOptionsDialog(QDialog):
         self.setMinimumWidth(400)
         disable_help_button(self)
         restoreGeom(self, self.TITLE, default_size=(800, 800))
-        addCloseShortcut(self)
+        add_close_shortcut(self)
 
         self.web = AnkiWebView(kind=AnkiWebViewKind.DECK_OPTIONS)
         self.web.load_sveltekit_page(f"deck-options/{self._deck['id']}")

--- a/qt/aqt/editcurrent.py
+++ b/qt/aqt/editcurrent.py
@@ -9,7 +9,7 @@ from anki.collection import OpChanges
 from anki.errors import NotFoundError
 from aqt import gui_hooks
 from aqt.qt import *
-from aqt.utils import restoreGeom, saveGeom, tr
+from aqt.utils import add_close_shortcut, restoreGeom, saveGeom, tr
 
 
 class EditCurrent(QMainWindow):
@@ -36,6 +36,7 @@ class EditCurrent(QMainWindow):
         close_button = self.form.buttonBox.button(QDialogButtonBox.StandardButton.Close)
         assert close_button is not None
         close_button.setShortcut(QKeySequence("Ctrl+Return"))
+        add_close_shortcut(self)
         # qt5.14+ doesn't handle numpad enter on Windows
         self.compat_add_shorcut = QShortcut(QKeySequence("Ctrl+Enter"), self)
         qconnect(self.compat_add_shorcut.activated, close_button.click)

--- a/qt/aqt/exporting.py
+++ b/qt/aqt/exporting.py
@@ -19,7 +19,7 @@ from aqt import gui_hooks
 from aqt.errors import show_exception
 from aqt.qt import *
 from aqt.utils import (
-    addCloseShortcut,
+    add_close_shortcut,
     checkInvalidFilename,
     disable_help_button,
     getSaveFile,
@@ -47,7 +47,7 @@ class ExportDialog(QDialog):
         self.cids = cids
         disable_help_button(self)
         self.setup(did)
-        addCloseShortcut(self)
+        add_close_shortcut(self)
         self.exec()
 
     def setup(self, did: DeckId | None) -> None:

--- a/qt/aqt/exporting.py
+++ b/qt/aqt/exporting.py
@@ -19,6 +19,7 @@ from aqt import gui_hooks
 from aqt.errors import show_exception
 from aqt.qt import *
 from aqt.utils import (
+    addCloseShortcut,
     checkInvalidFilename,
     disable_help_button,
     getSaveFile,
@@ -46,6 +47,7 @@ class ExportDialog(QDialog):
         self.cids = cids
         disable_help_button(self)
         self.setup(did)
+        addCloseShortcut(self)
         self.exec()
 
     def setup(self, did: DeckId | None) -> None:

--- a/qt/aqt/fields.py
+++ b/qt/aqt/fields.py
@@ -15,6 +15,7 @@ from aqt.qt import *
 from aqt.schema_change_tracker import ChangeTracker
 from aqt.utils import (
     HelpPage,
+    addCloseShortcut,
     askUser,
     disable_help_button,
     getOnlyText,
@@ -50,6 +51,7 @@ class FieldDialog(QDialog):
             without_unicode_isolation(tr.fields_fields_for(val=self.model["name"]))
         )
 
+        addCloseShortcut(self)
         disable_help_button(self)
         help_button = self.form.buttonBox.button(QDialogButtonBox.StandardButton.Help)
         assert help_button is not None

--- a/qt/aqt/fields.py
+++ b/qt/aqt/fields.py
@@ -15,7 +15,7 @@ from aqt.qt import *
 from aqt.schema_change_tracker import ChangeTracker
 from aqt.utils import (
     HelpPage,
-    addCloseShortcut,
+    add_close_shortcut,
     askUser,
     disable_help_button,
     getOnlyText,
@@ -51,7 +51,7 @@ class FieldDialog(QDialog):
             without_unicode_isolation(tr.fields_fields_for(val=self.model["name"]))
         )
 
-        addCloseShortcut(self)
+        add_close_shortcut(self)
         disable_help_button(self)
         help_button = self.form.buttonBox.button(QDialogButtonBox.StandardButton.Help)
         assert help_button is not None

--- a/qt/aqt/import_export/exporting.py
+++ b/qt/aqt/import_export/exporting.py
@@ -27,7 +27,7 @@ from aqt.operations import QueryOp
 from aqt.progress import ProgressUpdate
 from aqt.qt import *
 from aqt.utils import (
-    addCloseShortcut,
+    add_close_shortcut,
     checkInvalidFilename,
     disable_help_button,
     getSaveFile,
@@ -54,7 +54,7 @@ class ExportDialog(QDialog):
         self.nids = nids
         disable_help_button(self)
         self.setup(did)
-        addCloseShortcut(self)
+        add_close_shortcut(self)
         self.open()
 
     def setup(self, did: DeckId | None) -> None:

--- a/qt/aqt/import_export/exporting.py
+++ b/qt/aqt/import_export/exporting.py
@@ -27,6 +27,7 @@ from aqt.operations import QueryOp
 from aqt.progress import ProgressUpdate
 from aqt.qt import *
 from aqt.utils import (
+    addCloseShortcut,
     checkInvalidFilename,
     disable_help_button,
     getSaveFile,
@@ -53,6 +54,7 @@ class ExportDialog(QDialog):
         self.nids = nids
         disable_help_button(self)
         self.setup(did)
+        addCloseShortcut(self)
         self.open()
 
     def setup(self, did: DeckId | None) -> None:

--- a/qt/aqt/import_export/import_dialog.py
+++ b/qt/aqt/import_export/import_dialog.py
@@ -12,7 +12,7 @@ import aqt.deckconf
 import aqt.main
 import aqt.operations
 from aqt.qt import *
-from aqt.utils import addCloseShortcut, disable_help_button, restoreGeom, saveGeom, tr
+from aqt.utils import add_close_shortcut, disable_help_button, restoreGeom, saveGeom, tr
 from aqt.webview import AnkiWebView, AnkiWebViewKind
 
 
@@ -62,7 +62,7 @@ class ImportDialog(QDialog):
         self.setMinimumSize(*self.MIN_SIZE)
         disable_help_button(self)
         restoreGeom(self, self.args.title, default_size=self.DEFAULT_SIZE)
-        addCloseShortcut(self)
+        add_close_shortcut(self)
 
         self.web: AnkiWebView | None = AnkiWebView(kind=self.args.kind)
         self.web.setVisible(False)

--- a/qt/aqt/operations/scheduling.py
+++ b/qt/aqt/operations/scheduling.py
@@ -24,7 +24,7 @@ from anki.scheduler.v3 import CardAnswer
 from anki.scheduler.v3 import Scheduler as V3Scheduler
 from aqt.operations import CollectionOp
 from aqt.qt import *
-from aqt.utils import addCloseShortcut, disable_help_button, getText, tooltip, tr
+from aqt.utils import add_close_shortcut, disable_help_button, getText, tooltip, tr
 
 
 def set_due_date_dialog(
@@ -104,7 +104,7 @@ def forget_cards(
 
     dialog = QDialog(parent)
     disable_help_button(dialog)
-    addCloseShortcut(dialog)
+    add_close_shortcut(dialog)
     form = aqt.forms.forget.Ui_Dialog()
     form.setupUi(dialog)
 
@@ -154,7 +154,7 @@ def reposition_new_cards_dialog(
 
     dialog = QDialog(parent)
     disable_help_button(dialog)
-    addCloseShortcut(dialog)
+    add_close_shortcut(dialog)
     dialog.setWindowModality(Qt.WindowModality.WindowModal)
     form = aqt.forms.reposition.Ui_Dialog()
     form.setupUi(dialog)

--- a/qt/aqt/operations/scheduling.py
+++ b/qt/aqt/operations/scheduling.py
@@ -24,7 +24,7 @@ from anki.scheduler.v3 import CardAnswer
 from anki.scheduler.v3 import Scheduler as V3Scheduler
 from aqt.operations import CollectionOp
 from aqt.qt import *
-from aqt.utils import disable_help_button, getText, tooltip, tr
+from aqt.utils import addCloseShortcut, disable_help_button, getText, tooltip, tr
 
 
 def set_due_date_dialog(
@@ -153,6 +153,7 @@ def reposition_new_cards_dialog(
 
     dialog = QDialog(parent)
     disable_help_button(dialog)
+    addCloseShortcut(dialog)
     dialog.setWindowModality(Qt.WindowModality.WindowModal)
     form = aqt.forms.reposition.Ui_Dialog()
     form.setupUi(dialog)

--- a/qt/aqt/operations/scheduling.py
+++ b/qt/aqt/operations/scheduling.py
@@ -104,6 +104,7 @@ def forget_cards(
 
     dialog = QDialog(parent)
     disable_help_button(dialog)
+    addCloseShortcut(dialog)
     form = aqt.forms.forget.Ui_Dialog()
     form.setupUi(dialog)
 

--- a/qt/aqt/preferences.py
+++ b/qt/aqt/preferences.py
@@ -22,7 +22,7 @@ from aqt.sync import sync_login
 from aqt.theme import Theme
 from aqt.utils import (
     HelpPage,
-    addCloseShortcut,
+    add_close_shortcut,
     askUser,
     disable_help_button,
     is_win,
@@ -65,7 +65,7 @@ class Preferences(QDialog):
         self.setup_profile()
         self.setup_global()
         self.setup_configurable_answer_keys()
-        addCloseShortcut(self)
+        add_close_shortcut(self)
         self.show()
 
     def setup_configurable_answer_keys(self):

--- a/qt/aqt/preferences.py
+++ b/qt/aqt/preferences.py
@@ -22,6 +22,7 @@ from aqt.sync import sync_login
 from aqt.theme import Theme
 from aqt.utils import (
     HelpPage,
+    addCloseShortcut,
     askUser,
     disable_help_button,
     is_win,
@@ -64,6 +65,7 @@ class Preferences(QDialog):
         self.setup_profile()
         self.setup_global()
         self.setup_configurable_answer_keys()
+        addCloseShortcut(self)
         self.show()
 
     def setup_configurable_answer_keys(self):

--- a/qt/aqt/stats.py
+++ b/qt/aqt/stats.py
@@ -16,7 +16,7 @@ from aqt.operations.deck import set_current_deck
 from aqt.qt import *
 from aqt.theme import theme_manager
 from aqt.utils import (
-    addCloseShortcut,
+    add_close_shortcut,
     disable_help_button,
     getSaveFile,
     maybeHideClose,
@@ -69,7 +69,7 @@ class NewDeckStats(QDialog):
         assert b is not None
         b.setAutoDefault(False)
         maybeHideClose(self.form.buttonBox)
-        addCloseShortcut(self)
+        add_close_shortcut(self)
         gui_hooks.stats_dialog_will_show(self)
         self.form.web.set_kind(AnkiWebViewKind.DECK_STATS)
         self.form.web.hide_while_preserving_layout()
@@ -180,7 +180,7 @@ class DeckStats(QDialog):
         qconnect(f.year.clicked, lambda: self.changePeriod(1))
         qconnect(f.life.clicked, lambda: self.changePeriod(2))
         maybeHideClose(self.form.buttonBox)
-        addCloseShortcut(self)
+        add_close_shortcut(self)
         gui_hooks.stats_dialog_old_will_show(self)
         self.show()
         self.refresh()

--- a/qt/aqt/studydeck.py
+++ b/qt/aqt/studydeck.py
@@ -16,6 +16,7 @@ from aqt.qt import *
 from aqt.utils import (
     HelpPage,
     HelpPageArgument,
+    addCloseShortcut,
     disable_help_button,
     openHelp,
     restoreGeom,
@@ -52,6 +53,7 @@ class StudyDeck(QDialog):
         gui_hooks.state_did_reset.append(self.onReset)
         self.geomKey = f"studyDeck-{geomKey}"
         restoreGeom(self, self.geomKey)
+        addCloseShortcut(self)
         disable_help_button(self)
         if not cancel:
             self.form.buttonBox.removeButton(

--- a/qt/aqt/studydeck.py
+++ b/qt/aqt/studydeck.py
@@ -16,7 +16,7 @@ from aqt.qt import *
 from aqt.utils import (
     HelpPage,
     HelpPageArgument,
-    addCloseShortcut,
+    add_close_shortcut,
     disable_help_button,
     openHelp,
     restoreGeom,
@@ -53,7 +53,7 @@ class StudyDeck(QDialog):
         gui_hooks.state_did_reset.append(self.onReset)
         self.geomKey = f"studyDeck-{geomKey}"
         restoreGeom(self, self.geomKey)
-        addCloseShortcut(self)
+        add_close_shortcut(self)
         disable_help_button(self)
         if not cancel:
             self.form.buttonBox.removeButton(

--- a/qt/aqt/sync.py
+++ b/qt/aqt/sync.py
@@ -28,6 +28,7 @@ from aqt.qt import (
     qconnect,
 )
 from aqt.utils import (
+    addCloseShortcut,
     ask_user_dialog,
     disable_help_button,
     show_warning,
@@ -380,6 +381,7 @@ def get_id_and_pass_from_user(
     qconnect(bb.accepted, diag.accept)
     qconnect(bb.rejected, diag.reject)
     vbox.addWidget(bb)
+    addCloseShortcut(diag)
     diag.setLayout(vbox)
     diag.adjustSize()
     diag.show()

--- a/qt/aqt/sync.py
+++ b/qt/aqt/sync.py
@@ -28,7 +28,7 @@ from aqt.qt import (
     qconnect,
 )
 from aqt.utils import (
-    addCloseShortcut,
+    add_close_shortcut,
     ask_user_dialog,
     disable_help_button,
     show_warning,
@@ -381,7 +381,7 @@ def get_id_and_pass_from_user(
     qconnect(bb.accepted, diag.accept)
     qconnect(bb.rejected, diag.reject)
     vbox.addWidget(bb)
-    addCloseShortcut(diag)
+    add_close_shortcut(diag)
     diag.setLayout(vbox)
     diag.adjustSize()
     diag.show()

--- a/qt/aqt/utils.py
+++ b/qt/aqt/utils.py
@@ -560,7 +560,7 @@ def getText(
     d = GetTextDialog(
         parent, prompt, help=help, edit=edit, default=default, title=title, **kwargs
     )
-    addCloseShortcut(d)
+    add_close_shortcut(d)
     d.setWindowModality(Qt.WindowModality.WindowModal)
     if geomKey:
         restoreGeom(d, geomKey)
@@ -987,14 +987,6 @@ def maybeHideClose(bbox: QDialogButtonBox) -> None:
         b = bbox.button(QDialogButtonBox.StandardButton.Close)
         if b:
             bbox.removeButton(b)
-
-
-def addCloseShortcut(widg: QDialog) -> None:
-    if not is_mac:
-        return
-    shortcut = QShortcut(QKeySequence("Ctrl+W"), widg)
-    qconnect(shortcut.activated, widg.reject)
-    setattr(widg, "_closeShortcut", shortcut)
 
 
 def add_close_shortcut(widg: QWidget) -> None:

--- a/qt/aqt/utils.py
+++ b/qt/aqt/utils.py
@@ -560,6 +560,7 @@ def getText(
     d = GetTextDialog(
         parent, prompt, help=help, edit=edit, default=default, title=title, **kwargs
     )
+    addCloseShortcut(d)
     d.setWindowModality(Qt.WindowModality.WindowModal)
     if geomKey:
         restoreGeom(d, geomKey)


### PR DESCRIPTION
As I’ve been editing decks more often, I noticed that editor dialogs don’t respond to Cmd+W keyboard shortcut. Here’s an attempt to add the shortcut to “Edit Current”, “Fields” and “Cards” editor dialogs. And also to several modals.

<img width="759" alt="UI of “Edit Current” dialog with several input fields" src="https://github.com/user-attachments/assets/518f86b8-4a7a-4fed-9617-f160e0fb44b6" />
