### PR TITLE
Add a warning to "Ignore cards reviewed before"

### DIFF
--- a/ftl/core/deck-config.ftl
+++ b/ftl/core/deck-config.ftl
@@ -372,7 +372,7 @@ deck-config-good-above-easy = The easy interval should be at least as long as th
 deck-config-relearning-steps-above-minimum-interval = The minimum lapse interval should be at least as long as your final relearning step.
 deck-config-maximum-answer-secs-above-recommended = Anki can schedule your reviews more efficiently when you keep each question short.
 deck-config-too-short-maximum-interval = A maximum interval less than 6 months is not recommended.
-deck-config-ignore-cards = This will ignore entire cards, not just a part of their review history.
+deck-config-ignore-cards = This ignores entire cards reviewed before the selected date, not just their previous reviews.
 
 ## Selecting a deck
 

--- a/ftl/core/deck-config.ftl
+++ b/ftl/core/deck-config.ftl
@@ -372,6 +372,7 @@ deck-config-good-above-easy = The easy interval should be at least as long as th
 deck-config-relearning-steps-above-minimum-interval = The minimum lapse interval should be at least as long as your final relearning step.
 deck-config-maximum-answer-secs-above-recommended = Anki can schedule your reviews more efficiently when you keep each question short.
 deck-config-too-short-maximum-interval = A maximum interval less than 6 months is not recommended.
+deck-config-ignore-cards = This will ignore entire cards, not just a part of their review history.
 
 ## Selecting a deck
 

--- a/ts/routes/deck-options/AdvancedOptions.svelte
+++ b/ts/routes/deck-options/AdvancedOptions.svelte
@@ -91,6 +91,9 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
             ? tr.deckConfigTooShortMaximumInterval()
             : "";
 
+    $: ignoreCardsWarningClass = "alert-warning";
+    $: ignoreCardsWarning = "";
+
     let modal: Modal;
     let carousel: Carousel;
 
@@ -131,6 +134,11 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
         <Item>
             <Warning warning={maxIntervalWarning} className={maxIntervalWarningClass}
+            ></Warning>
+        </Item>
+
+        <Item>
+            <Warning warning={ignoreCardsWarning} className={ignoreCardsWarningClass}
             ></Warning>
         </Item>
 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/65b178f1-60f2-48f7-9812-5d9ec2dbc5c4)

Me and other users believe that currently "Ignore cards reviewed before" doesn't do a very good job of, well, conveying that it ignores **cards**, not just a part of their review history.