### PR TITLE
Close only “child” window (e.g. Preview) inside Browser on Cmd+W

### DIFF
--- a/qt/aqt/browser/browser.py
+++ b/qt/aqt/browser/browser.py
@@ -280,6 +280,19 @@ class Browser(QMainWindow):
         if note_type_id := self.get_active_note_type_id():
             add_cards.set_note_type(note_type_id)
 
+    # If in the Browser we open Preview and press Ctrl+W there,
+    # both Preview and Browser windows get closed by Qt out of the box.
+    # We circumvent that behavior by only closing the currently active window
+    def _handle_close(self):
+        active_window = QApplication.activeWindow()
+        if active_window and active_window != self:
+            if isinstance(active_window, QDialog):
+                active_window.reject()
+            else:
+                active_window.close()
+        else:
+            self.close()
+
     def setupMenus(self) -> None:
         # actions
         f = self.form

--- a/qt/aqt/forms/browser.ui
+++ b/qt/aqt/forms/browser.ui
@@ -785,7 +785,7 @@
    <sender>actionClose</sender>
    <signal>triggered()</signal>
    <receiver>Dialog</receiver>
-   <slot>close()</slot>
+   <slot>_handle_close()</slot>
    <hints>
     <hint type="sourcelabel">
      <x>-1</x>


### PR DESCRIPTION
Currently if we open Preview (for example) while being in the Browse mode, and then we try to close the Preview by pressing `Cmd+W`, both the Preview and the “parent” Browse window get closed. This feels counter-intuitive as `Cmd+W` should only close the “current window”.

#### Before

https://github.com/user-attachments/assets/c0f4f941-0b18-4690-8d2b-81ea69f1be45

#### After

https://github.com/user-attachments/assets/bc5e4d3e-cb22-43ce-9095-e33988ed86ec



_It is interesting that Qt does not do ”the right thing” out of the box. 📦_