### PR TITLE
Fix autoplay not being stopped on editor close if it interrupted another

### DIFF
--- a/qt/aqt/sound.py
+++ b/qt/aqt/sound.py
@@ -142,7 +142,7 @@ class AVPlayer:
     interrupt_current_audio = True
     # caller key for the current playback (optional)
     current_caller = None
-    # whether the last call to play_file_if_caller interrupted another
+    # whether the last call to play_file_with_caller interrupted another
     current_caller_interrupted = False
 
     def __init__(self) -> None:

--- a/qt/aqt/sound.py
+++ b/qt/aqt/sound.py
@@ -142,6 +142,8 @@ class AVPlayer:
     interrupt_current_audio = True
     # caller key for the current playback (optional)
     current_caller = None
+    # whether the last call to play_file_if_caller interrupted another
+    current_caller_interrupted = False
 
     def __init__(self) -> None:
         self._enqueued: list[AVTag] = []
@@ -178,6 +180,8 @@ class AVPlayer:
         self.play_tags([SoundOrVideoTag(filename=filename)])
 
     def play_file_with_caller(self, filename: str, caller) -> None:
+        if self.current_caller:
+            self.current_caller_interrupted = True
         self.current_caller = caller
         self.play_file(filename)
 
@@ -209,7 +213,9 @@ class AVPlayer:
         return self._enqueued.pop(0)
 
     def _on_play_finished(self) -> None:
-        self.current_caller = None
+        if not self.current_caller_interrupted:
+            self.current_caller = None
+        self.current_caller_interrupted = False
         gui_hooks.av_player_did_end_playing(self.current_player)
         self.current_player = None
         self._play_next_if_idle()


### PR DESCRIPTION
Found an edge case while testing drag/dropping that i had unfortunately left unresolved in #3666: if an autoplay interrupts another, closing the editor doesn't currently stop it

It's caused by the call to `_on_play_finished` corresponding to an interrupted autoplay happening **after** the latest autoplay's call to `play_file_if_caller`. The fix proposed is add and use a flag to track when such interruptions occur