### PR TITLE
Fix drag/drop breaking when editor is zoomed

### DIFF
--- a/qt/aqt/editor.py
+++ b/qt/aqt/editor.py
@@ -1053,9 +1053,10 @@ require("anki/ui").loaded.then(() => require("anki/NoteEditor").instances[0].too
             if ret:
                 self.doPaste(html, internal, extended)
 
-        self.web.evalWithCallback(
-            f"focusIfField({cursor_pos.x()}, {cursor_pos.y()});", pasteIfField
-        )
+        zoom = self.web.zoomFactor()
+        x, y = int(cursor_pos.x() / zoom), int(cursor_pos.y() / zoom)
+
+        self.web.evalWithCallback(f"focusIfField({x}, {y});", pasteIfField)
 
     def onPaste(self) -> None:
         self.web.onPaste()


### PR DESCRIPTION
Zooming the editor in/out causes the cursor coords qt provides to not match up with the [viewport's](https://developer.mozilla.org/en-US/docs/Web/API/Document/elementsFromPoint) when drag/dropping

Rather than disabling editor zoom (the browser explicitly provides menubar items for this), the fix proposed is to factor in zoom by scaling