### PR TITLE
service to state which card would be generated given note type id and field content

### DIFF
--- a/proto/anki/notetypes.proto
+++ b/proto/anki/notetypes.proto
@@ -33,6 +33,8 @@ service NotetypesService {
   rpc GetFieldNames(NotetypeId) returns (generic.StringList);
   rpc RestoreNotetypeToStock(RestoreNotetypeToStockRequest)
       returns (collection.OpChanges);
+  rpc GetNonEmptyCardIndexes(GetNonEmptyCardIndexesRequest)
+      returns (GetNonEmptyCardIndexesResponse);
 }
 
 // Implicitly includes any of the above methods that are not listed in the
@@ -241,4 +243,32 @@ enum ImageOcclusionField {
 enum ClozeField {
   CLOZE_FIELD_TEXT = 0;
   CLOZE_FIELD_BACK_EXTRA = 1;
+}
+
+message GetNonEmptyCardIndexesRequest {
+  int64 notetype_id = 1;
+  repeated string field_values = 2;
+}
+
+message GetNonEmptyCardIndexesResponse {
+  message GetNonEmptyCardIndexesNormalResponse {
+    enum IsEmpty {
+      EMPTY = 0;
+      NON_EMPTY = 1;
+      // The template could not be parsed.
+      ERROR = 2;
+    }
+
+    // There should be as many types as there are templates.
+    repeated IsEmpty is_empty = 1;
+  }
+
+  message GetNonEmptyCardIndexesClozeResponse {
+    repeated uint32 indexes = 1;
+  }
+
+  oneof response {
+    GetNonEmptyCardIndexesNormalResponse normal = 1;
+    GetNonEmptyCardIndexesClozeResponse cloze = 2;
+  }
 }

--- a/rslib/src/cloze.rs
+++ b/rslib/src/cloze.rs
@@ -442,6 +442,15 @@ pub fn add_cloze_numbers_in_string(field: &str, set: &mut HashSet<u16>) {
     add_cloze_numbers_in_text_with_clozes(&parse_text_with_clozes(field), set)
 }
 
+/// The set of cloze numbers as they appear in any of the field from `fields`.
+pub fn cloze_number_in_fields(fields: impl IntoIterator<Item: AsRef<str>>) -> HashSet<u16> {
+    let mut set = HashSet::with_capacity(4);
+    for field in fields {
+        add_cloze_numbers_in_string(field.as_ref(), &mut set);
+    }
+    set
+}
+
 fn strip_html_inside_mathjax(text: &str) -> Cow<str> {
     MATHJAX.replace_all(text, |caps: &Captures| -> String {
         format!(

--- a/rslib/src/cloze.rs
+++ b/rslib/src/cloze.rs
@@ -43,6 +43,7 @@ mod mathjax_caps {
 
 #[derive(Debug)]
 enum Token<'a> {
+    // The parameter is the cloze number as is appears in the field content.
     OpenCloze(u16),
     Text(&'a str),
     CloseCloze,
@@ -114,6 +115,7 @@ enum TextOrCloze<'a> {
 
 #[derive(Debug)]
 struct ExtractedCloze<'a> {
+    // `ordinal` is the cloze number as is appears in the field content.
     ordinal: u16,
     nodes: Vec<TextOrCloze<'a>>,
     hint: Option<&'a str>,
@@ -409,12 +411,14 @@ pub fn expand_clozes_to_reveal_latex(text: &str) -> String {
     buf
 }
 
+// Whether `text` contains any cloze with strictly positive number.
 pub(crate) fn contains_cloze(text: &str) -> bool {
     parse_text_with_clozes(text)
         .iter()
         .any(|node| matches!(node, TextOrCloze::Cloze(e) if e.ordinal != 0))
 }
 
+/// Returns the set of cloze number as the appear in the fields's content.
 pub fn cloze_numbers_in_string(html: &str) -> HashSet<u16> {
     let mut set = HashSet::with_capacity(4);
     add_cloze_numbers_in_string(html, &mut set);
@@ -432,6 +436,7 @@ fn add_cloze_numbers_in_text_with_clozes(nodes: &[TextOrCloze], set: &mut HashSe
     }
 }
 
+/// Add to `set` the cloze numbers as they appear in `field`.
 #[allow(clippy::implicit_hasher)]
 pub fn add_cloze_numbers_in_string(field: &str, set: &mut HashSet<u16>) {
     add_cloze_numbers_in_text_with_clozes(&parse_text_with_clozes(field), set)

--- a/rslib/src/notes/service.rs
+++ b/rslib/src/notes/service.rs
@@ -1,8 +1,6 @@
 // Copyright: Ankitects Pty Ltd and contributors
 // License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
-use std::collections::HashSet;
-
-use crate::cloze::add_cloze_numbers_in_string;
+use crate::cloze::cloze_number_in_fields;
 use crate::collection::Collection;
 use crate::decks::DeckId;
 use crate::error;
@@ -128,10 +126,7 @@ impl crate::services::NotesService for Collection {
         &mut self,
         note: anki_proto::notes::Note,
     ) -> error::Result<anki_proto::notes::ClozeNumbersInNoteResponse> {
-        let mut set = HashSet::with_capacity(4);
-        for field in &note.fields {
-            add_cloze_numbers_in_string(field, &mut set);
-        }
+        let set = cloze_number_in_fields(note.fields);
         Ok(anki_proto::notes::ClozeNumbersInNoteResponse {
             numbers: set.into_iter().map(|n| n as u32).collect(),
         })

--- a/rslib/src/notetype/cardgen.rs
+++ b/rslib/src/notetype/cardgen.rs
@@ -11,7 +11,7 @@ use rand::Rng;
 use rand::SeedableRng;
 
 use super::Notetype;
-use crate::cloze::add_cloze_numbers_in_string;
+use crate::cloze::cloze_number_in_fields;
 use crate::notetype::NotetypeKind;
 use crate::prelude::*;
 use crate::template::ParsedTemplate;
@@ -148,10 +148,7 @@ impl<N: Deref<Target = Notetype>> CardGenContext<N> {
         extracted: &ExtractedCardInfo,
     ) -> Vec<CardToGenerate> {
         // gather all cloze numbers
-        let mut set = HashSet::with_capacity(4);
-        for field in note.fields() {
-            add_cloze_numbers_in_string(field, &mut set);
-        }
+        let set = cloze_number_in_fields(note.fields());
         set.into_iter()
             .filter_map(|cloze_ord| {
                 let card_ord = cloze_ord.saturating_sub(1).min(499);

--- a/rslib/src/notetype/mod.rs
+++ b/rslib/src/notetype/mod.rs
@@ -6,6 +6,7 @@ mod checks;
 mod emptycards;
 mod fields;
 mod merge;
+mod nonempty;
 mod notetypechange;
 mod render;
 mod restore;

--- a/rslib/src/notetype/nonempty.rs
+++ b/rslib/src/notetype/nonempty.rs
@@ -1,0 +1,73 @@
+// Copyright: Ankitects Pty Ltd and contributors
+// License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
+
+use std::collections::HashSet;
+
+use anki_proto::notetypes::get_non_empty_card_indexes_response;
+
+use crate::cloze::cloze_number_in_fields;
+use crate::collection::Collection;
+use crate::error;
+use crate::error::OrNotFound;
+use crate::notetype::NotetypeId;
+use crate::notetype::NotetypeKind;
+use crate::template::field_is_empty;
+
+impl Collection {
+    pub(crate) fn get_non_empty_card_indexes(
+        &mut self,
+        ntid: NotetypeId,
+        field_contents: Vec<std::string::String>,
+    ) -> error::Result<anki_proto::notetypes::GetNonEmptyCardIndexesResponse> {
+        let nt = self.get_notetype(ntid)?.or_not_found(ntid)?;
+        Ok(match nt.config.kind() {
+            NotetypeKind::Normal => {
+                let mut non_empty_fields: HashSet<&str> =
+                    HashSet::with_capacity(field_contents.len());
+                let field_names = self.storage.get_field_names(ntid)?;
+                for (field_idx, field_content) in field_contents.iter().enumerate() {
+                    if !field_is_empty(&field_content) {
+                        let field_name: &str = &field_names[field_idx];
+                        non_empty_fields.insert(field_name);
+                    }
+                }
+                anki_proto::notetypes::GetNonEmptyCardIndexesResponse {
+                    response: Some (
+                        anki_proto::notetypes::get_non_empty_card_indexes_response::Response::Normal(
+                            anki_proto::notetypes::get_non_empty_card_indexes_response::GetNonEmptyCardIndexesNormalResponse{
+                                is_empty: nt.templates.iter().map(|tmpl|
+                                    if let Some(parsed_question) = tmpl.parsed_question() {
+                                    if parsed_question.renders_with_fields(&non_empty_fields) {
+                                        get_non_empty_card_indexes_response::get_non_empty_card_indexes_normal_response::IsEmpty::NonEmpty
+                                    } else {
+                                        get_non_empty_card_indexes_response::get_non_empty_card_indexes_normal_response::IsEmpty::Empty
+                                    }
+                                    } else {
+                                    get_non_empty_card_indexes_response::get_non_empty_card_indexes_normal_response::IsEmpty::Error
+                                    } as i32
+                                ).collect()
+                                }
+                            )
+                        )
+                }
+            }
+            NotetypeKind::Cloze => {
+                let mut cloze_numbers: Vec<u32> = Vec::from_iter(
+                    cloze_number_in_fields(field_contents)
+                        .into_iter()
+                        // Decrementing so that we get the card order instead of the cloze number
+                        // from the field.
+                        .map(|i| (i - 1) as u32),
+                );
+                cloze_numbers.sort();
+                anki_proto::notetypes::GetNonEmptyCardIndexesResponse {
+                    response: Some(anki_proto::notetypes::get_non_empty_card_indexes_response::Response::Cloze(
+                        anki_proto::notetypes::get_non_empty_card_indexes_response::GetNonEmptyCardIndexesClozeResponse{
+                            indexes: cloze_numbers
+                        }
+                    ))
+                }
+            }
+        })
+    }
+}

--- a/rslib/src/notetype/service.rs
+++ b/rslib/src/notetype/service.rs
@@ -212,6 +212,13 @@ impl crate::services::NotetypesService for Collection {
         )
         .map(Into::into)
     }
+
+    fn get_non_empty_card_indexes(
+        &mut self,
+        input: anki_proto::notetypes::GetNonEmptyCardIndexesRequest,
+    ) -> error::Result<anki_proto::notetypes::GetNonEmptyCardIndexesResponse> {
+        self.get_non_empty_card_indexes(NotetypeId(input.notetype_id), input.field_values)
+    }
 }
 
 impl From<anki_proto::notetypes::Notetype> for Notetype {

--- a/rslib/src/template.rs
+++ b/rslib/src/template.rs
@@ -15,7 +15,7 @@ use nom::combinator::map;
 use nom::sequence::delimited;
 use regex::Regex;
 
-use crate::cloze::add_cloze_numbers_in_string;
+use crate::cloze::cloze_number_in_fields;
 use crate::error::AnkiError;
 use crate::error::Result;
 use crate::error::TemplateError;
@@ -673,11 +673,7 @@ pub fn render_card(
 }
 
 fn cloze_is_empty(field_map: &HashMap<&str, Cow<str>>, card_ord: u16) -> bool {
-    let mut set = HashSet::with_capacity(4);
-    for field in field_map.values() {
-        add_cloze_numbers_in_string(field.as_ref(), &mut set);
-    }
-    !set.contains(&(card_ord + 1))
+    cloze_number_in_fields(field_map.values().map(|cow| cow)).contains(&(card_ord + 1))
 }
 
 // Field requirements


### PR DESCRIPTION
Introduce get_non_empty_card_indexes

This method takes a note type id and the content of fields. It returns
the order of the cards that would be non-empty according to this note.

To be more specific, for cloze type, it return any cloze
number (except 0), even if it does not appear in a cloze field, in
order to be consistent with the way anki generates note.

For normal type, for each template, it returns whether the card would
be generated, and also whether the template has an error.

The goal here is to allow ankidroid to display in the note editor's
previewer which card will be generated. Which is done currently by
checking whether the "empty card" message appear in the previewer,
which is not ideal.

Please let me know whether you'd accept this service. In which case I'll add a few tests with the default note type. I preferred not to spend more time adding tests until I know whether it'd be useful or not