### PR TITLE
Fix: correct typo and adjust indentation in docstring

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -220,6 +220,7 @@ Valerie Enfys <val@unidentified.systems>
 Julien Chol <https://github.com/chel-ou>
 ikkz <ylei.mk@gmail.com>
 rreemmii-dev <https://github.com/rreemmii-dev>
+babofitos <https://github.com/babofitos>
 
 ********************
 

--- a/qt/tools/genhooks_gui.py
+++ b/qt/tools/genhooks_gui.py
@@ -778,24 +778,24 @@ hooks = [
         name="webview_did_inject_style_into_page",
         args=["webview: aqt.webview.AnkiWebView"],
         doc='''Called after standard styling is injected into an external
-html file, such as when loading the new graphs. You can use this hook to
-mutate the DOM before the page is revealed.
-
-For example:
-
-def mytest(webview: AnkiWebView):
-    if webview.kind != AnkiWebViewKind.DECK_STATS:
-        return
-    web.eval(
-        """
-    div = document.createElement("div");
-    div.innerHTML = 'hello';
-    document.body.appendChild(div);
-"""
-    )
-
-gui_hooks.webview_did_inject_style_into_page.append(mytest)
-''',
+        html file, such as when loading the new graphs. You can use this hook to
+        mutate the DOM before the page is revealed.
+        
+        For example:
+        
+        def mytest(webview: AnkiWebView):
+            if webview.kind != AnkiWebViewKind.DECK_STATS:
+                return
+            webview.eval(
+                """
+                div = document.createElement("div");
+                div.innerHTML = 'hello';
+                document.body.appendChild(div);
+                """
+            )
+        
+        gui_hooks.webview_did_inject_style_into_page.append(mytest)
+        ''',
     ),
     # Main
     ###################


### PR DESCRIPTION
Fixed a small typo in the example test function in webview_did_inject_style_into_page's docstring and adjusted indentation for consistency.