### PR TITLE
Fix error when middle clicking in editor on systems w/o global mouse selection

### DIFF
--- a/qt/aqt/about.py
+++ b/qt/aqt/about.py
@@ -219,6 +219,7 @@ def show(mw: aqt.AnkiQt) -> QDialog:
             "Brayan Oliveira",
             "Market345",
             "Yuki",
+            "🦙 (siid)",
         )
     )
 

--- a/qt/aqt/editor.py
+++ b/qt/aqt/editor.py
@@ -1497,8 +1497,8 @@ class EditorWebView(AnkiWebView):
 
     def _get_clipboard_html_for_field(self, mode: QClipboard.Mode) -> str | None:
         clip = self._clipboard()
-        mime = clip.mimeData(mode)
-        assert mime is not None
+        if not (mime := clip.mimeData(mode)):
+            return None
         if not mime.hasHtml():
             return None
         return mime.html()
@@ -1540,9 +1540,9 @@ class EditorWebView(AnkiWebView):
             print("reuse internal")
             self.editor.doPaste(html, True, extended)
         else:
+            if not (mime := clipboard.mimeData(mode=mode)):
+                return
             print("use clipboard")
-            mime = clipboard.mimeData(mode=mode)
-            assert mime is not None
             html, internal = self._processMime(mime, extended)
             if html:
                 self.editor.doPaste(html, internal, extended)


### PR DESCRIPTION
On my system, middle clicking in the editor throws:
```
Traceback (most recent call last):
  File "/anki/qt/aqt/webview.py", line 354, in eventFilter
    self.onMiddleClickPaste()
  File "/anki/qt/aqt/editor.py", line 1554, in onMiddleClickPaste
    self._onPaste(QClipboard.Mode.Selection)
  File "/anki/qt/aqt/editor.py", line 1537, in _onPaste
    self._on_clipboard_change(mode)
  File "/anki/qt/aqt/editor.py", line 1492, in _on_clipboard_change
    elif self._internal_field_text_for_paste != self._get_clipboard_html_for_field(
  File "/anki/qt/aqt/editor.py", line 1501, in _get_clipboard_html_for_field
    assert mime is not None
AssertionError
```
> Returns a pointer to a QMimeData representation of the current clipboard data (can be nullptr if the given mode is not supported by the platform).
https://doc.qt.io/qt-6/qclipboard.html#mimeData

The asserts after calls to QClipboard.mimeData with a non-default mode don't always hold, as the docs suggest. The fix proposed is to replace them with guard clauses. Tested in an ubuntu vm to ensure middle-clicking still works when global mouse selection is supported

Regarding the existing middle-click option pr, this still has merit imo, as users shouldn't have to see errors to then dig into how to disable it via the debug console if their systems don't support it in the first place

Also took the opportunity to update about.py, seeing as this'd be my 50th pr 😄
