### PR TITLE
Harden access to internal API

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
         "bootstrap-icons": "^1.10.5",
         "codemirror": "^5.63.1",
         "d3": "^7.0.0",
+        "dompurify": "^3.2.5",
         "fabric": "^5.3.0",
         "hammerjs": "^2.0.8",
         "intl-pluralrules": "^2.0.0",

--- a/qt/aqt/mediasrv.py
+++ b/qt/aqt/mediasrv.py
@@ -720,6 +720,7 @@ def _check_dynamic_request_permissions():
         "/_anki/getSchedulingStatesWithContext",
         "/_anki/setSchedulingStates",
         "/_anki/i18nResources",
+        "/_anki/congratsInfo",
     ):
         pass
     else:

--- a/qt/aqt/sound.py
+++ b/qt/aqt/sound.py
@@ -141,7 +141,7 @@ class AVPlayer:
     # audio be stopped?
     interrupt_current_audio = True
     # caller key for the current playback (optional)
-    current_caller = None
+    current_caller: Any = None
     # whether the last call to play_file_with_caller interrupted another
     current_caller_interrupted = False
 
@@ -167,7 +167,7 @@ class AVPlayer:
         self._enqueued = []
         self._stop_if_playing()
 
-    def stop_and_clear_queue_if_caller(self, caller) -> None:
+    def stop_and_clear_queue_if_caller(self, caller: Any) -> None:
         if caller == self.current_caller:
             self.stop_and_clear_queue()
 
@@ -179,7 +179,7 @@ class AVPlayer:
     def play_file(self, filename: str) -> None:
         self.play_tags([SoundOrVideoTag(filename=filename)])
 
-    def play_file_with_caller(self, filename: str, caller) -> None:
+    def play_file_with_caller(self, filename: str, caller: Any) -> None:
         if self.current_caller:
             self.current_caller_interrupted = True
         self.current_caller = caller

--- a/qt/aqt/webview.py
+++ b/qt/aqt/webview.py
@@ -69,7 +69,7 @@ class AuthInterceptor(QWebEngineUrlRequestInterceptor):
     def interceptRequest(self, info):
         from aqt.mediasrv import _APIKEY
 
-        if self._api_enabled:
+        if self._api_enabled and info.requestUrl().host() == "127.0.0.1":
             info.setHttpHeader(b"Authorization", f"Bearer {_APIKEY}".encode("utf-8"))
 
 

--- a/qt/aqt/webview.py
+++ b/qt/aqt/webview.py
@@ -28,35 +28,88 @@ serverbaseurl = re.compile(r"^.+:\/\/[^\/]+")
 if TYPE_CHECKING:
     from aqt.mediasrv import PageContext
 
-
-# Page for debug messages
-##########################################################################
-
 BridgeCommandHandler = Callable[[str], Any]
 
 
+class AnkiWebViewKind(Enum):
+    """Enum registry of all web views managed by Anki
+
+    The value of each entry corresponds to the web view's title.
+
+    When introducing a new web view, please add it to the registry below.
+    """
+
+    DEFAULT = "default"
+    MAIN = "main webview"
+    TOP_TOOLBAR = "top toolbar"
+    BOTTOM_TOOLBAR = "bottom toolbar"
+    DECK_OPTIONS = "deck options"
+    EDITOR = "editor"
+    LEGACY_DECK_STATS = "legacy deck stats"
+    DECK_STATS = "deck stats"
+    PREVIEWER = "previewer"
+    CHANGE_NOTETYPE = "change notetype"
+    CARD_LAYOUT = "card layout"
+    BROWSER_CARD_INFO = "browser card info"
+    IMPORT_CSV = "csv import"
+    EMPTY_CARDS = "empty cards"
+    FIND_DUPLICATES = "find duplicates"
+    FIELDS = "fields"
+    IMPORT_LOG = "import log"
+    IMPORT_ANKI_PACKAGE = "anki package import"
+
+
+class AuthInterceptor(QWebEngineUrlRequestInterceptor):
+    _api_enabled = False
+
+    def __init__(self, parent: QObject | None = None, api_enabled: bool = False):
+        super().__init__(parent)
+        self._api_enabled = api_enabled
+
+    def interceptRequest(self, info):
+        from aqt.mediasrv import _APIKEY
+
+        if self._api_enabled:
+            info.setHttpHeader(b"Authorization", f"Bearer {_APIKEY}".encode("utf-8"))
+
+
+_profile_with_api_access: QWebEngineProfile | None = None
+_profile_without_api_access: QWebEngineProfile | None = None
+
+
 class AnkiWebPage(QWebEnginePage):
-    def __init__(self, onBridgeCmd: BridgeCommandHandler) -> None:
-        QWebEnginePage.__init__(self)
+    def __init__(
+        self,
+        onBridgeCmd: BridgeCommandHandler,
+        kind: AnkiWebViewKind,
+        parent: QObject | None,
+    ) -> None:
+        profile = self._profileForPage(kind)
+        QWebEnginePage.__init__(self, profile, parent)
         self._onBridgeCmd = onBridgeCmd
+        self._kind = kind
         self._setupBridge()
         self.open_links_externally = True
 
-    def _setupBridge(self) -> None:
-        class Bridge(QObject):
-            def __init__(self, bridge_handler: Callable[[str], Any]) -> None:
-                super().__init__()
-                self.onCmd = bridge_handler
+    def _profileForPage(self, kind: AnkiWebViewKind) -> QWebEngineProfile:
+        have_api_access = kind in (
+            AnkiWebViewKind.DECK_OPTIONS,
+            AnkiWebViewKind.EDITOR,
+            AnkiWebViewKind.DECK_STATS,
+            AnkiWebViewKind.CHANGE_NOTETYPE,
+            AnkiWebViewKind.BROWSER_CARD_INFO,
+        )
 
-            @pyqtSlot(str, result=str)  # type: ignore
-            def cmd(self, str: str) -> Any:
-                return json.dumps(self.onCmd(str))
+        global _profile_with_api_access, _profile_without_api_access
 
-        self._bridge = Bridge(self._onCmd)
+        # Use cached profile if available
+        if have_api_access and _profile_with_api_access is not None:
+            return _profile_with_api_access
+        elif not have_api_access and _profile_without_api_access is not None:
+            return _profile_without_api_access
 
-        self._channel = QWebChannel(self)
-        self._channel.registerObject("py", self._bridge)
-        self.setWebChannel(self._channel)
+        # Create a new profile if not cached
+        profile = QWebEngineProfile()
 
         qwebchannel = ":/qtwebchannel/qwebchannel.js"
         jsfile = QFile(qwebchannel)
@@ -90,11 +143,34 @@ class AnkiWebPage(QWebEnginePage):
         script.setInjectionPoint(QWebEngineScript.InjectionPoint.DocumentReady)
         script.setRunsOnSubFrames(False)
 
-        profile = self.profile()
-        assert profile is not None
         scripts = profile.scripts()
         assert scripts is not None
         scripts.insert(script)
+
+        interceptor = AuthInterceptor(profile, api_enabled=have_api_access)
+        profile.setUrlRequestInterceptor(interceptor)
+        if have_api_access:
+            _profile_with_api_access = profile
+        else:
+            _profile_without_api_access = profile
+
+        return profile
+
+    def _setupBridge(self) -> None:
+        class Bridge(QObject):
+            def __init__(self, bridge_handler: Callable[[str], Any]) -> None:
+                super().__init__()
+                self.onCmd = bridge_handler
+
+            @pyqtSlot(str, result=str)  # type: ignore
+            def cmd(self, str: str) -> Any:
+                return json.dumps(self.onCmd(str))
+
+        self._bridge = Bridge(self._onCmd)
+
+        self._channel = QWebChannel(self)
+        self._channel.registerObject("py", self._bridge)
+        self.setWebChannel(self._channel)
 
     def javaScriptConsoleMessage(
         self,
@@ -247,34 +323,6 @@ class WebContent:
 ##########################################################################
 
 
-class AnkiWebViewKind(Enum):
-    """Enum registry of all web views managed by Anki
-
-    The value of each entry corresponds to the web view's title.
-
-    When introducing a new web view, please add it to the registry below.
-    """
-
-    DEFAULT = "default"
-    MAIN = "main webview"
-    TOP_TOOLBAR = "top toolbar"
-    BOTTOM_TOOLBAR = "bottom toolbar"
-    DECK_OPTIONS = "deck options"
-    EDITOR = "editor"
-    LEGACY_DECK_STATS = "legacy deck stats"
-    DECK_STATS = "deck stats"
-    PREVIEWER = "previewer"
-    CHANGE_NOTETYPE = "change notetype"
-    CARD_LAYOUT = "card layout"
-    BROWSER_CARD_INFO = "browser card info"
-    IMPORT_CSV = "csv import"
-    EMPTY_CARDS = "empty cards"
-    FIND_DUPLICATES = "find duplicates"
-    FIELDS = "fields"
-    IMPORT_LOG = "import log"
-    IMPORT_ANKI_PACKAGE = "anki package import"
-
-
 class AnkiWebView(QWebEngineView):
     allow_drops = False
     _kind: AnkiWebViewKind
@@ -287,11 +335,8 @@ class AnkiWebView(QWebEngineView):
     ) -> None:
         QWebEngineView.__init__(self, parent=parent)
         self.set_kind(kind)
-        if title:
-            self.set_title(title)
-        self._page = AnkiWebPage(self._onBridgeCmd)
         # reduce flicker
-        self._page.setBackgroundColor(theme_manager.qcolor(colors.CANVAS))
+        self.page().setBackgroundColor(theme_manager.qcolor(colors.CANVAS))
 
         # in new code, use .set_bridge_command() instead of setting this directly
         self.onBridgeCmd: Callable[[str], Any] = self.defaultOnBridgeCmd
@@ -299,7 +344,6 @@ class AnkiWebView(QWebEngineView):
         self._domDone = True
         self._pendingActions: list[tuple[str, Sequence[Any]]] = []
         self.requiresCol = True
-        self.setPage(self._page)
         self._disable_zoom = False
 
         self.resetHandlers()
@@ -323,6 +367,15 @@ class AnkiWebView(QWebEngineView):
     def set_kind(self, kind: AnkiWebViewKind) -> None:
         self._kind = kind
         self.set_title(kind.value)
+        # this is an ugly hack to avoid breakages caused by
+        # creating a default webview then immediately calling set_kind, which results
+        # in the creation of two pages, and the second fails as the domDone
+        # signal from the first one is received
+        if kind != AnkiWebViewKind.DEFAULT:
+            self.setPage(AnkiWebPage(self._onBridgeCmd, kind, self))
+
+    def page(self) -> AnkiWebPage:
+        return cast(AnkiWebPage, super().page())
 
     @property
     def kind(self) -> AnkiWebViewKind:
@@ -357,7 +410,7 @@ class AnkiWebView(QWebEngineView):
         return False
 
     def set_open_links_externally(self, enable: bool) -> None:
-        self._page.open_links_externally = enable
+        self.page().open_links_externally = enable
 
     def onEsc(self) -> None:
         w = self.parent()
@@ -822,7 +875,7 @@ html {{ {font} }}
         Must be done on Windows prior to changing current working directory."""
         self.requiresCol = False
         self._domReady = False
-        self._page.setContent(cast(QByteArray, bytes("", "ascii")))
+        self.page().setContent(cast(QByteArray, bytes("", "ascii")))
 
     def cleanup(self) -> None:
         try:
@@ -836,14 +889,14 @@ html {{ {font} }}
         # defer page cleanup so that in-flight requests have a chance to complete first
         # https://forums.ankiweb.net/t/error-when-exiting-browsing-when-the-software-is-installed-in-the-path-c-program-files-anki/38363
         mw.progress.single_shot(5000, lambda: mw.mediaServer.clear_page_html(id(self)))
-        self._page.deleteLater()
+        self.page().deleteLater()
 
     def on_theme_did_change(self) -> None:
         # avoid flashes if page reloaded
-        self._page.setBackgroundColor(theme_manager.qcolor(colors.CANVAS))
+        self.page().setBackgroundColor(theme_manager.qcolor(colors.CANVAS))
         if hasattr(QWebEngineSettings.WebAttribute, "ForceDarkMode"):
             force_dark_mode = getattr(QWebEngineSettings.WebAttribute, "ForceDarkMode")
-            page_settings = self._page.settings()
+            page_settings = self.page().settings()
             if page_settings is not None:
                 page_settings.setAttribute(
                     force_dark_mode,

--- a/qt/aqt/webview.py
+++ b/qt/aqt/webview.py
@@ -137,6 +137,9 @@ class AnkiWebPage(QWebEnginePage):
             AnkiWebViewKind.DECK_STATS,
             AnkiWebViewKind.CHANGE_NOTETYPE,
             AnkiWebViewKind.BROWSER_CARD_INFO,
+            AnkiWebViewKind.IMPORT_ANKI_PACKAGE,
+            AnkiWebViewKind.IMPORT_CSV,
+            AnkiWebViewKind.IMPORT_LOG,
         )
 
         global _profile_with_api_access, _profile_without_api_access

--- a/qt/aqt/webview.py
+++ b/qt/aqt/webview.py
@@ -81,8 +81,8 @@ class AnkiWebPage(QWebEnginePage):
     def __init__(
         self,
         onBridgeCmd: BridgeCommandHandler,
-        kind: AnkiWebViewKind,
-        parent: QObject | None,
+        kind: AnkiWebViewKind = AnkiWebViewKind.DEFAULT,
+        parent: QObject | None = None,
     ) -> None:
         profile = self._profileForPage(kind)
         QWebEnginePage.__init__(self, profile, parent)

--- a/ts/editor/NoteEditor.svelte
+++ b/ts/editor/NoteEditor.svelte
@@ -133,7 +133,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         }
 
         for (const [index, [, fieldContent]] of fs.entries()) {
-            fieldStores[index].set(fieldContent);
+            fieldStores[index].set(sanitize(fieldContent));
         }
 
         fieldNames = newFieldNames;
@@ -424,6 +424,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     } from "../routes/image-occlusion/store";
     import CollapseLabel from "./CollapseLabel.svelte";
     import * as oldEditorAdapter from "./old-editor-adapter";
+    import { sanitize } from "$lib/domlib";
 
     $: isIOImageLoaded = false;
     $: ioImageLoadedStore.set(isIOImageLoaded);

--- a/ts/lib/domlib/index.ts
+++ b/ts/lib/domlib/index.ts
@@ -5,4 +5,5 @@ export * from "./content-editable";
 export * from "./location";
 export * from "./move-nodes";
 export * from "./place-caret";
+export * from "./sanitize";
 export * from "./surround";

--- a/ts/lib/domlib/sanitize.ts
+++ b/ts/lib/domlib/sanitize.ts
@@ -1,0 +1,10 @@
+// Copyright: Ankitects Pty Ltd and contributors
+// License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
+
+import DOMPurify from "dompurify";
+
+export function sanitize(html: string): string {
+    // We need to treat the text as a document fragment, or a style tag
+    // at the start of input will be discarded.
+    return DOMPurify.sanitize(html, { FORCE_BODY: true });
+}

--- a/ts/licenses.json
+++ b/ts/licenses.json
@@ -57,6 +57,12 @@
         "path": "node_modules/@tootallnate/once",
         "licenseFile": "node_modules/@tootallnate/once/LICENSE"
     },
+    "@types/trusted-types@2.0.7": {
+        "licenses": "MIT",
+        "repository": "https://github.com/DefinitelyTyped/DefinitelyTyped",
+        "path": "node_modules/@types/trusted-types",
+        "licenseFile": "node_modules/@types/trusted-types/LICENSE"
+    },
     "abab@2.0.6": {
         "licenses": "BSD-3-Clause",
         "repository": "https://github.com/jsdom/abab",
@@ -95,8 +101,8 @@
         "repository": "https://github.com/TooTallNate/node-agent-base",
         "publisher": "Nathan Rajlich",
         "email": "nathan@tootallnate.net",
-        "path": "node_modules/agent-base",
-        "licenseFile": "node_modules/agent-base/README.md"
+        "path": "node_modules/http-proxy-agent/node_modules/agent-base",
+        "licenseFile": "node_modules/http-proxy-agent/node_modules/agent-base/README.md"
     },
     "asynckit@0.4.0": {
         "licenses": "MIT",
@@ -436,6 +442,14 @@
         "path": "node_modules/domexception",
         "licenseFile": "node_modules/domexception/LICENSE.txt"
     },
+    "dompurify@3.2.5": {
+        "licenses": "(MPL-2.0 OR Apache-2.0)",
+        "repository": "https://github.com/cure53/DOMPurify",
+        "publisher": "Dr.-Ing. Mario Heiderich, Cure53",
+        "email": "mario@cure53.de",
+        "path": "node_modules/dompurify",
+        "licenseFile": "node_modules/dompurify/LICENSE"
+    },
     "empty-npm-package@1.0.0": {
         "licenses": "ISC",
         "path": "node_modules/canvas"
@@ -571,6 +585,14 @@
         "email": "john.david.dalton@gmail.com",
         "path": "node_modules/lodash-es",
         "licenseFile": "node_modules/lodash-es/LICENSE"
+    },
+    "lru-cache@10.4.3": {
+        "licenses": "ISC",
+        "repository": "https://github.com/isaacs/node-lru-cache",
+        "publisher": "Isaac Z. Schlueter",
+        "email": "i@izs.me",
+        "path": "node_modules/lru-cache",
+        "licenseFile": "node_modules/lru-cache/LICENSE"
     },
     "marked@5.1.2": {
         "licenses": "MIT",
@@ -768,16 +790,16 @@
         "repository": "https://github.com/jsdom/whatwg-url",
         "publisher": "Sebastian Mayr",
         "email": "github@smayr.name",
-        "path": "node_modules/whatwg-url",
-        "licenseFile": "node_modules/whatwg-url/LICENSE.txt"
+        "path": "node_modules/jsdom/node_modules/whatwg-url",
+        "licenseFile": "node_modules/jsdom/node_modules/whatwg-url/LICENSE.txt"
     },
     "whatwg-url@11.0.0": {
         "licenses": "MIT",
         "repository": "https://github.com/jsdom/whatwg-url",
         "publisher": "Sebastian Mayr",
         "email": "github@smayr.name",
-        "path": "node_modules/data-urls/node_modules/whatwg-url",
-        "licenseFile": "node_modules/data-urls/node_modules/whatwg-url/LICENSE.txt"
+        "path": "node_modules/whatwg-url",
+        "licenseFile": "node_modules/whatwg-url/LICENSE.txt"
     },
     "ws@8.18.0": {
         "licenses": "MIT",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1662,6 +1662,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/trusted-types@npm:^2.0.7":
+  version: 2.0.7
+  resolution: "@types/trusted-types@npm:2.0.7"
+  checksum: 10c0/4c4855f10de7c6c135e0d32ce462419d8abbbc33713b31d294596c0cc34ae1fa6112a2f9da729c8f7a20707782b0d69da3b1f8df6645b0366d08825ca1522e0c
+  languageName: node
+  linkType: hard
+
 "@typescript-eslint/eslint-plugin@npm:^5.60.1":
   version: 5.62.0
   resolution: "@typescript-eslint/eslint-plugin@npm:5.62.0"
@@ -2018,6 +2025,7 @@ __metadata:
     cross-env: "npm:^7.0.2"
     d3: "npm:^7.0.0"
     diff: "npm:^5.0.0"
+    dompurify: "npm:^3.2.5"
     dprint: "npm:^0.47.2"
     esbuild: "npm:^0.25.0"
     esbuild-sass-plugin: "npm:^2"
@@ -3166,6 +3174,18 @@ __metadata:
   dependencies:
     domelementtype: "npm:^2.3.0"
   checksum: 10c0/bba1e5932b3e196ad6862286d76adc89a0dbf0c773e5ced1eb01f9af930c50093a084eff14b8de5ea60b895c56a04d5de8bbc4930c5543d029091916770b2d2a
+  languageName: node
+  linkType: hard
+
+"dompurify@npm:^3.2.5":
+  version: 3.2.5
+  resolution: "dompurify@npm:3.2.5"
+  dependencies:
+    "@types/trusted-types": "npm:^2.0.7"
+  dependenciesMeta:
+    "@types/trusted-types":
+      optional: true
+  checksum: 10c0/b564167cc588933ad2d25c185296716bdd7124e9d2a75dac76efea831bb22d1230ce5205a1ab6ce4c1010bb32ac35f7a5cb2dd16c78cbf382111f1228362aa59
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
I received a report recently that our existing mitigations in mediasrv.py are not sufficient, meaning that a malicious shared deck could potentially access our internal API, and thus arbitrary data on the system. As users have an expectation that shared decks are safe to download, we'll need to get a fix for this out promptly. This is the least disruptive/invasive solution I could come up with:

- Stripping scripts from editor field content may end up breaking some decks that have such content embedded in fields. My thinking here is that such decks are quite rare, and placing such content in fields has never been encouraged.
- Switching to a custom URL scheme would have required a lot more changes, and [requires a newer Qt](https://github.com/ankitects/anki/issues/3871#issuecomment-2803806785).

@abdnh @glutanimate @iamllama feedback/testing would be appreciated. If nobody objects or has better ideas in the next ~24 hours, I'll merge this into main, and aim to get a bugfix build out with only this change about a day later.

