### PR TITLE
Fix `AnkiWebPage` not being initialized for default web view kinds (e.g. in add-ons)

### DIFF
--- a/qt/aqt/browser/find_duplicates.py
+++ b/qt/aqt/browser/find_duplicates.py
@@ -14,7 +14,6 @@ from anki.collection import SearchNode
 from anki.notes import NoteId
 from aqt.qt import *
 from aqt.qt import sip
-from aqt.webview import AnkiWebViewKind
 
 from ..operations import QueryOp
 from ..operations.tag import add_tags_to_notes
@@ -52,7 +51,6 @@ class FindDuplicatesDialog(QDialog):
         self._dupes: list[tuple[str, list[NoteId]]] = []
 
         # links
-        form.webView.set_kind(AnkiWebViewKind.FIND_DUPLICATES)
         form.webView.set_bridge_command(self._on_duplicate_clicked, context=self)
         form.webView.stdHtml("", context=self)
 

--- a/qt/aqt/emptycards.py
+++ b/qt/aqt/emptycards.py
@@ -15,7 +15,6 @@ from anki.collection import EmptyCardsReport
 from aqt import gui_hooks
 from aqt.qt import QDialog, QDialogButtonBox, qconnect
 from aqt.utils import disable_help_button, restoreGeom, saveGeom, tooltip, tr
-from aqt.webview import AnkiWebViewKind
 
 
 def show_empty_cards(mw: aqt.main.AnkiQt) -> None:
@@ -47,7 +46,6 @@ class EmptyCardsDialog(QDialog):
         self.setWindowTitle(tr.empty_cards_window_title())
         disable_help_button(self)
         self.form.keep_notes.setText(tr.empty_cards_preserve_notes_checkbox())
-        self.form.webview.set_kind(AnkiWebViewKind.EMPTY_CARDS)
         self.form.webview.set_bridge_command(self._on_note_link_clicked, self)
 
         gui_hooks.empty_cards_will_show(self)

--- a/qt/aqt/forms/emptycards.ui
+++ b/qt/aqt/forms/emptycards.ui
@@ -30,7 +30,7 @@
     <number>0</number>
    </property>
    <item>
-    <widget class="AnkiWebView" name="webview" native="true">
+    <widget class="EmptyCardsWebView" name="webview" native="true">
      <property name="url" stdset="0">
       <url>
        <string notr="true">about:blank</string>
@@ -81,7 +81,7 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>AnkiWebView</class>
+   <class>EmptyCardsWebView</class>
    <extends>QWidget</extends>
    <header location="global">aqt/webview</header>
    <container>1</container>

--- a/qt/aqt/forms/finddupes.ui
+++ b/qt/aqt/forms/finddupes.ui
@@ -73,7 +73,7 @@
        <number>0</number>
       </property>
       <item>
-       <widget class="AnkiWebView" name="webView" native="true">
+       <widget class="FindDupesWebView" name="webView" native="true">
         <property name="url" stdset="0">
          <url>
           <string notr="true">about:blank</string>
@@ -98,7 +98,7 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>AnkiWebView</class>
+   <class>FindDupesWebView</class>
    <extends>QWidget</extends>
    <header location="global">aqt/webview</header>
    <container>1</container>

--- a/qt/aqt/forms/stats.ui
+++ b/qt/aqt/forms/stats.ui
@@ -30,7 +30,7 @@
     <number>0</number>
    </property>
    <item>
-    <widget class="AnkiWebView" name="web" native="true">
+    <widget class="StatsWebView" name="web" native="true">
      <property name="url" stdset="0">
       <url>
        <string notr="true">about:blank</string>
@@ -146,7 +146,7 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>AnkiWebView</class>
+   <class>StatsWebView</class>
    <extends>QWidget</extends>
    <header location="global">aqt/webview</header>
    <container>1</container>

--- a/qt/aqt/stats.py
+++ b/qt/aqt/stats.py
@@ -25,7 +25,7 @@ from aqt.utils import (
     tooltip,
     tr,
 )
-from aqt.webview import AnkiWebViewKind
+from aqt.webview import LegacyStatsWebView
 
 
 class NewDeckStats(QDialog):
@@ -153,6 +153,9 @@ class DeckStats(QDialog):
         self.name = "deckStats"
         self.period = 0
         self.form = aqt.forms.stats.Ui_Dialog()
+        # Hack: Switch out web views dynamically to avoid maintaining multiple
+        # Qt forms for different versions of the stats dialog.
+        self.form.web = LegacyStatsWebView(self.mw)
         self.oldPos = None
         self.wholeCollection = False
         self.setMinimumWidth(700)
@@ -231,7 +234,6 @@ class DeckStats(QDialog):
         stats = self.mw.col.stats()
         stats.wholeCollection = self.wholeCollection
         self.report = stats.report(type=self.period)
-        self.form.web.set_kind(AnkiWebViewKind.LEGACY_DECK_STATS)
         self.form.web.stdHtml(
             f"<html><body>{self.report}</body></html>",
             js=["js/vendor/jquery.min.js", "js/vendor/plot.js"],

--- a/qt/aqt/stats.py
+++ b/qt/aqt/stats.py
@@ -71,7 +71,6 @@ class NewDeckStats(QDialog):
         maybeHideClose(self.form.buttonBox)
         addCloseShortcut(self)
         gui_hooks.stats_dialog_will_show(self)
-        self.form.web.set_kind(AnkiWebViewKind.DECK_STATS)
         self.form.web.hide_while_preserving_layout()
         self.show()
         self.refresh()

--- a/qt/aqt/webview.py
+++ b/qt/aqt/webview.py
@@ -984,5 +984,6 @@ def create_ankiwebview_subclass(kind: AnkiWebViewKind):
 # These convenience subclasses are used in qt designer ui files to
 # avoid calling AnkiWebView.set_kind after init (causes flashing)
 StatsWebView = create_ankiwebview_subclass(AnkiWebViewKind.DECK_STATS)
+LegacyStatsWebView = create_ankiwebview_subclass(AnkiWebViewKind.LEGACY_DECK_STATS)
 EmptyCardsWebView = create_ankiwebview_subclass(AnkiWebViewKind.EMPTY_CARDS)
 FindDupesWebView = create_ankiwebview_subclass(AnkiWebViewKind.FIND_DUPLICATES)

--- a/qt/aqt/webview.py
+++ b/qt/aqt/webview.py
@@ -968,3 +968,21 @@ html {{ {font} }}
     @deprecated(info="use theme_manager.qcolor() instead")
     def get_window_bg_color(self, night_mode: bool | None = None) -> QColor:
         return theme_manager.qcolor(colors.CANVAS)
+
+
+def create_ankiwebview_subclass(kind: AnkiWebViewKind):
+    class Subclass(AnkiWebView):
+        def __init__(
+            self,
+            parent: QWidget | None = None,
+        ) -> None:
+            super().__init__(parent, kind=kind)
+
+    return Subclass
+
+
+# These convenience subclasses are used in qt designer ui files to
+# avoid calling AnkiWebView.set_kind after init (causes flashing)
+StatsWebView = create_ankiwebview_subclass(AnkiWebViewKind.DECK_STATS)
+EmptyCardsWebView = create_ankiwebview_subclass(AnkiWebViewKind.EMPTY_CARDS)
+FindDupesWebView = create_ankiwebview_subclass(AnkiWebViewKind.FIND_DUPLICATES)

--- a/qt/aqt/webview.py
+++ b/qt/aqt/webview.py
@@ -362,7 +362,9 @@ class AnkiWebView(QWebEngineView):
         kind: AnkiWebViewKind = AnkiWebViewKind.DEFAULT,
     ) -> None:
         QWebEngineView.__init__(self, parent=parent)
-        self.set_kind(kind)
+        self._kind = kind
+        self.set_title(kind.value)
+        self.setPage(AnkiWebPage(self._onBridgeCmd, kind, self))
         # reduce flicker
         self.page().setBackgroundColor(theme_manager.qcolor(colors.CANVAS))
 
@@ -391,17 +393,6 @@ class AnkiWebView(QWebEngineView):
         });
         """
         )
-
-    def set_kind(self, kind: AnkiWebViewKind) -> None:
-        self._kind = kind
-        self.set_title(kind.value)
-        # this is an ugly hack to avoid breakages caused by
-        # creating a default webview then immediately calling set_kind, which results
-        # in the creation of two pages, and the second fails as the domDone
-        # signal from the first one is received
-        if kind != AnkiWebViewKind.DEFAULT:
-            self.setPage(AnkiWebPage(self._onBridgeCmd, kind, self))
-            self.page().setBackgroundColor(theme_manager.qcolor(colors.CANVAS))
 
     def page(self) -> AnkiWebPage:
         return cast(AnkiWebPage, super().page())


### PR DESCRIPTION
#3925 and in particular the `domDone` race condition workaround in 24bca15fd3d9dc386916509eb2d4862d1184e709 unfortunately break add-ons that depend on default-kind `AnkiWebViews` initializing with a corresponding `AnkiWebPage`. This affects any add-ons that rely on `bridgeCommand` in add-on managed web views (for instance Contanki, [as reported on the forums](https://forums.ankiweb.net/t/add-ons-and-25-02-1-default-ankiwebview-api-access-workarounds/59309)).

Because in testing #3925 we happened to primarily test add-ons that either manage page creation manually or do not use `bridgeCommand`, we unfortunately missed this incompatibility.

This PR uses (with some minor alterations) @iamllama's web view subclasses proposed in the original version of #3928 to completely avoid setting the web view kind after web view initialization. Additionally, we fully drop `set_kind()` from the AnkiWebView API to discourage its use in either Anki-native code or add-ons.

(I mentioned in the corresponding commit that I found one add-on that was using `set_kind()`, but it turns out that this is no longer the case in current versions of the add-on, so dropping this method should not introduce any add-on breakages)

@iamllama I hope picking your commits here is OK. I initially looked into whether Qt designer supports some way to supply arguments to custom widgets, but quickly found that this is not possible ­­­­- or at least not in a way that would allow us to change things at widget construction time. So I thought back to your initial solution for the Qt forms web view flashing and picked that up.