### PR TITLE
Persist tags when refetching csv metadata while importing

### DIFF
--- a/ts/routes/import-csv/lib.ts
+++ b/ts/routes/import-csv/lib.ts
@@ -99,6 +99,7 @@ export class ImportCsvState {
 
         const shouldRefetchMetadata = this.shouldRefetchMetadata(changed);
         if (shouldRefetchMetadata) {
+            const { globalTags, updatedTags } = changed;
             changed = await getCsvMetadata({
                 path: this.path,
                 delimiter: changed.delimiter,
@@ -106,6 +107,9 @@ export class ImportCsvState {
                 deckId: getDeckId(changed) ?? undefined,
                 isHtml: changed.isHtml,
             });
+            // carry over tags
+            changed.globalTags = globalTags;
+            changed.updatedTags = updatedTags;
         }
 
         const globalNotetype = getGlobalNotetype(changed);


### PR DESCRIPTION
Fixes #3937

Tags are now persisted across metadata refetches

NB: refetching rereads the csv file, so if the `#tags:...` header line is edited across a refetch, the new global tags won't be reflected post-pr. But not only is this unlikely, the import dialog's tag inputs are already (pre-pr) broken in such a way that those changes won't be shown (but will still be applied). After this pr, what's reflected in the tags input will now consistently be what's applied to the imported notes