### PR TITLE
Fix/Calculate missing memory states on simulate

### DIFF
--- a/rslib/src/scheduler/fsrs/simulator.rs
+++ b/rslib/src/scheduler/fsrs/simulator.rs
@@ -123,8 +123,14 @@ impl Collection {
             .col
             .storage
             .get_revlog_entries_for_searched_cards_in_card_order()?;
-        let cards = guard.col.storage.all_searched_cards()?;
+        let mut cards = guard.col.storage.all_searched_cards()?;
         drop(guard);
+        for card in &mut cards {
+            if card.memory_state.is_none() {
+                let new_state = self.compute_memory_state(card.id)?.state;
+                card.memory_state = new_state.map(Into::into);
+            }
+        }
         let days_elapsed = self.timing_today().unwrap().days_elapsed as i32;
         let new_cards = cards
             .iter()

--- a/rslib/src/scheduler/fsrs/simulator.rs
+++ b/rslib/src/scheduler/fsrs/simulator.rs
@@ -130,8 +130,10 @@ impl Collection {
         } 
         for c in &mut cards {
             if is_included_card(c) && c.memory_state.is_none() {
+                let original = c.clone();
                 let new_state = self.compute_memory_state(c.id)?.state;
                 c.memory_state = new_state.map(Into::into);
+                self.update_card_inner(c, original, self.usn()?)?;
             }
         }
         let days_elapsed = self.timing_today().unwrap().days_elapsed as i32;


### PR DESCRIPTION
Cards without memory states (likely due to being moved) are currently treated as new cards. This recalculates them.

Before:
![image](https://github.com/user-attachments/assets/f2ebcad7-6e10-4126-b299-1e3512246594)
After:
![image](https://github.com/user-attachments/assets/42b11af3-c26e-4cfb-a577-33c696a50aec)

This does slow the simulation down with "ignore reviews before" because cards that will have no memory state even after calculation are processed every time.
