### PR TITLE
Add add-on scripts to editor CSP

### DIFF
--- a/qt/aqt/mediasrv.py
+++ b/qt/aqt/mediasrv.py
@@ -752,8 +752,12 @@ def legacy_page_data() -> Response:
         # have access to our internal API, and is a security risk.
         if page.context == PageContext.EDITOR:
             port = aqt.mw.mediaServer.getPort()
+            csp_paths = (
+                f"http://127.0.0.1:{port}/_anki/",
+                f"http://127.0.0.1:{port}/_addons/",
+            )
             response.headers["Content-Security-Policy"] = (
-                f"script-src http://127.0.0.1:{port}/_anki/"
+                f"script-src {' '.join(csp_paths)}"
             )
         return response
     else:


### PR DESCRIPTION
Some add-ons (e.g. [Language Tools](https://ankiweb.net/shared/info/771677663), [Markdown Input](https://ankiweb.net/shared/info/904999275), others) load custom scripts in the editor context, so we need to include them in the CSP for the add-ons to continue working.

Follow-up to #3939