### PR TITLE
Fix fields with `\n` being ignored when searching all fields w/o regex

### DIFF
--- a/rslib/src/search/sqlwriter.rs
+++ b/rslib/src/search/sqlwriter.rs
@@ -555,7 +555,7 @@ impl SqlWriter<'_> {
     }
 
     fn write_all_fields(&mut self, val: &str) {
-        self.args.push(format!("(?i)^{}$", to_re(val)));
+        self.args.push(format!("(?is)^{}$", to_re(val)));
         write!(self.sql, "regexp_fields(?{}, n.flds)", self.args.len()).unwrap();
     }
 

--- a/rslib/src/search/sqlwriter.rs
+++ b/rslib/src/search/sqlwriter.rs
@@ -1081,7 +1081,7 @@ mod test {
             s(ctx, "*:te*st"),
             (
                 "(regexp_fields(?1, n.flds))".into(),
-                vec!["(?i)^te.*st$".into()]
+                vec!["(?is)^te.*st$".into()]
             )
         );
         // all field search with regex


### PR DESCRIPTION
Reported in https://forums.ankiweb.net/t/potential-bug-newline-character-in-fields-html-disrupts-search-for-wildcard-fields/59617

`*:*somestring*` gets rewritten to `(?i)^.*somestring.*$`. But this doesn't match against a field with
```
<div>
  somestring
</div>
```
> Perhaps surprisingly, the default behavior for . is not to match any character, but rather, to match any character except for the line terminator (which is \n by default). When this mode is enabled, the behavior changes such that . truly matches any character.
https://docs.rs/regex/latest/regex/struct.RegexBuilder.html#method.dot_matches_new_line

The fix proposed is to add the `(?s)` flag that enables the abovementioned mode