### PR TITLE
Update to FSRS-rs v3.0.0 (fix historic memory state)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2100,7 +2100,8 @@ dependencies = [
 [[package]]
 name = "fsrs"
 version = "3.0.0"
-source = "git+https://github.com/open-spaced-repetition/fsrs-rs.git?rev=c7717682997a8a6d53d97c7196281e745c5b3c8e#c7717682997a8a6d53d97c7196281e745c5b3c8e"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7e39017be91629761c3a2802032eb38d226227e1a21433381da4310612199ee"
 dependencies = [
  "burn",
  "itertools 0.14.0",
@@ -3377,7 +3378,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,9 +35,9 @@ git = "https://github.com/ankitects/linkcheck.git"
 rev = "184b2ca50ed39ca43da13f0b830a463861adb9ca"
 
 [workspace.dependencies.fsrs]
-# version = "=2.0.3"
-git = "https://github.com/open-spaced-repetition/fsrs-rs.git"
-rev = "c7717682997a8a6d53d97c7196281e745c5b3c8e"
+version = "3.0.0"
+# git = "https://github.com/open-spaced-repetition/fsrs-rs.git"
+# rev = "c7717682997a8a6d53d97c7196281e745c5b3c8e"
 # path = "../open-spaced-repetition/fsrs-rs"
 
 [workspace.dependencies]
@@ -66,7 +66,10 @@ axum-extra = { version = "0.9.4", features = ["typed-header"] }
 blake3 = "1.5.4"
 bytes = "1.7.2"
 camino = "1.1.9"
-chrono = { version = "0.4.38", default-features = false, features = ["std", "clock"] }
+chrono = { version = "0.4.38", default-features = false, features = [
+  "std",
+  "clock",
+] }
 clap = { version = "4.5.20", features = ["derive"] }
 coarsetime = "0.1.34"
 convert_case = "0.6.0"
@@ -110,11 +113,25 @@ prost-build = "0.13"
 prost-reflect = "0.14"
 prost-types = "0.13"
 pulldown-cmark = "0.9.6"
-pyo3 = { version = "0.24", features = ["extension-module", "abi3", "abi3-py39"] }
+pyo3 = { version = "0.24", features = [
+  "extension-module",
+  "abi3",
+  "abi3-py39",
+] }
 rand = "0.8.5"
 regex = "1.11.0"
-reqwest = { version = "0.12.8", default-features = false, features = ["json", "socks", "stream", "multipart"] }
-rusqlite = { version = "0.30.0", features = ["trace", "functions", "collation", "bundled"] }
+reqwest = { version = "0.12.8", default-features = false, features = [
+  "json",
+  "socks",
+  "stream",
+  "multipart",
+] }
+rusqlite = { version = "0.30.0", features = [
+  "trace",
+  "functions",
+  "collation",
+  "bundled",
+] }
 rustls-pemfile = "2.2.0"
 scopeguard = "1.2.0"
 serde = { version = "1.0.210", features = ["derive"] }
@@ -131,10 +148,18 @@ syn = { version = "2.0.82", features = ["parsing", "printing"] }
 tar = "0.4.42"
 tempfile = "3.13.0"
 termcolor = "1.4.1"
-tokio = { version = "1.40", features = ["fs", "rt-multi-thread", "macros", "signal"] }
+tokio = { version = "1.40", features = [
+  "fs",
+  "rt-multi-thread",
+  "macros",
+  "signal",
+] }
 tokio-util = { version = "0.7.12", features = ["io"] }
 tower-http = { version = "0.5", features = ["trace"] }
-tracing = { version = "0.1.40", features = ["max_level_trace", "release_max_level_debug"] }
+tracing = { version = "0.1.40", features = [
+  "max_level_trace",
+  "release_max_level_debug",
+] }
 tracing-appender = "0.2.3"
 tracing-subscriber = { version = "0.3.18", features = ["fmt", "env-filter"] }
 tugger-windows-codesign = "0.10.0"
@@ -145,7 +170,10 @@ walkdir = "2.5.0"
 which = "5.0.0"
 wiremock = "0.6.2"
 xz2 = "0.1.7"
-zip = { version = "0.6.6", default-features = false, features = ["deflate", "time"] }
+zip = { version = "0.6.6", default-features = false, features = [
+  "deflate",
+  "time",
+] }
 zstd = { version = "0.13.2", features = ["zstdmt"] }
 
 # Apply mild optimizations to our dependencies in dev mode, which among other things

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,10 +66,7 @@ axum-extra = { version = "0.9.4", features = ["typed-header"] }
 blake3 = "1.5.4"
 bytes = "1.7.2"
 camino = "1.1.9"
-chrono = { version = "0.4.38", default-features = false, features = [
-  "std",
-  "clock",
-] }
+chrono = { version = "0.4.38", default-features = false, features = ["std", "clock"] }
 clap = { version = "4.5.20", features = ["derive"] }
 coarsetime = "0.1.34"
 convert_case = "0.6.0"
@@ -113,25 +110,11 @@ prost-build = "0.13"
 prost-reflect = "0.14"
 prost-types = "0.13"
 pulldown-cmark = "0.9.6"
-pyo3 = { version = "0.24", features = [
-  "extension-module",
-  "abi3",
-  "abi3-py39",
-] }
+pyo3 = { version = "0.24", features = ["extension-module", "abi3", "abi3-py39"] }
 rand = "0.8.5"
 regex = "1.11.0"
-reqwest = { version = "0.12.8", default-features = false, features = [
-  "json",
-  "socks",
-  "stream",
-  "multipart",
-] }
-rusqlite = { version = "0.30.0", features = [
-  "trace",
-  "functions",
-  "collation",
-  "bundled",
-] }
+reqwest = { version = "0.12.8", default-features = false, features = ["json", "socks", "stream", "multipart"] }
+rusqlite = { version = "0.30.0", features = ["trace", "functions", "collation", "bundled"] }
 rustls-pemfile = "2.2.0"
 scopeguard = "1.2.0"
 serde = { version = "1.0.210", features = ["derive"] }
@@ -148,18 +131,10 @@ syn = { version = "2.0.82", features = ["parsing", "printing"] }
 tar = "0.4.42"
 tempfile = "3.13.0"
 termcolor = "1.4.1"
-tokio = { version = "1.40", features = [
-  "fs",
-  "rt-multi-thread",
-  "macros",
-  "signal",
-] }
+tokio = { version = "1.40", features = ["fs", "rt-multi-thread", "macros", "signal"] }
 tokio-util = { version = "0.7.12", features = ["io"] }
 tower-http = { version = "0.5", features = ["trace"] }
-tracing = { version = "0.1.40", features = [
-  "max_level_trace",
-  "release_max_level_debug",
-] }
+tracing = { version = "0.1.40", features = ["max_level_trace", "release_max_level_debug"] }
 tracing-appender = "0.2.3"
 tracing-subscriber = { version = "0.3.18", features = ["fmt", "env-filter"] }
 tugger-windows-codesign = "0.10.0"
@@ -170,10 +145,7 @@ walkdir = "2.5.0"
 which = "5.0.0"
 wiremock = "0.6.2"
 xz2 = "0.1.7"
-zip = { version = "0.6.6", default-features = false, features = [
-  "deflate",
-  "time",
-] }
+zip = { version = "0.6.6", default-features = false, features = ["deflate", "time"] }
 zstd = { version = "0.13.2", features = ["zstdmt"] }
 
 # Apply mild optimizations to our dependencies in dev mode, which among other things


### PR DESCRIPTION
It includes this patch: 
- https://github.com/open-spaced-repetition/fsrs-rs/pull/320

It fixed this bug:

> Currently, in Anki, A card with a review history completely ignored by ignore_reviews_before except for 1 review panics with
> 
> ```
> thread '<unnamed>' panicked at rslib/src/stats/card.rs:159:40:
> attempt to subtract with overflow
> ```
> 
> I presume this is the fix for that? We could also fix it in Anki with:
> 
> ```rust
>             let mut memory_states =
>                 fsrs.historical_memory_states(item.item, item.starting_state)?;
>             if let Some(starting_state) = item.starting_state {
>                 memory_states.insert(0, starting_state);
>             }
> ```
> 
> I'm not sure if it's best to fix it like this or let the programmer decide if they want to insert the starting state themselves manually like above?

