### PR TITLE
Line break before percentage

### DIFF
--- a/ts/routes/graphs/buttons.ts
+++ b/ts/routes/graphs/buttons.ts
@@ -148,7 +148,7 @@ export function renderButtons(
                                     kind = tr.statisticsCountsMatureCards();
                                     break;
                             }
-                            return `${kind} \u200e(${totalCorrect(d).percent}%)`;
+                            return `${kind}\u000a\u200e(${totalCorrect(d).percent}%)`;
                         }) as any,
                     )
                     .tickSizeOuter(0),


### PR DESCRIPTION
This is not tested – I'm apparently unable to build Anki locally.

The idea is to introduce a line break in the statistics in the "Answer buttons" section, before the percent value. Currently, the horizontal space is very restricted, and the percentage value restricts it further. Putting it in a new line would give more horizontal space for translators. And I think it looks better even when the horizontal space is not required. While #3841 would not be actually solved by this pull request, it would be a good-enough solution for most translations.

PS: Which is the correct new line? Is \u000a okay?