### PR TITLE
Fix/No memory state cards have revlogs in reverse order on card stats screen.

### DIFF
--- a/rslib/src/stats/card.rs
+++ b/rslib/src/stats/card.rs
@@ -176,7 +176,7 @@ impl Collection {
             }
             Ok(result.into_iter().rev().collect())
         } else {
-            Ok(revlog.iter().map(stats_revlog_entry).collect())
+            Ok(revlog.iter().rev().map(stats_revlog_entry).collect())
         }
     }
 }


### PR DESCRIPTION
Currently cards without a memory state have their revlogs appear descending:
(bug, note the dates descending)
![image](https://github.com/user-attachments/assets/ece52289-a4a4-401c-b6ed-fd073f7677fb)
