### PR TITLE
REMOVE percentages of x-axis in the answer buttons graph

### DIFF
--- a/ts/routes/graphs/buttons.ts
+++ b/ts/routes/graphs/buttons.ts
@@ -148,7 +148,6 @@ export function renderButtons(
                                     kind = tr.statisticsCountsMatureCards();
                                     break;
                             }
-                            console.log("Tick format for", d, "returns", kind);
                             return `${kind}`;
                         }) as any,
                     )
@@ -163,7 +162,6 @@ export function renderButtons(
                 .each(function(d) {
                     const current_text_element = this; 
                     const current_text_element_content = current_text_element.textContent;
-                    console.log("Current text content:", current_text_element_content);
 
                     current_text_element.textContent = "";
 

--- a/ts/routes/graphs/buttons.ts
+++ b/ts/routes/graphs/buttons.ts
@@ -156,30 +156,6 @@ export function renderButtons(
         )
         .attr("direction", "ltr");
 
-    svg.select<SVGGElement>(".x-ticks").selectAll<SVGTextElement, GroupKind>("text")
-        .each(function(this: SVGTextElement, d: GroupKind) {
-            if (!(this instanceof SVGElement)) {
-                return;
-            }
-            const current_text_element_content = this.textContent;
-
-            this.textContent = "";
-
-            // Create a tspan for the text content (the "kind" part)
-            const tspan_kind = document.createElementNS("http://www.w3.org/2000/svg", "tspan");
-            tspan_kind.textContent = current_text_element_content;
-            tspan_kind.setAttribute("dy", "0.5em");
-
-            // Create a tspan for the percentage
-            const tspan_percentage = document.createElementNS("http://www.w3.org/2000/svg", "tspan");
-            tspan_percentage.textContent = `\u200e(${totalCorrect(d).percent}%)`;
-            tspan_percentage.setAttribute("dy", "1em");
-            tspan_percentage.setAttribute("x", "0");
-
-            this.appendChild(tspan_kind);
-            this.appendChild(tspan_percentage);
-        });
-
     const xButton = scaleBand()
         .domain(["1", "2", "3", "4"])
         .range([0, xGroup.bandwidth()])

--- a/ts/routes/graphs/buttons.ts
+++ b/ts/routes/graphs/buttons.ts
@@ -183,8 +183,6 @@ export function renderButtons(
             });
     }, 0);
 
-    // \u200e(${totalCorrect(d).percent}%)
-
     const xButton = scaleBand()
         .domain(["1", "2", "3", "4"])
         .range([0, xGroup.bandwidth()])

--- a/ts/routes/graphs/buttons.ts
+++ b/ts/routes/graphs/buttons.ts
@@ -130,29 +130,27 @@ export function renderButtons(
         .domain(["learning", "young", "mature"])
         .range([bounds.marginLeft, bounds.width - bounds.marginRight]);
     svg.select<SVGGElement>(".x-ticks")
-        .call((selection) =>
-            selection.transition(trans).call(
-                axisBottom(xGroup)
-                    .tickFormat(
-                        ((d: GroupKind) => {
-                            let kind: string;
-                            switch (d) {
-                                case "learning":
-                                    kind = tr.statisticsCountsLearningCards();
-                                    break;
-                                case "young":
-                                    kind = tr.statisticsCountsYoungCards();
-                                    break;
-                                case "mature":
-                                default:
-                                    kind = tr.statisticsCountsMatureCards();
-                                    break;
-                            }
-                            return `${kind}`;
-                        }) as any,
-                    )
-                    .tickSizeOuter(0),
-            )
+        .call(
+            axisBottom(xGroup)
+                .tickFormat(
+                    ((d: GroupKind) => {
+                        let kind: string;
+                        switch (d) {
+                            case "learning":
+                                kind = tr.statisticsCountsLearningCards();
+                                break;
+                            case "young":
+                                kind = tr.statisticsCountsYoungCards();
+                                break;
+                            case "mature":
+                            default:
+                                kind = tr.statisticsCountsMatureCards();
+                                break;
+                        }
+                        return `${kind}`;
+                    }) as any,
+                )
+                .tickSizeOuter(0),
         )
         .attr("direction", "ltr");
 

--- a/ts/routes/graphs/buttons.ts
+++ b/ts/routes/graphs/buttons.ts
@@ -148,13 +148,41 @@ export function renderButtons(
                                     kind = tr.statisticsCountsMatureCards();
                                     break;
                             }
-                            return `${kind} \u200e(${totalCorrect(d).percent}%)`;
+                            console.log("Tick format for", d, "returns", kind);
+                            return `${kind}`;
                         }) as any,
                     )
                     .tickSizeOuter(0),
             )
         )
         .attr("direction", "ltr");
+        
+        // Add a timeout to ensure that the text elements are populated
+        setTimeout(() => {
+            svg.selectAll("text")
+                .each(function(d) {
+                    const current_text_element = this; 
+                    const current_text_element_content = current_text_element.textContent;
+                    console.log("Current text content:", current_text_element_content);
+
+                    current_text_element.textContent = "";
+
+                    // Create a tspan for the text content (the "kind" part)
+                    const tspan = document.createElementNS("http://www.w3.org/2000/svg", "tspan");
+                    tspan.textContent = current_text_element_content;
+                    tspan.setAttribute("dy", "0");
+                    
+                    // Create a tspan for the percentage
+                    const tspan2 = document.createElementNS("http://www.w3.org/2000/svg", "tspan");
+                    tspan2.textContent = `\u200e(${totalCorrect(d).percent}%)`;
+                    tspan2.setAttribute("dy", "1em");
+
+                    current_text_element.appendChild(tspan);
+                    current_text_element.appendChild(tspan2);
+                });
+        }, 0);
+
+// \u200e(${totalCorrect(d).percent}%)
 
     const xButton = scaleBand()
         .domain(["1", "2", "3", "4"])

--- a/ts/routes/graphs/buttons.ts
+++ b/ts/routes/graphs/buttons.ts
@@ -159,7 +159,7 @@ export function renderButtons(
         
         // Add a timeout to ensure that the text elements are populated
         setTimeout(() => {
-            svg.selectAll("text")
+            svg.select<SVGGElement>(".x-ticks").selectAll("text")
                 .each(function(d) {
                     const current_text_element = this; 
                     const current_text_element_content = current_text_element.textContent;

--- a/ts/routes/graphs/buttons.ts
+++ b/ts/routes/graphs/buttons.ts
@@ -170,12 +170,13 @@ export function renderButtons(
                     // Create a tspan for the text content (the "kind" part)
                     const tspan = document.createElementNS("http://www.w3.org/2000/svg", "tspan");
                     tspan.textContent = current_text_element_content;
-                    tspan.setAttribute("dy", "0");
+                    tspan.setAttribute("dy", "0.5em");
                     
                     // Create a tspan for the percentage
                     const tspan2 = document.createElementNS("http://www.w3.org/2000/svg", "tspan");
                     tspan2.textContent = `\u200e(${totalCorrect(d).percent}%)`;
                     tspan2.setAttribute("dy", "1em");
+                    tspan2.setAttribute("dx", "-4em"); // i realized it works. It's probably a coincidence and a hack
 
                     current_text_element.appendChild(tspan);
                     current_text_element.appendChild(tspan2);

--- a/ts/routes/graphs/buttons.ts
+++ b/ts/routes/graphs/buttons.ts
@@ -130,58 +130,53 @@ export function renderButtons(
         .domain(["learning", "young", "mature"])
         .range([bounds.marginLeft, bounds.width - bounds.marginRight]);
     svg.select<SVGGElement>(".x-ticks")
-        .call((selection) =>
-            selection.transition(trans).call(
-                axisBottom(xGroup)
-                    .tickFormat(
-                        ((d: GroupKind) => {
-                            let kind: string;
-                            switch (d) {
-                                case "learning":
-                                    kind = tr.statisticsCountsLearningCards();
-                                    break;
-                                case "young":
-                                    kind = tr.statisticsCountsYoungCards();
-                                    break;
-                                case "mature":
-                                default:
-                                    kind = tr.statisticsCountsMatureCards();
-                                    break;
-                            }
-                            return `${kind}`;
-                        }) as any,
-                    )
-                    .tickSizeOuter(0),
-            )
+        .call(
+            axisBottom(xGroup)
+                .tickFormat(
+                    ((d: GroupKind) => {
+                        let kind: string;
+                        switch (d) {
+                            case "learning":
+                                kind = tr.statisticsCountsLearningCards();
+                                break;
+                            case "young":
+                                kind = tr.statisticsCountsYoungCards();
+                                break;
+                            case "mature":
+                            default:
+                                kind = tr.statisticsCountsMatureCards();
+                                break;
+                        }
+                        return `${kind}`;
+                    }) as any,
+                )
+                .tickSizeOuter(0),
         )
         .attr("direction", "ltr");
 
-    // Add a timeout to ensure that the text elements are populated
-    setTimeout(() => {
-        svg.select<SVGGElement>(".x-ticks").selectAll<SVGTextElement, GroupKind>("text")
-            .each(function(this: SVGTextElement, d: GroupKind) {
-                if (!(this instanceof SVGElement)) {
-                    return;
-                }
-                const current_text_element_content = this.textContent;
+    svg.select<SVGGElement>(".x-ticks").selectAll<SVGTextElement, GroupKind>("text")
+        .each(function(this: SVGTextElement, d: GroupKind) {
+            if (!(this instanceof SVGElement)) {
+                return;
+            }
+            const current_text_element_content = this.textContent;
 
-                this.textContent = "";
+            this.textContent = "";
 
-                // Create a tspan for the text content (the "kind" part)
-                const tspan = document.createElementNS("http://www.w3.org/2000/svg", "tspan");
-                tspan.textContent = current_text_element_content;
-                tspan.setAttribute("dy", "0.5em");
+            // Create a tspan for the text content (the "kind" part)
+            const tspan = document.createElementNS("http://www.w3.org/2000/svg", "tspan");
+            tspan.textContent = current_text_element_content;
+            tspan.setAttribute("dy", "0.5em");
 
-                // Create a tspan for the percentage
-                const tspan2 = document.createElementNS("http://www.w3.org/2000/svg", "tspan");
-                tspan2.textContent = `\u200e(${totalCorrect(d).percent}%)`;
-                tspan2.setAttribute("dy", "1em");
-                tspan2.setAttribute("dx", "-4em"); // i realized it works. It's probably a coincidence and a hack
+            // Create a tspan for the percentage
+            const tspan2 = document.createElementNS("http://www.w3.org/2000/svg", "tspan");
+            tspan2.textContent = `\u200e(${totalCorrect(d).percent}%)`;
+            tspan2.setAttribute("dy", "1em");
+            tspan2.setAttribute("dx", "-4em"); // i realized it works. It's probably a coincidence and a hack
 
-                this.appendChild(tspan);
-                this.appendChild(tspan2);
-            });
-    }, 0);
+            this.appendChild(tspan);
+            this.appendChild(tspan2);
+        });
 
     const xButton = scaleBand()
         .domain(["1", "2", "3", "4"])

--- a/ts/routes/graphs/buttons.ts
+++ b/ts/routes/graphs/buttons.ts
@@ -155,33 +155,35 @@ export function renderButtons(
             )
         )
         .attr("direction", "ltr");
-        
-        // Add a timeout to ensure that the text elements are populated
-        setTimeout(() => {
-            svg.select<SVGGElement>(".x-ticks").selectAll("text")
-                .each(function(d) {
-                    const current_text_element = this; 
-                    const current_text_element_content = current_text_element.textContent;
 
-                    current_text_element.textContent = "";
+    // Add a timeout to ensure that the text elements are populated
+    setTimeout(() => {
+        svg.select<SVGGElement>(".x-ticks").selectAll<SVGTextElement, GroupKind>("text")
+            .each(function(this: SVGTextElement, d: GroupKind) {
+                if (!(this instanceof SVGElement)) {
+                    return;
+                }
+                const current_text_element_content = this.textContent;
 
-                    // Create a tspan for the text content (the "kind" part)
-                    const tspan = document.createElementNS("http://www.w3.org/2000/svg", "tspan");
-                    tspan.textContent = current_text_element_content;
-                    tspan.setAttribute("dy", "0.5em");
-                    
-                    // Create a tspan for the percentage
-                    const tspan2 = document.createElementNS("http://www.w3.org/2000/svg", "tspan");
-                    tspan2.textContent = `\u200e(${totalCorrect(d).percent}%)`;
-                    tspan2.setAttribute("dy", "1em");
-                    tspan2.setAttribute("dx", "-4em"); // i realized it works. It's probably a coincidence and a hack
+                this.textContent = "";
 
-                    current_text_element.appendChild(tspan);
-                    current_text_element.appendChild(tspan2);
-                });
-        }, 0);
+                // Create a tspan for the text content (the "kind" part)
+                const tspan = document.createElementNS("http://www.w3.org/2000/svg", "tspan");
+                tspan.textContent = current_text_element_content;
+                tspan.setAttribute("dy", "0.5em");
 
-// \u200e(${totalCorrect(d).percent}%)
+                // Create a tspan for the percentage
+                const tspan2 = document.createElementNS("http://www.w3.org/2000/svg", "tspan");
+                tspan2.textContent = `\u200e(${totalCorrect(d).percent}%)`;
+                tspan2.setAttribute("dy", "1em");
+                tspan2.setAttribute("dx", "-4em"); // i realized it works. It's probably a coincidence and a hack
+
+                this.appendChild(tspan);
+                this.appendChild(tspan2);
+            });
+    }, 0);
+
+    // \u200e(${totalCorrect(d).percent}%)
 
     const xButton = scaleBand()
         .domain(["1", "2", "3", "4"])

--- a/ts/routes/graphs/buttons.ts
+++ b/ts/routes/graphs/buttons.ts
@@ -130,27 +130,29 @@ export function renderButtons(
         .domain(["learning", "young", "mature"])
         .range([bounds.marginLeft, bounds.width - bounds.marginRight]);
     svg.select<SVGGElement>(".x-ticks")
-        .call(
-            axisBottom(xGroup)
-                .tickFormat(
-                    ((d: GroupKind) => {
-                        let kind: string;
-                        switch (d) {
-                            case "learning":
-                                kind = tr.statisticsCountsLearningCards();
-                                break;
-                            case "young":
-                                kind = tr.statisticsCountsYoungCards();
-                                break;
-                            case "mature":
-                            default:
-                                kind = tr.statisticsCountsMatureCards();
-                                break;
-                        }
-                        return `${kind}`;
-                    }) as any,
-                )
-                .tickSizeOuter(0),
+        .call((selection) =>
+            selection.transition(trans).call(
+                axisBottom(xGroup)
+                    .tickFormat(
+                        ((d: GroupKind) => {
+                            let kind: string;
+                            switch (d) {
+                                case "learning":
+                                    kind = tr.statisticsCountsLearningCards();
+                                    break;
+                                case "young":
+                                    kind = tr.statisticsCountsYoungCards();
+                                    break;
+                                case "mature":
+                                default:
+                                    kind = tr.statisticsCountsMatureCards();
+                                    break;
+                            }
+                            return `${kind}`;
+                        }) as any,
+                    )
+                    .tickSizeOuter(0),
+            )
         )
         .attr("direction", "ltr");
 

--- a/ts/routes/graphs/buttons.ts
+++ b/ts/routes/graphs/buttons.ts
@@ -164,18 +164,18 @@ export function renderButtons(
             this.textContent = "";
 
             // Create a tspan for the text content (the "kind" part)
-            const tspan = document.createElementNS("http://www.w3.org/2000/svg", "tspan");
-            tspan.textContent = current_text_element_content;
-            tspan.setAttribute("dy", "0.5em");
+            const tspan_kind = document.createElementNS("http://www.w3.org/2000/svg", "tspan");
+            tspan_kind.textContent = current_text_element_content;
+            tspan_kind.setAttribute("dy", "0.5em");
 
             // Create a tspan for the percentage
-            const tspan2 = document.createElementNS("http://www.w3.org/2000/svg", "tspan");
-            tspan2.textContent = `\u200e(${totalCorrect(d).percent}%)`;
-            tspan2.setAttribute("dy", "1em");
-            tspan2.setAttribute("x", "0");
+            const tspan_percentage = document.createElementNS("http://www.w3.org/2000/svg", "tspan");
+            tspan_percentage.textContent = `\u200e(${totalCorrect(d).percent}%)`;
+            tspan_percentage.setAttribute("dy", "1em");
+            tspan_percentage.setAttribute("x", "0");
 
-            this.appendChild(tspan);
-            this.appendChild(tspan2);
+            this.appendChild(tspan_kind);
+            this.appendChild(tspan_percentage);
         });
 
     const xButton = scaleBand()

--- a/ts/routes/graphs/buttons.ts
+++ b/ts/routes/graphs/buttons.ts
@@ -172,7 +172,7 @@ export function renderButtons(
             const tspan2 = document.createElementNS("http://www.w3.org/2000/svg", "tspan");
             tspan2.textContent = `\u200e(${totalCorrect(d).percent}%)`;
             tspan2.setAttribute("dy", "1em");
-            tspan2.setAttribute("dx", "-4em"); // i realized it works. It's probably a coincidence and a hack
+            tspan2.setAttribute("x", "0");
 
             this.appendChild(tspan);
             this.appendChild(tspan2);


### PR DESCRIPTION
Fixes: #3841 
Makes #3950 obsolete.

<details><summary>Old description</summary>
<p>

This seems to work, though I'm not sure if that's the right way to go about things. `d3` is like black magic to me, and being a novice at programming certainly doesn't help either.

I coded a line like this:
```ts
tspan2.setAttribute("dx", "-4em"); // i realized it works. It's probably a coincidence and a hack
```
The `-4em` part was retrieved by trial and error and is probably a hack. It does work perfectly fine on my machine, though.

Here's how the graph looks like with this PR:
![anki](https://github.com/user-attachments/assets/39faa174-f854-4a32-85f7-4f990c4734a3)

@sommerluk maybe you could build and try this?

</p>
</details> 


This PR breaks the percentage into a separate line (for the answer buttons graph only). This might improve translations, as longer strings can now be used correctly.

The transition has been removed from the graph. Not sure why that works, but @iamllama kindly pointed this out (see [forum post](https://forums.ankiweb.net/t/i-need-help-with-my-pr-splitting-the-x-axis-of-svg-d3-into-two-separate-lines-cuts-off-text-and-is-misaligned/59819/2?u=anon_0000)).

Here's what the graph with the current PR looks like:
_English_
![anki](https://github.com/user-attachments/assets/01531357-324f-46d5-bff7-fb2361f2338d)
_German_
![anki](https://github.com/user-attachments/assets/11249e9b-db86-4e2b-9c8d-f0a8e8e2dcc7)
