### PR TITLE
add toggle for browser sidebar

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -223,6 +223,7 @@ derivativeoflog7 <https://github.com/derivativeoflog7>
 rreemmii-dev <https://github.com/rreemmii-dev>
 babofitos <https://github.com/babofitos>
 Jonathan Schoreels <https://github.com/JSchoreels>
+JL710
 
 ********************
 

--- a/ftl/qt/qt-accel.ftl
+++ b/ftl/qt/qt-accel.ftl
@@ -40,6 +40,7 @@ qt-accel-layout-horizontal = &Horizontal
 qt-accel-zoom-in = Zoom &In
 qt-accel-zoom-out = Zoom &Out
 qt-accel-reset-zoom = &Reset Zoom
+qt-accel-toggle-sidebar = Toggle Sidebar
 qt-accel-zoom-editor-in = Zoom Editor &In
 qt-accel-zoom-editor-out = Zoom Editor &Out
 qt-accel-create-backup = Create &Backup

--- a/qt/aqt/browser/browser.py
+++ b/qt/aqt/browser/browser.py
@@ -366,6 +366,7 @@ class Browser(QMainWindow):
         qconnect(f.actionFind.triggered, self.onFind)
         qconnect(f.actionNote.triggered, self.onNote)
         qconnect(f.actionSidebar.triggered, self.focusSidebar)
+        qconnect(f.actionToggleSidebar.triggered, self.toggle_sidebar)
         qconnect(f.actionCardList.triggered, self.onCardList)
 
         # help
@@ -695,7 +696,7 @@ class Browser(QMainWindow):
 
     def setupSidebar(self) -> None:
         dw = self.sidebarDockWidget = QDockWidget(tr.browsing_sidebar(), self)
-        dw.setFeatures(QDockWidget.DockWidgetFeature.NoDockWidgetFeatures)
+        dw.setFeatures(QDockWidget.DockWidgetFeature.DockWidgetClosable)
         dw.setObjectName("Sidebar")
         dock_area = (
             Qt.DockWidgetArea.RightDockWidgetArea
@@ -729,8 +730,11 @@ class Browser(QMainWindow):
         # UI is more responsive
         self.mw.progress.timer(10, self.sidebar.refresh, False, parent=self.sidebar)
 
-    def showSidebar(self) -> None:
-        self.sidebarDockWidget.setVisible(True)
+    def showSidebar(self, show: bool = True) -> None:
+        want_visible = not self.sidebarDockWidget.isVisible()
+        self.sidebarDockWidget.setVisible(show)
+        if want_visible and show:
+            self.sidebar.refresh()
 
     def focusSidebar(self) -> None:
         self.showSidebar()
@@ -741,10 +745,7 @@ class Browser(QMainWindow):
         self.sidebar.searchBar.setFocus()
 
     def toggle_sidebar(self) -> None:
-        want_visible = not self.sidebarDockWidget.isVisible()
-        self.sidebarDockWidget.setVisible(want_visible)
-        if want_visible:
-            self.sidebar.refresh()
+        self.showSidebar(not self.sidebarDockWidget.isVisible())
 
     # legacy
 

--- a/qt/aqt/forms/browser.ui
+++ b/qt/aqt/forms/browser.ui
@@ -317,6 +317,8 @@
     <addaction name="separator"/>
     <addaction name="actionFullScreen"/>
     <addaction name="separator"/>
+    <addaction name="actionToggleSidebar"/>
+    <addaction name="separator"/>
     <addaction name="actionZoomIn"/>
     <addaction name="actionZoomOut"/>
     <addaction name="actionResetZoom"/>
@@ -701,6 +703,11 @@
    <property name="text">
     <string>qt_accel_full_screen</string>
    </property>
+  </action>
+  <action name="actionToggleSidebar">
+    <property name="text">
+      <string>qt_accel_toggle_sidebar</string>
+    </property>
   </action>
   <action name="actionZoomIn">
    <property name="text">


### PR DESCRIPTION
This PR enables the user to toggle the sidebar of the browser. 

The use case is for usage in split screen editing. If you have anki on a device like a laptop and editing notes while looking at another document, you often have anki only on one half of the screen. In that scenario the sidebar takes a lot of space. This PR enables you to toggle/hide it.