### PR TITLE
Fix mathjax images erroneously appearing enlarged

### DIFF
--- a/ts/editable/ContentEditable.svelte
+++ b/ts/editable/ContentEditable.svelte
@@ -69,6 +69,8 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         &:focus {
             outline: none;
         }
+
+        min-height: 1.5em;
     }
 
     /* editable-base.scss contains styling targeting user HTML */

--- a/ts/editable/editable-base.scss
+++ b/ts/editable/editable-base.scss
@@ -2,7 +2,6 @@
 
 * {
     max-width: 100%;
-    min-height: 1.5em;
 }
 
 p {


### PR DESCRIPTION
Reported in https://forums.ankiweb.net/t/anki-25-05-beta/59710/28

The `min-height` property added in https://github.com/ankitects/anki/commit/e7fbf159a67f8e73c21f871b8329f9275671aa80 wasn't specific enough and affected mathjax images. The fix proposed is to move it into the `anki-editable` scope (`min-height` is not inherited)