### PR TITLE
 Remove dead code in reviews_for_fsrs

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -224,6 +224,7 @@ rreemmii-dev <https://github.com/rreemmii-dev>
 babofitos <https://github.com/babofitos>
 Jonathan Schoreels <https://github.com/JSchoreels>
 JL710
+Matt Brubeck <mbrubeck@limpet.net>
 
 ********************
 

--- a/rslib/src/scheduler/fsrs/params.rs
+++ b/rslib/src/scheduler/fsrs/params.rs
@@ -322,8 +322,6 @@ pub(crate) fn reviews_for_fsrs(
         if user_graded && entry.review_kind == RevlogReviewKind::Learning {
             first_of_last_learn_entries = Some(index);
             revlogs_complete = true;
-        } else if first_of_last_learn_entries.is_some() {
-            break;
         } else if matches!(
             (entry.review_kind, entry.ease_factor),
             (RevlogReviewKind::Manual, 0)
@@ -343,6 +341,10 @@ pub(crate) fn reviews_for_fsrs(
             } else {
                 return None;
             }
+        // Previous versions of Anki didn't add a revlog entry when the card was
+        // reset.
+        } else if first_of_last_learn_entries.is_some() {
+            break;
         }
     }
     if training {


### PR DESCRIPTION
The code removed here is never executed, because an earlier check for `first_of_last_learn_entries` would always break out of the loop before this check could succeed.  The code is also unnecessary because when `first_of_last_learn_entries` is set, `revlogs_complete` is already set to `true`.