### PR TITLE
Fix unescaped deck names missing from tooltips when deleted

### DIFF
--- a/qt/aqt/operations/deck.py
+++ b/qt/aqt/operations/deck.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import html
 from collections.abc import Sequence
 
 from anki.collection import OpChanges, OpChangesWithCount, OpChangesWithId
@@ -22,7 +23,7 @@ def remove_decks(
         lambda out: tooltip(
             tr.browsing_cards_deleted_with_deckname(
                 count=out.count,
-                deck_name=deck_name,
+                deck_name=html.escape(deck_name),
             ),
             parent=parent,
         )


### PR DESCRIPTION
> If I delete a deck containing < in its name, the deck name in the tooltip is truncated.
https://forums.ankiweb.net/t/anki-25-05-beta/59710/20

`tooltip` takes in html, so the fix proposed is to html-escape the deck name. Translations are allowed to include html, but grepping doesn't show it being passed to `tooltip`, so the conservative choice was made to not move the escaping into it