### PR TITLE
Check if self.card.reps>0 before substracing 1

### DIFF
--- a/rslib/src/scheduler/answering/current.rs
+++ b/rslib/src/scheduler/answering/current.rs
@@ -71,14 +71,7 @@ impl CardStateUpdater {
                     // Decrease reps by 1 to get correct seed for fuzz.
                     // If the fuzz calculation changes, this will break.
                     let last_ivl_with_fuzz = self.learning_ivl_with_fuzz(
-                        get_fuzz_seed_for_id_and_reps(
-                            self.card.id,
-                            if self.card.reps > 0 {
-                                self.card.reps - 1
-                            } else {
-                                0
-                            },
-                        ),
+                        get_fuzz_seed_for_id_and_reps(self.card.id, self.card.reps.wrapping_sub(1)),
                         last_ivl,
                     );
                     let last_answered_time = due as i64 - last_ivl_with_fuzz as i64;

--- a/rslib/src/scheduler/answering/current.rs
+++ b/rslib/src/scheduler/answering/current.rs
@@ -71,7 +71,10 @@ impl CardStateUpdater {
                     // Decrease reps by 1 to get correct seed for fuzz.
                     // If the fuzz calculation changes, this will break.
                     let last_ivl_with_fuzz = self.learning_ivl_with_fuzz(
-                        get_fuzz_seed_for_id_and_reps(self.card.id, self.card.reps - 1),
+                        get_fuzz_seed_for_id_and_reps(
+                            self.card.id,
+                            if self.card.reps > 0 { self.card.reps - 1 } else { 0 }
+                        ),
                         last_ivl,
                     );
                     let last_answered_time = due as i64 - last_ivl_with_fuzz as i64;

--- a/rslib/src/scheduler/answering/current.rs
+++ b/rslib/src/scheduler/answering/current.rs
@@ -73,7 +73,11 @@ impl CardStateUpdater {
                     let last_ivl_with_fuzz = self.learning_ivl_with_fuzz(
                         get_fuzz_seed_for_id_and_reps(
                             self.card.id,
-                            if self.card.reps > 0 { self.card.reps - 1 } else { 0 }
+                            if self.card.reps > 0 {
+                                self.card.reps - 1
+                            } else {
+                                0
+                            },
                         ),
                         last_ivl,
                     );


### PR DESCRIPTION
Hello, today I used the "Learn Now" from AJT Card Management : https://ankiweb.net/shared/info/1021636467

And when it marked a card as "Learning" (but without reps or anything), it caused some PanicException when clicking on the deck :
`thread '<unnamed>' panicked at rslib/src/scheduler/answering/current.rs:74:69:
attempt to subtract with overflow`

Looking at the code, I was able to make the issue disappear by checking that self.card.reps is greater than 0 before substracting, and else return 0. So in case of overflow, it will just return 0

It's not per se an Anki issue but I think treating those values a bit more safely shouldn't hurt ?

This is the state of the card that cause the issue : [carddata.json](https://github.com/user-attachments/files/19941700/carddata.json). It misses the field "reviews", which could explain the panic ?

