### PR TITLE
Clear notetypes cache on import

### DIFF
--- a/qt/aqt/main.py
+++ b/qt/aqt/main.py
@@ -872,6 +872,9 @@ class AnkiQt(QMainWindow):
         if changes.mtime:
             self.toolbar.update_sync_status()
 
+        if changes.notetype:
+            self.col.models._clear_cache()
+
     def on_focus_did_change(
         self, new_focus: QWidget | None, _old: QWidget | None
     ) -> None:

--- a/qt/aqt/mediasrv.py
+++ b/qt/aqt/mediasrv.py
@@ -522,6 +522,7 @@ def import_done() -> bytes:
                 window.setWindowModality(Qt.WindowModality.NonModal)
                 window.show()
 
+    aqt.mw.col.models._clear_cache()
     aqt.mw.taskman.run_on_main(update_window_modality)
     return b""
 

--- a/qt/aqt/mediasrv.py
+++ b/qt/aqt/mediasrv.py
@@ -522,7 +522,6 @@ def import_done() -> bytes:
                 window.setWindowModality(Qt.WindowModality.NonModal)
                 window.show()
 
-    aqt.mw.col.models._clear_cache()
     aqt.mw.taskman.run_on_main(update_window_modality)
     return b""
 


### PR DESCRIPTION
Noticed this is needed after importing a deck with merge_notetypes enabled (which added a new template to a notetype) then opening the Card Types screen and getting this error:
```
Traceback (most recent call last):
  File "D:\dev\anki\repo\qt\aqt\webview.py", line 747, in handler
    cb(val)
  File "D:\dev\anki\repo\qt\aqt\editor.py", line 649, in <lambda>
    self.web.evalWithCallback("saveNow(%d)" % keepFocus, lambda res: callback())
  File "D:\dev\anki\repo\qt\aqt\editor.py", line 380, in _onCardLayout
    CardLayout(
  File "D:\dev\anki\repo\qt\aqt\clayout.py", line 92, in __init__
    self.redraw_everything()
  File "D:\dev\anki\repo\qt\aqt\clayout.py", line 106, in redraw_everything
    self.update_current_ordinal_and_redraw(self.ord)
  File "D:\dev\anki\repo\qt\aqt\clayout.py", line 113, in update_current_ordinal_and_redraw
    self.fill_fields_from_template()
  File "D:\dev\anki\repo\qt\aqt\clayout.py", line 488, in fill_fields_from_template
    t = self.current_template()
  File "D:\dev\anki\repo\qt\aqt\clayout.py", line 485, in current_template
    return self.templates[self.ord]
IndexError: list index out of range
```

I guess any backend operation on note types should invalidate the cache. We can add this to AnkiQt.on_operation_did_execute() but then the cache will be less useful when there are any updates:
```python
if changes.notetype:
    self.col.models._clear_cache()
```
