### PR TITLE
Fix/stability doesn't increase after pressing good

### DIFF
--- a/rslib/src/storage/card/data.rs
+++ b/rslib/src/storage/card/data.rs
@@ -85,7 +85,7 @@ impl CardData {
 
     pub(crate) fn convert_to_json(&mut self) -> Result<String> {
         if let Some(v) = &mut self.fsrs_stability {
-            round_to_places(v, 3)
+            round_to_places(v, 4)
         }
         if let Some(v) = &mut self.fsrs_difficulty {
             round_to_places(v, 3)
@@ -173,7 +173,7 @@ mod test {
         };
         assert_eq!(
             data.convert_to_json().unwrap(),
-            r#"{"s":123.457,"d":1.235,"dr":0.99,"decay":0.123}"#
+            r#"{"s":123.4568,"d":1.235,"dr":0.99,"decay":0.123}"#
         );
     }
 }


### PR DESCRIPTION
Because the minimum of stability is 0.001 in FSRS-6, the stabilities before and after a good rating could be 0.001 and 0.0012. In previous implementation, the stability will be rounded to 0.001. It leads to this problem:

![image](https://github.com/user-attachments/assets/718c5b67-1b18-4a66-8e58-1cc5fcdf7bc5)

With this PR, it's fixed:

![image](https://github.com/user-attachments/assets/af38e16e-a4e8-4a63-8fc9-00b8ef949586)
