### PR TITLE
feat(scheduler): Allow bypassing queue logic via CardAnswer flag

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -225,6 +225,7 @@ babofitos <https://github.com/babofitos>
 Jonathan Schoreels <https://github.com/JSchoreels>
 JL710
 Matt Brubeck <mbrubeck@limpet.net>
+Yaoliang Chen <yaoliang.ch@gmail.com>
 
 ********************
 

--- a/proto/anki/scheduler.proto
+++ b/proto/anki/scheduler.proto
@@ -279,6 +279,7 @@ message CardAnswer {
   Rating rating = 4;
   int64 answered_at_millis = 5;
   uint32 milliseconds_taken = 6;
+  optional bool from_queue = 7;
 }
 
 message CustomStudyRequest {

--- a/rslib/src/scheduler/reviews.rs
+++ b/rslib/src/scheduler/reviews.rs
@@ -163,10 +163,10 @@ impl Collection {
                     rating,
                     milliseconds_taken: 0,
                     answered_at_millis: TimestampMillis::now().into(),
+                    // Process the card without updating queues yet
+                    from_queue: Some(false),
                 }
                 .into();
-                // Process the card without updating queues yet
-                answer.from_queue = false;
                 col.answer_card_inner(&mut answer)?;
             }
             Ok(())

--- a/rslib/src/scheduler/service/answering.rs
+++ b/rslib/src/scheduler/service/answering.rs
@@ -21,7 +21,7 @@ impl From<anki_proto::scheduler::CardAnswer> for CardAnswer {
             answered_at: TimestampMillis(answer.answered_at_millis),
             milliseconds_taken: answer.milliseconds_taken,
             custom_data,
-            from_queue: true,
+            from_queue: answer.from_queue.unwrap_or(true),
         }
     }
 }


### PR DESCRIPTION
## Problem

Currently, the backend scheduler assumes all card answers processed via the `answer_card` endpoint originate from the standard review queue (`from_queue` is implicitly true). This doesn't accurately represent scenarios like card previews or potentially some custom study sessions where answering a card should not affect the main queue counts or state.

## Solution

This PR introduces an optional boolean field `from_queue` to the `CardAnswer` protobuf message definition (`proto/anki/scheduler.proto`).

When `from_queue` is set to `false` by the client, the backend service (`rslib/src/scheduler/service/answering.rs`) will now set the internal `from_queue` flag to `false` for that specific answer. This allows the scheduler to correctly handle answers that should not modify the standard queue state.

If `from_queue` is omitted or set to `true`, the behavior remains unchanged (the answer is considered `from_queue = true`).

## Impact

This change provides more flexibility for clients interacting with the scheduler, enabling them to distinguish between answers that are part of the normal review flow and those that occur outside of it (e.g., previews), ensuring queue metrics remain accurate.