### PR TITLE
Properly align label and radio input in the stats window

### DIFF
--- a/ts/routes/graphs/RangeBox.svelte
+++ b/ts/routes/graphs/RangeBox.svelte
@@ -112,6 +112,15 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 <div class="range-box-pad"></div>
 
 <style lang="scss">
+    label {
+        display: inline-flex;
+        align-items: center;
+    }
+
+    input[type="radio"] {
+        margin-right: 0.3em;
+    }
+
     .range-box {
         position: sticky;
         z-index: 1;

--- a/ts/routes/graphs/RangeBox.svelte
+++ b/ts/routes/graphs/RangeBox.svelte
@@ -118,7 +118,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     }
 
     input[type="radio"] {
-        margin-right: 0.3em;
+        margin-inline-end: 0.3em;
     }
 
     .range-box {


### PR DESCRIPTION
The way it currently looks is all over the place (especially visible for _deck_ and _all history_ ):
![anki](https://github.com/user-attachments/assets/cb77200e-9c21-49c9-82df-a097dd5f629b)

After this PR the radio button circles and their labels are properly aligned:
![anki](https://github.com/user-attachments/assets/b689c0be-ab95-4c73-85e6-42ed17986848)
