### PR TITLE
UPDATE answer button graph tooltip to include I) answer button name and II) description of what "correct" means

### DIFF
--- a/ftl/core/statistics.ftl
+++ b/ftl/core/statistics.ftl
@@ -229,7 +229,7 @@ statistics-stability-day-single =
 # hour range, eg "From 14:00-15:00"
 statistics-hours-range = From { $hourStart }:00~{ $hourEnd }:00
 statistics-hours-correct = { $correct }/{ $total } correct ({ $percent }%)
-statistics-hours-correct-info = → pressed "hard", "good", or "easy"
+statistics-hours-correct-info = → (not 'Again')
 # the emoji depicts the graph displaying this number
 statistics-hours-reviews = 📊 { $reviews } reviews
 # the emoji depicts the graph displaying this number

--- a/ftl/core/statistics.ftl
+++ b/ftl/core/statistics.ftl
@@ -229,6 +229,7 @@ statistics-stability-day-single =
 # hour range, eg "From 14:00-15:00"
 statistics-hours-range = From { $hourStart }:00~{ $hourEnd }:00
 statistics-hours-correct = { $correct }/{ $total } correct ({ $percent }%)
+statistics-hours-correct-info = → pressed "hard", "good", or "easy"
 # the emoji depicts the graph displaying this number
 statistics-hours-reviews = 📊 { $reviews } reviews
 # the emoji depicts the graph displaying this number

--- a/ts/routes/graphs/buttons.ts
+++ b/ts/routes/graphs/buttons.ts
@@ -222,6 +222,7 @@ export function renderButtons(
         const button = tr.statisticsAnswerButtonsButtonNumber();
         const timesPressed = tr.statisticsAnswerButtonsButtonPressed();
         const correctStr = tr.statisticsHoursCorrect(totalCorrect(d.group));
+        const correctStrInfo = tr.statisticsHoursCorrectInfo();
         const pressedStr = `${timesPressed}: ${totalPressedStr(d)}`;
         
         let buttonText: string;
@@ -235,7 +236,7 @@ export function renderButtons(
             buttonText = tr.studyingEasy();
         }
         
-        return `${button}: ${d.buttonNum} (${buttonText})<br>${pressedStr}<br>${correctStr}`;
+        return `${button}: ${d.buttonNum} (${buttonText})<br>${pressedStr}<br>${correctStr} ${correctStrInfo}`;
     }
 
     svg.select("g.hover-columns")

--- a/ts/routes/graphs/buttons.ts
+++ b/ts/routes/graphs/buttons.ts
@@ -224,7 +224,7 @@ export function renderButtons(
         const correctStr = tr.statisticsHoursCorrect(totalCorrect(d.group));
         const correctStrInfo = tr.statisticsHoursCorrectInfo();
         const pressedStr = `${timesPressed}: ${totalPressedStr(d)}`;
-        
+
         let buttonText: string;
         if (d.buttonNum === 1) {
             buttonText = tr.studyingAgain();
@@ -234,8 +234,10 @@ export function renderButtons(
             buttonText = tr.studyingGood();
         } else if (d.buttonNum === 4) {
             buttonText = tr.studyingEasy();
+        } else {
+            buttonText = "";
         }
-        
+
         return `${button}: ${d.buttonNum} (${buttonText})<br>${pressedStr}<br>${correctStr} ${correctStrInfo}`;
     }
 

--- a/ts/routes/graphs/buttons.ts
+++ b/ts/routes/graphs/buttons.ts
@@ -223,7 +223,19 @@ export function renderButtons(
         const timesPressed = tr.statisticsAnswerButtonsButtonPressed();
         const correctStr = tr.statisticsHoursCorrect(totalCorrect(d.group));
         const pressedStr = `${timesPressed}: ${totalPressedStr(d)}`;
-        return `${button}: ${d.buttonNum}<br>${pressedStr}<br>${correctStr}`;
+        
+        let buttonText: string;
+        if (d.buttonNum === 1) {
+            buttonText = tr.studyingAgain();
+        } else if (d.buttonNum === 2) {
+            buttonText = tr.studyingHard();
+        } else if (d.buttonNum === 3) {
+            buttonText = tr.studyingGood();
+        } else if (d.buttonNum === 4) {
+            buttonText = tr.studyingEasy();
+        }
+        
+        return `${button}: ${d.buttonNum} (${buttonText})<br>${pressedStr}<br>${correctStr}`;
     }
 
     svg.select("g.hover-columns")


### PR DESCRIPTION
This is somewhat a followup to #3952 .

# Problems
1. Users might not know that "1" → "Again", "2" → "Hard"...
2. It's not obvious what "correct" means in the tooltip.

# Proposed solutions
1. We can just add the name of the button.
2. I added a very short description. Not 100% content with it, but I think this kind of info should certainly be prominently displayed. Adding it to the graphs description felt wrong though, as this info is only relevant once you read the tooltips.

# Visuals
_Before this PR:_
![anki](https://github.com/user-attachments/assets/ae2c0b00-d29e-4a19-938f-029596472137)


_With this PR:_
![anki](https://github.com/user-attachments/assets/271b03c2-e745-4216-8ba1-0d67bddf0bf4)
