### PR TITLE
CHANGE collection size too large error to add MB values and info about compressed vs. uncompressed.

### DIFF
--- a/ftl/core/sync.ftl
+++ b/ftl/core/sync.ftl
@@ -53,7 +53,7 @@ sync-clock-off = Unable to sync - your clock is not set to the correct time.
 sync-upload-too-large =
     Your collection file is too large to send to AnkiWeb. You can reduce its size by removing any unwanted decks (optionally exporting them first), and then using Check Database to shrink the file size down.
     
-    ({ $details })
+    { $details } (uncompressed)
 sync-sign-in = Sign in
 sync-ankihub-dialog-heading = AnkiHub Login
 sync-ankihub-username-label = Username or Email:

--- a/ftl/core/sync.ftl
+++ b/ftl/core/sync.ftl
@@ -51,9 +51,9 @@ sync-account-required =
 sync-sanity-check-failed = Please use the Check Database function, then sync again. If problems persist, please force a one-way sync in the preferences screen.
 sync-clock-off = Unable to sync - your clock is not set to the correct time.
 sync-upload-too-large =
-    Your collection file is too large to send to AnkiWeb. You can reduce its
-    size by removing any unwanted decks (optionally exporting them first), and
-    then using Check Database to shrink the file size down. ({ $details })
+    Your collection file is too large to send to AnkiWeb. You can reduce its size by removing any unwanted decks (optionally exporting them first), and then using Check Database to shrink the file size down.
+    
+    ({ $details })
 sync-sign-in = Sign in
 sync-ankihub-dialog-heading = AnkiHub Login
 sync-ankihub-username-label = Username or Email:

--- a/rslib/src/sync/collection/upload.rs
+++ b/rslib/src/sync/collection/upload.rs
@@ -123,10 +123,11 @@ pub fn check_upload_limit(size: usize, limit: usize) -> Result<()> {
     let collection_size_in_mb: f64 = size as f64 / size_of_one_mb;
     let limit_size_in_mb: f64 = limit as f64 / size_of_one_mb;
 
-    if size >= limit {
+    //if size >= limit {
+    if true {
         Err(AnkiError::sync_error(
             format!(
-                "{collection_size_in_mb} MB (uncompressed) > {limit_size_in_mb} MB (uncompressed)"
+                "{collection_size_in_mb:.2} MB > {limit_size_in_mb:.2} MB (uncompressed)"
             ),
             SyncErrorKind::UploadTooLarge,
         ))

--- a/rslib/src/sync/collection/upload.rs
+++ b/rslib/src/sync/collection/upload.rs
@@ -125,9 +125,7 @@ pub fn check_upload_limit(size: usize, limit: usize) -> Result<()> {
 
     if size >= limit {
         Err(AnkiError::sync_error(
-            format!(
-                "{collection_size_in_mb:.2} MB > {limit_size_in_mb:.2} MB"
-            ),
+            format!("{collection_size_in_mb:.2} MB > {limit_size_in_mb:.2} MB"),
             SyncErrorKind::UploadTooLarge,
         ))
     } else {

--- a/rslib/src/sync/collection/upload.rs
+++ b/rslib/src/sync/collection/upload.rs
@@ -127,7 +127,7 @@ pub fn check_upload_limit(size: usize, limit: usize) -> Result<()> {
     if true {
         Err(AnkiError::sync_error(
             format!(
-                "{collection_size_in_mb:.2} MB > {limit_size_in_mb:.2} MB (uncompressed)"
+                "{collection_size_in_mb:.2} MB > {limit_size_in_mb:.2} MB"
             ),
             SyncErrorKind::UploadTooLarge,
         ))

--- a/rslib/src/sync/collection/upload.rs
+++ b/rslib/src/sync/collection/upload.rs
@@ -119,9 +119,15 @@ pub enum UploadResponse {
 }
 
 pub fn check_upload_limit(size: usize, limit: usize) -> Result<()> {
+    let size_of_one_mb: f64 = 1024.0 * 1024.0;
+    let collection_size_in_mb: f64 = size as f64 / size_of_one_mb;
+    let limit_size_in_mb: f64 = limit as f64 / size_of_one_mb;
+
     if size >= limit {
         Err(AnkiError::sync_error(
-            format!("{size} > {limit}"),
+            format!(
+                "{collection_size_in_mb} MB (uncompressed) > {limit_size_in_mb} MB (uncompressed)"
+            ),
             SyncErrorKind::UploadTooLarge,
         ))
     } else {

--- a/rslib/src/sync/collection/upload.rs
+++ b/rslib/src/sync/collection/upload.rs
@@ -123,8 +123,7 @@ pub fn check_upload_limit(size: usize, limit: usize) -> Result<()> {
     let collection_size_in_mb: f64 = size as f64 / size_of_one_mb;
     let limit_size_in_mb: f64 = limit as f64 / size_of_one_mb;
 
-    //if size >= limit {
-    if true {
+    if size >= limit {
         Err(AnkiError::sync_error(
             format!(
                 "{collection_size_in_mb:.2} MB > {limit_size_in_mb:.2} MB"


### PR DESCRIPTION
fixes: https://forums.ankiweb.net/t/your-collection-size-is-large-suggestions/60084

I have added a conversion from bytes to MB and passed this to the error function instead of just the bytes. I also added the info that this is the uncompressed value, not the compressed value.

**Important:**
I don't know how to trigger this error without having an account and a large enough collection, so couldn't actually test it. I'm not sure whether it's okay to create a test ankiweb account for these kind of things and I'd not be sure how to create a collection large enough to be affected by this restriction anyways.

I'd love to know how I could test this!

`./check` does pass though.


**Edit:** I forgot to add translatable strings for "uncompressed". I'll do so later, but first I'd like to know how to test this window / make the window appear for testing purposes.