### PR TITLE
docs: correct reference for linux dockerfile

### DIFF
--- a/docs/linux.md
+++ b/docs/linux.md
@@ -8,7 +8,7 @@ mentioned there no longer apply:
 https://forums.ankiweb.net/t/guide-how-to-build-and-run-anki-from-source-with-xubuntu-20-04/12865
 
 You can see a full list of buildtime and runtime requirements by looking at the
-[Dockerfiles](../.buildkite/linux/docker/Dockerfile.amd64) used to build the
+[Dockerfile](../.buildkite/linux/docker/Dockerfile) used to build the
 official releases.
 
 **Ensure some basic tools are installed**:


### PR DESCRIPTION
After https://github.com/thedroiddiv/anki/commit/0653dae86cbe8889cdcb457de339b54f3c476b39, dockerfile name was changed but docs still had the reference to old file. 