### PR TITLE
fix(scheduler): Clear queues when answering a card that is not the top card

### DIFF
--- a/rslib/src/scheduler/answering/mod.rs
+++ b/rslib/src/scheduler/answering/mod.rs
@@ -355,7 +355,7 @@ impl Collection {
             }
         }
 
-        // Handle queue updates based on from_queue flag
+        // Handle queue updates based on from_queue flag.
         if answer.from_queue {
             self.update_queues_after_answering_card(
                 &card,
@@ -368,6 +368,9 @@ impl Collection {
                     }))
                 ),
             )?;
+        } else {
+            // Clear in-memory study queues as the card might be hidden inside the queue.
+            self.clear_study_queues();
         }
 
         Ok(())


### PR DESCRIPTION
I found in my local build that PR #3976 might trigger the bug `bug: card modified without updating queue` at https://github.com/ankitects/anki/blob/1f95d030bbc7ebcc004ffe1e2be2a320c9fe1e94/rslib/src/scheduler/queue/mod.rs#L113

I considered first checking if the answered card_id actually exists within the current in-memory queue (CardQueues) before deciding whether to clear it. However, the simplicity and guaranteed correctness of the clear-and-rebuild strategy outweigh the minor potential performance gain in a very infrequent scenario. I also welcome a review on this point. Thanks so much.