### PR TITLE
Fix "Open Image" being broken for filenames with certain reserved characters

### DIFF
--- a/qt/aqt/utils.py
+++ b/qt/aqt/utils.py
@@ -930,7 +930,7 @@ def openFolder(path: str) -> None:
         subprocess.run(["explorer", f"file://{path}"], check=False)
     else:
         with no_bundled_libs():
-            QDesktopServices.openUrl(QUrl(f"file://{path}"))
+            QDesktopServices.openUrl(QUrl.fromLocalFile(path))
 
 
 def show_in_folder(path: str) -> None:
@@ -947,7 +947,7 @@ def show_in_folder(path: str) -> None:
     else:
         # Just open the file in any other platform
         with no_bundled_libs():
-            QDesktopServices.openUrl(QUrl(f"file://{path}"))
+            QDesktopServices.openUrl(QUrl.fromLocalFile(path))
 
 
 def _show_in_folder_win32(path: str) -> None:


### PR DESCRIPTION
Fixes #3984

> QUrl will automatically percent encode all characters that are not allowed in a URL and decode the percent-encoded sequences that represent an unreserved character (letters, digits, hyphens, underscores, dots and tildes). All other characters are left in their original forms.
https://doc.qt.io/qt-6/qurl.html#QUrl-3

This meant `#`s weren't escaped when constructing the `QUrl`, and caused the filename to be truncated. The fix proposed is to ~~quote the path beforehand~~ use [QUrl.fromLocalFile](https://doc.qt.io/qt-6/qurl.html#fromLocalFile) to construct the file url

No change is needed for windows, but i haven't been able to test on mac