### PR TITLE
Fix polygons closing when clicking existing masks while editing IO

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -201,7 +201,7 @@ Dongjin Ouyang <1113117424@qq.com>
 Sawan Sunar <sawansunar24072002@gmail.com>
 hideo aoyama <https://github.com/boukendesho>
 Ross Brown <rbrownwsws@googlemail.com>
-🦙 <github.com/iamllama>
+🦙 <gh@siid.sh>
 Lukas Sommer <sommerluk@gmail.com>
 Luca Auer <lolle2000.la@gmail.com>
 Niclas Heinz <nheinz@hpost.net>

--- a/ts/routes/image-occlusion/Toolbar.svelte
+++ b/ts/routes/image-occlusion/Toolbar.svelte
@@ -299,7 +299,10 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
                         ? 'left-border-radius'
                         : 'right-border-radius'}"
                     {iconSize}
-                    on:click={tool.action}
+                    on:click={() => {
+                        tool.action();
+                        handleToolChanges(activeTool);
+                    }}
                     tooltip="{tool.tooltip()} ({getPlatformString(tool.shortcut)})"
                     disabled={tool.name === "undo"
                         ? !$undoStack.undoable

--- a/ts/routes/image-occlusion/shapes/base.ts
+++ b/ts/routes/image-occlusion/shapes/base.ts
@@ -25,6 +25,7 @@ export class Shape {
     occludeInactive?: boolean;
     /* Cloze ordinal */
     ordinal: number | undefined;
+    id: string | undefined;
 
     constructor(
         { left = 0, top = 0, fill = SHAPE_MASK_COLOR, occludeInactive, ordinal = undefined }: ConstructorParams<Shape> =

--- a/ts/routes/image-occlusion/shapes/ellipse.ts
+++ b/ts/routes/image-occlusion/shapes/ellipse.ts
@@ -17,6 +17,7 @@ export class Ellipse extends Shape {
         super(rest);
         this.rx = rx;
         this.ry = ry;
+        this.id = "ellipse-" + new Date().getTime();
     }
 
     toDataForCloze(): EllipseDataForCloze {

--- a/ts/routes/image-occlusion/shapes/polygon.ts
+++ b/ts/routes/image-occlusion/shapes/polygon.ts
@@ -15,6 +15,7 @@ export class Polygon extends Shape {
     constructor({ points = [], ...rest }: ConstructorParams<Polygon> = {}) {
         super(rest);
         this.points = points;
+        this.id = "polygon-" + new Date().getTime();
     }
 
     toDataForCloze(): PolygonDataForCloze {

--- a/ts/routes/image-occlusion/shapes/rectangle.ts
+++ b/ts/routes/image-occlusion/shapes/rectangle.ts
@@ -17,6 +17,7 @@ export class Rectangle extends Shape {
         super(rest);
         this.width = width;
         this.height = height;
+        this.id = "rect-" + new Date().getTime();
     }
 
     toDataForCloze(): RectangleDataForCloze {

--- a/ts/routes/image-occlusion/shapes/text.ts
+++ b/ts/routes/image-occlusion/shapes/text.ts
@@ -28,6 +28,7 @@ export class Text extends Shape {
         this.scaleX = scaleX;
         this.scaleY = scaleY;
         this.fontSize = fontSize;
+        this.id = "text-" + new Date().getTime();
     }
 
     toDataForCloze(): TextDataForCloze {

--- a/ts/routes/image-occlusion/tools/tool-polygon.ts
+++ b/ts/routes/image-occlusion/tools/tool-polygon.ts
@@ -197,6 +197,7 @@ const generatePolygon = (canvas: fabric.Canvas, pointsList): void => {
         strokeWidth: 1,
         strokeUniform: true,
         noScaleCache: false,
+        selectable: false,
         opacity: get(opacityStateStore) ? 0.4 : 1,
     });
     polygon["id"] = "polygon-" + new Date().getTime();

--- a/ts/routes/image-occlusion/tools/tool-undo-redo.ts
+++ b/ts/routes/image-occlusion/tools/tool-undo-redo.ts
@@ -116,7 +116,7 @@ class UndoStack {
     }
 
     private push(): void {
-        const entry = JSON.stringify(this.canvas);
+        const entry = JSON.stringify(this.canvas?.toJSON(["id"]));
         if (entry === this.stack[this.stack.length - 1]) {
             return;
         }


### PR DESCRIPTION
> The only issue I noticed turned out to be an existing one, where clicking on an existing polygon will close an open one.
https://github.com/ankitects/anki/pull/3989#issuecomment-2863246099

The polygon tool checks whether a point was clicked by comparing against a mask's `id`. This prop is set when making new masks, but not when the masks are first hydrated from clozes. The fix proposed is to set the prop then as well

66eb527fc is for preventing new polygons from being selected/dragged while the polygon tool is active. This is made possible by 2b463a816 but doesn't seem intended given that existing polygons aren't selectable
~~EDIT: undoing and redoing don't preserve this ([previously noted](https://github.com/ankitects/anki/blob/5cc44b3f687aba2fce865f11904803a9470c9eb5/ts/routes/image-occlusion/tools/tool-undo-redo.ts#L92))~~ fixed