### PR TITLE
Fix existing IO mask borders getting scaled

### DIFF
--- a/ts/routes/image-occlusion/tools/lib.ts
+++ b/ts/routes/image-occlusion/tools/lib.ts
@@ -263,6 +263,8 @@ export function enableUniformScaling(canvas: fabric.Canvas, obj: fabric.Object):
 
 export function addBorder(obj: fabric.Object): void {
     obj.stroke = BORDER_COLOR;
+    obj.strokeWidth = 1;
+    obj.strokeUniform = true;
 }
 
 export const redraw = (canvas: fabric.Canvas): void => {


### PR DESCRIPTION
Currently, scaling existing masks causes their borders to be scaled as well. This can cause the scaled mask to be unintuitively shifted in the direction of the stretched border(s), and is visible when undoing and then redoing:
![image](https://github.com/user-attachments/assets/efca3b3a-b614-4b0d-bc5e-4983dea406aa)

Newly created masks don't exhibit this, as they already have the `strokeUniform` prop enabled