### PR TITLE
Fix/Leech suspended tooltip

### DIFF
--- a/qt/aqt/reviewer.py
+++ b/qt/aqt/reviewer.py
@@ -551,7 +551,7 @@ class Reviewer:
         def after_answer(changes: OpChanges) -> None:
             if gui_hooks.reviewer_did_answer_card.count() > 0:
                 self.card.load()
-            suspended = self.card and self.card.queue < 0
+            suspended = self.card is not None and self.card.queue < 0
             self._after_answering(ease)
             if sched.state_is_leech(answer.new_state):
                 self.onLeech(suspended)

--- a/qt/aqt/reviewer.py
+++ b/qt/aqt/reviewer.py
@@ -551,7 +551,7 @@ class Reviewer:
         def after_answer(changes: OpChanges) -> None:
             if gui_hooks.reviewer_did_answer_card.count() > 0:
                 self.card.load()
-            suspended = self.card.queue < 0
+            suspended = self.card and self.card.queue < 0
             self._after_answering(ease)
             if sched.state_is_leech(answer.new_state):
                 self.onLeech(suspended)

--- a/qt/aqt/reviewer.py
+++ b/qt/aqt/reviewer.py
@@ -551,6 +551,7 @@ class Reviewer:
         def after_answer(changes: OpChanges) -> None:
             if gui_hooks.reviewer_did_answer_card.count() > 0:
                 self.card.load()
+            # v3 scheduler doesn't report this
             suspended = self.card is not None and self.card.queue < 0
             self._after_answering(ease)
             if sched.state_is_leech(answer.new_state):
@@ -953,7 +954,6 @@ timerStopped = false;
     def onLeech(self, suspended: bool = False) -> None:
         # for now
         s = tr.studying_card_was_a_leech()
-        # v3 scheduler doesn't report this
         if suspended:
             s += f" {tr.studying_it_has_been_suspended()}"
         tooltip(s)

--- a/qt/aqt/reviewer.py
+++ b/qt/aqt/reviewer.py
@@ -551,9 +551,10 @@ class Reviewer:
         def after_answer(changes: OpChanges) -> None:
             if gui_hooks.reviewer_did_answer_card.count() > 0:
                 self.card.load()
+            suspended = self.card.queue < 0
             self._after_answering(ease)
             if sched.state_is_leech(answer.new_state):
-                self.onLeech()
+                self.onLeech(suspended)
 
         self.state = "transition"
         answer_card(parent=self.mw, answer=answer).success(
@@ -949,11 +950,11 @@ timerStopped = false;
     # Leeches
     ##########################################################################
 
-    def onLeech(self, card: Card | None = None) -> None:
+    def onLeech(self, suspended: bool = False) -> None:
         # for now
         s = tr.studying_card_was_a_leech()
         # v3 scheduler doesn't report this
-        if card and card.queue < 0:
+        if suspended:
             s += f" {tr.studying_it_has_been_suspended()}"
         tooltip(s)
 


### PR DESCRIPTION
https://github.com/ankitects/anki/blob/44ade0653e100fe98bf0702c42632798263b9dca/qt/aqt/reviewer.py#L556
Seems to set `self.card` to the state that was in
https://github.com/ankitects/anki/blob/44ade0653e100fe98bf0702c42632798263b9dca/qt/aqt/reviewer.py#L545-L549? This means that it will use the previous card's state if you pass `self.card` to `self.onLeech` (which wasn't attempted so I assume is a known issue)
To circumvent this, I store the suspended value before that function is called and pass that to `self.onLeech` as a boolean instead.