### PR TITLE
Fix syncserver docker image build by bumping Dockerfile rust version

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -226,6 +226,7 @@ Jonathan Schoreels <https://github.com/JSchoreels>
 JL710
 Matt Brubeck <mbrubeck@limpet.net>
 Yaoliang Chen <yaoliang.ch@gmail.com>
+KolbyML <https://github.com/KolbyML>
 
 ********************
 

--- a/docs/syncserver/Dockerfile
+++ b/docs/syncserver/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.83.0-alpine3.20 AS builder
+FROM rust:1.85.0-alpine3.20 AS builder
 
 ARG ANKI_VERSION
 

--- a/docs/syncserver/Dockerfile.distroless
+++ b/docs/syncserver/Dockerfile.distroless
@@ -1,4 +1,4 @@
-FROM rust:1.83.0 AS builder
+FROM rust:1.85.0 AS builder
 
 ARG ANKI_VERSION
 


### PR DESCRIPTION
A while ago I made a PR bumping the rust version in the docker file to `1.85` but then I changed it to `latest` and was told if we are bumping we should stick to a defined version.

I didn't have time to investigate this for 2 weeks due to being busy, so my last PR was closed https://github.com/ankitects/anki/pull/3876

![image](https://github.com/user-attachments/assets/448027a6-cc1f-4ff3-b3aa-3d38c18b1b7c)
https://github.com/ankitects/anki/pull/3876#issuecomment-2744972087

^ I was left this comment, and no --locked didn't work 

https://github.com/KolbyML/docker_images/actions/runs/14952884320/job/42004660151 here is my CI job trying to build `25.05b2`

```rust
#12 7.216 Caused by:
#12 7.216   feature `edition2024` is required
#12 7.216 
#12 7.216   The package requires the Cargo feature called `edition2024`, but that feature is not stabilized in this version of Cargo (1.83.0 (5ffbef321 2024-10-29)).
#12 7.216   Consider trying a newer version of Cargo (this may require the nightly release).
#12 7.216   See https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#edition-2024 for more information about the status of this feature.
#12 ERROR: process "/bin/sh -c cargo install --git https://github.com/ankitects/anki.git --tag ${ANKI_VERSION} --root /anki-server  --locked anki-sync-server" did not complete successfully: exit code: 101
```

So `--locked` didn't help me.

So I am making a PR to just bump the rust version to the latest stable release `1.87.0`, which will fix me not building able to build the docker image.

My anki-sync-server is out of date and doesn't appear to work anymore (not exactly sure why, but I might as well update it to the latest version), so I am hoping to get this fix in so I can deploy it to my server to sync my anki deck between devices again :pray: 