### PR TITLE
Feat/90% desired retention warning

### DIFF
--- a/ftl/core/deck-config.ftl
+++ b/ftl/core/deck-config.ftl
@@ -475,6 +475,7 @@ deck-config-a-100-day-interval =
         [one] A 100 day interval will become { $days } day.
        *[other] A 100 day interval will become { $days } days.
     }
+deck-config-90-percent-desired-retention-warning = The higher the desired retention, the shorter the intervals between reviews.
 deck-config-percent-of-reviews =  
     { $reviews ->
         [one] { $pct }% of { $reviews } review

--- a/ts/routes/deck-options/FsrsOptions.svelte
+++ b/ts/routes/deck-options/FsrsOptions.svelte
@@ -75,7 +75,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
             (stability / factor) * (Math.pow(retention, 1 / decay) - 1),
         );
         if (days === 100) {
-            return "";
+            return tr.deckConfig90PercentDesiredRetentionWarning();
         }
         return tr.deckConfigA100DayInterval({ days });
     }


### PR DESCRIPTION
Keeps a warning active when the users desired retention 90% to try and hint at the correlation between desired retention and intervals.

I'm not positive on what the message should be, suggestions welcome.

c.c. @Expertium 