### PR TITLE
Clarify field separator being a guess when importing csv

### DIFF
--- a/ftl/core/importing.ftl
+++ b/ftl/core/importing.ftl
@@ -15,6 +15,7 @@ importing-colon = Colon
 importing-comma = Comma
 importing-empty-first-field = Empty first field: { $val }
 importing-field-separator = Field separator
+importing-field-separator-guessed =  Field separator (guessed)
 importing-field-mapping = Field mapping
 importing-field-of-file-is = Field <b>{ $val }</b> of file is:
 importing-fields-separated-by = Fields separated by: { $val }

--- a/ftl/core/importing.ftl
+++ b/ftl/core/importing.ftl
@@ -218,6 +218,9 @@ importing-field-separator-help =
     Please note that if this character appears in any field itself, the field has to be
     quoted accordingly to the CSV standard. Spreadsheet programs like LibreOffice will
     do this automatically.
+
+    It cannot be changed if the text file forces use of a specific separator via a file header.
+    If a file header is not present, Anki will try to guess what the separator is.
 importing-allow-html-in-fields-help =
     Enable this if the file contains HTML formatting. E.g. if the file contains the string
     '&lt;br&gt;', it will appear as a line break on your card. On the other hand, with this

--- a/ts/routes/import-csv/FileOptions.svelte
+++ b/ts/routes/import-csv/FileOptions.svelte
@@ -65,7 +65,9 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         <SettingTitle
             on:click={() => openHelpModal(Object.keys(settings).indexOf("delimiter"))}
         >
-            {settings.delimiter.title}
+            {$metadata.forceDelimiter
+                ? settings.delimiter.title
+                : tr.importingFieldSeparatorGuessed()}
         </SettingTitle>
     </EnumSelectorRow>
 


### PR DESCRIPTION
Relevant: https://forums.ankiweb.net/t/csv-delimiter-detection-fails/60682 and https://github.com/ankitects/anki/issues/3853

This pr proposes to hint to users that the field separator guessed by anki is in fact a guess, and that it should be changed if said guess is wrong

#3786 added a warning to do just that if preview data is almost definitely deformed, but IMO its also useful to highlight in the general case

Its help text has also been changed to explain why the field separator cannot be modified sometimes (when the file has a `#separator:...`), which is not something i've seen the manual cover