### PR TITLE
Style the fsrs params input

### DIFF
--- a/ts/lib/sass/base.scss
+++ b/ts/lib/sass/base.scss
@@ -75,6 +75,9 @@ input[type="radio"],
 input[type="checkbox"] {
     cursor: pointer;
 }
+
+textarea,
+input[type="date"],
 input[type="text"] {
     border-radius: prop(border-radius);
     outline: none;

--- a/ts/routes/deck-options/DateInput.svelte
+++ b/ts/routes/deck-options/DateInput.svelte
@@ -29,10 +29,5 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         width: 100%;
         -webkit-appearance: none;
         appearance: none;
-        background: var(--canvas-inset);
-        border: 1px solid var(--border);
-        border-radius: var(--border-radius);
-        padding: 1px 0.5em;
-        outline: none !important;
     }
 </style>


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/219e1e82-c618-4866-9cd6-b07b58ed3f2c)

After:
![image](https://github.com/user-attachments/assets/09758a06-4ce8-4030-8b53-201433c3ba6a)

The styling for the date input (ignore before) is cleaned up as well