### PR TITLE
Resize fsrs params input to fit content

### DIFF
--- a/ts/routes/deck-options/ParamsInput.svelte
+++ b/ts/routes/deck-options/ParamsInput.svelte
@@ -36,6 +36,8 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     }
 </script>
 
+<svelte:window onresize={updateHeight} />
+
 <textarea
     bind:this={taRef}
     value={stringValue}

--- a/ts/routes/deck-options/ParamsInput.svelte
+++ b/ts/routes/deck-options/ParamsInput.svelte
@@ -3,11 +3,25 @@ Copyright: Ankitects Pty Ltd and contributors
 License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 -->
 <script lang="ts">
+    import { tick } from "svelte";
+
     export let value: number[];
     export let defaults: number[];
 
     let stringValue: string;
-    $: stringValue = render(value);
+    let taRef: HTMLTextAreaElement;
+
+    function updateHeight() {
+        if (taRef) {
+            taRef.style.height = "auto";
+            taRef.style.height = `${taRef.scrollHeight}px`;
+        }
+    }
+
+    $: {
+        stringValue = render(value);
+        tick().then(updateHeight);
+    }
 
     function render(params: number[]): string {
         return params.map((v) => v.toFixed(4)).join(", ");
@@ -23,6 +37,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 </script>
 
 <textarea
+    bind:this={taRef}
     value={stringValue}
     on:blur={update}
     class="w-100"


### PR DESCRIPTION
> Is it possible to make sure the text box always show all contents? It would be helpful when we debug based on users' screenshot.
https://github.com/ankitects/anki/pull/3997#issuecomment-2875008497

[field-sizing](https://developer.mozilla.org/en-US/docs/Web/CSS/field-sizing) would've been perfect for this, but its only available on chromium 123 and later