### PR TITLE
Fix pressing Ctrl+Shift+N in browser editor potentially discarding field changes

### DIFF
--- a/qt/aqt/browser/browser.py
+++ b/qt/aqt/browser/browser.py
@@ -1244,11 +1244,13 @@ class Browser(QMainWindow):
         self._line_edit().selectAll()
 
     def onNote(self) -> None:
-        assert self.editor is not None
-        assert self.editor.web is not None
+        def cb():
+            assert self.editor is not None and self.editor.web is not None
+            self.editor.web.setFocus()
+            self.editor.loadNote(focusTo=0)
 
-        self.editor.web.setFocus()
-        self.editor.loadNote(focusTo=0)
+        assert self.editor is not None
+        self.editor.call_after_note_saved(cb)
 
     def onCardList(self) -> None:
         self.form.tableView.setFocus()


### PR DESCRIPTION
Forum post: https://forums.ankiweb.net/t/suspected-bug-browser-editors-ctrl-shift-n-reverts-any-changes-in-selected-field-since-last-cursor-blink/60825

When making a change and then reloading the note via Ctrl+Shift+N within 600ms, it doesn't get saved. The fix proposed is to force a save before reloading