### PR TITLE
Fix URL schemes translation

### DIFF
--- a/ftl/core/preferences.ftl
+++ b/ftl/core/preferences.ftl
@@ -85,10 +85,10 @@ preferences-third-party-description = Third-party services are unaffiliated with
 
 ## URL scheme related
 preferences-url-schemes = URL Schemes
-preferences-url-scheme-prompt = Allowed { preferences-url-schemes } (space-separated):
+preferences-url-scheme-prompt = Allowed URL Schemes (space-separated):
 preferences-url-scheme-warning = Blocked attempt to open `{ $link }`, which may be a security issue.
 
-    If you trust the deck author and wish to proceed, you can add `{ $scheme }` to your allowed { preferences-url-schemes }.
+    If you trust the deck author and wish to proceed, you can add `{ $scheme }` to your allowed URL Schemes.
 preferences-url-scheme-allow-once = Allow Once
 preferences-url-scheme-always-allow = Always Allow
 


### PR DESCRIPTION
Fixes URL Schemes Translation

The problem with the new URL schemes string introduced in #3994 is that it’s essentially a word puzzle. Word puzzles are terrible for translators because it’s not always obvious—or, in some cases, even completely impossible—to know exactly which string will be placed in which parameter. Therefore, word puzzles should be avoided whenever possible.

What might seem straightforward in English can become incredibly complicated in foreign languages with different grammatical structures. In this specific case, the string:
```
Allowed { preferences-url-schemes } (space-separated):
```
uses `{ preferences-url-schemes }` as a subject, whereas:
```
If you trust the deck author and wish to proceed, you can add `{ $scheme }` to your allowed { preferences-url-schemes }
```
uses it as an indirect object. In languages that require declension, subjects take the nominative case while indirect objects take the dative case, necessitating corresponding endings. Additionally, `preferences-url-schemes` might sometimes be used independently. Identifying all possible grammatical variations and then restructuring the strings to ensure correct declension across all cases is an exceptionally time-consuming task.

It is much easier to use plain strings without ambiguous references. Simply writing “URL schemes” simplifies a translator’s task. However, referencing `preferences-url-schemes` complicates the process significantly. The translator must first search for `preferences-url-schemes`, then locate all other strings that reference it,  just to make sure the translation works in all cases—an incredibly time-consuming process. Otherwise, translators might resort to literal translation, resulting in unclear or unintelligible text.

For this reason, I strongly advocate for a change in translation policy. While there is a tendency to avoid modifying existing strings to prevent disruption of previously completed translations, new translations should follow a different approach: no more word puzzles!

This PR proposes fixing the URL schemes strings. Immediately afterward, the Pontoon translation system should be updated to reflect these changes before additional translators begin working with the current string. (These adjustments should remain compatible with yet existing translations, however.)