### PR TITLE
Fix/Prevent manual resize of params input

### DIFF
--- a/ts/routes/deck-options/ParamsInput.svelte
+++ b/ts/routes/deck-options/ParamsInput.svelte
@@ -14,7 +14,8 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     function updateHeight() {
         if (taRef) {
             taRef.style.height = "auto";
-            taRef.style.height = `${taRef.scrollHeight}px`;
+            // +2 for "overflow-y: auto" in case js breaks
+            taRef.style.height = `${taRef.scrollHeight + 2}px`;
         }
     }
 
@@ -45,3 +46,10 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     class="w-100"
     placeholder={render(defaults)}
 ></textarea>
+
+<style>
+    textarea {
+        resize: none;
+        overflow-y: auto;
+    }
+</style>


### PR DESCRIPTION
related:

- #3999
- https://github.com/ankitects/anki/pull/3997#issuecomment-2875008497

Prevents the user from manually changing the size of the box. Also removes the scroll bar in cases when its not needed (should never be needed).

![image](https://github.com/user-attachments/assets/dddc945a-4f23-4d38-9487-a860b8d6b213) -> 
![image](https://github.com/user-attachments/assets/ab842e65-9b94-4cd3-8149-29690ed3e73b)

