### PR TITLE
Fix searching for non-blank adjacent wildcard fields

### DIFF
--- a/rslib/src/search/sqlwriter.rs
+++ b/rslib/src/search/sqlwriter.rs
@@ -1334,7 +1334,8 @@ c.odue != 0 then c.odue else c.due end) != {days}) or (c.queue in (1,4) and
     #[allow(clippy::single_range_in_vec_init)]
     #[test]
     fn ranges() {
-        assert_eq!([1, 2, 3].collect_ranges(), [1..4]);
-        assert_eq!([1, 3, 4].collect_ranges(), [1..2, 3..5]);
+        assert_eq!([1, 2, 3].collect_ranges(true), [1..4]);
+        assert_eq!([1, 3, 4].collect_ranges(true), [1..2, 3..5]);
+        assert_eq!([1, 2, 5, 6].collect_ranges(false), [1..2, 2..3, 5..6, 6..7]);
     }
 }

--- a/rslib/src/search/sqlwriter.rs
+++ b/rslib/src/search/sqlwriter.rs
@@ -899,7 +899,7 @@ impl RequiredTable {
 /// contiguous numbers.
 trait CollectRanges {
     type Item;
-    fn collect_ranges(self) -> Vec<Range<Self::Item>>;
+    fn collect_ranges(self, join: bool) -> Vec<Range<Self::Item>>;
 }
 
 impl<
@@ -909,7 +909,7 @@ impl<
 {
     type Item = Idx;
 
-    fn collect_ranges(self) -> Vec<Range<Self::Item>> {
+    fn collect_ranges(self, join: bool) -> Vec<Range<Self::Item>> {
         let mut result = Vec::new();
         let mut iter = self.into_iter();
         let next = iter.next();
@@ -920,7 +920,7 @@ impl<
         let mut end = next.unwrap();
 
         for i in iter {
-            if i == end + 1.into() {
+            if join && i == end + 1.into() {
                 end = end + 1.into();
             } else {
                 result.push(start..end + 1.into());

--- a/rslib/src/search/sqlwriter.rs
+++ b/rslib/src/search/sqlwriter.rs
@@ -697,7 +697,7 @@ impl SqlWriter<'_> {
                     }
                     (!field.config.exclude_from_search).then_some(ord)
                 })
-                .collect_ranges();
+                .collect_ranges(true);
             if !matched_fields.is_empty() {
                 field_map.push(UnqualifiedSearchContext {
                     ntid: nt.id,


### PR DESCRIPTION
Fixes #4006

When searching, adjacent fields are lumped together for efficiency. But this breaks when searching for non-blank fields (`_*`) as the field separator (0x1f) is picked up by the resulting query

The fix proposed is to split up adjacent fields in this case