### PR TITLE
Restore richtext editor focus on mathjax overlay close event

### DIFF
--- a/ts/editor/mathjax-overlay/MathjaxOverlay.svelte
+++ b/ts/editor/mathjax-overlay/MathjaxOverlay.svelte
@@ -232,7 +232,10 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
                             placeHandle(true);
                             resetHandle();
                         }}
-                        on:close={resetHandle}
+                        on:close={() => {
+                            placeHandle(true);
+                            resetHandle();
+                        }}
                         let:editor={mathjaxEditor}
                     >
                         <Shortcut


### PR DESCRIPTION
Closes #4014

Focus is currently restored when moving past the start/end in the overlay editor but not during the close event that's dispatched when pressing Esc or forcing a save, which this pr proposes to rectify