### PR TITLE
Fix IO masks not saving when scaled

### DIFF
--- a/ts/routes/image-occlusion/mask-editor.ts
+++ b/ts/routes/image-occlusion/mask-editor.ts
@@ -116,7 +116,6 @@ function initCanvas(): fabric.Canvas {
             modifiedPolygon(canvas, evt.target);
             undoStack.onObjectModified();
         }
-        saveNeededStore.set(true);
     });
     canvas.on("text:editing:entered", function() {
         textEditingState.set(true);

--- a/ts/routes/image-occlusion/tools/lib.ts
+++ b/ts/routes/image-occlusion/tools/lib.ts
@@ -4,7 +4,7 @@
 import { fabric } from "fabric";
 import { get } from "svelte/store";
 
-import { opacityStateStore } from "../store";
+import { opacityStateStore, saveNeededStore } from "../store";
 import type { Size } from "../types";
 
 export const SHAPE_MASK_COLOR = "#ffeba2";
@@ -244,6 +244,7 @@ const setShapePosition = (
     }
 
     object.setCoords();
+    saveNeededStore.set(true);
 };
 
 export function enableUniformScaling(canvas: fabric.Canvas, obj: fabric.Object): void {


### PR DESCRIPTION
Fixes #3988

Masks are potentially re-modified to be bounded and have normalised scale factors, but that doesn't retrigger a save, which this pr rectifies