### PR TITLE
Use non breaking spaces for names on about page

### DIFF
--- a/qt/aqt/about.py
+++ b/qt/aqt/about.py
@@ -225,7 +225,7 @@ def show(mw: aqt.AnkiQt) -> QDialog:
         )
     )
 
-    allusers = [user.replace(" ", "&nbsp") for user in allusers]
+    allusers = [user.replace(" ", "&nbsp;") for user in allusers]
     abouttext += "<p>" + tr.about_written_by_damien_elmes_with_patches(
         cont=", ".join(allusers) + f", {tr.about_and_others()}"
     )

--- a/qt/aqt/about.py
+++ b/qt/aqt/about.py
@@ -225,6 +225,7 @@ def show(mw: aqt.AnkiQt) -> QDialog:
         )
     )
 
+    allusers = [user.replace(" ", "&nbsp") for user in allusers]
     abouttext += "<p>" + tr.about_written_by_damien_elmes_with_patches(
         cont=", ".join(allusers) + f", {tr.about_and_others()}"
     )


### PR DESCRIPTION
Prevents line wrapping mid name:
![image](https://github.com/user-attachments/assets/655827b3-26d7-4769-8b90-ae24ce48b805)

like this:
![image](https://github.com/user-attachments/assets/8ddce7d0-d496-4007-b5da-d2e4bb61ca2c)
