### PR TITLE
Fix IO undo logic error

### DIFF
--- a/ts/routes/image-occlusion/tools/tool-undo-redo.ts
+++ b/ts/routes/image-occlusion/tools/tool-undo-redo.ts
@@ -117,7 +117,7 @@ class UndoStack {
 
     private push(): void {
         const entry = JSON.stringify(this.canvas?.toJSON(["id"]));
-        if (entry === this.stack[this.stack.length - 1]) {
+        if (entry === this.stack[this.index]) {
             return;
         }
         this.stack.length = this.index + 1;


### PR DESCRIPTION
On opening an IO note with a text label "test" in the browser editor:
- edit the label to "blah"
- undo once
- edit the label to "blah"
- notice that undoing isn't possible
- redo once
- notice that it was a no-op, i.e still "blah"

The fix proposed is to compare against the next-available redo step, instead of the top of the stack, when avoiding pushing duplicate undo entries