### PR TITLE
Remove incorrect "double-click to expand" overlay label on small images in editor

### DIFF
--- a/ts/editor/image-overlay/ImageOverlay.svelte
+++ b/ts/editor/image-overlay/ImageOverlay.svelte
@@ -303,7 +303,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
                 />
 
                 <HandleLabel>
-                    {#if isSizeConstrained}
+                    {#if isSizeConstrained && !shrinkingDisabled}
                         <span>{`(${tr.editingDoubleClickToExpand()})`}</span>
                     {:else}
                         <span>{actualWidth}&times;{actualHeight}</span>


### PR DESCRIPTION
Related to #4028

The editor image overlay only allows expanding an image if it's shrunk down to the set max width and height (fixed at 250x125). But the "double-click to expand" label still misleadingly appears on small images that aren't and thus can't be expanded