### PR TITLE
Align LaTeX with surrounding text

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -230,6 +230,7 @@ KolbyML <https://github.com/KolbyML>
 Adnane Taghi <dev@soleuniverse.me>
 Spiritual Father <https://github.com/spiritualfather>
 Emmanuel Ferdman <https://github.com/emmanuel-ferdman>
+Tony Zorman <mail@tony-zorman.com>
 
 ********************
 

--- a/rslib/src/notetype/header.tex
+++ b/rslib/src/notetype/header.tex
@@ -2,6 +2,9 @@
 \special{papersize=3in,5in}
 \usepackage[utf8]{inputenc}
 \usepackage{amssymb,amsmath}
+\usepackage[active,tightpage]{preview}
 \pagestyle{empty}
 \setlength{\parindent}{0in}
+\setlength{\abovedisplayskip}{0pt}
 \begin{document}
+\begin{preview}

--- a/rslib/src/notetype/mod.rs
+++ b/rslib/src/notetype/mod.rs
@@ -66,7 +66,7 @@ define_newtype!(NotetypeId, i64);
 pub(crate) const DEFAULT_CSS: &str = include_str!("styling.css");
 pub(crate) const DEFAULT_CLOZE_CSS: &str = include_str!("cloze_styling.css");
 pub(crate) const DEFAULT_LATEX_HEADER: &str = include_str!("header.tex");
-pub(crate) const DEFAULT_LATEX_FOOTER: &str = r"\end{document}";
+pub(crate) const DEFAULT_LATEX_FOOTER: &str = r"\end{preview}\end{document}";
 /// New entries must be handled in render.rs/add_special_fields().
 static SPECIAL_FIELDS: LazyLock<HashSet<&'static str>> = LazyLock::new(|| {
     HashSet::from_iter(vec![


### PR DESCRIPTION
So far, LaTeX images were just rendered and included as pictures as-is. However, the bounding box of the image might not necessarily coincide with the actual baseline of the equation. By using preview.sty (which is hopefully not that big of an additional dependency), we can however access the "depth" -- the offset from the baseline -- of the generated image and correct for that.

---

The Anki manual sports a picture of the default PNG rendering:

![](https://docs.ankiweb.net/math/convergence_question.png)

I've generally found it to be a bit better with SVGs + some CSS that just vertically centres the pictures:

![2025-05-24-132320_798x111_scrot](https://github.com/user-attachments/assets/4c416012-3c34-43b5-be10-316cb9633908)

This PR gives a further improvement on that:

![2025-05-24-132358_799x123_scrot](https://github.com/user-attachments/assets/d85c16ed-d779-4afa-8aeb-b969273c72be)

---

+ Alignment is not perfect all the time (at least I've spotted a few weird outliers, of which I however forgot to take screenshots), for which I have no clear explanation at this point.

+ I don't know the codebase at all, so it's very possible that I'm doing something very stupid -- feel free to shout at me :)

+ I've tested this manually with `./run`, but haven't managed to properly build the tests yet. I would imagine that `test_latex.py` might fail due to it checking the length of the media directory (where we now have more files). Since I couldn't actually test it, though, I refrained from making any changes here. My hope is that a possible CI will catch this