### PR TITLE
offload mpv callback registration to background thread to avoid UI bl…

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -230,7 +230,7 @@ KolbyML <https://github.com/KolbyML>
 Adnane Taghi <dev@soleuniverse.me>
 Spiritual Father <https://github.com/spiritualfather>
 Emmanuel Ferdman <https://github.com/emmanuel-ferdman>
-
+Marvin Kopf <marvinkopf@outlook.com>
 ********************
 
 The text of the 3 clause BSD license follows:

--- a/qt/aqt/mpv.py
+++ b/qt/aqt/mpv.py
@@ -41,6 +41,7 @@ import time
 from queue import Empty, Full, Queue
 from shutil import which
 
+import aqt
 from anki.utils import is_mac, is_win
 
 
@@ -444,7 +445,7 @@ class MPV(MPVBase):
 
         super().__init__(*args, **kwargs)
 
-        self._register_callbacks()
+        aqt.mw.taskman.run_in_background(self._register_callbacks, None)
 
     def _register_callbacks(self):
         self._callbacks = {}


### PR DESCRIPTION
…ocking

Instantiating `MPV(MPVBase)` triggers multiple synchronous `command()` calls to the mpv process during callback registration. These calls block the main thread and degrade startup performance. This change defers registration via `taskman.run_in_background`.