### PR TITLE
Ensure media files are passed relative to the media folder

### DIFF
--- a/pylib/anki/media.py
+++ b/pylib/anki/media.py
@@ -76,7 +76,7 @@ class MediaManager(DeprecatedNamesMixin):
         return self.col._backend.strip_av_tags(text)
 
     def _extract_filenames(self, text: str) -> list[str]:
-        "This only exists do support a legacy function; do not use."
+        "This only exists to support a legacy function; do not use."
         out = self.col._backend.extract_av_tags(text=text, question_side=True)
         return [
             x.filename

--- a/pylib/anki/sound.py
+++ b/pylib/anki/sound.py
@@ -9,9 +9,12 @@ These can be accessed via eg card.question_av_tags()
 
 from __future__ import annotations
 
+import os
 import re
 from dataclasses import dataclass
 from typing import Union
+
+from anki import hooks
 
 
 @dataclass
@@ -37,6 +40,13 @@ class SoundOrVideoTag:
     """
 
     filename: str
+
+    def path(self, media_folder: str) -> str:
+        "Prepend the media folder to the filename."
+        # Ensure filename doesn't reference parent folder
+        filename = os.path.basename(self.filename)
+        filename = hooks.media_file_filter(filename)
+        return os.path.join(media_folder, filename)
 
 
 # note this does not include image tags, which are handled with HTML.

--- a/qt/aqt/sound.py
+++ b/qt/aqt/sound.py
@@ -23,7 +23,6 @@ from markdown import markdown
 import aqt
 import aqt.mpv
 import aqt.qt
-from anki import hooks
 from anki.cards import Card
 from anki.sound import AV_REF_RE, AVTag, SoundOrVideoTag
 from anki.utils import is_lin, is_mac, is_win, namedtmp
@@ -327,7 +326,7 @@ class SimpleProcessPlayer(Player):  # pylint: disable=abstract-method
     def _play(self, tag: AVTag) -> None:
         assert isinstance(tag, SoundOrVideoTag)
         self._process = subprocess.Popen(
-            self.args + ["--", tag.filename],
+            self.args + ["--", tag.path(self._media_folder)],
             env=self.env,
             cwd=self._media_folder,
             stdout=subprocess.DEVNULL,
@@ -453,8 +452,7 @@ class MpvManager(MPV, SoundOrVideoPlayer):
     def play(self, tag: AVTag, on_done: OnDoneCallback) -> None:
         assert isinstance(tag, SoundOrVideoTag)
         self._on_done = on_done
-        filename = hooks.media_file_filter(tag.filename)
-        path = os.path.join(self.media_folder, filename)
+        path = tag.path(self.media_folder)
 
         if self.mpv_version is None or self.mpv_version >= (0, 38, 0):
             self.command("loadfile", path, "replace", -1, "pause=no")
@@ -506,10 +504,8 @@ class SimpleMplayerSlaveModePlayer(SimpleMplayerPlayer):
     def _play(self, tag: AVTag) -> None:
         assert isinstance(tag, SoundOrVideoTag)
 
-        filename = hooks.media_file_filter(tag.filename)
-
         self._process = subprocess.Popen(
-            self.args + ["--", filename],
+            self.args + ["--", tag.path(self.media_folder)],
             env=self.env,
             cwd=self.media_folder,
             stdin=subprocess.PIPE,


### PR DESCRIPTION
We were (partially) doing this for MpvManager, but not for Windows' SimpleMpvPlayer. By passing a media file starting with a special scheme, a malicious actor could have caused a file to be written to the filesystem on Windows.

Thanks once again to Michael Lappas for the report.

@abdnh @iamllama mind giving this a quick review?