### PR TITLE
FIX diacritics being cutoff in input card templates

### DIFF
--- a/ts/reviewer/reviewer.scss
+++ b/ts/reviewer/reviewer.scss
@@ -71,6 +71,7 @@ pre {
     width: 100%;
     // https://anki.tenderapp.com/discussions/beta-testing/1854-using-margin-auto-causes-horizontal-scrollbar-on-typesomething
     box-sizing: border-box;
+    line-height: 1.75;
 }
 
 code#typeans {


### PR DESCRIPTION
# Changes
This adds a bit of line-height to make the diacritics visible. It doesn't look out of place for latin letters in my opinion, even though the input field becomes slighter heigher due to the change in this PR.

# Rationale
While this can be done via templates as well, I think anki should support other languages without any additional, special setup.

# Tests
I asked a AI service to provide me a Dzongkha word and it provided _བཀྲ་ཤིས་_. I tested with this string and with a few random latin strings.

# Pictures
All these pictures are with the change from this PR.

_Dzongkha and latin next to each other:_
![anki](https://github.com/user-attachments/assets/ec61f79a-6cac-4e3a-9b67-0e9040b99b96)

_Only Dzongkha:_
![anki](https://github.com/user-attachments/assets/9641bc3c-3f67-48fb-a7dc-c8c9ef132705)

_Only Latin:_
![anki](https://github.com/user-attachments/assets/94b34f1f-fb88-426d-98b7-bed1ed6051ad)


# Source
https://forums.ankiweb.net/t/type-to-answer-box-not-high-enough-to-display-diacritics/62073?u=anon_0000
