### PR TITLE
Fix/Invalid parameter counts saveable

### DIFF
--- a/rslib/src/deckconfig/mod.rs
+++ b/rslib/src/deckconfig/mod.rs
@@ -110,9 +110,9 @@ impl DeckConfig {
 
     /// Retrieve the FSRS 6.0 params, falling back on 5.0 or 4.x ones.
     pub fn fsrs_params(&self) -> &Vec<f32> {
-        if self.inner.fsrs_params_6.len() == 21 {
+        if self.inner.fsrs_params_6.len() > 0 {
             &self.inner.fsrs_params_6
-        } else if self.inner.fsrs_params_5.len() == 19 {
+        } else if self.inner.fsrs_params_5.len() > 0 {
             &self.inner.fsrs_params_5
         } else {
             &self.inner.fsrs_params_4

--- a/rslib/src/deckconfig/mod.rs
+++ b/rslib/src/deckconfig/mod.rs
@@ -110,9 +110,9 @@ impl DeckConfig {
 
     /// Retrieve the FSRS 6.0 params, falling back on 5.0 or 4.x ones.
     pub fn fsrs_params(&self) -> &Vec<f32> {
-        if self.inner.fsrs_params_6.len() > 0 {
+        if !self.inner.fsrs_params_6.is_empty() {
             &self.inner.fsrs_params_6
-        } else if self.inner.fsrs_params_5.len() > 0 {
+        } else if !self.inner.fsrs_params_5.is_empty() {
             &self.inner.fsrs_params_5
         } else {
             &self.inner.fsrs_params_4

--- a/ts/routes/deck-options/ParamsInput.svelte
+++ b/ts/routes/deck-options/ParamsInput.svelte
@@ -4,6 +4,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 -->
 <script lang="ts">
     import { tick } from "svelte";
+    import * as tr from "@generated/ftl";
 
     export let value: number[];
     export let defaults: number[];
@@ -28,12 +29,22 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         return params.map((v) => v.toFixed(4)).join(", ");
     }
 
-    function update(this: HTMLInputElement): void {
-        value = this.value
+    const validParamCounts = [0, 17, 19, 21];
+
+    function update(e: Event): void {
+        const input = e.target as HTMLInputElement;
+        let newValue = input.value
             .replace(/ /g, "")
             .split(",")
             .filter((e) => e)
             .map((v) => Number(v));
+
+        if (validParamCounts.includes(newValue.length)) {
+            value = newValue;
+        } else {
+            alert(tr.deckConfigInvalidParameters());
+            input.value = stringValue;
+        }
     }
 </script>
 

--- a/ts/routes/deck-options/ParamsInput.svelte
+++ b/ts/routes/deck-options/ParamsInput.svelte
@@ -32,7 +32,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     const validParamCounts = [0, 17, 19, 21];
 
     function update(e: Event): void {
-        const input = e.target as HTMLInputElement;
+        const input = e.target as HTMLTextAreaElement;
         const newValue = input.value
             .replace(/ /g, "")
             .split(",")

--- a/ts/routes/deck-options/ParamsInput.svelte
+++ b/ts/routes/deck-options/ParamsInput.svelte
@@ -33,7 +33,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
     function update(e: Event): void {
         const input = e.target as HTMLInputElement;
-        let newValue = input.value
+        const newValue = input.value
             .replace(/ /g, "")
             .split(",")
             .filter((e) => e)


### PR DESCRIPTION
Before, if you set your parameters to a value which is not 21 numbers long, it would fallback to the previous versions parameter counts. These counts could be valid (blank for default for example) and allow the values to be saved.

I fixed this in svelte before I noticed the real bug, If you don't want that revert 75ccf58765d9b9cc7554fb69696155698ff054f4.