### PR TITLE
Add answer key shortcuts to Grade Now dialog

### DIFF
--- a/qt/aqt/browser/browser.py
+++ b/qt/aqt/browser/browser.py
@@ -1139,6 +1139,9 @@ class Browser(QMainWindow):
                     dialog=dialog,
                 ),
             )
+            if key := aqt.mw.pm.get_answer_key(ease):
+                QShortcut(key, dialog, activated=btn.click)  # type: ignore
+                btn.setToolTip(tr.actions_shortcut_key(key))
             layout.addWidget(btn)
 
         # Add cancel button


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/d89f258b-85b6-4f46-9841-68eef3ce5407)

Seeing as the Grade Now dialog is meant to mimic the reviewer's button bar, this pr proposes to allow using the configured answer key shortcuts in it as well