### PR TITLE
improve the accuracy of the expected workload calculation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2295,7 +2295,7 @@ dependencies = [
 [[package]]
 name = "fsrs"
 version = "4.0.0"
-source = "git+https://github.com/open-spaced-repetition/fsrs-rs.git?rev=33ec3ee4d5d73e704633469cf5bf1a42e620a524#33ec3ee4d5d73e704633469cf5bf1a42e620a524"
+source = "git+https://github.com/open-spaced-repetition/fsrs-rs.git?rev=a7f7efc10f0a26b14ee348cc7402155685f2a24f#a7f7efc10f0a26b14ee348cc7402155685f2a24f"
 dependencies = [
  "burn",
  "itertools 0.14.0",
@@ -5010,9 +5010,9 @@ dependencies = [
 
 [[package]]
 name = "priority-queue"
-version = "2.3.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef08705fa1589a1a59aa924ad77d14722cb0cd97b67dd5004ed5f4a4873fce8d"
+checksum = "5676d703dda103cbb035b653a9f11448c0a7216c7926bd35fcb5865475d0c970"
 dependencies = [
  "autocfg",
  "equivalent",
@@ -6290,18 +6290,18 @@ checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
 
 [[package]]
 name = "snafu"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "223891c85e2a29c3fe8fb900c1fae5e69c2e42415e3177752e8718475efa5019"
+checksum = "320b01e011bf8d5d7a4a4a4be966d9160968935849c83b918827f6a435e7f627"
 dependencies = [
  "snafu-derive",
 ]
 
 [[package]]
 name = "snafu-derive"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03c3c6b7927ffe7ecaa769ee0e3994da3b8cafc8f444578982c83ecb161af917"
+checksum = "1961e2ef424c1424204d3a5d6975f934f56b6d50ff5732382d84ebf460e147f7"
 dependencies = [
  "heck",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ rev = "184b2ca50ed39ca43da13f0b830a463861adb9ca"
 [workspace.dependencies.fsrs]
 # version = "3.0.0"
 git = "https://github.com/open-spaced-repetition/fsrs-rs.git"
-rev = "33ec3ee4d5d73e704633469cf5bf1a42e620a524"
+rev = "a7f7efc10f0a26b14ee348cc7402155685f2a24f"
 # path = "../open-spaced-repetition/fsrs-rs"
 
 [workspace.dependencies]
@@ -125,7 +125,7 @@ serde_tuple = "0.5.0"
 sha1 = "0.10.6"
 sha2 = { version = "0.10.8" }
 simple-file-manifest = "0.11.0"
-snafu = { version = "0.8.5", features = ["rust_1_61"] }
+snafu = { version = "0.8.6", features = ["rust_1_61"] }
 strum = { version = "0.26.3", features = ["derive"] }
 syn = { version = "2.0.82", features = ["parsing", "printing"] }
 tar = "0.4.42"

--- a/rslib/src/deckconfig/service.rs
+++ b/rslib/src/deckconfig/service.rs
@@ -101,11 +101,13 @@ impl crate::services::DeckConfigService for Collection {
         &mut self,
         input: anki_proto::deck_config::GetRetentionWorkloadRequest,
     ) -> Result<anki_proto::deck_config::GetRetentionWorkloadResponse> {
-        const LEARN_SPAN: usize = 1000;
+        const LEARN_SPAN: usize = 100_000_000;
+        const TERMINATION_PROB: f32 = 0.01;
 
         let guard =
             self.search_cards_into_table(&input.search, crate::search::SortMode::NoOrder)?;
-        let (pass_cost, fail_cost, learn_cost) = guard.col.storage.get_costs_for_retention()?;
+        let (pass_cost, fail_cost, learn_cost, initial_pass_rate) =
+            guard.col.storage.get_costs_for_retention()?;
 
         let before = fsrs::expected_workload(
             &input.w,
@@ -113,18 +115,20 @@ impl crate::services::DeckConfigService for Collection {
             LEARN_SPAN,
             pass_cost,
             fail_cost,
-            0.,
-            input.before,
-        )? + learn_cost;
+            learn_cost,
+            initial_pass_rate,
+            TERMINATION_PROB,
+        )?;
         let after = fsrs::expected_workload(
             &input.w,
             input.after,
             LEARN_SPAN,
             pass_cost,
             fail_cost,
-            0.,
-            input.after,
-        )? + learn_cost;
+            learn_cost,
+            initial_pass_rate,
+            TERMINATION_PROB,
+        )?;
 
         Ok(anki_proto::deck_config::GetRetentionWorkloadResponse {
             factor: after / before,

--- a/rslib/src/storage/card/get_costs_for_retention.sql
+++ b/rslib/src/storage/card/get_costs_for_retention.sql
@@ -1,5 +1,9 @@
 WITH searched_revlogs AS (
-  SELECT *
+  SELECT *,
+    RANK() OVER (
+      PARTITION BY cid
+      ORDER BY id ASC
+    ) AS rank_num
   FROM revlog
   WHERE ease > 0
     AND cid IN search_cids
@@ -42,8 +46,19 @@ summed_learns AS (
 average_learn AS (
   SELECT AVG(total_time) AS avg_learn_time
   FROM summed_learns
+),
+initial_pass_rate AS (
+  SELECT AVG(
+      CASE
+        WHEN ease > 1 THEN 1.0
+        ELSE 0.0
+      END
+    ) AS initial_pass_rate
+  FROM searched_revlogs
+  WHERE rank_num = 1
 )
 SELECT *
 FROM average_pass,
   average_fail,
-  average_learn;
+  average_learn,
+  initial_pass_rate;

--- a/rslib/src/storage/card/mod.rs
+++ b/rslib/src/storage/card/mod.rs
@@ -747,7 +747,7 @@ impl super::SqliteStorage {
             .get(0)?)
     }
 
-    pub(crate) fn get_costs_for_retention(&self) -> Result<(f32, f32, f32)> {
+    pub(crate) fn get_costs_for_retention(&self) -> Result<(f32, f32, f32, f32)> {
         let mut statement = self
             .db
             .prepare(include_str!("get_costs_for_retention.sql"))?;
@@ -758,6 +758,7 @@ impl super::SqliteStorage {
             row.get(0).unwrap_or(7000.),
             row.get(1).unwrap_or(23_000.),
             row.get(2).unwrap_or(30_000.),
+            row.get(3).unwrap_or(0.5),
         ))
     }
 


### PR DESCRIPTION
**Key Changes:**

*   **Enhanced Workload Calculation:**
    *   The `fsrs::expected_workload` function now incorporates an `initial_pass_rate` (the pass rate of the first review for a card) and a `TERMINATION_PROB` for more precise estimations.
    *   The `LEARN_SPAN` constant, used in the workload calculation, has been significantly increased from `1000` to `100_000_000`. This change makes the workload curve smoother than before.
    *   The method for retrieving review costs (`get_costs_for_retention`) has been updated to fetch the `initial_pass_rate` from the database. This involved modifying the SQL query to calculate this new metric.

*   **Dependency Updates:**
    *   Updated `fsrs` to git revision `a7f7efc10f0a26b14ee348cc7402155685f2a24f`.
    *   Upgraded `priority-queue` from version `2.3.1` to `2.5.0`.
    *   Upgraded `snafu` and `snafu-derive` from version `0.8.5` to `0.8.6`.

**Detailed Changes by File:**

*   **`Cargo.lock` & `Cargo.toml`**:
    *   Reflect the version updates for `fsrs`, `priority-queue`, `snafu`, and `snafu-derive`.

*   **`rslib/src/deckconfig/service.rs`**:
    *   In `GetRetentionWorkloadRequest` handling:
        *   Changed `LEARN_SPAN` from `1000` to `100_000_000`.
        *   Introduced a new constant `TERMINATION_PROB` set to `0.01`.
        *   Modified the calls to `fsrs::expected_workload` to pass `learn_cost`, the newly fetched `initial_pass_rate`, and `TERMINATION_PROB` as arguments.

*   **`rslib/src/storage/card/get_costs_for_retention.sql`**:
    *   Added a Common Table Expression (CTE) named `initial_pass_rate`. This CTE calculates the average pass rate of the first review (where `ease > 1`) for cards included in `search_cids` by using `RANK() OVER (PARTITION BY cid ORDER BY id ASC)`.
    *   The final `SELECT` statement now includes this `initial_pass_rate`.

*   **`rslib/src/storage/card/mod.rs`**:
    *   Updated the function signature of `get_costs_for_retention` to return `Result<(f32, f32, f32, f32)>` to include the `initial_pass_rate`.
    *   Adjusted the implementation to retrieve and return this fourth value, defaulting to `0.5` if the database query doesn't return it.