### PR TITLE
trim file to basename before creating SoundOrVideoTag

### DIFF
--- a/pylib/anki/sound.py
+++ b/pylib/anki/sound.py
@@ -10,6 +10,7 @@ These can be accessed via eg card.question_av_tags()
 from __future__ import annotations
 
 import os
+import os.path
 import re
 from dataclasses import dataclass
 from typing import Union

--- a/pylib/anki/template.py
+++ b/pylib/anki/template.py
@@ -28,6 +28,7 @@ template_legacy.py file, using the legacy addHook() system.
 
 from __future__ import annotations
 
+import os.path
 from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import Any, Union

--- a/qt/aqt/sound.py
+++ b/qt/aqt/sound.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import os
+import os.path
 import platform
 import re
 import subprocess


### PR DESCRIPTION
Follow-up to #4054

This would allow add-ons to freely create `SoundOrVideoTag` objects using full paths, but users won't be able to use the `[sound:/path/to/file]` syntax anymore.

