### PR TITLE
refactor: split responsibilities between MainWindow and ProfileManager

### DIFF
--- a/qt/aqt/__init__.py
+++ b/qt/aqt/__init__.py
@@ -778,6 +778,10 @@ def _run(argv: list[str] | None = None, exec: bool = True) -> AnkiApp | None:
             )
             sys.exit(1)
 
+    from aqt.utils import cleanup_and_exit
+
+    cleanup_and_exit.app = app
+
     # load the main window
     import aqt.main
 

--- a/qt/aqt/cleanupandexitusecase.py
+++ b/qt/aqt/cleanupandexitusecase.py
@@ -1,0 +1,42 @@
+import gc
+from typing import Callable, List
+
+
+class CleanupAndExitUseCase:
+    """
+    Handles graceful application shutdown by notifying registered subscribers and exiting the app.
+    """
+
+    def __init__(self):
+        self.app = None
+        self._subscribers: List[Callable[[], None]] = []
+
+    def subscribe(self, callback: Callable[[], None]):
+        """
+        Registers a callback to be called before application exit.
+
+        Args:
+            callback: A no-argument function to run before exiting.
+        """
+        self._subscribers.append(callback)
+
+    def unsubscribe(self, callback: Callable[[], None]):
+        """
+        Unregisters a previously registered callback.
+
+        Args:
+            callback: The function to remove from the subscriber list.
+        """
+        if callback in self._subscribers:
+            self._subscribers.remove(callback)
+
+    def __call__(self):
+        """
+        Executes all registered callbacks, performs cleanup, and exits the app.
+        """
+        for callback in self._subscribers:
+            callback()
+
+        gc.collect()
+        self.app._unset_windows_shutdown_block_reason()
+        self.app.exit(0)

--- a/qt/aqt/import_export/importing.py
+++ b/qt/aqt/import_export/importing.py
@@ -215,3 +215,24 @@ def import_progress_update(progress: Progress, update: ProgressUpdate) -> None:
     update.label = progress.importing
     if update.user_wants_abort:
         update.abort = True
+
+from aqt.openbackup import (
+            restore_backup,
+            restore_backup_with_confirm,
+            choose_and_restore_backup,
+    )
+
+def _restore(path, success, error):
+    from aqt import mw
+
+    if mw.col:
+        mw.unloadCollection(lambda: import_collection_package_op(
+            mw, path, success=success
+        ).failure(error).run_in_background())
+    else:
+        import_collection_package_op(
+            mw, path, success=success
+        ).failure(error).run_in_background()
+
+
+restore_backup.set_restore_func(_restore)

--- a/qt/aqt/openbackup.py
+++ b/qt/aqt/openbackup.py
@@ -1,0 +1,73 @@
+import os
+
+from PyQt6.QtWidgets import QMessageBox
+
+from aqt.utils import tr
+from aqt.utils import getFile, askUser, showInfo
+
+
+def confirm(path):
+    return askUser(
+        tr.qt_misc_replace_your_collection_with_an_earlier2(os.path.basename(path)),
+        msgfunc=QMessageBox.warning,
+        defaultno=True,
+    )
+
+def inform():
+    showInfo("Automatic syncing and backups have been disabled while restoring. To enable them again, close the profile or restart Anki.")
+
+
+class RestoreBackupUseCase:
+    def __init__(self):
+        self.restore_func = lambda path, success, error: error(Exception("No back up function set."))
+        self.inform_func = lambda: None
+
+    def set_restore_func(self, restore_func):
+        self.restore_func = restore_func
+
+    def set_inform_func(self, inform_func):
+        self.inform_func = inform_func
+
+    def __call__(self, path: str, success, error):
+        self.inform_func()
+        self.restore_func(path, success, error)
+
+class RestoreBackupWithConfirmUseCase:
+    def __init__(self, open_backup_use_case: RestoreBackupUseCase):
+        self.confirm_func = lambda path: False
+        self.open_backup_use_case = open_backup_use_case
+
+    def set_confirm_func(self, confirm_func):
+        self.confirm_func = confirm_func
+
+    def __call__(self, path: str, success, error):
+        if self.confirm_func(path):
+            self.open_backup_use_case(path, success, error)
+
+class ChooseBackupUseCase:
+    def __init__(self, restore_use_case: RestoreBackupUseCase):
+        self.choose_path_func = lambda callback: None
+        self.confirm_func = lambda path: False
+        self.restore_use_case = restore_use_case
+
+    def set_choose_path_func(self, choose_path_func):
+        self.choose_path_func = choose_path_func
+
+    def set_confirm_func(self, confirm_func):
+        self.confirm_func = confirm_func
+
+    def __call__(self, success, error):
+        def on_path_chosen(path):
+            if self.confirm_func(path):
+                self.restore_use_case(path, success, error)
+
+        self.choose_path_func(on_path_chosen)
+
+
+restore_backup = RestoreBackupUseCase()
+
+restore_backup_with_confirm = RestoreBackupWithConfirmUseCase(restore_backup)
+restore_backup_with_confirm.set_confirm_func(confirm)
+
+choose_and_restore_backup = ChooseBackupUseCase(restore_backup)
+choose_and_restore_backup.set_confirm_func(confirm)

--- a/qt/aqt/profiledialog.py
+++ b/qt/aqt/profiledialog.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+from concurrent.futures import Future
+
+from PyQt6.QtWidgets import QMessageBox, QMainWindow
+
+from aqt import mw
+from aqt.profiles import ProfileManager as ProfileManagerType
+from aqt.utils import askUser, checkInvalidFilename, getOnlyText, showInfo, showWarning, tr
+
+
+class ProfileDialog:
+    _activeProfile: int = 0
+    _profiles = []
+
+    def __init__(self, pm: ProfileManagerType):
+        self.pm = pm
+
+    def _refreshProfiles(self):
+        self._profiles = self.pm.profiles()
+        try:
+            self._activeProfile = self._profiles.index(self.pm.name)
+        except Exception:
+            self._activeProfile = 0
+        mw.profileForm.profiles.clear()
+        mw.profileForm.profiles.addItems(self._profiles)
+        mw.profileForm.profiles.setCurrentRow(self._activeProfile)
+
+    def _profileNameOk(self, name: str) -> bool:
+        return not checkInvalidFilename(name) and name != "addons21"
+
+    def _activeProfileName(self):
+        return self._profiles[self._activeProfile]
+
+    def onOpenProfile(self) -> None:
+        self.pm.load(self._activeProfileName())
+        if mw.loadCollection():
+            self.d.hide()
+
+    def onAddProfile(self) -> None:
+        name = getOnlyText(tr.actions_name()).strip()
+        if name:
+            if name in self._profiles:
+                showWarning(tr.qt_misc_name_exists())
+                return
+            if not self._profileNameOk(name):
+                return
+            self.pm.create(name)
+            self.pm.name = name
+            self._refreshProfiles()
+
+    def onOpenBackup(self) -> None:
+        from aqt.openbackup import (
+            restore_backup,
+            restore_backup_with_confirm,
+            choose_and_restore_backup
+        )
+
+        def success():
+            self.pm.load(self._activeProfileName())
+            if mw.loadCollection():
+                self.d.hide()
+
+        def error(e: Exception):
+            showWarning("Backup could not be restored\n" + str(e))
+
+        choose_and_restore_backup(success, error)
+
+    def onQuit(self) -> None:
+        from aqt.utils import cleanup_and_exit
+
+        cleanup_and_exit()
+
+    def onRenameProfile(self) -> None:
+        name = getOnlyText(
+            tr.actions_new_name(), default=self._activeProfileName()
+        ).strip()
+        if not name:
+            return
+        if name == self._activeProfileName():
+            return
+        if name in self._profiles:
+            showWarning(tr.qt_misc_name_exists())
+            return
+        if not self._profileNameOk(name):
+            return
+        self.pm.rename(name)
+        self._refreshProfiles()
+
+    def onRemProfile(self) -> None:
+        if len(self._profiles) < 2:
+            showWarning(tr.qt_misc_there_must_be_at_least_one())
+            return
+        # sure?
+        if not askUser(
+            tr.qt_misc_all_cards_notes_and_media_for2(name=self._activeProfileName()),
+            msgfunc=QMessageBox.warning,
+            defaultno=True,
+        ):
+            return
+        self.pm.remove(self._activeProfileName())
+        self._refreshProfiles()
+
+    def onProfileRowChange(self, n: int) -> None:
+        if n < 0:
+            # called on .clear()
+            return
+
+        self._activeProfile = n
+
+    def onDowngrade(self) -> None:
+        mw.progress.start()
+        profiles = mw.pm.profiles()
+
+        def downgrade() -> list[str]:
+            return mw.pm.downgrade(profiles)
+
+        def on_done(future: Future) -> None:
+            mw.progress.finish()
+            problems = future.result()
+            if not problems:
+                showInfo("Profiles can now be opened with an older version of Anki.")
+            else:
+                showWarning(
+                    "The following profiles could not be downgraded: {}".format(
+                        ", ".join(problems)
+                    )
+                )
+                return
+            from aqt.utils import cleanup_and_exit
+
+            cleanup_and_exit()
+
+        mw.taskman.run_in_background(downgrade, on_done)
+
+    def show(self):
+        import aqt
+        from aqt.qt import QKeySequence, QShortcut, qconnect
+        from aqt.utils import tr
+
+        d = self.d = QMainWindow()
+        f = mw.profileForm = aqt.forms.profiles.Ui_MainWindow()
+        f.setupUi(d)
+        qconnect(f.login.clicked, self.onOpenProfile)
+        qconnect(f.profiles.itemDoubleClicked, self.onOpenProfile)
+        qconnect(f.openBackup.clicked, self.onOpenBackup)
+        qconnect(f.quit.clicked, self.onQuit)
+        qconnect(f.add.clicked, self.onAddProfile)
+        qconnect(f.rename.clicked, self.onRenameProfile)
+        d.closeEvent = lambda ev: self.onQuit()
+        qconnect(f.delete_2.clicked, self.onRemProfile)
+        qconnect(f.profiles.currentRowChanged, self.onProfileRowChange)
+        f.statusbar.setVisible(False)
+        qconnect(f.downgrade_button.clicked, self.onDowngrade)
+        f.downgrade_button.setText(tr.profiles_downgrade_and_quit())
+        # enter key opens profile
+        QShortcut(QKeySequence("Return"), d, activated=self.onOpenProfile)  # type: ignore
+        self._refreshProfiles()
+        # raise first, for osx testing
+        d.show()
+        d.activateWindow()
+        d.raise_()
+

--- a/qt/aqt/utils.py
+++ b/qt/aqt/utils.py
@@ -28,6 +28,7 @@ from anki.utils import (
     no_bundled_libs,
     version_with_build,
 )
+from aqt.cleanupandexitusecase import CleanupAndExitUseCase
 from aqt.qt import *
 from aqt.qt import (
     PYQT_VERSION_STR,
@@ -84,6 +85,8 @@ from aqt.theme import theme_manager
 
 if TYPE_CHECKING:
     TextFormat = Literal["plain", "rich", "markdown"]
+
+cleanup_and_exit = CleanupAndExitUseCase()
 
 
 def aqt_data_path() -> Path:

--- a/qt/tests/test_profiledialog.py
+++ b/qt/tests/test_profiledialog.py
@@ -1,0 +1,125 @@
+import importlib
+import sys
+import os
+
+# Add the root project directory to sys.path
+
+import unittest
+from unittest.mock import Mock, patch, call
+
+
+
+class TestProfileDialog(unittest.TestCase):
+    def setUp(self):
+        self.pm = Mock()
+        self.pm.profiles.return_value = ["user1", "user2"]
+        self.pm.name = "user1"
+
+        # Patch mw and profileForm
+        patcher1 = patch("aqt.mw")
+
+        self.mock_mw = patcher1.start()
+        self.addCleanup(patcher1.stop)
+        if "aqt.profiledialog" in sys.modules:
+            importlib.reload(sys.modules["aqt.profiledialog"])
+        else:
+            importlib.import_module("aqt.profiledialog")
+
+        from aqt.profiledialog import ProfileDialog
+
+        # mock profileForm
+        self.mock_profiles = Mock()
+        self.mock_mw.profileForm.profiles = self.mock_profiles
+
+        # other mocks
+        self.mock_mw.profileNameOk.return_value = True
+        self.mock_mw.pm = self.pm
+        self.mock_mw.taskman = Mock()
+        self.mock_mw.progress = Mock()
+
+        self.dialog = ProfileDialog(self.pm)
+
+    def test_refresh_profiles_sets_correct_index(self):
+        self.dialog._refreshProfiles()
+
+        self.assertEqual(self.dialog._activeProfile, 0)
+        self.mock_profiles.clear.assert_called_once()
+        self.mock_profiles.addItems.assert_called_once_with(["user1", "user2"])
+        self.mock_profiles.setCurrentRow.assert_called_once_with(0)
+
+    def test_active_profile_name(self):
+        self.dialog._profiles = ["x", "y"]
+        self.dialog._activeProfile = 1
+        self.assertEqual(self.dialog._activeProfileName(), "y")
+
+    def test_on_open_profile_calls_load(self):
+        self.dialog._profiles = ["user1"]
+        self.dialog._activeProfile = 0
+        self.dialog.onOpenProfile()
+        self.pm.load.assert_called_once_with("user1")
+        self.mock_mw.loadCollection.assert_called_once()
+
+    def test_on_add_profile_adds_new_profile(self):
+        self.dialog._profiles = ["user1"]
+        with patch("aqt.profiledialog.getOnlyText", return_value="newuser"), \
+                patch("aqt.profiledialog.tr") as mock_tr:
+            mock_tr.actions_name.return_value = "Enter name"
+            self.dialog.onAddProfile()
+            self.pm.create.assert_called_once_with("newuser")
+            self.assertEqual(self.pm.name, "newuser")
+
+    def test_on_add_profile_duplicate(self):
+        self.dialog._profiles = ["user1", "dupe"]
+        with patch("aqt.profiledialog.getOnlyText", return_value="dupe"), \
+                patch("aqt.profiledialog.tr") as mock_tr, \
+                patch("aqt.profiledialog.showWarning") as mock_warn:
+            mock_tr.actions_name.return_value = "Enter name"
+            mock_tr.qt_misc_name_exists.return_value = "Name exists"
+            self.dialog.onAddProfile()
+            mock_warn.assert_called_once_with("Name exists")
+
+    def test_on_rename_profile_valid(self):
+        self.dialog._profiles = ["user1"]
+        self.dialog._activeProfile = 0
+        with patch("aqt.profiledialog.getOnlyText", return_value="renamed"), \
+                patch("aqt.profiledialog.tr") as mock_tr:
+            mock_tr.actions_new_name.return_value = "New name"
+            self.dialog.onRenameProfile()
+            self.pm.rename.assert_called_once_with("renamed")
+
+    def test_on_rem_profile_confirms_and_removes(self):
+        self.dialog._profiles = ["user1", "user2"]
+        self.dialog._activeProfile = 0
+        with patch("aqt.profiledialog.tr") as mock_tr, \
+                patch("aqt.profiledialog.askUser", return_value=True):
+            mock_tr.qt_misc_all_cards_notes_and_media_for2.return_value = "Delete?"
+            self.dialog.onRemProfile()
+            self.pm.remove.assert_called_once_with("user1")
+
+    def test_on_profile_row_change_updates_index(self):
+        self.dialog._activeProfile = 0
+        self.dialog.onProfileRowChange(1)
+        self.assertEqual(self.dialog._activeProfile, 1)
+
+    def test_on_profile_row_change_negative_does_not_update(self):
+        self.dialog._activeProfile = 0
+        self.dialog.onProfileRowChange(-1)
+        self.assertEqual(self.dialog._activeProfile, 0)
+
+    def test_on_downgrade_runs_task(self):
+        self.mock_mw.pm.downgrade.return_value = []
+        future = Mock()
+        future.result.return_value = []
+        on_done = None
+
+        def run_in_background(fn, cb):
+            nonlocal on_done
+            on_done = cb
+            return fn()
+
+        self.mock_mw.taskman.run_in_background.side_effect = run_in_background
+        self.dialog.onDowngrade()
+        self.assertTrue(callable(on_done))
+        on_done(Mock(result=lambda: []))
+        self.mock_mw.progress.start.assert_called()
+        self.mock_mw.progress.finish.assert_called()

--- a/qt/tools/genhooks_gui.py
+++ b/qt/tools/genhooks_gui.py
@@ -41,6 +41,11 @@ hooks = [
     # Reviewing
     ###################
     Hook(
+        name="collection_load_did_fail",
+        args=["e: Exception"],
+        doc="""Called when the collection could not be loaded.""",
+    ),
+    Hook(
         name="overview_did_refresh",
         args=["overview: aqt.overview.Overview"],
         doc="""Allow to update the overview window. E.g. add the deck name in the


### PR DESCRIPTION
refactor: split responsibilities between MainWindow and ProfileManager

- Extracted MainWindow and ProfileManager into separate classes
- Introduced use case classes (e.g. RestoreBackupUseCase, CleanupAndExitUseCase) to decouple logic from UI
- Use cases are callable and support external callback injection for integration
- Added global singleton instances for app-wide access

This refactoring lays the groundwork for another PR that adds dynamic routing to MainWindow.
[See also](https://forums.ankiweb.net/t/adding-dynamic-routing-to-the-ankiqt-class/61959)

WIP but mostly done. Is this something that could be merged? Or are the changes too much?
