### PR TITLE
Delay retention workload info display after FSRS optimization alerts

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -230,6 +230,7 @@ KolbyML <https://github.com/KolbyML>
 Adnane Taghi <dev@soleuniverse.me>
 Spiritual Father <https://github.com/spiritualfather>
 Emmanuel Ferdman <https://github.com/emmanuel-ferdman>
+Sunong2008 <https://github.com/Sunrongguo2008>
 Marvin Kopf <marvinkopf@outlook.com>
 ********************
 

--- a/ts/routes/deck-options/FsrsOptions.svelte
+++ b/ts/routes/deck-options/FsrsOptions.svelte
@@ -405,7 +405,8 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
     :global(.two-line) {
         white-space: pre-wrap;
-        min-height: calc(2ch + 30px);
+        height: calc(2 * 1.5em + 10px);
+        line-height: 1.5em;
         box-sizing: content-box;
         display: flex;
         align-content: center;

--- a/ts/routes/deck-options/FsrsOptions.svelte
+++ b/ts/routes/deck-options/FsrsOptions.svelte
@@ -411,5 +411,6 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         display: flex;
         align-content: center;
         flex-wrap: wrap;
+        width: 100%;
     }
 </style>

--- a/ts/routes/deck-options/FsrsOptions.svelte
+++ b/ts/routes/deck-options/FsrsOptions.svelte
@@ -412,6 +412,5 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         display: flex;
         align-content: center;
         flex-wrap: wrap;
-        width: 100%;
     }
 </style>

--- a/ts/routes/deck-options/FsrsOptions.svelte
+++ b/ts/routes/deck-options/FsrsOptions.svelte
@@ -66,7 +66,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     $: desiredRetentionWarning = getRetentionLongShortWarning(roundedRetention);
 
     let timeoutId: ReturnType<typeof setTimeout> | undefined = undefined;
-    const WORKLOAD_UPDATE_DELAY_MS = 250;
+    const WORKLOAD_UPDATE_DELAY_MS = 100;
 
     let desiredRetentionChangeInfo = "";
     $: {
@@ -207,7 +207,9 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
                     }
                     if (!already_optimal) {
                         $config.fsrsParams6 = resp.params;
-                        optimized = true;
+                        setTimeout(() => {
+                            optimized = true;
+                        }, 201);
                     }
                     if (computeParamsProgress) {
                         computeParamsProgress.current = computeParamsProgress.total;

--- a/ts/routes/deck-options/FsrsOptions.svelte
+++ b/ts/routes/deck-options/FsrsOptions.svelte
@@ -66,7 +66,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     $: desiredRetentionWarning = getRetentionLongShortWarning(roundedRetention);
 
     let timeoutId: ReturnType<typeof setTimeout> | undefined = undefined;
-    const WORKLOAD_UPDATE_DELAY_MS = 100;
+    const WORKLOAD_UPDATE_DELAY_MS = 250;
 
     let desiredRetentionChangeInfo = "";
     $: {

--- a/ts/routes/deck-options/FsrsOptions.svelte
+++ b/ts/routes/deck-options/FsrsOptions.svelte
@@ -407,8 +407,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
     :global(.two-line) {
         white-space: pre-wrap;
-        height: calc(2 * 1.5em + 10px);
-        line-height: 1.5em;
+        min-height: calc(2ch + 30px);
         box-sizing: content-box;
         display: flex;
         align-content: center;


### PR DESCRIPTION
When clicking the "Optimize current preset" button in FSRS settings, "The higher this value, the more frequently cards will be shown to you."(using `.two-line`) would experience layout shifts during async operations. The element would initially render with single-line height before the completion alert, then expand to proper two-line height after user dismisses the alert dialog.
![图片](https://github.com/user-attachments/assets/43eff691-3599-4d06-82ae-b24ced9ade3c)
![图片](https://github.com/user-attachments/assets/7aa294c2-5997-4ee0-a32d-3bbc59698e72)
Guess the reason is:
1. High computational issue: Currently using `min-height: calc(2ch + 30px)`, where the `ch` unit is based on the width of the character "0". Layout needs to be recalculated after text updates
2. Rendering Timing Issue: The alert pop-up blocks the main thread, leading to: After state update (`optimized=true`), it cannot immediately re-render, and the browser can only execute the rendering queue after the user clicks "OK".
I Modified CSS styles for `.two-line` class in FSRS settings component.
I haven't tested it, so I don't know if my changes are effective.