### PR TITLE
Feat/Message at 100% progress for optimize

### DIFF
--- a/ftl/core/deck-config.ftl
+++ b/ftl/core/deck-config.ftl
@@ -483,6 +483,7 @@ deck-config-percent-of-reviews =
        *[other] { $pct }% of { $reviews } reviews
     }
 deck-config-percent-input = { $pct }%
+deck-config-checking-for-improvement = Checking for improvement...
 deck-config-optimizing-preset = Optimizing preset { $current_count }/{ $total_count }...
 deck-config-fsrs-must-be-enabled = FSRS must be enabled first.
 deck-config-fsrs-params-optimal = The FSRS parameters currently appear to be optimal.

--- a/ts/routes/deck-options/FsrsOptions.svelte
+++ b/ts/routes/deck-options/FsrsOptions.svelte
@@ -281,7 +281,11 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         if (val instanceof ComputeRetentionProgress) {
             return `${pct}%`;
         } else {
-            return tr.deckConfigPercentOfReviews({ pct, reviews: val.reviews });
+            if (val.current === val.total) {
+                return tr.deckConfigCheckingForImprovement();
+            } else {
+                return tr.deckConfigPercentOfReviews({ pct, reviews: val.reviews });
+            }
         }
     }
 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/198ba193-6d4d-452b-96d3-59ec1cb4c925)

Note this will show regardless of if it is stalling at 100% due to the health check or if it is stalling at 100% due to the 2 evaluates which determine if the parameters have improved since last optimization.