### PR TITLE
Ignore TaskManager's on_done callback if collection unloaded

### DIFF
--- a/qt/aqt/taskman.py
+++ b/qt/aqt/taskman.py
@@ -84,8 +84,15 @@ class TaskManager(QObject):
         fut = executor.submit(task, **args)
 
         if on_done is not None:
+
+            def wrapped_done(future: Future) -> None:
+                if uses_collection and not self.mw.col:
+                    print(f"Ignored on_done as collection unloaded: {repr(on_done)}")
+                    return
+                on_done(future)
+
             fut.add_done_callback(
-                lambda future: self.run_on_main(lambda: on_done(future))
+                lambda future: self.run_on_main(lambda: wrapped_done(future))
             )
 
         return fut


### PR DESCRIPTION
AnkiHub runs sync-related background tasks before shutdown, and they often throw errors inside on_done callbacks depending on timing [1].

@RisingOrange heads-up in case you have feedback.

[1]: https://github.com/AnkiHubSoftware/ankihub_addon/pull/1128