### PR TITLE
Fix IO text labels' fill attr being saved even if default colour

### DIFF
--- a/ts/routes/image-occlusion/shapes/base.ts
+++ b/ts/routes/image-occlusion/shapes/base.ts
@@ -49,7 +49,6 @@ export class Shape {
             left: floatToDisplay(this.left),
             top: floatToDisplay(this.top),
             ...(!angle ? {} : { angle: angle.toString() }),
-            ...(this.fill === SHAPE_MASK_COLOR ? {} : { fill: this.fill }),
         };
     }
 

--- a/ts/routes/image-occlusion/shapes/ellipse.ts
+++ b/ts/routes/image-occlusion/shapes/ellipse.ts
@@ -3,6 +3,7 @@
 
 import { fabric } from "fabric";
 
+import { SHAPE_MASK_COLOR } from "../tools/lib";
 import type { ConstructorParams, Size } from "../types";
 import type { ShapeDataForCloze } from "./base";
 import { Shape } from "./base";
@@ -25,6 +26,7 @@ export class Ellipse extends Shape {
             ...super.toDataForCloze(),
             rx: floatToDisplay(this.rx),
             ry: floatToDisplay(this.ry),
+            ...(this.fill === SHAPE_MASK_COLOR ? {} : { fill: this.fill }),
         };
     }
 

--- a/ts/routes/image-occlusion/shapes/polygon.ts
+++ b/ts/routes/image-occlusion/shapes/polygon.ts
@@ -3,6 +3,7 @@
 
 import { fabric } from "fabric";
 
+import { SHAPE_MASK_COLOR } from "../tools/lib";
 import type { ConstructorParams, Size } from "../types";
 import type { ShapeDataForCloze } from "./base";
 import { Shape } from "./base";
@@ -22,6 +23,7 @@ export class Polygon extends Shape {
         return {
             ...super.toDataForCloze(),
             points: this.points.map(({ x, y }) => `${floatToDisplay(x)},${floatToDisplay(y)}`).join(" "),
+            ...(this.fill === SHAPE_MASK_COLOR ? {} : { fill: this.fill }),
         };
     }
 

--- a/ts/routes/image-occlusion/shapes/rectangle.ts
+++ b/ts/routes/image-occlusion/shapes/rectangle.ts
@@ -3,6 +3,7 @@
 
 import { fabric } from "fabric";
 
+import { SHAPE_MASK_COLOR } from "../tools/lib";
 import type { ConstructorParams, Size } from "../types";
 import type { ShapeDataForCloze } from "./base";
 import { Shape } from "./base";
@@ -25,6 +26,7 @@ export class Rectangle extends Shape {
             ...super.toDataForCloze(),
             width: floatToDisplay(this.width),
             height: floatToDisplay(this.height),
+            ...(this.fill === SHAPE_MASK_COLOR ? {} : { fill: this.fill }),
         };
     }
 

--- a/ts/routes/image-occlusion/tools/tool-text.ts
+++ b/ts/routes/image-occlusion/tools/tool-text.ts
@@ -11,6 +11,7 @@ import {
     isPointerInBoundingBox,
     stopDraw,
     TEXT_BACKGROUND_COLOR,
+    TEXT_COLOR,
     TEXT_FONT_FAMILY,
     TEXT_PADDING,
 } from "./lib";
@@ -41,6 +42,7 @@ export const drawText = (canvas: fabric.Canvas, onActivated: Callback): void => 
             selectable: true,
             strokeWidth: 1,
             noScaleCache: false,
+            fill: TEXT_COLOR,
             fontFamily: TEXT_FONT_FAMILY,
             backgroundColor: TEXT_BACKGROUND_COLOR,
             padding: TEXT_PADDING,


### PR DESCRIPTION
Realised i had made a mistake in #4048 after seeing that new text labels in the default colour were saved with the attr `fill=rgb(0,0,0)`, which this pr fixes