### PR TITLE
Fix unescaped deck names potentially missing from overview

### DIFF
--- a/qt/aqt/overview.py
+++ b/qt/aqt/overview.py
@@ -2,6 +2,7 @@
 # License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 from __future__ import annotations
 
+import html
 from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any
@@ -191,7 +192,7 @@ class Overview:
             self._show_finished_screen()
             return
         content = OverviewContent(
-            deck=deck["name"],
+            deck=html.escape(deck["name"]),
             shareLink=shareLink,
             desc=self._desc(deck),
             table=self._table(),

--- a/qt/aqt/overview.py
+++ b/qt/aqt/overview.py
@@ -192,12 +192,13 @@ class Overview:
             self._show_finished_screen()
             return
         content = OverviewContent(
-            deck=html.escape(deck["name"]),
+            deck=deck["name"],
             shareLink=shareLink,
             desc=self._desc(deck),
             table=self._table(),
         )
         gui_hooks.overview_will_render_content(self, content)
+        content.deck = html.escape(content.deck)
         self.web.stdHtml(
             self._body % content.__dict__,
             css=["css/overview.css"],


### PR DESCRIPTION
Fixes the same bug as:
- https://github.com/ankitects/anki/pull/3960

but for the deck overview page