### PR TITLE
Limit study time to hours in reviews graph

### DIFF
--- a/ts/lib/tslib/time.ts
+++ b/ts/lib/tslib/time.ts
@@ -36,25 +36,21 @@ export function unitName(unit: TimespanUnit): string {
     }
 }
 
-export function naturalUnit(secs: number, maxUnit: TimespanUnit = TimespanUnit.Years): TimespanUnit {
+export function naturalUnit(secs: number): TimespanUnit {
     secs = Math.abs(secs);
-    const thresholds = [
-        { unit: TimespanUnit.Years, min: YEAR },
-        { unit: TimespanUnit.Months, min: MONTH },
-        { unit: TimespanUnit.Days, min: DAY },
-        { unit: TimespanUnit.Hours, min: HOUR },
-        { unit: TimespanUnit.Minutes, min: MINUTE },
-        { unit: TimespanUnit.Seconds, min: 0 },
-    ];
-    for (const { unit, min } of thresholds) {
-        if (unit > maxUnit) {
-            continue;
-        }
-        if (secs >= min) {
-            return unit;
-        }
+    if (secs < MINUTE) {
+        return TimespanUnit.Seconds;
+    } else if (secs < HOUR) {
+        return TimespanUnit.Minutes;
+    } else if (secs < DAY) {
+        return TimespanUnit.Hours;
+    } else if (secs < MONTH) {
+        return TimespanUnit.Days;
+    } else if (secs < YEAR) {
+        return TimespanUnit.Months;
+    } else {
+        return TimespanUnit.Years;
     }
-    return TimespanUnit.Seconds;
 }
 
 /** Number of seconds in a given unit. */
@@ -156,7 +152,7 @@ export function timeSpan(
     precise = true,
     maxUnit: TimespanUnit = TimespanUnit.Years,
 ): string {
-    const unit = naturalUnit(seconds, maxUnit);
+    const unit = Math.min(naturalUnit(seconds), maxUnit);
     let amount = unitAmount(unit, seconds);
     if (!precise && unit < TimespanUnit.Months) {
         amount = Math.round(amount);

--- a/ts/routes/card-info/CardStats.svelte
+++ b/ts/routes/card-info/CardStats.svelte
@@ -5,7 +5,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 <script lang="ts">
     import type { CardStatsResponse } from "@generated/anki/stats_pb";
     import * as tr2 from "@generated/ftl";
-    import { DAY, timeSpan, Timestamp } from "@tslib/time";
+    import { DAY, timeSpan, TimespanUnit, Timestamp } from "@tslib/time";
 
     export let stats: CardStatsResponse;
 
@@ -58,7 +58,12 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         if (stats.memoryState) {
             let stability = timeSpan(stats.memoryState.stability * 86400, false, false);
             if (stats.memoryState.stability > 31) {
-                const nativeStability = stats.memoryState.stability.toFixed(0);
+                const nativeStability = timeSpan(
+                    stats.memoryState.stability * 86400,
+                    false,
+                    false,
+                    TimespanUnit.Days,
+                );
                 stability += ` (${nativeStability})`;
             }
             statsRows.push({

--- a/ts/routes/graphs/reviews.ts
+++ b/ts/routes/graphs/reviews.ts
@@ -8,7 +8,7 @@
 import type { GraphsResponse } from "@generated/anki/stats_pb";
 import * as tr from "@generated/ftl";
 import { localizedNumber } from "@tslib/i18n";
-import { dayLabel, timeSpan } from "@tslib/time";
+import { dayLabel, timeSpan, TimespanUnit } from "@tslib/time";
 import type { Bin, ScaleSequential } from "d3";
 import {
     area,
@@ -141,7 +141,7 @@ export function renderReviews(
 
     const yTickFormat = (n: number): string => {
         if (showTime) {
-            return timeSpan(n / 1000, true);
+            return timeSpan(n / 1000, true, false, TimespanUnit.Hours);
         } else {
             if (Math.round(n) != n) {
                 return "";
@@ -205,7 +205,7 @@ export function renderReviews(
 
     function valueLabel(n: number): string {
         if (showTime) {
-            return timeSpan(n / 1000);
+            return timeSpan(n / 1000, false, true, TimespanUnit.Hours);
         } else {
             return tr.statisticsReviews({ reviews: n });
         }
@@ -340,7 +340,7 @@ export function renderReviews(
         averageAnswerTime: string,
         averageAnswerTimeLabel: string;
     if (showTime) {
-        totalString = timeSpan(total / 1000, false);
+        totalString = timeSpan(total / 1000, false, true, TimespanUnit.Hours);
         averageForDaysStudied = tr.statisticsMinutesPerDay({
             count: Math.round(studiedAvg / 1000 / 60),
         });


### PR DESCRIPTION
Relevant discussions:
- https://forums.ankiweb.net/t/reviews-graph-units-of-total-time-studied-suggestion/61237
- https://forums.ankiweb.net/t/why-does-anki-display-study-time-in-months/37722
- https://forums.ankiweb.net/t/poll-use-hours-in-total-time-stats/62076
- https://github.com/ankitects/anki/pull/3901#issuecomment-2973161601

I couldn't build Anki to test this but I am pretty confident that the changes would work.