### PR TITLE
Clear desired retention and decay when changing decks

### DIFF
--- a/rslib/src/card/mod.rs
+++ b/rslib/src/card/mod.rs
@@ -189,6 +189,8 @@ impl Card {
     fn set_deck(&mut self, deck: DeckId) {
         self.remove_from_filtered_deck_restoring_queue();
         self.memory_state = None;
+        self.desired_retention = None;
+        self.decay = None;
         self.deck_id = deck;
     }
 


### PR DESCRIPTION
These values are preset-specific and entries from previous deck may cause issues.

PS:
I created a somewhat related [bug report](https://github.com/open-spaced-repetition/fsrs4anki-helper/issues/575) in the FSRS Helper add-on repo and the proposed solution ended up requiring creation of a new function in Anki (which will also solve a bug in Anki). Please share your thoughts on the proposed solution there.