### PR TITLE
Update the default value of FSRS-6 decay in forgetting curve

### DIFF
--- a/ts/routes/card-info/CardInfo.svelte
+++ b/ts/routes/card-info/CardInfo.svelte
@@ -22,12 +22,12 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     $: decay = (() => {
         const paramsLength = stats?.fsrsParams?.length ?? 0;
         if (paramsLength === 0) {
-            return 0.2; // default decay for FSRS-6
+            return 0.1542; // default decay for FSRS-6
         }
         if (paramsLength < 21) {
             return 0.5; // default decay for FSRS-4.5 and FSRS-5
         }
-        return stats?.fsrsParams?.[20] ?? 0.2;
+        return stats?.fsrsParams?.[20] ?? 0.1542;
     })();
 </script>
 


### PR DESCRIPTION
Changed in https://github.com/open-spaced-repetition/fsrs-rs/commit/037345fd57472ea392a6086f217b1c73a9fa171a

I am not sure what's the best way to do this. Ideally, Anki should automatically use the value from FSRS-rs here.