### PR TITLE
Save dr and decay in card even if item is None

### DIFF
--- a/rslib/src/scheduler/fsrs/memory_state.rs
+++ b/rslib/src/scheduler/fsrs/memory_state.rs
@@ -105,8 +105,9 @@ impl Collection {
                 progress.update(true, |state| state.current_cards = idx as u32 + 1)?;
                 let mut card = self.storage.get_card(card_id)?.or_not_found(card_id)?;
                 let original = card.clone();
-                // store decay and desired retention in the card so that add-ons, card info and
-                // Stats don't need to access the deck config
+                // store decay and desired retention in the card so that add-ons, card info,
+                // Stats and browser search/sorts don't need to access the deck config.
+                // Values stored in the card are not used by the scheduler.
                 card.desired_retention = desired_retention;
                 card.decay = decay;
                 if let (Some(req), Some(item)) = (&req, item) {

--- a/rslib/src/scheduler/fsrs/memory_state.rs
+++ b/rslib/src/scheduler/fsrs/memory_state.rs
@@ -112,7 +112,7 @@ impl Collection {
                     card.desired_retention = desired_retention;
                     card.decay = decay;
                     if let Some(item) = &item {
-                        card.set_memory_state(&fsrs, item, historical_retention.unwrap())?;
+                        card.set_memory_state(&fsrs, Some(item.clone()), historical_retention.unwrap())?;
                         // if rescheduling
                         if let Some(reviews) = &last_revlog_info {
                             // and we have a last review time for the card

--- a/rslib/src/scheduler/fsrs/memory_state.rs
+++ b/rslib/src/scheduler/fsrs/memory_state.rs
@@ -130,7 +130,7 @@ impl Collection {
                                         let original_interval = card.interval;
                                         let interval = fsrs.next_interval(
                                             Some(state.stability),
-                                            desired_retention,
+                                            desired_retention.unwrap(),
                                             0,
                                         );
                                         card.interval = rescheduler
@@ -215,7 +215,7 @@ impl Collection {
             })
         } else {
             card.memory_state = None;
-            card.desired_retention = desired_retention;
+            card.desired_retention = Some(desired_retention);
             Ok(ComputeMemoryStateResponse {
                 state: None,
                 desired_retention,

--- a/rslib/src/scheduler/fsrs/memory_state.rs
+++ b/rslib/src/scheduler/fsrs/memory_state.rs
@@ -111,8 +111,8 @@ impl Collection {
                     // Unlike memory states, scheduler doesn't use decay and dr stored in the card.
                     card.desired_retention = desired_retention;
                     card.decay = decay;
-                    if let Some(item) = &item {
-                        card.set_memory_state(&fsrs, Some(item.clone()), historical_retention.unwrap())?;
+                    if let Some(item) = item {
+                        card.set_memory_state(&fsrs, Some(item), historical_retention.unwrap())?;
                         // if rescheduling
                         if let Some(reviews) = &last_revlog_info {
                             // and we have a last review time for the card

--- a/rslib/src/scheduler/fsrs/memory_state.rs
+++ b/rslib/src/scheduler/fsrs/memory_state.rs
@@ -105,7 +105,8 @@ impl Collection {
                 progress.update(true, |state| state.current_cards = idx as u32 + 1)?;
                 let mut card = self.storage.get_card(card_id)?.or_not_found(card_id)?;
                 let original = card.clone();
-                // store decay and desired retention in the card so that add-ons, card info and Stats don't need to access the deck config
+                // store decay and desired retention in the card so that add-ons, card info and
+                // Stats don't need to access the deck config
                 card.desired_retention = desired_retention;
                 card.decay = decay;
                 if let (Some(req), Some(item)) = (&req, item) {


### PR DESCRIPTION
Functional changes:
- DR and decay are now stored in the card even if item is None because they don't depend on items
- Stored value of decay is now cleared when FSRS is disabled

Non-functional changes:
- Non-functional code from `compute_memory_state` was removed. This function is used by add-ons to fetch information. This function doesn't update the cards on its own.
- Document why we store DR and decay in the card
- In
```rs
let interval = fsrs.next_interval(Some(state.stability), card.desired_retention.unwrap(), 0);
```
`card.desired_retention.unwrap()` was replaced by `desired_retention.unwrap()`.

<details>
<summary>Original PR description</summary>
I think I had a very wrong idea about why desired retention and decay were stored in the card. (this doesn't affect my other PRs or requests though)

@L-M-Sherlock, please confirm that this documentation is correct. Also, please confirm whether the scheduler uses any of these stored values during reviews.
</details>