### PR TITLE
Fix repeated ticks in reviews graph

### DIFF
--- a/ts/routes/graphs/reviews.ts
+++ b/ts/routes/graphs/reviews.ts
@@ -141,7 +141,7 @@ export function renderReviews(
 
     const yTickFormat = (n: number): string => {
         if (showTime) {
-            return timeSpan(n / 1000, true, false, TimespanUnit.Hours);
+            return timeSpan(n / 1000, true, true, TimespanUnit.Hours);
         } else {
             if (Math.round(n) != n) {
                 return "";


### PR DESCRIPTION
In #4086, I tried to make the ticks looks cleaner because ticks like 16.67m, 33.33m, 1.11h, 1.39h, etc. look unclean. 

However, this resulted in a regression. In 25.06b4, the graph looks like this. Note the repeated 1h and 2h ticks.
<img width=500 src="https://github.com/user-attachments/assets/f4513cdd-d701-4087-ac95-c57de5327675">

This PR fixes that regression by setting precise=True again. I think we need a better way to control the rounding precision (https://forums.ankiweb.net/t/reduce-precision-of-time-studied-today/42309). But, that's out of scope of this PR.