### PR TITLE
Fix/Add check_output_timestamps to PythonEnvironment

### DIFF
--- a/build/ninja_gen/src/build.rs
+++ b/build/ninja_gen/src/build.rs
@@ -261,9 +261,10 @@ impl BuildStatement<'_> {
             panic!("{} must generate at least one output", action.name());
         }
         stmt.variables.push(("description".into(), group.into()));
-        if action.check_output_timestamps() {
-            stmt.rule_variables.push(("restat".into(), "1".into()));
-        }
+        stmt.rule_variables.push((
+            "restat".into(),
+            (action.check_output_timestamps() as u32).to_string(),
+        ));
         if action.generator() {
             stmt.rule_variables.push(("generator".into(), "1".into()));
         }

--- a/build/ninja_gen/src/build.rs
+++ b/build/ninja_gen/src/build.rs
@@ -261,10 +261,9 @@ impl BuildStatement<'_> {
             panic!("{} must generate at least one output", action.name());
         }
         stmt.variables.push(("description".into(), group.into()));
-        stmt.rule_variables.push((
-            "restat".into(),
-            (action.check_output_timestamps() as u32).to_string(),
-        ));
+        if action.check_output_timestamps() {
+            stmt.rule_variables.push(("restat".into(), "1".into()));
+        }
         if action.generator() {
             stmt.rule_variables.push(("generator".into(), "1".into()));
         }

--- a/build/ninja_gen/src/python.rs
+++ b/build/ninja_gen/src/python.rs
@@ -159,6 +159,10 @@ impl BuildAction for PythonEnvironment {
         }
         build.add_output_stamp(format!("{}/.stamp", self.venv_folder));
     }
+
+    fn check_output_timestamps(&self) -> bool {
+        true
+    }
 }
 
 pub struct PythonTypecheck {


### PR DESCRIPTION
~~`restat` defaults to 1 (Though the docs don't make it seem that way?) meaning that `.check_output_timestamps()` doesn't do anything.~~

This, for me, fixes the python environment rebuilding every run.
