### PR TITLE
Fix tag editor's focus outline appearing cut off

### DIFF
--- a/ts/lib/tag-editor/TagEditor.svelte
+++ b/ts/lib/tag-editor/TagEditor.svelte
@@ -510,7 +510,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         border: 1px solid var(--border);
         border-radius: var(--border-radius);
         padding: 6px;
-        margin: 1px;
+        margin: 1px 3px 3px 1px;
 
         &:focus-within {
             outline-offset: -1px;


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/d372c444-3d52-4086-a150-64a0f789fcb1)
After:
![image](https://github.com/user-attachments/assets/8148f433-b37d-4f5b-8899-7e61a7a85746)