### PR TITLE
Feat/Cmrr target selector

### DIFF
--- a/proto/anki/scheduler.proto
+++ b/proto/anki/scheduler.proto
@@ -389,12 +389,6 @@ message FsrsReview {
   uint32 delta_t = 2;
 }
 
-enum CMRRTarget {
-  memorized = 0;
-  loss_aversion = 1;
-  stability = 2;
-};
-
 message SimulateFsrsReviewRequest {
   repeated float params = 1;
   float desired_retention = 2;
@@ -409,6 +403,19 @@ message SimulateFsrsReviewRequest {
   deck_config.DeckConfig.Config.ReviewCardOrder review_order = 11;
   optional uint32 suspend_after_lapse_count = 12;
   // For CMRR
+  message CMRRTarget {
+    message Memorized {
+      float loss_aversion = 1;
+    };
+
+    message Stability {};
+
+    oneof kind {
+      Memorized memorized = 1;
+      Stability stability = 2;
+    };
+  };
+
   optional CMRRTarget target = 13;
 }
 

--- a/proto/anki/scheduler.proto
+++ b/proto/anki/scheduler.proto
@@ -410,9 +410,19 @@ message SimulateFsrsReviewRequest {
 
     message Stability {};
 
+    message FutureMemorized {
+      int32 days = 1;
+    };
+
+    message AverageFutureMemorized {
+      int32 days = 1;
+    };
+
     oneof kind {
       Memorized memorized = 1;
       Stability stability = 2;
+      FutureMemorized future_memorized = 3;
+      AverageFutureMemorized average_future_memorized = 4;
     };
   };
 

--- a/proto/anki/scheduler.proto
+++ b/proto/anki/scheduler.proto
@@ -389,6 +389,11 @@ message FsrsReview {
   uint32 delta_t = 2;
 }
 
+enum CMRRTarget {
+  memorised = 0;
+  stability = 1;
+};
+
 message SimulateFsrsReviewRequest {
   repeated float params = 1;
   float desired_retention = 2;
@@ -402,6 +407,8 @@ message SimulateFsrsReviewRequest {
   repeated float easy_days_percentages = 10;
   deck_config.DeckConfig.Config.ReviewCardOrder review_order = 11;
   optional uint32 suspend_after_lapse_count = 12;
+  // For CMRR
+  optional CMRRTarget target = 13;
 }
 
 message SimulateFsrsReviewResponse {

--- a/proto/anki/scheduler.proto
+++ b/proto/anki/scheduler.proto
@@ -391,7 +391,8 @@ message FsrsReview {
 
 enum CMRRTarget {
   memorized = 0;
-  stability = 1;
+  loss_aversion = 1;
+  stability = 2;
 };
 
 message SimulateFsrsReviewRequest {

--- a/proto/anki/scheduler.proto
+++ b/proto/anki/scheduler.proto
@@ -390,7 +390,7 @@ message FsrsReview {
 }
 
 enum CMRRTarget {
-  memorised = 0;
+  memorized = 0;
   stability = 1;
 };
 

--- a/rslib/src/scheduler/fsrs/retention.rs
+++ b/rslib/src/scheduler/fsrs/retention.rs
@@ -55,12 +55,23 @@ impl Collection {
         }
         let (mut config, cards) = self.simulate_request_to_config(&req)?;
 
+        dbg!(&target_type);
         if let Some(Kind::Memorized(settings)) = target_type {
             let loss_aversion = settings.loss_aversion;
+
+            dbg!(&loss_aversion);
 
             config.relearning_step_transitions[0][0] *= loss_aversion;
             config.relearning_step_transitions[1][0] *= loss_aversion;
             config.relearning_step_transitions[2][0] *= loss_aversion;
+
+            config.learning_step_transitions[0][0] *= loss_aversion;
+            config.learning_step_transitions[1][0] *= loss_aversion;
+            config.learning_step_transitions[2][0] *= loss_aversion;
+
+            config.state_rating_costs[0][0] *= loss_aversion;
+            config.state_rating_costs[1][0] *= loss_aversion;
+            config.state_rating_costs[2][0] *= loss_aversion;
         }
 
         Ok(fsrs

--- a/rslib/src/scheduler/fsrs/retention.rs
+++ b/rslib/src/scheduler/fsrs/retention.rs
@@ -1,6 +1,6 @@
-use anki_proto::scheduler::simulate_fsrs_review_request::cmrr_target::Kind;
 // Copyright: Ankitects Pty Ltd and contributors
 // License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
+use anki_proto::scheduler::simulate_fsrs_review_request::cmrr_target::Kind;
 use anki_proto::scheduler::SimulateFsrsReviewRequest;
 use fsrs::extract_simulator_config;
 use fsrs::SimulationResult;

--- a/rslib/src/scheduler/fsrs/retention.rs
+++ b/rslib/src/scheduler/fsrs/retention.rs
@@ -34,7 +34,7 @@ impl Collection {
         let days_to_simulate = req.days_to_simulate as f32;
 
         let target = match target {
-            Some(CmrrTarget::Memorised) => None,
+            Some(CmrrTarget::Memorized) => None,
             Some(CmrrTarget::Stability) => {
                 wrap!(move |SimulationResult {
                                 cards,

--- a/ts/routes/deck-options/FsrsOptions.svelte
+++ b/ts/routes/deck-options/FsrsOptions.svelte
@@ -97,7 +97,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         newCardsIgnoreReviewLimit: $newCardsIgnoreReviewLimit,
         easyDaysPercentages: $config.easyDaysPercentages,
         reviewOrder: $config.reviewOrder,
-        target: CMRRTarget.memorised,
+        target: CMRRTarget.memorized,
     });
 
     const DESIRED_RETENTION_LOW_THRESHOLD = 0.8;

--- a/ts/routes/deck-options/FsrsOptions.svelte
+++ b/ts/routes/deck-options/FsrsOptions.svelte
@@ -7,7 +7,10 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         ComputeRetentionProgress,
         type ComputeParamsProgress,
     } from "@generated/anki/collection_pb";
-    import { SimulateFsrsReviewRequest } from "@generated/anki/scheduler_pb";
+    import {
+        CMRRTarget,
+        SimulateFsrsReviewRequest,
+    } from "@generated/anki/scheduler_pb";
     import {
         computeFsrsParams,
         evaluateParams,
@@ -94,6 +97,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         newCardsIgnoreReviewLimit: $newCardsIgnoreReviewLimit,
         easyDaysPercentages: $config.easyDaysPercentages,
         reviewOrder: $config.reviewOrder,
+        target: CMRRTarget.memorised,
     });
 
     const DESIRED_RETENTION_LOW_THRESHOLD = 0.8;

--- a/ts/routes/deck-options/FsrsOptions.svelte
+++ b/ts/routes/deck-options/FsrsOptions.svelte
@@ -102,7 +102,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
             kind: {
                 case: "memorized",
                 value: new SimulateFsrsReviewRequest_CMRRTarget_Memorized({
-                    lossAversion: 1,
+                    lossAversion: 1.6,
                 }),
             },
         }),

--- a/ts/routes/deck-options/FsrsOptions.svelte
+++ b/ts/routes/deck-options/FsrsOptions.svelte
@@ -8,8 +8,9 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         type ComputeParamsProgress,
     } from "@generated/anki/collection_pb";
     import {
-        CMRRTarget,
         SimulateFsrsReviewRequest,
+        SimulateFsrsReviewRequest_CMRRTarget,
+        SimulateFsrsReviewRequest_CMRRTarget_Memorized,
     } from "@generated/anki/scheduler_pb";
     import {
         computeFsrsParams,
@@ -97,7 +98,14 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         newCardsIgnoreReviewLimit: $newCardsIgnoreReviewLimit,
         easyDaysPercentages: $config.easyDaysPercentages,
         reviewOrder: $config.reviewOrder,
-        target: CMRRTarget.memorized,
+        target: new SimulateFsrsReviewRequest_CMRRTarget({
+            kind: {
+                case: "memorized",
+                value: new SimulateFsrsReviewRequest_CMRRTarget_Memorized({
+                    lossAversion: 1,
+                }),
+            },
+        }),
     });
 
     const DESIRED_RETENTION_LOW_THRESHOLD = 0.8;

--- a/ts/routes/deck-options/SimulatorModal.svelte
+++ b/ts/routes/deck-options/SimulatorModal.svelte
@@ -19,6 +19,8 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     import { computeOptimalRetention, simulateFsrsReview } from "@generated/backend";
     import { runWithBackendProgress } from "@tslib/progress";
     import {
+        SimulateFsrsReviewRequest_CMRRTarget_AverageFutureMemorized,
+        SimulateFsrsReviewRequest_CMRRTarget_FutureMemorized,
         SimulateFsrsReviewRequest_CMRRTarget_Memorized,
         SimulateFsrsReviewRequest_CMRRTarget_Stability,
         type ComputeOptimalRetentionResponse,
@@ -49,6 +51,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     export let onPresetChange: () => void;
 
     let cmrrTargetType = DEFAULT_CMRR_TARGET;
+    // All added types must be updated in the proceeding switch statement.
     let lastCmrrTargetType = cmrrTargetType;
     $: if (simulateFsrsRequest?.target && cmrrTargetType !== lastCmrrTargetType) {
         switch (cmrrTargetType) {
@@ -64,6 +67,22 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
                 simulateFsrsRequest.target.kind = {
                     case: "stability",
                     value: new SimulateFsrsReviewRequest_CMRRTarget_Stability({}),
+                };
+                break;
+            case "futureMemorized":
+                simulateFsrsRequest.target.kind = {
+                    case: "futureMemorized",
+                    value: new SimulateFsrsReviewRequest_CMRRTarget_FutureMemorized({
+                        days: 365,
+                    }),
+                };
+                break;
+            case "averageFutureMemorized":
+                simulateFsrsRequest.target.kind = {
+                    case: "averageFutureMemorized",
+                    value: new SimulateFsrsReviewRequest_CMRRTarget_AverageFutureMemorized(
+                        { days: 365 },
+                    ),
                 };
                 break;
         }
@@ -454,9 +473,24 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
                     {#if simulateFsrsRequest.target?.kind.case === "memorized"}
                         <SpinBoxFloatRow
-                            bind:value={simulateFsrsRequest.target.kind.value.lossAversion} defaultValue={1}>
+                            bind:value={simulateFsrsRequest.target.kind.value
+                                .lossAversion}
+                            defaultValue={1}
+                        >
                             <SettingTitle>
                                 {"Fail Cost Multiplier: "}
+                            </SettingTitle>
+                        </SpinBoxFloatRow>
+                    {/if}
+
+                    {#if simulateFsrsRequest.target?.kind.case === "futureMemorized" || simulateFsrsRequest.target?.kind.case === "averageFutureMemorized"}
+                        <SpinBoxFloatRow
+                            bind:value={simulateFsrsRequest.target.kind.value.days}
+                            defaultValue={365}
+                            step={1}
+                        >
+                            <SettingTitle>
+                                {"Days after simulation end: "}
                             </SettingTitle>
                         </SpinBoxFloatRow>
                     {/if}

--- a/ts/routes/deck-options/SimulatorModal.svelte
+++ b/ts/routes/deck-options/SimulatorModal.svelte
@@ -19,7 +19,8 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     import { computeOptimalRetention, simulateFsrsReview } from "@generated/backend";
     import { runWithBackendProgress } from "@tslib/progress";
     import {
-        CMRRTarget,
+        SimulateFsrsReviewRequest_CMRRTarget_Memorized,
+        SimulateFsrsReviewRequest_CMRRTarget_Stability,
         type ComputeOptimalRetentionResponse,
         type SimulateFsrsReviewRequest,
         type SimulateFsrsReviewResponse,
@@ -28,7 +29,11 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     import SwitchRow from "$lib/components/SwitchRow.svelte";
     import GlobalLabel from "./GlobalLabel.svelte";
     import SpinBoxFloatRow from "./SpinBoxFloatRow.svelte";
-    import { CMRRTargetChoices, reviewOrderChoices } from "./choices";
+    import {
+        DEFAULT_CMRR_TARGET,
+        CMRRTargetChoices,
+        reviewOrderChoices,
+    } from "./choices";
     import EnumSelectorRow from "$lib/components/EnumSelectorRow.svelte";
     import { DeckConfig_Config_LeechAction } from "@generated/anki/deck_config_pb";
     import EasyDaysInput from "./EasyDaysInput.svelte";
@@ -42,6 +47,26 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     export let computing: boolean;
     export let openHelpModal: (key: string) => void;
     export let onPresetChange: () => void;
+
+    let cmrrTargetType = DEFAULT_CMRR_TARGET;
+    $: if (simulateFsrsRequest?.target) {
+        switch (cmrrTargetType) {
+            case "memorized":
+                simulateFsrsRequest.target.kind = {
+                    case: "memorized",
+                    value: new SimulateFsrsReviewRequest_CMRRTarget_Memorized({
+                        lossAversion: 1,
+                    }),
+                };
+                break;
+            case "stability":
+                simulateFsrsRequest.target.kind = {
+                    case: "stability",
+                    value: new SimulateFsrsReviewRequest_CMRRTarget_Stability({}),
+                };
+                break;
+        }
+    }
 
     const config = state.currentConfig;
     let simulateSubgraph: SimulateSubgraph = SimulateSubgraph.count;
@@ -416,8 +441,8 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
                     <Item>
                         <EnumSelectorRow
                             choices={CMRRTargetChoices()}
-                            bind:value={simulateFsrsRequest.target}
-                            defaultValue={CMRRTarget.memorized}
+                            bind:value={cmrrTargetType}
+                            defaultValue={DEFAULT_CMRR_TARGET}
                         >
                             <SettingTitle>
                                 {"Target: "}

--- a/ts/routes/deck-options/SimulatorModal.svelte
+++ b/ts/routes/deck-options/SimulatorModal.svelte
@@ -18,21 +18,23 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     import { renderSimulationChart } from "../graphs/simulator";
     import { computeOptimalRetention, simulateFsrsReview } from "@generated/backend";
     import { runWithBackendProgress } from "@tslib/progress";
-    import type {
-        ComputeOptimalRetentionResponse,
-        SimulateFsrsReviewRequest,
-        SimulateFsrsReviewResponse,
+    import {
+        CMRRTarget,
+        type ComputeOptimalRetentionResponse,
+        type SimulateFsrsReviewRequest,
+        type SimulateFsrsReviewResponse,
     } from "@generated/anki/scheduler_pb";
     import type { DeckOptionsState } from "./lib";
     import SwitchRow from "$lib/components/SwitchRow.svelte";
     import GlobalLabel from "./GlobalLabel.svelte";
     import SpinBoxFloatRow from "./SpinBoxFloatRow.svelte";
-    import { reviewOrderChoices } from "./choices";
+    import { CMRRTargetChoices, reviewOrderChoices } from "./choices";
     import EnumSelectorRow from "$lib/components/EnumSelectorRow.svelte";
     import { DeckConfig_Config_LeechAction } from "@generated/anki/deck_config_pb";
     import EasyDaysInput from "./EasyDaysInput.svelte";
     import Warning from "./Warning.svelte";
     import type { ComputeRetentionProgress } from "@generated/anki/collection_pb";
+    import Item from "$lib/components/Item.svelte";
 
     export let shown = false;
     export let state: DeckOptionsState;
@@ -410,6 +412,18 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
                     {#if computingRetention}
                         <div>{computeRetentionProgressString}</div>
                     {/if}
+
+                    <Item>
+                        <EnumSelectorRow
+                        choices={CMRRTargetChoices()}
+                        bind:value={simulateFsrsRequest.target}
+                        defaultValue={CMRRTarget.memorised}
+                        >
+                        <SettingTitle>
+                            {"Target: "}
+                        </SettingTitle>
+                        </EnumSelectorRow>
+                    </Item>
                 </details>
 
                 <button

--- a/ts/routes/deck-options/SimulatorModal.svelte
+++ b/ts/routes/deck-options/SimulatorModal.svelte
@@ -59,7 +59,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
                 simulateFsrsRequest.target.kind = {
                     case: "memorized",
                     value: new SimulateFsrsReviewRequest_CMRRTarget_Memorized({
-                        lossAversion: 1,
+                        lossAversion: 1.6,
                     }),
                 };
                 break;
@@ -475,7 +475,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
                         <SpinBoxFloatRow
                             bind:value={simulateFsrsRequest.target.kind.value
                                 .lossAversion}
-                            defaultValue={1}
+                            defaultValue={1.6}
                         >
                             <SettingTitle>
                                 {"Fail Cost Multiplier: "}

--- a/ts/routes/deck-options/SimulatorModal.svelte
+++ b/ts/routes/deck-options/SimulatorModal.svelte
@@ -415,13 +415,13 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
                     <Item>
                         <EnumSelectorRow
-                        choices={CMRRTargetChoices()}
-                        bind:value={simulateFsrsRequest.target}
-                        defaultValue={CMRRTarget.memorised}
+                            choices={CMRRTargetChoices()}
+                            bind:value={simulateFsrsRequest.target}
+                            defaultValue={CMRRTarget.memorized}
                         >
-                        <SettingTitle>
-                            {"Target: "}
-                        </SettingTitle>
+                            <SettingTitle>
+                                {"Target: "}
+                            </SettingTitle>
                         </EnumSelectorRow>
                     </Item>
                 </details>

--- a/ts/routes/deck-options/SimulatorModal.svelte
+++ b/ts/routes/deck-options/SimulatorModal.svelte
@@ -49,7 +49,8 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     export let onPresetChange: () => void;
 
     let cmrrTargetType = DEFAULT_CMRR_TARGET;
-    $: if (simulateFsrsRequest?.target) {
+    let lastCmrrTargetType = cmrrTargetType;
+    $: if (simulateFsrsRequest?.target && cmrrTargetType !== lastCmrrTargetType) {
         switch (cmrrTargetType) {
             case "memorized":
                 simulateFsrsRequest.target.kind = {
@@ -66,6 +67,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
                 };
                 break;
         }
+        lastCmrrTargetType = cmrrTargetType;
     }
 
     const config = state.currentConfig;
@@ -449,6 +451,15 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
                             </SettingTitle>
                         </EnumSelectorRow>
                     </Item>
+
+                    {#if simulateFsrsRequest.target?.kind.case === "memorized"}
+                        <SpinBoxFloatRow
+                            bind:value={simulateFsrsRequest.target.kind.value.lossAversion} defaultValue={1}>
+                            <SettingTitle>
+                                {"Fail Cost Multiplier: "}
+                            </SettingTitle>
+                        </SpinBoxFloatRow>
+                    {/if}
                 </details>
 
                 <button

--- a/ts/routes/deck-options/choices.ts
+++ b/ts/routes/deck-options/choices.ts
@@ -212,11 +212,11 @@ export function CMRRTargetChoices(): Choice<string>[] {
             value: "stability",
         },
         {
-            label: "Future Retention (Experimental)",
+            label: "Post Abandon Memorized (Experimental)",
             value: "futureMemorized",
         },
         {
-            label: "Average Future Retention (Experimental)",
+            label: "Average Post Abandon Memorized (Experimental)",
             value: "averageFutureMemorized",
         },
     ] as const;

--- a/ts/routes/deck-options/choices.ts
+++ b/ts/routes/deck-options/choices.ts
@@ -204,7 +204,7 @@ export function CMRRTargetChoices(): Choice<CMRRTarget>[] {
     return [
         {
             label: "Memorized (Default)",
-            value: CMRRTarget.memorised,
+            value: CMRRTarget.memorized,
         },
         {
             label: "Stability (Experimental)",

--- a/ts/routes/deck-options/choices.ts
+++ b/ts/routes/deck-options/choices.ts
@@ -219,7 +219,7 @@ export function CMRRTargetChoices(): Choice<string>[] {
             label: "Average Post Abandon Memorized (Experimental)",
             value: "averageFutureMemorized",
         },
-    ] as const;
+    ];
 }
 
 function difficultyOrders(fsrs: boolean): Choice<DeckConfig_Config_ReviewCardOrder>[] {

--- a/ts/routes/deck-options/choices.ts
+++ b/ts/routes/deck-options/choices.ts
@@ -207,6 +207,10 @@ export function CMRRTargetChoices(): Choice<CMRRTarget>[] {
             value: CMRRTarget.memorized,
         },
         {
+            label: "Memorized (Double cost)",
+            values: CMRRTarget.loss_aversion,
+        },
+        {
             label: "Stability (Experimental)",
             value: CMRRTarget.stability,
         },

--- a/ts/routes/deck-options/choices.ts
+++ b/ts/routes/deck-options/choices.ts
@@ -11,7 +11,6 @@ import {
     DeckConfig_Config_ReviewCardOrder,
     DeckConfig_Config_ReviewMix,
 } from "@generated/anki/deck_config_pb";
-import { CMRRTarget } from "@generated/anki/scheduler_pb";
 import * as tr from "@generated/ftl";
 
 import type { Choice } from "$lib/components/EnumSelector.svelte";
@@ -200,21 +199,19 @@ export function questionActionChoices(): Choice<DeckConfig_Config_QuestionAction
     ];
 }
 
-export function CMRRTargetChoices(): Choice<CMRRTarget>[] {
+export const DEFAULT_CMRR_TARGET = "memorized";
+
+export function CMRRTargetChoices(): Choice<string>[] {
     return [
         {
             label: "Memorized (Default)",
-            value: CMRRTarget.memorized,
-        },
-        {
-            label: "Memorized (Double cost)",
-            values: CMRRTarget.loss_aversion,
+            value: "memorized",
         },
         {
             label: "Stability (Experimental)",
-            value: CMRRTarget.stability,
+            value: "stability",
         },
-    ];
+    ] as const;
 }
 
 function difficultyOrders(fsrs: boolean): Choice<DeckConfig_Config_ReviewCardOrder>[] {

--- a/ts/routes/deck-options/choices.ts
+++ b/ts/routes/deck-options/choices.ts
@@ -211,6 +211,14 @@ export function CMRRTargetChoices(): Choice<string>[] {
             label: "Stability (Experimental)",
             value: "stability",
         },
+        {
+            label: "Future Retention (Experimental)",
+            value: "futureMemorized",
+        },
+        {
+            label: "Average Future Retention (Experimental)",
+            value: "averageFutureMemorized",
+        },
     ] as const;
 }
 

--- a/ts/routes/deck-options/choices.ts
+++ b/ts/routes/deck-options/choices.ts
@@ -11,6 +11,7 @@ import {
     DeckConfig_Config_ReviewCardOrder,
     DeckConfig_Config_ReviewMix,
 } from "@generated/anki/deck_config_pb";
+import { CMRRTarget } from "@generated/anki/scheduler_pb";
 import * as tr from "@generated/ftl";
 
 import type { Choice } from "$lib/components/EnumSelector.svelte";
@@ -195,6 +196,19 @@ export function questionActionChoices(): Choice<DeckConfig_Config_QuestionAction
         {
             label: tr.deckConfigQuestionActionShowReminder(),
             value: DeckConfig_Config_QuestionAction.SHOW_REMINDER,
+        },
+    ];
+}
+
+export function CMRRTargetChoices(): Choice<CMRRTarget>[] {
+    return [
+        {
+            label: "Memorized (Default)",
+            value: CMRRTarget.memorised,
+        },
+        {
+            label: "Stability (Experimental)",
+            value: CMRRTarget.stability,
         },
     ];
 }


### PR DESCRIPTION
Allows you to select your preferred target for CMRR.

Regular with customisable loss aversion:
![image](https://github.com/user-attachments/assets/af7359ab-024b-4ef6-b313-1ad906658630)

S*R:
![image](https://github.com/user-attachments/assets/334cb8bd-217c-4c1a-afc5-534091830bb4)

Retention on a after day you stop reviewing at the end of the simulation:
![image](https://github.com/user-attachments/assets/dfda1ed7-d1db-4e3e-8179-84f619119c3d)

Average retention of the days between when you stopped reviewing and a certain date:
![image](https://github.com/user-attachments/assets/72ceb6ec-8421-48d9-bce7-2baf36004790)

ref: https://forums.ankiweb.net/t/anki-25-06-beta/62271/39?u=a_blokee
