### PR TITLE
Update toolbar.scss

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -232,6 +232,7 @@ Spiritual Father <https://github.com/spiritualfather>
 Emmanuel Ferdman <https://github.com/emmanuel-ferdman>
 Sunong2008 <https://github.com/Sunrongguo2008>
 Marvin Kopf <marvinkopf@outlook.com>
+jcznk <https://github.com/jcznk>
 ********************
 
 The text of the 3 clause BSD license follows:

--- a/qt/aqt/data/web/css/toolbar.scss
+++ b/qt/aqt/data/web/css/toolbar.scss
@@ -56,13 +56,13 @@ body {
     padding: 0;
     -webkit-user-select: none;
     overflow: hidden;
+    margin-bottom: 5px;
 
     &:not(.fancy).hidden {
         opacity: 0;
     }
 
     &.fancy {
-        margin-bottom: 5px;
 
         &.hidden {
             transform: translateY(-100vh);


### PR DESCRIPTION
This fixes a layout inconsistency that caused the bottom part of the top toolbar to be cut off when switching from minimal to fancy mode without restarting Anki.
The problem was that `margin-bottom` was scoped only to `.fancy`, which doesn’t always seem to be applied dynamically.
Moving the margin rule outside the `.fancy` scope ensures the toolbar has consistent spacing in both modes.

1. Before
![image](https://github.com/user-attachments/assets/d47c6aa1-040c-4f56-9a14-96c03dfd64c9)
2. After
![image](https://github.com/user-attachments/assets/df975bc3-6e9b-48e0-9db5-4437349b1ca5)