### PR TITLE
Refactor FSRS data clearing into Card::clear_fsrs_data

### DIFF
--- a/rslib/src/card/mod.rs
+++ b/rslib/src/card/mod.rs
@@ -185,12 +185,16 @@ impl Card {
         self.usn = usn;
     }
 
-    /// Caller must ensure provided deck exists and is not filtered.
-    fn set_deck(&mut self, deck: DeckId) {
-        self.remove_from_filtered_deck_restoring_queue();
+    pub fn clear_fsrs_data(&mut self) {
         self.memory_state = None;
         self.desired_retention = None;
         self.decay = None;
+    }
+
+    /// Caller must ensure provided deck exists and is not filtered.
+    fn set_deck(&mut self, deck: DeckId) {
+        self.remove_from_filtered_deck_restoring_queue();
+        self.clear_fsrs_data();
         self.deck_id = deck;
     }
 

--- a/rslib/src/scheduler/fsrs/memory_state.rs
+++ b/rslib/src/scheduler/fsrs/memory_state.rs
@@ -188,9 +188,7 @@ impl Collection {
                     }
                 } else {
                     // clear FSRS data if FSRS is disabled
-                    card.memory_state = None;
-                    card.desired_retention = None;
-                    card.decay = None;
+                    card.clear_fsrs_data();
                 }
                 self.update_card_inner(&mut card, original, usn)?;
             }


### PR DESCRIPTION
Extracted repeated logic for clearing FSRS-related fields into a new Card::clear_fsrs_data() method. Updated set_deck and FSRS disabling code paths to use this method for improved code reuse and maintainability.

https://github.com/ankitects/anki/pull/4106/files#r2159996769