### PR TITLE
Remove newline: 'Restore to default confirmation'

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -63,6 +63,7 @@ Jakub Kaczmarzyk <jakub.kaczmarzyk@gmail.com>
 Akshara Balachandra <akshara.bala.18@gmail.com>
 lukkea <github.com/lukkea/>
 David Allison <davidallisongithub@gmail.com>
+David Allison <62114487+david-allison@users.noreply.github.com>
 Tsung-Han Yu <johan456789@gmail.com>
 Piotr Kubowicz <piotr.kubowicz@gmail.com>
 RumovZ <gp5glkw78@relay.firefox.com>

--- a/ftl/core/card-templates.ftl
+++ b/ftl/core/card-templates.ftl
@@ -60,7 +60,6 @@ card-templates-this-will-create-card-proceed =
     }
 card-templates-type-boxes-warning = Only one typing box per card template is supported.
 card-templates-restore-to-default = Restore to Default
-card-templates-restore-to-default-confirmation = This will reset all fields and templates in this note type to their default
-    values, removing any extra fields/templates and their content, and any custom styling. Do you wish to proceed?
+card-templates-restore-to-default-confirmation = This will reset all fields and templates in this note type to their default values, removing any extra fields/templates and their content, and any custom styling. Do you wish to proceed?
 card-templates-restored-to-default = Note type has been restored to its original state.
 


### PR DESCRIPTION
AnkiDroid strings show this as `\n`, and it appears as a paragraph break on Pontoon: https://i18n.ankiweb.net/en-GB/core/core/templates/card-templates.ftl/?search=reset+all&string=25225

* https://github.com/ankidroid/Anki-Android/pull/17461#issuecomment-3008619960