### PR TITLE
Fix unique blank decks being created per row with empty deck column when importing csv

### DIFF
--- a/rslib/src/import_export/text/import.rs
+++ b/rslib/src/import_export/text/import.rs
@@ -274,6 +274,9 @@ impl<'a> Context<'a> {
             deck.name = NativeDeckName::from_human_name(name);
             self.col.add_deck_inner(&mut deck, self.usn)?;
             self.deck_ids.insert(deck.id, deck.human_name());
+            if name.is_empty() {
+                self.deck_ids.default = Some(deck.id);
+            }
             Some(deck.id)
         } else {
             None


### PR DESCRIPTION
Fixes the bug where if `#deck column:...` is used, each row with an empty field in the deck column would create its own new blank deck. After this pr, at most one new blank deck is created and used per import

![image](https://github.com/user-attachments/assets/ff48a080-b88a-40b5-a28a-32af2ba725a7)