### PR TITLE
Fix launcher glibc version check

### DIFF
--- a/qt/launcher/src/platform/unix.rs
+++ b/qt/launcher/src/platform/unix.rs
@@ -90,7 +90,7 @@ pub fn ensure_glibc_supported() -> Result<()> {
     };
 
     let (major, minor) = get_glibc_version().unwrap_or_default();
-    if major < 3 || (major == 2 && minor < 36) {
+    if major < 2 || (major == 2 && minor < 36) {
         anyhow::bail!("Anki requires a modern Linux distro with glibc 2.36 or later.");
     }
 


### PR DESCRIPTION
Tried building the launcher, and got back `Error: Anki requires a modern Linux distro with glibc 2.36 or later.` even though my system's is 2.39, which this pr fixes