### PR TITLE
Revert "Use system font for webviews instead of bootstrap font stack"

### DIFF
--- a/ts/lib/sass/base.scss
+++ b/ts/lib/sass/base.scss
@@ -44,7 +44,6 @@ html {
 }
 
 body {
-    font-family: inherit;
     overflow-x: hidden;
     &:not(.isMac),
     &:not(.isMac) * {


### PR DESCRIPTION
Reverts ankitects/anki#4147

This caused a regression in the appearance of editor fields - we'll need to address that if we re-apply this.