### PR TITLE
Use system font for webviews instead of bootstrap font stack and add exception for note editor

### DIFF
--- a/ts/editor/editor-base.scss
+++ b/ts/editor/editor-base.scss
@@ -10,5 +10,6 @@ $btn-disabled-opacity: 0.4;
 
 html,
 body {
+    font-family: var(--bs-font-sans-serif);
     overflow: hidden;
 }

--- a/ts/lib/sass/base.scss
+++ b/ts/lib/sass/base.scss
@@ -44,6 +44,7 @@ html {
 }
 
 body {
+    font-family: inherit;
     overflow-x: hidden;
     &:not(.isMac),
     &:not(.isMac) * {


### PR DESCRIPTION
Reverts ankitects/anki#4159
Fixes: #4158

My previous fix works for every view I tested, except for the note editor, which inherits Noto Sans on my machine (or the bs font stack, if all `font-family` are removed from the code).

This PR adds back the fix to the webviews that work as expected, while adding an exception for the note editor. I couldn't figure out how to solve this, which is why I plan to open a new issue onces this PR is merged.