### PR TITLE
Fix/Help modal appears behind simulator modal

### DIFF
--- a/ts/lib/components/HelpModal.svelte
+++ b/ts/lib/components/HelpModal.svelte
@@ -181,6 +181,11 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         margin-bottom: 1.5rem;
     }
 
+    .modal {
+        z-index: 1066;
+        background-color: rgba($color: black, $alpha: 0.5);
+    }
+
     .modal-title {
         margin-inline-end: 0.75rem;
     }

--- a/ts/routes/deck-options/SimulatorModal.svelte
+++ b/ts/routes/deck-options/SimulatorModal.svelte
@@ -296,7 +296,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
                     min={0}
                     max={9999}
                 >
-                    <SettingTitle on:click={() => openHelpModal("simulateFsrsReview")}>
+                    <SettingTitle on:click={() => openHelpModal("newLimit")}>
                         {tr.schedulingNewCardsday()}
                     </SettingTitle>
                 </SpinBoxRow>
@@ -307,7 +307,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
                     min={0}
                     max={9999}
                 >
-                    <SettingTitle on:click={() => openHelpModal("simulateFsrsReview")}>
+                    <SettingTitle on:click={() => openHelpModal("reviewLimit")}>
                         {tr.schedulingMaximumReviewsday()}
                     </SettingTitle>
                 </SpinBoxRow>
@@ -327,9 +327,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
                         min={1}
                         max={36500}
                     >
-                        <SettingTitle
-                            on:click={() => openHelpModal("simulateFsrsReview")}
-                        >
+                        <SettingTitle on:click={() => openHelpModal("maximumInterval")}>
                             {tr.schedulingMaximumInterval()}
                         </SettingTitle>
                     </SpinBoxRow>
@@ -339,9 +337,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
                         defaultValue={$config.reviewOrder}
                         choices={reviewOrderChoices($fsrs)}
                     >
-                        <SettingTitle
-                            on:click={() => openHelpModal("simulateFsrsReview")}
-                        >
+                        <SettingTitle on:click={() => openHelpModal("reviewSortOrder")}>
                             {tr.deckConfigReviewSortOrder()}
                         </SettingTitle>
                     </EnumSelectorRow>
@@ -351,7 +347,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
                         defaultValue={$newCardsIgnoreReviewLimit}
                     >
                         <SettingTitle
-                            on:click={() => openHelpModal("simulateFsrsReview")}
+                            on:click={() => openHelpModal("newCardsIgnoreReviewLimit")}
                         >
                             <GlobalLabel
                                 title={tr.deckConfigNewCardsIgnoreReviewLimit()}
@@ -372,9 +368,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
                         defaultValue={$config.leechAction ==
                             DeckConfig_Config_LeechAction.SUSPEND}
                     >
-                        <SettingTitle
-                            on:click={() => openHelpModal("simulateFsrsReview")}
-                        >
+                        <SettingTitle on:click={() => openHelpModal("leechAction")}>
                             {tr.deckConfigSuspendLeeches()}
                         </SettingTitle>
                     </SwitchRow>
@@ -387,7 +381,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
                             max={9999}
                         >
                             <SettingTitle
-                                on:click={() => openHelpModal("simulateFsrsReview")}
+                                on:click={() => openHelpModal("leechThreshold")}
                             >
                                 {tr.schedulingLeechThreshold()}
                             </SettingTitle>


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/4fc9e474-d75c-4187-81d9-f9a41d0a6ea6)

I think this comes with the caveat of making the background of the help modal everywhere else 75% opaque (as there will be 2 layers), but its quite un-noticeable.