### PR TITLE
Debounce mathjax rendering via cooldown instead

### DIFF
--- a/ts/editable/cooldown-timer.ts
+++ b/ts/editable/cooldown-timer.ts
@@ -1,0 +1,31 @@
+// Copyright: Ankitects Pty Ltd and contributors
+// License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
+
+export class CooldownTimer {
+    private executing = false;
+    private queuedAction: (() => void) | null = null;
+    private delay: number;
+
+    constructor(delayMs: number) {
+        this.delay = delayMs;
+    }
+
+    schedule(action: () => void): void {
+        if (this.executing) {
+            this.queuedAction = action;
+        } else {
+            this.executing = true;
+            action();
+            setTimeout(this.#pop.bind(this), this.delay);
+        }
+    }
+
+    #pop(): void {
+        this.executing = false;
+        if (this.queuedAction) {
+            const action = this.queuedAction;
+            this.queuedAction = null;
+            this.schedule(action);
+        }
+    }
+}


### PR DESCRIPTION
> If we want to debounce while typing, the correct fix would be to wait to render until 500 ms after the last render attempt, not 500 ms after the user stops typing
https://github.com/ankitects/anki/issues/3803#issuecomment-3037844038

Currently, mathjax renders 500ms after typing ends. This pr changes it such that it renders immediately,  with a 500ms cooldown between each render, even while typing, which should shorten the feedback loop and make it appear more responsive 

The only time i've ever noticed lag with mathjax was during the case that https://github.com/ankitects/anki/pull/3828 handles, so perhaps the existing deboucing really is too conservative