### PR TITLE
[A11Y] FIX: revert button is visible for screenreaders

### DIFF
--- a/ts/lib/components/RevertButton.svelte
+++ b/ts/lib/components/RevertButton.svelte
@@ -76,7 +76,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     }
 
     .hide :global(.badge) {
-        opacity: 0;
+        display: none;
         cursor: initial;
     }
 </style>


### PR DESCRIPTION
Fixes: Planned To-Do number 2 from https://forums.ankiweb.net/t/reminder-for-myself-improve-a11y-in-the-deck-options/63506?u=anon_0000#p-174852-planned-todos-3

# Issue
In the deck options, the revert buttons were hidden with `opacity: 0;`. This makes it invisible to the human eye, but not to screen readers. We don't want screen readers to read the invisible revert button though, as that button only becomes relevant once it's un-hidden.

# Proposed Fix
`display: none;` should be used instead. Quote from https://developer.mozilla.org/en-US/docs/Web/CSS/display#display_none:

> Using a display value of none on an element will remove it from the accessibility tree. This will cause the element and all its descendant elements to no longer be announced by screen reading technology.