### PR TITLE
Reorder CardInfo to show Retention Chart before a potentially long Review Log

### DIFF
--- a/ts/routes/card-info/CardInfo.svelte
+++ b/ts/routes/card-info/CardInfo.svelte
@@ -37,14 +37,14 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
             <CardStats {stats} />
         </Row>
 
-        {#if showRevlog}
-            <Row>
-                <Revlog revlog={stats.revlog} {fsrsEnabled} />
-            </Row>
-        {/if}
         {#if fsrsEnabled && showCurve}
             <Row>
                 <ForgettingCurve revlog={stats.revlog} {desiredRetention} {decay} />
+            </Row>
+        {/if}
+        {#if showRevlog}
+            <Row>
+                <Revlog revlog={stats.revlog} {fsrsEnabled} />
             </Row>
         {/if}
     {:else}

--- a/ts/routes/card-info/ForgettingCurve.svelte
+++ b/ts/routes/card-info/ForgettingCurve.svelte
@@ -108,7 +108,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     .forgetting-curve {
         width: 100%;
         max-width: 50em;
-        margin-bottom: 10em;
+        margin-bottom: 1em;
     }
 
     .time-range-selector {


### PR DESCRIPTION
Before, even with this huge window, the useful Retention Chart ends up out of view if the card has a long review history. Some of my cards are over a decade of history. It feels silly having to scroll through potentially decades of logs over and over to see the fixed size chart.

Before:
![20250707_03h14m40s_grim](https://github.com/user-attachments/assets/b5d5df44-713b-4919-86ba-a641429604dd)

After:
![20250707_03h11m24s_grim](https://github.com/user-attachments/assets/96278028-a1b7-4f35-a3cb-eaf66e99d457)
