### PR TITLE
Try unix terminals in roughly most specific to least specific.

### DIFF
--- a/qt/launcher/src/platform/unix.rs
+++ b/qt/launcher/src/platform/unix.rs
@@ -9,17 +9,23 @@ use anyhow::Result;
 pub fn relaunch_in_terminal() -> Result<()> {
     let current_exe = std::env::current_exe().context("Failed to get current executable path")?;
 
-    // Try terminals in order of preference
+    // Try terminals in roughly most specific to least specific.
+    // First, try commonly used terminals for riced systems.
+    // Second, try the minimalist/compatibility terminals.
+    // Finally, try terminals usually installed by default.
     let terminals = [
-        ("x-terminal-emulator", vec!["-e"]),
-        ("gnome-terminal", vec!["--"]),
-        ("konsole", vec!["-e"]),
-        ("xfce4-terminal", vec!["-e"]),
+        // commonly used for riced systems
         ("alacritty", vec!["-e"]),
         ("kitty", vec![]),
+        // minimalistic terminals for constrained systems
         ("foot", vec![]),
         ("urxvt", vec!["-e"]),
         ("xterm", vec!["-e"]),
+        ("x-terminal-emulator", vec!["-e"]),
+        // default installs for the most common distros
+        ("xfce4-terminal", vec!["-e"]),
+        ("gnome-terminal", vec!["--"]),
+        ("konsole", vec!["-e"]),
     ];
 
     for (terminal_cmd, args) in &terminals {


### PR DESCRIPTION
I found this while looking into why the launcher wasn't working on one of my systems (no issue with Anki, an old gnome-terminal was throwing a fit with my wayland DE). 

I figured since I was already here, I should make it a bit more pleasant for people who might have installed linux with gnome or kde, but have since installed new terminals.

Feel free to close if we think https://github.com/ankitects/anki/issues/4152 will be done before a new release. I don't think it's worth going into being able to define terminals just for the temporary launcher. 