### PR TITLE
Feat/Replace easy day table with display:grid

### DIFF
--- a/ts/routes/deck-options/EasyDaysInput.svelte
+++ b/ts/routes/deck-options/EasyDaysInput.svelte
@@ -20,31 +20,38 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 </script>
 
 <Item>
-    <div class="easy-days-settings">
-        <span></span>
-        <span class="header min-col">{tr.deckConfigEasyDaysMinimum()}</span>
-        <span class="header">{tr.deckConfigEasyDaysReduced()}</span>
-        <span class="header normal-col">{tr.deckConfigEasyDaysNormal()}</span>
+    <div class="container">
+        <div class="easy-days-settings">
+            <span></span>
+            <span class="header min-col">{tr.deckConfigEasyDaysMinimum()}</span>
+            <span class="header">{tr.deckConfigEasyDaysReduced()}</span>
+            <span class="header normal-col">{tr.deckConfigEasyDaysNormal()}</span>
 
-        {#each easyDays as day, index}
-            <span class="day">{day}</span>
-            <div class="input-container">
-                <input
-                    type="range"
-                    bind:value={values[index]}
-                    step={0.5}
-                    max={1.0}
-                    min={0.0}
-                    list="easy_day_steplist"
-                />
-            </div>
-        {/each}
+            {#each easyDays as day, index}
+                <span class="day">{day}</span>
+                <div class="input-container">
+                    <input
+                        type="range"
+                        bind:value={values[index]}
+                        step={0.5}
+                        max={1.0}
+                        min={0.0}
+                        list="easy_day_steplist"
+                    />
+                </div>
+            {/each}
+        </div>
     </div>
 </Item>
 
 <style lang="scss">
+    .container {
+        display: flex;
+        justify-content: center;
+    }
     .easy-days-settings {
         width: 100%;
+        max-width: 1000px;
         border-collapse: collapse;
 
         display: grid;


### PR DESCRIPTION
Apparently the previous implementation ran into issues on small screens (@brishtibheja).

# After

![image](https://github.com/user-attachments/assets/f4a73ec9-b00f-44f8-894b-659798fe0404)
## Simulator:
![image](https://github.com/user-attachments/assets/a29447a2-5478-4cec-9c7e-24c7098de5b6)


# Before

![image](https://github.com/user-attachments/assets/d760406d-1739-41b9-8436-d82c045aae5a)
## Simulator:
![image](https://github.com/user-attachments/assets/55cb4492-01c6-4c66-b378-4bec4bfd54bd)