### PR TITLE
aqt wheel: fix unintended inclusion of qt/aqt/data

### DIFF
--- a/qt/hatch_build.py
+++ b/qt/hatch_build.py
@@ -67,16 +67,12 @@ class CustomBuildHook(BuildHookInterface):
 
     def _should_exclude(self, path: Path) -> bool:
         """Check if a file should be excluded from the wheel."""
-        path_str = str(path)
-
         # Exclude __pycache__
-        if "/__pycache__/" in path_str:
+        if "/__pycache__/" in str(path):
             return True
 
         if path.suffix in [".ui", ".scss", ".map", ".ts"]:
             return True
         if path.name.startswith("tsconfig"):
-            return True
-        if "/aqt/data" in path_str:
             return True
         return False

--- a/qt/pyproject.toml
+++ b/qt/pyproject.toml
@@ -77,7 +77,7 @@ ankiw = "aqt:run"
 
 [tool.hatch.build.targets.wheel]
 packages = ["aqt"]
-exclude = ["**/*.scss", "**/*.ui"]
+exclude = ["aqt/data", "**/*.ui"]
 
 [tool.hatch.version]
 source = "code"


### PR DESCRIPTION
The inclusion of files under `qt/aqt` is handled by `qt/pyproject.toml`, not `qt/hatch_build.py`, which works with the files under `out/qt/_aqt`.

Excluding qt/aqt/data and all files ending in `.ui` in `qt/pyproject.toml` fixes the issue, since the other unwanted files (**/*.scss, **/*.ts, and **/tsconfig*) all reside under `qt/aqt/data`.

Fixes: 04996c77f3866ff23441ed357f075424e583f99a