### PR TITLE
Fix/FSRS simulator fallback to memory_state_from_sm2 for after setting “Ignore cards reviewed before”

### DIFF
--- a/proto/anki/scheduler.proto
+++ b/proto/anki/scheduler.proto
@@ -404,6 +404,7 @@ message SimulateFsrsReviewRequest {
   repeated float easy_days_percentages = 10;
   deck_config.DeckConfig.Config.ReviewCardOrder review_order = 11;
   optional uint32 suspend_after_lapse_count = 12;
+  float historical_retention = 13;
 }
 
 message SimulateFsrsReviewResponse {

--- a/rslib/src/scheduler/fsrs/memory_state.rs
+++ b/rslib/src/scheduler/fsrs/memory_state.rs
@@ -377,6 +377,7 @@ pub(crate) fn fsrs_item_for_memory_state(
             Ok(None)
         }
     } else {
+        // no revlogs (new card or caused by ignore_revlogs_before)
         Ok(None)
     }
 }

--- a/rslib/src/scheduler/fsrs/memory_state.rs
+++ b/rslib/src/scheduler/fsrs/memory_state.rs
@@ -377,7 +377,7 @@ pub(crate) fn fsrs_item_for_memory_state(
             Ok(None)
         }
     } else {
-        // no revlogs (new card or caused by ignore_revlogs_before)
+        // no revlogs (new card or caused by ignore_revlogs_before or deleted revlogs)
         Ok(None)
     }
 }

--- a/rslib/src/scheduler/fsrs/simulator.rs
+++ b/rslib/src/scheduler/fsrs/simulator.rs
@@ -153,7 +153,8 @@ impl Collection {
             .filter_map(|c| {
                 let memory_state = match c.memory_state {
                     Some(state) => state,
-                    // cards that lack memory states after compute_memory_state have no FSRS items, implying a truncated or ignored revlog
+                    // cards that lack memory states after compute_memory_state have no FSRS items,
+                    // implying a truncated or ignored revlog
                     None => fsrs
                         .memory_state_from_sm2(
                             c.ease_factor(),

--- a/rslib/src/scheduler/fsrs/simulator.rs
+++ b/rslib/src/scheduler/fsrs/simulator.rs
@@ -153,6 +153,7 @@ impl Collection {
             .filter_map(|c| {
                 let memory_state = match c.memory_state {
                     Some(state) => state,
+                    // cards that lack memory states after compute_memory_state have no FSRS items, implying a truncated or ignored revlog
                     None => fsrs
                         .memory_state_from_sm2(
                             c.ease_factor(),

--- a/rslib/src/scheduler/fsrs/simulator.rs
+++ b/rslib/src/scheduler/fsrs/simulator.rs
@@ -146,7 +146,6 @@ impl Collection {
         let new_cards =
             cards.iter().filter(|c| c.queue == CardQueue::New).count() + req.deck_size as usize;
         let fsrs = FSRS::new(Some(&req.params))?;
-        let historical_retention = req.desired_retention;
         let mut converted_cards = cards
             .into_iter()
             .filter(is_included_card)
@@ -157,7 +156,7 @@ impl Collection {
                         .memory_state_from_sm2(
                             c.ease_factor(),
                             c.interval as f32,
-                            historical_retention,
+                            req.historical_retention,
                         )
                         .ok()?
                         .into(),

--- a/rslib/src/scheduler/fsrs/simulator.rs
+++ b/rslib/src/scheduler/fsrs/simulator.rs
@@ -16,6 +16,7 @@ use rand::rngs::StdRng;
 use rand::Rng;
 
 use crate::card::CardQueue;
+use crate::card::CardType;
 use crate::card::FsrsMemoryState;
 use crate::prelude::*;
 use crate::scheduler::states::fuzz::constrained_fuzz_bounds;

--- a/rslib/src/scheduler/fsrs/simulator.rs
+++ b/rslib/src/scheduler/fsrs/simulator.rs
@@ -144,7 +144,7 @@ impl Collection {
         }
         let days_elapsed = self.timing_today().unwrap().days_elapsed as i32;
         let new_cards =
-            cards.iter().filter(|c| c.queue == CardQueue::New).count() + req.deck_size as usize;
+            cards.iter().filter(|c| c.ctype == CardType::New).count() + req.deck_size as usize;
         let fsrs = FSRS::new(Some(&req.params))?;
         let mut converted_cards = cards
             .into_iter()

--- a/rslib/src/scheduler/fsrs/simulator.rs
+++ b/rslib/src/scheduler/fsrs/simulator.rs
@@ -10,11 +10,13 @@ use fsrs::simulate;
 use fsrs::PostSchedulingFn;
 use fsrs::ReviewPriorityFn;
 use fsrs::SimulatorConfig;
+use fsrs::FSRS;
 use itertools::Itertools;
 use rand::rngs::StdRng;
 use rand::Rng;
 
 use crate::card::CardQueue;
+use crate::card::FsrsMemoryState;
 use crate::prelude::*;
 use crate::scheduler::states::fuzz::constrained_fuzz_bounds;
 use crate::scheduler::states::load_balancer::calculate_easy_days_modifiers;
@@ -141,15 +143,27 @@ impl Collection {
             }
         }
         let days_elapsed = self.timing_today().unwrap().days_elapsed as i32;
-        let new_cards = cards
-            .iter()
-            .filter(|c| c.memory_state.is_none() || c.queue == CardQueue::New)
-            .count()
-            + req.deck_size as usize;
+        let new_cards =
+            cards.iter().filter(|c| c.queue == CardQueue::New).count() + req.deck_size as usize;
+        let fsrs = FSRS::new(Some(&req.params))?;
+        let historical_retention = req.desired_retention;
         let mut converted_cards = cards
             .into_iter()
             .filter(is_included_card)
-            .filter_map(|c| Card::convert(c, days_elapsed))
+            .filter_map(|c| {
+                let memory_state = match c.memory_state {
+                    Some(state) => state,
+                    None => fsrs
+                        .memory_state_from_sm2(
+                            c.ease_factor(),
+                            c.interval as f32,
+                            historical_retention,
+                        )
+                        .ok()?
+                        .into(),
+                };
+                Card::convert(c, days_elapsed, memory_state)
+            })
             .collect_vec();
         let introduced_today_count = self
             .search_cards(&format!("{} introduced:1", &req.search), SortMode::NoOrder)?
@@ -251,39 +265,34 @@ impl Collection {
 }
 
 impl Card {
-    fn convert(card: Card, days_elapsed: i32) -> Option<fsrs::Card> {
-        match card.memory_state {
-            Some(state) => match card.queue {
-                CardQueue::DayLearn | CardQueue::Review => {
-                    let due = card.original_or_current_due();
-                    let relative_due = due - days_elapsed;
-                    let last_date = (relative_due - card.interval as i32).min(0) as f32;
-                    Some(fsrs::Card {
-                        id: card.id.0,
-                        difficulty: state.difficulty,
-                        stability: state.stability,
-                        last_date,
-                        due: relative_due as f32,
-                        interval: card.interval as f32,
-                        lapses: card.lapses,
-                    })
-                }
-                CardQueue::New => None,
-                CardQueue::Learn | CardQueue::SchedBuried | CardQueue::UserBuried => {
-                    Some(fsrs::Card {
-                        id: card.id.0,
-                        difficulty: state.difficulty,
-                        stability: state.stability,
-                        last_date: 0.0,
-                        due: 0.0,
-                        interval: card.interval as f32,
-                        lapses: card.lapses,
-                    })
-                }
-                CardQueue::PreviewRepeat => None,
-                CardQueue::Suspended => None,
-            },
-            None => None,
+    fn convert(card: Card, days_elapsed: i32, memory_state: FsrsMemoryState) -> Option<fsrs::Card> {
+        match card.queue {
+            CardQueue::DayLearn | CardQueue::Review => {
+                let due = card.original_or_current_due();
+                let relative_due = due - days_elapsed;
+                let last_date = (relative_due - card.interval as i32).min(0) as f32;
+                Some(fsrs::Card {
+                    id: card.id.0,
+                    difficulty: memory_state.difficulty,
+                    stability: memory_state.stability,
+                    last_date,
+                    due: relative_due as f32,
+                    interval: card.interval as f32,
+                    lapses: card.lapses,
+                })
+            }
+            CardQueue::New => None,
+            CardQueue::Learn | CardQueue::SchedBuried | CardQueue::UserBuried => Some(fsrs::Card {
+                id: card.id.0,
+                difficulty: memory_state.difficulty,
+                stability: memory_state.stability,
+                last_date: 0.0,
+                due: 0.0,
+                interval: card.interval as f32,
+                lapses: card.lapses,
+            }),
+            CardQueue::PreviewRepeat => None,
+            CardQueue::Suspended => None,
         }
     }
 }

--- a/ts/routes/deck-options/FsrsOptions.svelte
+++ b/ts/routes/deck-options/FsrsOptions.svelte
@@ -95,6 +95,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         newCardsIgnoreReviewLimit: $newCardsIgnoreReviewLimit,
         easyDaysPercentages: $config.easyDaysPercentages,
         reviewOrder: $config.reviewOrder,
+        historicalRetention: $config.historicalRetention,
     });
 
     const DESIRED_RETENTION_LOW_THRESHOLD = 0.8;


### PR DESCRIPTION
source: https://forums.ankiweb.net/t/strange-fsrs-simulator-result-after-setting-ignore-cards-reviewed-before/59876

It's a following patch for #3940