### PR TITLE
set UV_PYTHON_DOWNLOADS=auto when doing `uv sync`

### DIFF
--- a/build/runner/src/pyenv.rs
+++ b/build/runner/src/pyenv.rs
@@ -34,8 +34,9 @@ pub fn setup_pyenv(args: PyenvArgs) {
 
     run_command(
         Command::new(args.uv_bin)
+            .env_clear()
             .env("UV_PROJECT_ENVIRONMENT", args.pyenv_folder.clone())
-            .args(["sync", "--locked"])
+            .args(["sync", "--locked", "--no-config"])
             .args(args.extra_args),
     );
 

--- a/qt/launcher/src/main.rs
+++ b/qt/launcher/src/main.rs
@@ -255,27 +255,13 @@ fn handle_version_install_or_update(state: &State, choice: MainMenuChoice) -> Re
         None
     };
 
-    // `uv sync` sometimes does not pull in Python automatically
-    // This might be system/platform specific and/or a uv bug.
-    let mut command = Command::new(&state.uv_path);
-    command
-        .current_dir(&state.uv_install_root)
-        .env("UV_CACHE_DIR", &state.uv_cache_dir)
-        .env("UV_PYTHON_INSTALL_DIR", &state.uv_python_install_dir)
-        .args(["python", "install", "--managed-python"]);
-
-    // Add python version if .python-version file exists
-    if let Some(version) = &python_version_trimmed {
-        command.args([version]);
-    }
-
-    command.ensure_success().context("Python install failed")?;
-
     // Sync the venv
     let mut command = Command::new(&state.uv_path);
     command
         .current_dir(&state.uv_install_root)
         .env("UV_CACHE_DIR", &state.uv_cache_dir)
+        // We always want to download python, even if the user has their system set to 'never'
+        .env("UV_PYTHON_DOWNLOADS", "auto")
         .env("UV_PYTHON_INSTALL_DIR", &state.uv_python_install_dir)
         .args(["sync", "--upgrade", "--managed-python"]);
 

--- a/qt/launcher/src/main.rs
+++ b/qt/launcher/src/main.rs
@@ -255,15 +255,14 @@ fn handle_version_install_or_update(state: &State, choice: MainMenuChoice) -> Re
         None
     };
 
-    // Sync the venv
+    // Prepare to sync the venv
     let mut command = Command::new(&state.uv_path);
     command
         .current_dir(&state.uv_install_root)
+        .env_clear()
         .env("UV_CACHE_DIR", &state.uv_cache_dir)
-        // We always want to download python, even if the user has their system set to 'never'
-        .env("UV_PYTHON_DOWNLOADS", "auto")
         .env("UV_PYTHON_INSTALL_DIR", &state.uv_python_install_dir)
-        .args(["sync", "--upgrade", "--managed-python"]);
+        .args(["sync", "--upgrade", "--managed-python", "--no-config"]);
 
     // Add python version if .python-version file exists
     if let Some(version) = &python_version_trimmed {


### PR DESCRIPTION
This is a proper fix for https://github.com/ankitects/anki/pull/4162

uv scans many paths. At least the System, User, and Workspace. It silently merges the options. This PR is a revert of our workaround and explicitly overrides the `UV_PYTHON_DOWNLOADS` flag to always download python.