### PR TITLE
FIX Graph Tooltip uses wrong font

### DIFF
--- a/ts/routes/graphs/Tooltip.svelte
+++ b/ts/routes/graphs/Tooltip.svelte
@@ -47,6 +47,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         white-space: nowrap;
         padding: 15px;
         border-radius: 5px;
+        font-family: inherit;
         font-size: 15px;
         opacity: 0;
         pointer-events: none;


### PR DESCRIPTION
Fixes the tooltip issue mentioned in https://forums.ankiweb.net/t/inconsistent-chinese-japanese-ui-font-when-anki-is-in-a-different-language-than-the-system-language-on-windows/63261/9?u=anon_0000

Basically, the tooltip continued to use the bootstrap font instead of using the system font.