### PR TITLE
Minor string change

### DIFF
--- a/ftl/core/preferences.ftl
+++ b/ftl/core/preferences.ftl
@@ -34,7 +34,7 @@ preferences-when-adding-default-to-current-deck = When adding, default to curren
 preferences-you-can-restore-backups-via-fileswitch = You can restore backups via File > Switch Profile.
 preferences-legacy-timezone-handling = Legacy timezone handling (buggy, but required for AnkiDroid <= 2.14)
 preferences-default-search-text = Default search text
-preferences-default-search-text-example = eg. 'deck:current '
+preferences-default-search-text-example = e.g. "deck:current"
 preferences-theme = Theme
 preferences-theme-follow-system = Follow System
 preferences-theme-light = Light


### PR DESCRIPTION
`"deck:current"` is a valid search so I replaced the single quote with double quotes. I'm fine with single quotes, but thought double would be better here.

Then there was a missing full stop and unnecessary space.