### PR TITLE
Add margin to QPushButton to prevent label from being clipped

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -234,6 +234,7 @@ Emmanuel Ferdman <https://github.com/emmanuel-ferdman>
 Sunong2008 <https://github.com/Sunrongguo2008>
 Marvin Kopf <marvinkopf@outlook.com>
 Kevin Nakamura <grinkers@grinkers.net>
+jcznk <https://github.com/jcznk>
 
 ********************
 

--- a/qt/aqt/stylesheets.py
+++ b/qt/aqt/stylesheets.py
@@ -198,6 +198,7 @@ class CustomStyles:
                 tm.var(colors.BUTTON_GRADIENT_END),
             )
         };
+        
     }}
     QPushButton:default:hover {{
         border-width: 2px;

--- a/qt/aqt/stylesheets.py
+++ b/qt/aqt/stylesheets.py
@@ -177,9 +177,13 @@ class CustomStyles:
     QPushButton:default {{
         border: 1px solid {tm.var(colors.BORDER_FOCUS)};
     }}
+    QPushButton {{
+        margin: 1px;
+    }}
     QPushButton:focus {{
         border: 2px solid {tm.var(colors.BORDER_FOCUS)};
         outline: none;
+        margin: 0px;
     }}
     QPushButton:hover,
     QTabBar::tab:hover,


### PR DESCRIPTION
Closes #4183 

https://stackoverflow.com/questions/66637388/is-there-a-way-to-change-the-external-border-of-a-qpushbutton

This trick should prevent border growth on QPushButtons on `focus` and `hover` from shrinking the space available for the button’s label. Previously, this could cause text (such as `Yes` in confirmation dialogs) to be clipped on the left and right.

Before: 
<img width="615" height="274" alt="image" src="https://github.com/user-attachments/assets/5a4985a9-041b-4eae-8c8c-b32431b64895" />

After:
<img width="615" height="274" alt="image" src="https://github.com/user-attachments/assets/75a9f4c4-e9e5-45c7-a665-7fc34d9a8509" />