### PR TITLE
Fix wrong tab order in preferences

### DIFF
--- a/qt/aqt/forms/preferences.ui
+++ b/qt/aqt/forms/preferences.ui
@@ -1292,9 +1292,10 @@
   <tabstop>daily_backups</tabstop>
   <tabstop>weekly_backups</tabstop>
   <tabstop>monthly_backups</tabstop>
-  <tabstop>tabWidget</tabstop>
   <tabstop>syncAnkiHubLogout</tabstop>
   <tabstop>syncAnkiHubLogin</tabstop>
+  <tabstop>buttonBox</tabstop>
+  <tabstop>tabWidget</tabstop>
  </tabstops>
  <resources/>
  <connections>

--- a/qt/aqt/preferences.py
+++ b/qt/aqt/preferences.py
@@ -82,11 +82,14 @@ class Preferences(QDialog):
         )
         group = self.form.preferences_answer_keys
         group.setLayout(layout := QFormLayout())
+        tab_widget: QWidget = self.form.url_schemes
         for ease, label in ease_labels:
             layout.addRow(
                 label,
                 line_edit := QLineEdit(self.mw.pm.get_answer_key(ease) or ""),
             )
+            QWidget.setTabOrder(tab_widget, line_edit)
+            tab_widget = line_edit
             qconnect(
                 line_edit.textChanged,
                 functools.partial(self.mw.pm.set_answer_key, ease),


### PR DESCRIPTION
This fixes wrong tab order in the Backups and Review sections.

Closes #4203
