### PR TITLE
Add last_review_time to _to_backend_card

### DIFF
--- a/pylib/anki/cards.py
+++ b/pylib/anki/cards.py
@@ -133,6 +133,7 @@ class Card(DeprecatedNamesMixin):
             memory_state=self.memory_state,
             desired_retention=self.desired_retention,
             decay=self.decay,
+            last_review_time_secs=self.last_review_time,
         )
 
     @deprecated(info="please use col.update_card()")


### PR DESCRIPTION
~Presumably,~ without this change, add-ons would delete the value of last_review_time from the card when they modify the card.

Also, a quick question: Is this code used by Anki itself? I think no. So, is it kept only for use by add-ons?

Based on my search in Anki's codebase, `_to_backend_card` is used by `update_cards`, `update_card` and `flush` functions in pylib and these Python functions are not used anywhere in Anki. So, I think that these 4 functions are kept only for use by add-ons.