### PR TITLE
Set min size for card info dialog

### DIFF
--- a/qt/aqt/browser/card_info.py
+++ b/qt/aqt/browser/card_info.py
@@ -51,6 +51,7 @@ class CardInfoDialog(QDialog):
 
     def _setup_ui(self, card_id: CardId | None) -> None:
         self.mw.garbage_collect_on_dialog_finish(self)
+        self.setMinimumSize(400, 300)
         disable_help_button(self)
         restoreGeom(self, self.GEOMETRY_KEY, default_size=(800, 800))
         add_close_shortcut(self)


### PR DESCRIPTION
ref: https://forums.ankiweb.net/t/card-info-does-not-work-in-version-25-02-4-a5c33ad0/59903 and https://discord.com/channels/368267295601983490/1397334353436082311/1397334353436082311

This tiny pr sets a min size of 400x300 for the card info dialog (like the import/export and change notetype dialogs currently do)

Before (potentially):
<img width="175" height="129" alt="image" src="https://github.com/user-attachments/assets/7561aef3-f638-4c2a-8b15-d61061e0fe15" />
After:
<img width="631" height="531" alt="image" src="https://github.com/user-attachments/assets/809ad74a-ab6c-4442-a0a1-0bbd77c0c73a" />