### PR TITLE
Refactor IO fill tool target check logic

### DIFF
--- a/ts/routes/image-occlusion/mask-editor.ts
+++ b/ts/routes/image-occlusion/mask-editor.ts
@@ -109,6 +109,8 @@ function initCanvas(): fabric.Canvas {
     // snap rotation around 0 by +-3deg
     fabric.Object.prototype.snapAngle = 360;
     fabric.Object.prototype.snapThreshold = 3;
+    // populate canvas.targets with subtargets during mouse events
+    fabric.Group.prototype.subTargetCheck = true;
     // disable rotation when selecting
     canvas.on("selection:created", () => {
         const g = canvas.getActiveObject();

--- a/ts/routes/image-occlusion/tools/lib.ts
+++ b/ts/routes/image-occlusion/tools/lib.ts
@@ -105,21 +105,6 @@ export const unGroupShapes = (canvas: fabric.Canvas): void => {
     redraw(canvas);
 };
 
-/** Check for the target within a (potentially nested) group
- * NOTE: assumes that masks do not overlap */
-export const findTargetInGroup = (group: fabric.Group, p: fabric.Point): fabric.Object | undefined => {
-    if (!group) { return; }
-    const point = fabric.util.transformPoint(p, fabric.util.invertTransform(group.calcOwnMatrix()));
-    for (const shape of group.getObjects()) {
-        if (shape instanceof fabric.Group) {
-            const ret = findTargetInGroup(shape, point);
-            if (ret) { return ret; }
-        } else if (shape.containsPoint(point)) {
-            return shape;
-        }
-    }
-};
-
 const copyItem = (canvas: fabric.Canvas): void => {
     const activeObject = canvas.getActiveObject();
     if (!activeObject) {

--- a/ts/routes/image-occlusion/tools/tool-fill.ts
+++ b/ts/routes/image-occlusion/tools/tool-fill.ts
@@ -17,9 +17,7 @@ export const fillMask = (canvas: fabric.Canvas, colourStore: Readable<string>): 
     stopDraw(canvas);
 
     canvas.on("mouse:down", function(o) {
-        const target = o.target instanceof fabric.Group
-            ? findTargetInGroup(o.target, canvas.getPointer(o.e) as fabric.Point)
-            : o.target;
+        const target = o.target instanceof fabric.Group ? canvas.targets[0] : o.target;
         const colour = get(colourStore);
         if (!target || target.fill === colour) { return; }
         target.fill = colour;

--- a/ts/routes/image-occlusion/tools/tool-fill.ts
+++ b/ts/routes/image-occlusion/tools/tool-fill.ts
@@ -4,7 +4,7 @@
 import { fabric } from "fabric";
 
 import { get, type Readable } from "svelte/store";
-import { findTargetInGroup, stopDraw } from "./lib";
+import { stopDraw } from "./lib";
 import { undoStack } from "./tool-undo-redo";
 
 export const fillMask = (canvas: fabric.Canvas, colourStore: Readable<string>): void => {


### PR DESCRIPTION
I've only recently found out about https://fabric5.fabricjs.com/docs/fabric.Group.html#subTargetCheck, which when set, causes event handlers to do what `findTargetInGroup` does, but without the z-index bug. This pr proposes to use that instead