### PR TITLE
Feat/Card stats update review time

### DIFF
--- a/rslib/src/stats/card.rs
+++ b/rslib/src/stats/card.rs
@@ -38,7 +38,6 @@ impl Collection {
             let last_review_time = TimestampSecs(
                 self.storage
                     .time_of_last_review(card.id)?
-                    .map(|ts| timing.now.elapsed_secs_since(ts))
                     .unwrap_or_default(),
             );
             new_card.last_review_time = Some(last_review_time);

--- a/rslib/src/stats/card.rs
+++ b/rslib/src/stats/card.rs
@@ -42,8 +42,7 @@ impl Collection {
 
             new_card.last_review_time = Some(last_review_time);
 
-            let usn = self.usn()?;
-            self.update_card_inner(&mut new_card, card.clone(), usn)?;
+            self.storage.update_card(&new_card)?;
             last_review_time
         };
 

--- a/rslib/src/stats/card.rs
+++ b/rslib/src/stats/card.rs
@@ -35,11 +35,11 @@ impl Collection {
             last_review_time
         } else {
             let mut new_card = card.clone();
-            let last_review_time = TimestampSecs(
-                self.storage
-                    .time_of_last_review(card.id)?
-                    .unwrap_or_default(),
-            );
+            let last_review_time = self
+                .storage
+                .time_of_last_review(card.id)?
+                .unwrap_or_default();
+
             new_card.last_review_time = Some(last_review_time);
 
             let usn = self.usn()?;


### PR DESCRIPTION
Updates the `last_review_time` of a card when opening the stats menu as the value is calculated anyway.

I'm not sure if you're comfortable having `card_stats` modify the database but if you are here you go :)