### PR TITLE
Fix Cards with Missing Last Review Time During Database Check

### DIFF
--- a/ftl/core/database-check.ftl
+++ b/ftl/core/database-check.ftl
@@ -5,6 +5,11 @@ database-check-card-properties =
         [one] Fixed { $count } invalid card property.
        *[other] Fixed { $count } invalid card properties.
     }
+database-check-card-last-review-time-empty =
+    { $count ->
+        [one] Fixed { $count } card with no last review time.
+       *[other] Fixed { $count } cards with no last review time.
+    }
 database-check-missing-templates =
     { $count ->
         [one] Deleted { $count } card with missing template.

--- a/ftl/core/database-check.ftl
+++ b/ftl/core/database-check.ftl
@@ -7,8 +7,8 @@ database-check-card-properties =
     }
 database-check-card-last-review-time-empty =
     { $count ->
-        [one] Filled missing last review time in { $count } card.
-       *[other] Filled missing last review time in { $count } cards.
+        [one] Added last review time to { $count } card.
+       *[other] Added last review time to { $count } cards.
     }
 database-check-missing-templates =
     { $count ->

--- a/ftl/core/database-check.ftl
+++ b/ftl/core/database-check.ftl
@@ -7,8 +7,8 @@ database-check-card-properties =
     }
 database-check-card-last-review-time-empty =
     { $count ->
-        [one] Fixed { $count } card with no last review time.
-       *[other] Fixed { $count } cards with no last review time.
+        [one] Filled missing last review time in { $count } card.
+       *[other] Filled missing last review time in { $count } cards.
     }
 database-check-missing-templates =
     { $count ->

--- a/rslib/src/dbcheck.rs
+++ b/rslib/src/dbcheck.rs
@@ -24,6 +24,7 @@ use crate::notetype::NotetypeId;
 use crate::notetype::NotetypeKind;
 use crate::prelude::*;
 use crate::progress::ThrottlingProgressHandler;
+use crate::storage::card::CardFixStats;
 use crate::timestamp::TimestampMillis;
 use crate::timestamp::TimestampSecs;
 
@@ -164,15 +165,19 @@ impl Collection {
 
     fn check_card_properties(&mut self, out: &mut CheckDatabaseOutput) -> Result<()> {
         let timing = self.timing_today()?;
-        let (new_cnt, other_cnt, last_review_time_cnt) = self.storage.fix_card_properties(
+        let CardFixStats {
+            new_cards_fixed,
+            other_cards_fixed,
+            last_review_time_fixed,
+        } = self.storage.fix_card_properties(
             timing.days_elapsed,
             TimestampSecs::now(),
             self.usn()?,
             self.scheduler_version() == SchedulerVersion::V1,
         )?;
-        out.card_position_too_high = new_cnt;
-        out.card_properties_invalid += other_cnt;
-        out.card_last_review_time_empty = last_review_time_cnt;
+        out.card_position_too_high = new_cards_fixed;
+        out.card_properties_invalid += other_cards_fixed;
+        out.card_last_review_time_empty = last_review_time_fixed;
         Ok(())
     }
 

--- a/rslib/src/dbcheck.rs
+++ b/rslib/src/dbcheck.rs
@@ -40,6 +40,7 @@ pub struct CheckDatabaseOutput {
     notetypes_recovered: usize,
     invalid_utf8: usize,
     invalid_ids: usize,
+    card_last_review_time_empty: usize,
 }
 
 #[derive(Debug, Clone, Copy, Default)]
@@ -68,6 +69,11 @@ impl CheckDatabaseOutput {
         }
         if self.card_properties_invalid > 0 {
             probs.push(tr.database_check_card_properties(self.card_properties_invalid));
+        }
+        if self.card_last_review_time_empty > 0 {
+            probs.push(
+                tr.database_check_card_last_review_time_empty(self.card_last_review_time_empty),
+            );
         }
         if self.cards_missing_note > 0 {
             probs.push(tr.database_check_card_missing_note(self.cards_missing_note));
@@ -158,7 +164,7 @@ impl Collection {
 
     fn check_card_properties(&mut self, out: &mut CheckDatabaseOutput) -> Result<()> {
         let timing = self.timing_today()?;
-        let (new_cnt, other_cnt) = self.storage.fix_card_properties(
+        let (new_cnt, other_cnt, last_review_time_cnt) = self.storage.fix_card_properties(
             timing.days_elapsed,
             TimestampSecs::now(),
             self.usn()?,
@@ -166,6 +172,7 @@ impl Collection {
         )?;
         out.card_position_too_high = new_cnt;
         out.card_properties_invalid += other_cnt;
+        out.card_last_review_time_empty = last_review_time_cnt;
         Ok(())
     }
 

--- a/rslib/src/dbcheck.rs
+++ b/rslib/src/dbcheck.rs
@@ -178,6 +178,12 @@ impl Collection {
         out.card_position_too_high = new_cards_fixed;
         out.card_properties_invalid += other_cards_fixed;
         out.card_last_review_time_empty = last_review_time_fixed;
+
+        // Trigger one-way sync if last_review_time was updated to avoid conflicts
+        if last_review_time_fixed > 0 {
+            self.set_schema_modified()?;
+        }
+
         Ok(())
     }
 

--- a/rslib/src/revlog/mod.rs
+++ b/rslib/src/revlog/mod.rs
@@ -85,6 +85,13 @@ impl RevlogEntry {
         .unwrap()
     }
 
+    /// Returns true if this entry represents a reset operation.
+    /// These entries are created when a card is reset using
+    /// [`Collection::reschedule_cards_as_new`].
+    pub(crate) fn is_reset(&self) -> bool {
+        self.review_kind == RevlogReviewKind::Manual && self.ease_factor == 0
+    }
+
     /// Returns true if the review entry is not manually rescheduled and not
     /// cramming. Used to filter out entries that shouldn't be considered
     /// for statistics and scheduling.

--- a/rslib/src/revlog/mod.rs
+++ b/rslib/src/revlog/mod.rs
@@ -88,19 +88,21 @@ impl RevlogEntry {
     /// Returns true if this entry represents a reset operation.
     /// These entries are created when a card is reset using
     /// [`Collection::reschedule_cards_as_new`].
-    /// The `ease_factor` should be 0 because
-    /// [`Collection::set_due_date`] also sets created `RevlogEntry` with
-    /// `RevlogReviewKind::Manual` but the `ease_factor` is not 0.
+    /// The 0 value of `ease_factor` differentiates it
+    /// from entry created by [`Collection::set_due_date`] that has
+    /// `RevlogReviewKind::Manual` but non-zero `ease_factor`.
     pub(crate) fn is_reset(&self) -> bool {
         self.review_kind == RevlogReviewKind::Manual && self.ease_factor == 0
     }
 
     /// Returns true if this entry represents a cramming operation.
-    /// These entries are created when a card is previewed using
+    /// These entries are created when a card is reviewed in a
+    /// filtered deck with "Reschedule cards based on my answers
+    /// in this deck" disabled.
     /// [`crate::scheduler::answering::CardStateUpdater::apply_preview_state`].
-    /// The `ease_factor` should be 0 because
-    /// [`crate::scheduler::states::ReviewState::revlog_kind`] returns
-    /// `RevlogReviewKind::Filtered` when `days_late() < 0`.
+    /// The 0 value of `ease_factor` distinguishes it from the entry
+    /// created when a card is reviewed before its due date in a
+    /// filtered deck with reschedule enabled or using Grade Now.
     pub(crate) fn is_cramming(&self) -> bool {
         self.review_kind == RevlogReviewKind::Filtered && self.ease_factor == 0
     }

--- a/rslib/src/revlog/mod.rs
+++ b/rslib/src/revlog/mod.rs
@@ -88,7 +88,7 @@ impl RevlogEntry {
     /// Returns true if the review entry is not manually rescheduled and not
     /// cramming. Used to filter out entries that shouldn't be considered
     /// for statistics and scheduling.
-    pub(crate) fn has_rating_and_affect_scheduling(&self) -> bool {
+    pub(crate) fn has_rating_and_affects_scheduling(&self) -> bool {
         // not rescheduled/set due date/reset
         self.button_chosen > 0
             // not cramming

--- a/rslib/src/revlog/mod.rs
+++ b/rslib/src/revlog/mod.rs
@@ -102,12 +102,16 @@ impl RevlogEntry {
         self.review_kind == RevlogReviewKind::Filtered && self.ease_factor == 0
     }
 
+    pub(crate) fn has_rating(&self) -> bool {
+        self.button_chosen > 0
+    }
+
     /// Returns true if the review entry is not manually rescheduled and not
     /// cramming. Used to filter out entries that shouldn't be considered
     /// for statistics and scheduling.
     pub(crate) fn has_rating_and_affects_scheduling(&self) -> bool {
         // not rescheduled/set due date/reset
-        self.button_chosen > 0
+        self.has_rating()
             // not cramming
             && !self.is_cramming()
     }

--- a/rslib/src/revlog/mod.rs
+++ b/rslib/src/revlog/mod.rs
@@ -92,6 +92,16 @@ impl RevlogEntry {
         self.review_kind == RevlogReviewKind::Manual && self.ease_factor == 0
     }
 
+    /// Returns true if this entry represents a cramming operation.
+    /// These entries are created when a card is previewed using
+    /// [`crate::scheduler::answering::CardStateUpdater::apply_preview_state`].
+    /// The `ease_factor` should be 0 because
+    /// [`crate::scheduler::states::ReviewState::revlog_kind`] returns
+    /// `RevlogReviewKind::Filtered` when `days_late() < 0`.
+    pub(crate) fn is_cramming(&self) -> bool {
+        self.review_kind == RevlogReviewKind::Filtered && self.ease_factor == 0
+    }
+
     /// Returns true if the review entry is not manually rescheduled and not
     /// cramming. Used to filter out entries that shouldn't be considered
     /// for statistics and scheduling.
@@ -99,7 +109,7 @@ impl RevlogEntry {
         // not rescheduled/set due date/reset
         self.button_chosen > 0
             // not cramming
-            && (self.review_kind != RevlogReviewKind::Filtered || self.ease_factor != 0)
+            && !self.is_cramming()
     }
 }
 

--- a/rslib/src/revlog/mod.rs
+++ b/rslib/src/revlog/mod.rs
@@ -88,6 +88,9 @@ impl RevlogEntry {
     /// Returns true if this entry represents a reset operation.
     /// These entries are created when a card is reset using
     /// [`Collection::reschedule_cards_as_new`].
+    /// The `ease_factor` should be 0 because
+    /// [`Collection::set_due_date`] also sets created `RevlogEntry` with
+    /// `RevlogReviewKind::Manual` but the `ease_factor` is not 0.
     pub(crate) fn is_reset(&self) -> bool {
         self.review_kind == RevlogReviewKind::Manual && self.ease_factor == 0
     }

--- a/rslib/src/revlog/mod.rs
+++ b/rslib/src/revlog/mod.rs
@@ -84,6 +84,16 @@ impl RevlogEntry {
         })
         .unwrap()
     }
+
+    /// Returns true if the review entry is not manually rescheduled and not
+    /// cramming. Used to filter out entries that shouldn't be considered
+    /// for statistics and scheduling.
+    pub(crate) fn has_rating_and_affect_scheduling(&self) -> bool {
+        // not rescheduled/set due date/reset
+        self.button_chosen > 0
+            // not cramming
+            && (self.review_kind != RevlogReviewKind::Filtered || self.ease_factor != 0)
+    }
 }
 
 impl Collection {

--- a/rslib/src/scheduler/fsrs/memory_state.rs
+++ b/rslib/src/scheduler/fsrs/memory_state.rs
@@ -313,7 +313,7 @@ pub(crate) struct LastRevlogInfo {
     pub(crate) last_reviewed_at: Option<TimestampSecs>,
 }
 
-/// Return a map of cards to info about last review/reschedule.
+/// Return a map of cards to info about last review.
 pub(crate) fn get_last_revlog_info(revlogs: &[RevlogEntry]) -> HashMap<CardId, LastRevlogInfo> {
     let mut out = HashMap::new();
     revlogs

--- a/rslib/src/scheduler/fsrs/memory_state.rs
+++ b/rslib/src/scheduler/fsrs/memory_state.rs
@@ -325,6 +325,8 @@ pub(crate) fn get_last_revlog_info(revlogs: &[RevlogEntry]) -> HashMap<CardId, L
             for e in group.into_iter() {
                 if e.has_rating_and_affects_scheduling() {
                     last_reviewed_at = Some(e.id.as_secs());
+                } else if e.is_reset() {
+                    last_reviewed_at = None;
                 }
             }
             out.insert(card_id, LastRevlogInfo { last_reviewed_at });

--- a/rslib/src/scheduler/fsrs/memory_state.rs
+++ b/rslib/src/scheduler/fsrs/memory_state.rs
@@ -306,15 +306,15 @@ pub(crate) fn fsrs_items_for_memory_states(
         .collect()
 }
 
-struct LastRevlogInfo {
+pub(crate) struct LastRevlogInfo {
     /// Used to determine the actual elapsed time between the last time the user
     /// reviewed the card and now, so that we can determine an accurate period
     /// when the card has subsequently been rescheduled to a different day.
-    last_reviewed_at: Option<TimestampSecs>,
+    pub(crate) last_reviewed_at: Option<TimestampSecs>,
 }
 
 /// Return a map of cards to info about last review/reschedule.
-fn get_last_revlog_info(revlogs: &[RevlogEntry]) -> HashMap<CardId, LastRevlogInfo> {
+pub(crate) fn get_last_revlog_info(revlogs: &[RevlogEntry]) -> HashMap<CardId, LastRevlogInfo> {
     let mut out = HashMap::new();
     revlogs
         .iter()
@@ -323,7 +323,7 @@ fn get_last_revlog_info(revlogs: &[RevlogEntry]) -> HashMap<CardId, LastRevlogIn
         .for_each(|(card_id, group)| {
             let mut last_reviewed_at = None;
             for e in group.into_iter() {
-                if e.button_chosen >= 1 {
+                if e.has_rating_and_affect_scheduling() {
                     last_reviewed_at = Some(e.id.as_secs());
                 }
             }

--- a/rslib/src/scheduler/fsrs/memory_state.rs
+++ b/rslib/src/scheduler/fsrs/memory_state.rs
@@ -323,7 +323,7 @@ pub(crate) fn get_last_revlog_info(revlogs: &[RevlogEntry]) -> HashMap<CardId, L
         .for_each(|(card_id, group)| {
             let mut last_reviewed_at = None;
             for e in group.into_iter() {
-                if e.has_rating_and_affect_scheduling() {
+                if e.has_rating_and_affects_scheduling() {
                     last_reviewed_at = Some(e.id.as_secs());
                 }
             }

--- a/rslib/src/scheduler/fsrs/params.rs
+++ b/rslib/src/scheduler/fsrs/params.rs
@@ -409,10 +409,7 @@ pub(crate) fn reviews_for_fsrs(
         if user_graded && entry.review_kind == RevlogReviewKind::Learning {
             first_of_last_learn_entries = Some(index);
             revlogs_complete = true;
-        } else if matches!(
-            (entry.review_kind, entry.ease_factor),
-            (RevlogReviewKind::Manual, 0)
-        ) {
+        } else if entry.is_reset() {
             // Ignore entries prior to a `Reset` if a learning step has come after,
             // but consider revlogs complete.
             if first_of_last_learn_entries.is_some() {

--- a/rslib/src/scheduler/fsrs/params.rs
+++ b/rslib/src/scheduler/fsrs/params.rs
@@ -548,10 +548,14 @@ pub(crate) mod tests {
     }
 
     pub(crate) fn revlog(review_kind: RevlogReviewKind, days_ago: i64) -> RevlogEntry {
+        let button_chosen = match review_kind {
+            RevlogReviewKind::Manual | RevlogReviewKind::Rescheduled => 0,
+            _ => 3,
+        };
         RevlogEntry {
             review_kind,
             id: days_ago_ms(days_ago).into(),
-            button_chosen: 3,
+            button_chosen,
             interval: 1,
             ..Default::default()
         }

--- a/rslib/src/scheduler/fsrs/params.rs
+++ b/rslib/src/scheduler/fsrs/params.rs
@@ -400,7 +400,7 @@ pub(crate) fn reviews_for_fsrs(
         // For incomplete review histories, initial memory state is based on the first
         // user-graded review after the cutoff date with interval >= 1d.
         let within_cutoff = entry.id.0 > ignore_revlogs_before.0;
-        let user_graded = matches!(entry.button_chosen, 1..=4);
+        let user_graded = entry.has_rating();
         let interday = entry.interval >= 1 || entry.interval <= -86400;
         if user_graded && within_cutoff && interday {
             first_user_grade_idx = Some(index);
@@ -469,16 +469,7 @@ pub(crate) fn reviews_for_fsrs(
     }
 
     // Filter out unwanted entries
-    entries.retain(|entry| {
-        !(
-            // set due date, reset or rescheduled
-            (entry.review_kind == RevlogReviewKind::Manual || entry.button_chosen == 0)
-            || // cram
-            entry.is_cramming()
-            || // rescheduled
-            (entry.review_kind == RevlogReviewKind::Rescheduled)
-        )
-    });
+    entries.retain(|entry| entry.has_rating_and_affects_scheduling());
 
     // Compute delta_t for each entry
     let delta_ts = iter::once(0)

--- a/rslib/src/scheduler/fsrs/params.rs
+++ b/rslib/src/scheduler/fsrs/params.rs
@@ -394,7 +394,7 @@ pub(crate) fn reviews_for_fsrs(
     let mut revlogs_complete = false;
     // Working backwards from the latest review...
     for (index, entry) in entries.iter().enumerate().rev() {
-        if entry.review_kind == RevlogReviewKind::Filtered && entry.ease_factor == 0 {
+        if entry.is_cramming() {
             continue;
         }
         // For incomplete review histories, initial memory state is based on the first
@@ -474,7 +474,7 @@ pub(crate) fn reviews_for_fsrs(
             // set due date, reset or rescheduled
             (entry.review_kind == RevlogReviewKind::Manual || entry.button_chosen == 0)
             || // cram
-            (entry.review_kind == RevlogReviewKind::Filtered && entry.ease_factor == 0)
+            entry.is_cramming()
             || // rescheduled
             (entry.review_kind == RevlogReviewKind::Rescheduled)
         )

--- a/rslib/src/stats/card.rs
+++ b/rslib/src/stats/card.rs
@@ -187,7 +187,7 @@ impl Collection {
 }
 
 fn average_and_total_secs_strings(revlog: &[RevlogEntry]) -> (f32, f32) {
-    let normal_answer_count = revlog.iter().filter(|r| r.button_chosen > 0).count();
+    let normal_answer_count = revlog.iter().filter(|r| r.has_rating()).count();
     let total_secs: f32 = revlog
         .iter()
         .map(|entry| (entry.taken_millis as f32) / 1000.0)

--- a/rslib/src/stats/graphs/retention.rs
+++ b/rslib/src/stats/graphs/retention.rs
@@ -53,7 +53,7 @@ impl GraphsContext {
         self.revlog
             .iter()
             .filter(|review| {
-                review.has_rating_and_affect_scheduling()
+                review.has_rating_and_affects_scheduling()
                     // cards with an interval ≥ 1 day
                     && (review.review_kind == RevlogReviewKind::Review
                         || review.last_interval <= -86400

--- a/rslib/src/stats/graphs/retention.rs
+++ b/rslib/src/stats/graphs/retention.rs
@@ -53,10 +53,7 @@ impl GraphsContext {
         self.revlog
             .iter()
             .filter(|review| {
-                // not rescheduled/set due date/reset
-                review.button_chosen > 0
-                    // not cramming
-                    && (review.review_kind != RevlogReviewKind::Filtered || review.ease_factor != 0)
+                review.has_rating_and_affect_scheduling()
                     // cards with an interval ≥ 1 day
                     && (review.review_kind == RevlogReviewKind::Review
                         || review.last_interval <= -86400

--- a/rslib/src/storage/card/mod.rs
+++ b/rslib/src/storage/card/mod.rs
@@ -43,6 +43,13 @@ use crate::timestamp::TimestampMillis;
 use crate::timestamp::TimestampSecs;
 use crate::types::Usn;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct CardFixStats {
+    pub new_cards_fixed: usize,
+    pub other_cards_fixed: usize,
+    pub last_review_time_fixed: usize,
+}
+
 impl FromSql for CardType {
     fn column_result(value: ValueRef<'_>) -> result::Result<Self, FromSqlError> {
         if let ValueRef::Integer(i) = value {
@@ -366,7 +373,7 @@ impl super::SqliteStorage {
         mtime: TimestampSecs,
         usn: Usn,
         v1_sched: bool,
-    ) -> Result<(usize, usize, usize)> {
+    ) -> Result<CardFixStats> {
         let new_cnt = self
             .db
             .prepare(include_str!("fix_due_new.sql"))?
@@ -404,7 +411,11 @@ impl super::SqliteStorage {
                 }
             }
         }
-        Ok((new_cnt, other_cnt, last_review_time_cnt))
+        Ok(CardFixStats {
+            new_cards_fixed: new_cnt,
+            other_cards_fixed: other_cnt,
+            last_review_time_fixed: last_review_time_cnt,
+        })
     }
 
     pub(crate) fn delete_orphaned_cards(&self) -> Result<usize> {

--- a/rslib/src/storage/card/mod.rs
+++ b/rslib/src/storage/card/mod.rs
@@ -399,7 +399,7 @@ impl super::SqliteStorage {
             if let Some(mut card) = card {
                 if card.ctype != CardType::New && card.last_review_time.is_none() {
                     card.last_review_time = last_revlog_info.last_reviewed_at;
-                    self.update_card(&mut card)?;
+                    self.update_card(&card)?;
                     last_review_time_cnt += 1;
                 }
             }


### PR DESCRIPTION
### Problem

It takes a long time to fill all existing cards' `last_review_time` because the user needs to review them all.

Source: https://forums.ankiweb.net/t/fill-the-card-last-review-time-field-when-check-database/64792

### Solution
This PR adds functionality to the database check process to automatically fix cards with missing last review times by:

1. **Identifying affected cards**: During database check, find cards that are not new (have been reviewed) but have no `last_review_time` recorded
2. **Recovery from revlog**: Use the revision log entries to determine the actual last review time for these cards
3. **Automatic repair**: Update the cards with the correct `last_review_time` based on their review history
4. **User feedback**: Report the number of fixed cards to the user through the database check results

### Key Changes

- **New database check category**: Added `card_last_review_time_empty` counter to track and report fixed cards
- **Improved revlog filtering**: Refactored review entry filtering logic into a reusable `has_rating_and_affect_scheduling()` method that properly excludes manual reschedules and cramming sessions
- **Enhanced card repair**: Extended `fix_card_properties()` to also repair missing last review times by cross-referencing with revlog data
- **Localization support**: Added user-facing messages to inform users about the repair process

### Benefits

- **Better scheduling accuracy**: Cards with proper last review times will be scheduled more accurately
- **Improved statistics**: Review statistics will be more accurate when all cards have correct last review times  
- **Automatic repair**: Users don't need to manually fix corrupted card data - it's handled automatically during database check
- **Transparency**: Users are informed about what was fixed during the database check process

The fix is conservative and only updates cards where the data is clearly missing, ensuring no valid data is overwritten.
