### PR TITLE
Statistics Reviews graph, make the color of New and Learning cards co…

### DIFF
--- a/ts/routes/graphs/reviews.ts
+++ b/ts/routes/graphs/reviews.ts
@@ -20,6 +20,7 @@ import {
     curveBasis,
     interpolateBlues,
     interpolateGreens,
+    interpolateOranges,
     interpolatePurples,
     interpolateReds,
     max,
@@ -181,7 +182,7 @@ export function renderReviews(
     const reds = scaleSequential((n) => interpolateReds(cappedRange(n)!)).domain(
         x.domain() as any,
     );
-    const blues = scaleSequential((n) => interpolateBlues(cappedRange(n)!)).domain(
+    const oranges = scaleSequential((n) => interpolateOranges(cappedRange(n)!)).domain(
         x.domain() as any,
     );
     const purples = scaleSequential((n) => interpolatePurples(cappedRange(n)!)).domain(
@@ -195,7 +196,7 @@ export function renderReviews(
             case BinIndex.Young:
                 return lighterGreens;
             case BinIndex.Learn:
-                return blues;
+                return oranges;
             case BinIndex.Relearn:
                 return reds;
             case BinIndex.Filtered:


### PR DESCRIPTION
Issue reference: Fixes #3895

To improve visual consistency and reduce potential confusion, I updated the color scheme of the reviews graph to match that of the card count graph.

Before:
<img width="1250" height="732" alt="Old Reviews Graph" src="https://github.com/user-attachments/assets/e7d888c1-98b9-4312-9ccd-3259ad78061e" />

After:
<img width="1222" height="647" alt="Updated Reviews Graph" src="https://github.com/user-attachments/assets/fb5953b7-86c2-4581-b1fd-0cb7b112005d" />


This update aligns the visual language across related graphs, making the UI more intuitive and reducing ambiguity.