### PR TITLE
Fix show_exception's messagebox always formatting as plaintext

### DIFF
--- a/qt/aqt/errors.py
+++ b/qt/aqt/errors.py
@@ -179,7 +179,6 @@ def _init_message_box(
     _mbox.setWindowTitle("Anki")
     _mbox.setText(user_text)
     _mbox.setIcon(QMessageBox.Icon.Warning)
-    _mbox.setTextFormat(Qt.TextFormat.PlainText)
 
     def show_help():
         openHelp(help_page)


### PR DESCRIPTION
Fixes https://forums.ankiweb.net/t/anki-25-08-beta-3/64738/25

The [default behaviour](https://doc.qt.io/qt-6/qmessagebox.html#textFormat-prop), which this pr proposes to use, is to format text as richtext if detected as such, and plaintext otherwise