### PR TITLE
Fix simulator graph not visible when viewport height < 400px

### DIFF
--- a/ts/routes/deck-options/SimulatorModal.svelte
+++ b/ts/routes/deck-options/SimulatorModal.svelte
@@ -646,7 +646,8 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
     .svg-container {
         width: 100%;
-        max-height: calc(100vh - 400px); /* Account for modal header, controls, etc */
+        /* Account for modal header, controls, etc */
+        max-height: max(calc(100vh - 400px), 200px);
         aspect-ratio: 600 / 250;
         display: flex;
         align-items: center;


### PR DESCRIPTION
ref: https://forums.ankiweb.net/t/landscape-mode-doesnt-work-with-simulator/65089

Its max height is currently `calc(100vh - 400px)`, which can go negative when on landscape mode. The fix proposed is to set a lower bound of 200px