### PR TITLE
Use space-around for tabbed values

### DIFF
--- a/ts/routes/deck-options/TabbedValue.svelte
+++ b/ts/routes/deck-options/TabbedValue.svelte
@@ -55,6 +55,9 @@
         width: 100%;
         display: flex;
         flex-wrap: nowrap;
+        &:has(li:nth-child(3)) {
+            justify-content: space-between;
+        }
         justify-content: space-around;
         padding-inline: 0;
         margin-bottom: 0.5rem;


### PR DESCRIPTION
ref:
- https://github.com/ankitects/anki/pull/4194#discussion_r2214379398

before/after
<img width="638" height="74" alt="image" src="https://github.com/user-attachments/assets/37402bfd-70e8-422f-8532-f3d2dce82b65" />
<img width="631" height="76" alt="image" src="https://github.com/user-attachments/assets/63f9dcba-a125-4971-9dd1-4e87f116c055" />
