### PR TITLE
Fix/Retention help button bounds

### DIFF
--- a/ts/lib/components/TitledContainer.svelte
+++ b/ts/lib/components/TitledContainer.svelte
@@ -12,7 +12,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     export { className as class };
 
     export let title: string;
-    export let onTitleClick: ((_e: MouseEvent | KeyboardEvent) => void) | null = null;
+    export let onHelpClick: ((_e: MouseEvent | KeyboardEvent) => void) | null = null;
 </script>
 
 <div
@@ -29,8 +29,8 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
             {title}
         </h1>
         <div
-            on:click={onTitleClick}
-            on:keydown={onTitleClick}
+            on:click={onHelpClick}
+            on:keydown={onHelpClick}
             role="button"
             tabindex="0"
             class="help-badge position-absolute"

--- a/ts/lib/components/TitledContainer.svelte
+++ b/ts/lib/components/TitledContainer.svelte
@@ -25,23 +25,17 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     style:--container-margin="0"
 >
     <div class="position-relative">
-        {#if onTitleClick}
-            <span
-                on:click={onTitleClick}
-                on:keydown={onTitleClick}
-                role="button"
-                tabindex="0"
-            >
-                <h1>
-                    {title}
-                </h1>
-            </span>
-        {:else}
-            <h1>
-                {title}
-            </h1>
-        {/if}
-        <div class="help-badge position-absolute" class:rtl>
+        <h1>
+            {title}
+        </h1>
+        <div
+            on:click={onTitleClick}
+            on:keydown={onTitleClick}
+            role="button"
+            tabindex="0"
+            class="help-badge position-absolute"
+            class:rtl
+        >
             <slot name="tooltip" />
         </div>
     </div>

--- a/ts/lib/components/TitledContainer.svelte
+++ b/ts/lib/components/TitledContainer.svelte
@@ -28,16 +28,18 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         <h1>
             {title}
         </h1>
-        <div
-            on:click={onHelpClick}
-            on:keydown={onHelpClick}
-            role="button"
-            tabindex="0"
-            class="help-badge position-absolute"
-            class:rtl
-        >
-            <slot name="tooltip" />
-        </div>
+        {#if onHelpClick}
+            <div
+                on:click={onHelpClick}
+                on:keydown={onHelpClick}
+                role="button"
+                tabindex="0"
+                class="help-badge position-absolute"
+                class:rtl
+            >
+                <slot name="tooltip" />
+            </div>
+        {/if}
     </div>
     <slot />
 </div>

--- a/ts/routes/graphs/Graph.svelte
+++ b/ts/routes/graphs/Graph.svelte
@@ -8,7 +8,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     // When title is null (default), the graph is inlined, not having TitledContainer wrapper.
     export let title: string | null = null;
     export let subtitle: string | null = null;
-    export let onTitleClick: ((_e: MouseEvent | KeyboardEvent) => void) | null = null;
+    export let onHelpClick: ((_e: MouseEvent | KeyboardEvent) => void) | null = null;
 </script>
 
 {#if title == null}
@@ -19,7 +19,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         <slot />
     </div>
 {:else}
-    <TitledContainer class="d-flex flex-column" {title} {onTitleClick}>
+    <TitledContainer class="d-flex flex-column" {title} {onHelpClick}>
         <slot slot="tooltip" name="tooltip"></slot>
         <div class="graph d-flex flex-grow-1 flex-column justify-content-center">
             {#if subtitle}

--- a/ts/routes/graphs/TrueRetention.svelte
+++ b/ts/routes/graphs/TrueRetention.svelte
@@ -57,12 +57,12 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
     const title = tr.statisticsTrueRetentionTitle();
     const subtitle = tr.statisticsTrueRetentionSubtitle();
-    const onTitleClick = () => {
+    const onHelpClick = () => {
         openHelpModal(Object.keys(retentionHelp).indexOf("trueRetention"));
     };
 </script>
 
-<Graph {title} {subtitle} {onTitleClick}>
+<Graph {title} {subtitle} {onHelpClick}>
     <HelpModal
         title={tr.statisticsTrueRetentionTitle()}
         url={HelpPage.DeckOptions.fsrs}


### PR DESCRIPTION
Forum link: https://forums.ankiweb.net/t/retention-stat-click-area/64220?u=a_blokee

Restricts the area which you click to activate the help button to the (?) circular question mark (as opposed to the entire title).