### PR TITLE
Change FSRS button placement

### DIFF
--- a/ts/routes/deck-options/FsrsOptions.svelte
+++ b/ts/routes/deck-options/FsrsOptions.svelte
@@ -436,17 +436,18 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
                 {/if}
             </button>
         {/if}
-        <div style:margin-left="0.5rem">
-            {#if computingParams || checkingParams}
-                {computeParamsProgressString}
-            {:else if totalReviews !== undefined}
-                {tr.statisticsReviews({ reviews: totalReviews })}
-            {/if}
-        </div>
 
         <button class="btn btn-primary float-right" on:click={() => computeAllParams()}>
             {tr.deckConfigSaveAndOptimize()}
         </button>
+    </div>
+
+    <div style:min-height="1.5em">
+        {#if computingParams || checkingParams}
+            {computeParamsProgressString}
+        {:else if totalReviews !== undefined}
+            {tr.statisticsReviews({ reviews: totalReviews })}
+        {/if}
     </div>
 
     <Warning warning={lastOptimizationWarning} className="alert-warning" />

--- a/ts/routes/deck-options/FsrsOptions.svelte
+++ b/ts/routes/deck-options/FsrsOptions.svelte
@@ -411,45 +411,45 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         </SettingTitle>
     </SwitchRow>
 
-    <button
-        class="btn {computingParams ? 'btn-warning' : 'btn-primary'}"
-        disabled={!computingParams && computing}
-        on:click={() => computeParams()}
-    >
-        {#if computingParams}
-            {tr.actionsCancel()}
-        {:else}
-            {tr.deckConfigOptimizeButton()}
-        {/if}
-    </button>
-    {#if state.legacyEvaluate}
+    <div class="m-1 button-bar">
         <button
-            class="btn {checkingParams ? 'btn-warning' : 'btn-primary'}"
-            disabled={!checkingParams && computing}
-            on:click={() => checkParams()}
+            class="btn {computingParams ? 'btn-warning' : 'btn-primary'}"
+            disabled={!computingParams && computing}
+            on:click={() => computeParams()}
         >
-            {#if checkingParams}
+            {#if computingParams}
                 {tr.actionsCancel()}
             {:else}
-                {tr.deckConfigEvaluateButton()}
+                {tr.deckConfigOptimizeButton()}
             {/if}
         </button>
-    {/if}
-    <div>
-        {#if computingParams || checkingParams}
-            {computeParamsProgressString}
-        {:else if totalReviews !== undefined}
-            {tr.statisticsReviews({ reviews: totalReviews })}
+        {#if state.legacyEvaluate}
+            <button
+                class="btn {checkingParams ? 'btn-warning' : 'btn-primary'}"
+                disabled={!checkingParams && computing}
+                on:click={() => checkParams()}
+            >
+                {#if checkingParams}
+                    {tr.actionsCancel()}
+                {:else}
+                    {tr.deckConfigEvaluateButton()}
+                {/if}
+            </button>
         {/if}
+        <div style:margin-left="0.5rem">
+            {#if computingParams || checkingParams}
+                {computeParamsProgressString}
+            {:else if totalReviews !== undefined}
+                {tr.statisticsReviews({ reviews: totalReviews })}
+            {/if}
+        </div>
+
+        <button class="btn btn-primary float-right" on:click={() => computeAllParams()}>
+            {tr.deckConfigSaveAndOptimize()}
+        </button>
     </div>
-</div>
 
-<div class="m-1">
     <Warning warning={lastOptimizationWarning} className="alert-warning" />
-
-    <button class="btn btn-primary" on:click={() => computeAllParams()}>
-        {tr.deckConfigSaveAndOptimize()}
-    </button>
 </div>
 
 <hr />
@@ -496,5 +496,15 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     hr {
         border-top: 1px solid var(--border);
         opacity: 1;
+    }
+
+    .float-right {
+        margin-left: auto;
+    }
+
+    .button-bar {
+        display: flex;
+        align-items: baseline;
+        gap: 0.2rem;
     }
 </style>


### PR DESCRIPTION
People seem to prefer something like this. 

Forum post: https://forums.ankiweb.net/t/move-optimize-current-preset-on-the-same-level-as-optimize-all-presets/65740?u=a_blokee

<img width="622" height="114" alt="image" src="https://github.com/user-attachments/assets/09db2df2-0dda-4e12-b7c9-0a0b13cf78cf" />
<img width="622" height="114" alt="image" src="https://github.com/user-attachments/assets/4c9aab4c-93a9-4298-b8ca-372dc700ac41" />
<img width="347" height="180" alt="image" src="https://github.com/user-attachments/assets/d06a67f4-3c45-4952-b0ae-b2cd4e841a30" />
<img width="347" height="200" alt="image" src="https://github.com/user-attachments/assets/6f863bf2-43d8-4020-92d5-8fae58027e7c" />