### PR TITLE
Fix/Simulator intervals decending overflows

### DIFF
--- a/rslib/src/scheduler/fsrs/simulator.rs
+++ b/rslib/src/scheduler/fsrs/simulator.rs
@@ -97,7 +97,7 @@ fn create_review_priority_fn(
 
         // Interval-based ordering
         IntervalsAscending => wrap!(|c, _w| c.interval as i32),
-        IntervalsDescending => wrap!(|c, _w| 0i32.saturating_sub(c.interval as i32)),
+        IntervalsDescending => wrap!(|c, _w| (c.interval as i32).saturating_neg()),
         // Retrievability-based ordering
         RetrievabilityAscending => {
             wrap!(move |c, w| (c.retrievability(w) * 1000.0) as i32)

--- a/rslib/src/scheduler/fsrs/simulator.rs
+++ b/rslib/src/scheduler/fsrs/simulator.rs
@@ -97,7 +97,7 @@ fn create_review_priority_fn(
 
         // Interval-based ordering
         IntervalsAscending => wrap!(|c, _w| c.interval as i32),
-        IntervalsDescending => wrap!(|c, _w| -((c.interval as i32).max(-i32::MAX))),
+        IntervalsDescending => wrap!(|c, _w| 0i32.saturating_sub(c.interval as i32)),
         // Retrievability-based ordering
         RetrievabilityAscending => {
             wrap!(move |c, w| (c.retrievability(w) * 1000.0) as i32)

--- a/rslib/src/scheduler/fsrs/simulator.rs
+++ b/rslib/src/scheduler/fsrs/simulator.rs
@@ -97,7 +97,7 @@ fn create_review_priority_fn(
 
         // Interval-based ordering
         IntervalsAscending => wrap!(|c, _w| c.interval as i32),
-        IntervalsDescending => wrap!(|c, _w| -(c.interval as i32)),
+        IntervalsDescending => wrap!(|c, _w| -((c.interval as i32).max(-i32::MAX))),
         // Retrievability-based ordering
         RetrievabilityAscending => {
             wrap!(move |c, w| (c.retrievability(w) * 1000.0) as i32)


### PR DESCRIPTION
Maybe the new cards having -infinity as an interval has something to do with the root cause? I think this fixes it regardless. Anki should panic when using descending intervals before this pr:

<img width="645" height="49" alt="image" src="https://github.com/user-attachments/assets/5132b969-1dc0-4a3d-98b4-006f7d23105f" />
