### PR TITLE
Fix sync errors not being reported in some cases

### DIFF
--- a/qt/aqt/sync.py
+++ b/qt/aqt/sync.py
@@ -73,7 +73,7 @@ def handle_sync_error(mw: aqt.main.AnkiQt, err: Exception) -> None:
     elif isinstance(err, Interrupted):
         # no message to show
         return
-    show_warning(str(err))
+    show_warning(str(err), parent=mw)
 
 
 def on_normal_sync_timer(mw: aqt.main.AnkiQt) -> None:

--- a/qt/aqt/utils.py
+++ b/qt/aqt/utils.py
@@ -226,29 +226,45 @@ def ask_user_dialog(
     )
 
 
-def show_info(text: str, callback: Callable | None = None, **kwargs: Any) -> MessageBox:
+def show_info(
+    text: str,
+    callback: Callable | None = None,
+    parent: QWidget | None = None,
+    **kwargs: Any,
+) -> MessageBox:
     "Show a small info window with an OK button."
     if "icon" not in kwargs:
         kwargs["icon"] = QMessageBox.Icon.Information
     return MessageBox(
         text,
         callback=(lambda _: callback()) if callback is not None else None,
+        parent=parent,
         **kwargs,
     )
 
 
 def show_warning(
-    text: str, callback: Callable | None = None, **kwargs: Any
+    text: str,
+    callback: Callable | None = None,
+    parent: QWidget | None = None,
+    **kwargs: Any,
 ) -> MessageBox:
     "Show a small warning window with an OK button."
-    return show_info(text, icon=QMessageBox.Icon.Warning, callback=callback, **kwargs)
+    return show_info(
+        text, icon=QMessageBox.Icon.Warning, callback=callback, parent=parent, **kwargs
+    )
 
 
 def show_critical(
-    text: str, callback: Callable | None = None, **kwargs: Any
+    text: str,
+    callback: Callable | None = None,
+    parent: QWidget | None = None,
+    **kwargs: Any,
 ) -> MessageBox:
     "Show a small critical error window with an OK button."
-    return show_info(text, icon=QMessageBox.Icon.Critical, callback=callback, **kwargs)
+    return show_info(
+        text, icon=QMessageBox.Icon.Critical, callback=callback, parent=parent, **kwargs
+    )
 
 
 def showWarning(


### PR DESCRIPTION
The lack of an explicit parent arg for show_waring() in handle_sync_error() was causing the dialog to be closed immediately in case the parent happens to be the progress dialog spawned by taskman.with_progress(). I was able to confirm this by triggering an error in col.sync_collection().

This should fix a commonly reported issue in AnkiHub, where many new users (that probably didn't confirm their emails yet) reported AnkiHub showing "AnkiHub sync cancelled" at startup (the add-on hooks AnkiWeb sync to handle cases where a full sync is triggered by AnkiHub changes).

Related PR from last year: https://github.com/ankitects/anki/pull/3222 (I noticed fewer reports after this one, so I assume it did fix the issue for many users).