### PR TITLE
Replace deprecated $app/stores with $app/state in SvelteKit frontend

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -238,6 +238,7 @@ Bradley Szoke <bradleyszoke@gmail.com>
 jcznk <https://github.com/jcznk>
 Thomas Rixen <thomas.rixen@student.uclouvain.be>
 Siyuan Mattuwu Yan <syan4@ualberta.ca>
+Lee Doughty <https://github.com/leedoughty>
 
 ********************
 

--- a/ts/routes/+error.svelte
+++ b/ts/routes/+error.svelte
@@ -3,9 +3,9 @@ Copyright: Ankitects Pty Ltd and contributors
 License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 -->
 <script lang="ts">
-    import { page } from "$app/stores";
+    import { page } from "$app/state";
 
-    $: message = $page.error!.message;
+    $: message = page.error!.message;
 </script>
 
 {message}

--- a/ts/routes/card-info/[cardId]/+page.svelte
+++ b/ts/routes/card-info/[cardId]/+page.svelte
@@ -3,7 +3,7 @@ Copyright: Ankitects Pty Ltd and contributors
 License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 -->
 <script lang="ts">
-    import { page } from "$app/stores";
+    import { page } from "$app/state";
 
     import CardInfo from "../CardInfo.svelte";
     import type { PageData } from "./$types";
@@ -11,7 +11,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
     export let data: PageData;
 
-    const showRevlog = $page.url.searchParams.get("revlog") !== "0";
+    const showRevlog = page.url.searchParams.get("revlog") !== "0";
 
     globalThis.anki ||= {};
     globalThis.anki.updateCard = async (card_id: string): Promise<void> => {

--- a/ts/routes/card-info/[cardId]/[previousId]/+page.svelte
+++ b/ts/routes/card-info/[cardId]/[previousId]/+page.svelte
@@ -3,7 +3,7 @@ Copyright: Ankitects Pty Ltd and contributors
 License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 -->
 <script lang="ts">
-    import { page } from "$app/stores";
+    import { page } from "$app/state";
 
     import CardInfo from "../../CardInfo.svelte";
     import type { PageData } from "./$types";
@@ -11,8 +11,8 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
     export let data: PageData;
 
-    const showRevlog = $page.url.searchParams.get("revlog") !== "0";
-    const showCurve = $page.url.searchParams.get("curve") !== "0";
+    const showRevlog = page.url.searchParams.get("revlog") !== "0";
+    const showCurve = page.url.searchParams.get("curve") !== "0";
 
     globalThis.anki ||= {};
     globalThis.anki.updateCardInfos = async (card_id: string): Promise<void> => {


### PR DESCRIPTION
This PR updates the frontend Svelte code to use `$app/state` introduced in SvelteKit 2.12. The `$app/stores` module is deprecated and scheduled for removal in SvelteKit 3.

Further details can be found here: https://svelte.dev/docs/kit/migrating-to-sveltekit-2#SvelteKit-2.12:-$app-stores-deprecated