### PR TITLE
Increase randomness in random sorting of new cards

### DIFF
--- a/rslib/src/scheduler/queue/builder/gathering.rs
+++ b/rslib/src/scheduler/queue/builder/gathering.rs
@@ -61,13 +61,14 @@ impl QueueBuilder {
     }
 
     fn gather_new_cards(&mut self, col: &mut Collection) -> Result<()> {
+        let salt = knuth_salt(self.context.timing.days_elapsed);
         match self.context.sort_options.new_gather_priority {
             NewCardGatherPriority::Deck => {
                 self.gather_new_cards_by_deck(col, NewCardSorting::LowestPosition)
             }
             NewCardGatherPriority::DeckThenRandomNotes => self.gather_new_cards_by_deck(
                 col,
-                NewCardSorting::RandomNotes(self.context.timing.days_elapsed),
+                NewCardSorting::RandomNotes(salt),
             ),
             NewCardGatherPriority::LowestPosition => {
                 self.gather_new_cards_sorted(col, NewCardSorting::LowestPosition)
@@ -77,11 +78,11 @@ impl QueueBuilder {
             }
             NewCardGatherPriority::RandomNotes => self.gather_new_cards_sorted(
                 col,
-                NewCardSorting::RandomNotes(self.context.timing.days_elapsed),
+                NewCardSorting::RandomNotes(salt),
             ),
             NewCardGatherPriority::RandomCards => self.gather_new_cards_sorted(
                 col,
-                NewCardSorting::RandomCards(self.context.timing.days_elapsed),
+                NewCardSorting::RandomCards(salt),
             ),
         }
     }
@@ -168,5 +169,11 @@ impl QueueBuilder {
             self.new.push(card);
             true
         }
+    }
+
+    // Generates a salt for use with fnvhash. Useful to increase randomness
+    // when the base salt is a small integer.
+    fn knuth_salt(base_salt: u32) -> u32 {
+        base_salt.wrapping_mul(2654435761)
     }
 }

--- a/rslib/src/scheduler/queue/builder/gathering.rs
+++ b/rslib/src/scheduler/queue/builder/gathering.rs
@@ -61,29 +61,26 @@ impl QueueBuilder {
     }
 
     fn gather_new_cards(&mut self, col: &mut Collection) -> Result<()> {
-        let salt = knuth_salt(self.context.timing.days_elapsed);
+        let salt = Self::knuth_salt(self.context.timing.days_elapsed);
         match self.context.sort_options.new_gather_priority {
             NewCardGatherPriority::Deck => {
                 self.gather_new_cards_by_deck(col, NewCardSorting::LowestPosition)
             }
-            NewCardGatherPriority::DeckThenRandomNotes => self.gather_new_cards_by_deck(
-                col,
-                NewCardSorting::RandomNotes(salt),
-            ),
+            NewCardGatherPriority::DeckThenRandomNotes => {
+                self.gather_new_cards_by_deck(col, NewCardSorting::RandomNotes(salt))
+            }
             NewCardGatherPriority::LowestPosition => {
                 self.gather_new_cards_sorted(col, NewCardSorting::LowestPosition)
             }
             NewCardGatherPriority::HighestPosition => {
                 self.gather_new_cards_sorted(col, NewCardSorting::HighestPosition)
             }
-            NewCardGatherPriority::RandomNotes => self.gather_new_cards_sorted(
-                col,
-                NewCardSorting::RandomNotes(salt),
-            ),
-            NewCardGatherPriority::RandomCards => self.gather_new_cards_sorted(
-                col,
-                NewCardSorting::RandomCards(salt),
-            ),
+            NewCardGatherPriority::RandomNotes => {
+                self.gather_new_cards_sorted(col, NewCardSorting::RandomNotes(salt))
+            }
+            NewCardGatherPriority::RandomCards => {
+                self.gather_new_cards_sorted(col, NewCardSorting::RandomCards(salt))
+            }
         }
     }
 


### PR DESCRIPTION
Currently, the new cards appear roughly in the same order on consecutive days (if they are skipped by burying). This change aims to increase randomness by spreading out the salt across the hash space.