### PR TITLE
Fix compilation under rust 1.89

### DIFF
--- a/rslib/i18n/src/generated.rs
+++ b/rslib/i18n/src/generated.rs
@@ -4,6 +4,5 @@
 // Include auto-generated content
 
 #![allow(clippy::all)]
-#![allow(text_direction_codepoint_in_literal)]
 
 include!(concat!(env!("OUT_DIR"), "/strings.rs"));

--- a/rslib/i18n/src/lib.rs
+++ b/rslib/i18n/src/lib.rs
@@ -1,6 +1,7 @@
 // Copyright: Ankitects Pty Ltd and contributors
 // License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
+#![allow(text_direction_codepoint_in_literal)]
 mod generated;
 
 use std::borrow::Cow;


### PR DESCRIPTION
Rust 1.89 produces the following output for `cargo build` in `rslib/i18n`:

```
error: unicode codepoint changing visible direction of text present in literal
...
warning: allow(text_direction_codepoint_in_literal) is ignored unless specified at crate level
 --> rslib/i18n/src/generated.rs:7:10
  |
7 | #![allow(text_direction_codepoint_in_literal)]
  |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

This change fixes it.

This ensures that some third-party crate that pulls in this code as library code (and thus isn't subject to the rust-toolchain file in this repo) doesn't hit this compilation error.

... also the nixpkgs build of anki uses nixpkg's current rust version, not anki's `rust-toolchain` version :upside_down_face: