### PR TITLE
Fix ninja BuildAction name sanitization

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -239,6 +239,7 @@ jcznk <https://github.com/jcznk>
 Thomas Rixen <thomas.rixen@student.uclouvain.be>
 Siyuan Mattuwu Yan <syan4@ualberta.ca>
 Lee Doughty <https://github.com/leedoughty>
+memchr <memchr@proton.me>
 
 ********************
 


### PR DESCRIPTION
rust commit [8296ad0](https://github.com/rust-lang/rust/commit/8296ad04568597fbfab4460530032cd54f5cd26b#diff-d43cdd86cb96902ecb316c5956a0769c5de03808dd81512c6d916697c9ab058eR24) changes the output of std::any::type_name to include
regions such as lifetime and generic arguments, which results in invalid
Ninja rule names being generated, such as `CargoBuild<_>`.

This commit removes the substring starting at (and including) the first `<`.
