### PR TITLE
Add desired_retention field to NormalDeckSchema11

### DIFF
--- a/rslib/src/decks/schema11.rs
+++ b/rslib/src/decks/schema11.rs
@@ -135,6 +135,8 @@ pub struct NormalDeckSchema11 {
     review_limit_today: Option<DayLimit>,
     #[serde(default, deserialize_with = "default_on_invalid")]
     new_limit_today: Option<DayLimit>,
+    #[serde(default, deserialize_with = "default_on_invalid")]
+    desired_retention: Option<u32>,
 }
 
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
@@ -249,6 +251,7 @@ impl Default for NormalDeckSchema11 {
             new_limit: None,
             review_limit_today: None,
             new_limit_today: None,
+            desired_retention: None,
         }
     }
 }
@@ -325,7 +328,7 @@ impl From<NormalDeckSchema11> for NormalDeck {
             new_limit: deck.new_limit,
             review_limit_today: deck.review_limit_today,
             new_limit_today: deck.new_limit_today,
-            desired_retention: None,
+            desired_retention: deck.desired_retention.map(|v| v as f32 / 100.0),
         }
     }
 }
@@ -367,6 +370,7 @@ impl From<Deck> for DeckSchema11 {
                 new_limit: norm.new_limit,
                 review_limit_today: norm.review_limit_today,
                 new_limit_today: norm.new_limit_today,
+                desired_retention: norm.desired_retention.map(|v| (v * 100.0) as u32),
                 common: deck.into(),
             }),
             DeckKind::Filtered(ref filt) => DeckSchema11::Filtered(FilteredDeckSchema11 {


### PR DESCRIPTION
To allow add-ons to read the deck-specific desired retention, I add `desired_retention` to `NormalDeckSchema11`.
- https://github.com/open-spaced-repetition/fsrs4anki-helper/issues/602

But `f32` is not allowed due to the trait `Eq`, so I convert it to `u32`. Is it the best practice?