### PR TITLE
FIX gap above bury

### DIFF
--- a/ts/routes/deck-options/DeckOptionsPage.svelte
+++ b/ts/routes/deck-options/DeckOptionsPage.svelte
@@ -136,12 +136,13 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
         :global(.container-columns) {
             display: grid;
-            gap: 20px;
+            gap: 0px;
         }
 
         @include bp.with-breakpoint("lg") {
             :global(.container-columns) {
                 grid-template-columns: repeat(2, 1fr);
+                gap: 20px;
             }
         }
     }


### PR DESCRIPTION
Fixes: #4279

The issue was that the `gap` was set to 20px by default, instead of only setting the gap when we use a dual-column layout.