### PR TITLE
Fix/Invalid memory states in simulator after parameters changed

### DIFF
--- a/ftl/core/deck-config.ftl
+++ b/ftl/core/deck-config.ftl
@@ -498,6 +498,7 @@ deck-config-desired-retention-below-optimal = Your desired retention is below op
 # cards that can be recalled or retrieved on a specific date.
 deck-config-fsrs-simulator-experimental = FSRS Simulator (Experimental)
 deck-config-fsrs-simulate-desired-retention-experimental = FSRS Desired Retention Simulator (Experimental)
+deck-config-fsrs-simulate-save-preset = After optimizing, please save your config before running the simulator.
 deck-config-fsrs-desired-retention-help-me-decide-experimental = Help Me Decide (Experimental)
 deck-config-additional-new-cards-to-simulate = Additional new cards to simulate
 deck-config-simulate = Simulate

--- a/ts/routes/deck-options/FsrsOptions.svelte
+++ b/ts/routes/deck-options/FsrsOptions.svelte
@@ -340,9 +340,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     }
 
     function showSimulatorModal(modal: Modal) {
-        if (
-            fsrsParams($config).toString() === initialParams.toString()
-        ) {
+        if (fsrsParams($config).toString() === initialParams.toString()) {
             modal?.show();
         } else {
             alert(tr.deckConfigFsrsSimulateSavePreset());

--- a/ts/routes/deck-options/FsrsOptions.svelte
+++ b/ts/routes/deck-options/FsrsOptions.svelte
@@ -341,7 +341,6 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
     function showSimulatorModal(modal: Modal) {
         if (
-            initialParmas.length === 0 ||
             fsrsParams($config).toString() === initialParmas.toString()
         ) {
             modal?.show();

--- a/ts/routes/deck-options/FsrsOptions.svelte
+++ b/ts/routes/deck-options/FsrsOptions.svelte
@@ -53,7 +53,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     let desiredRetentionFocused = false;
     let desiredRetentionEverFocused = false;
     let optimized = false;
-    const initialParmas = [...fsrsParams($config)];
+    const initialParams = [...fsrsParams($config)];
     $: if (desiredRetentionFocused) {
         desiredRetentionEverFocused = true;
     }
@@ -341,7 +341,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
     function showSimulatorModal(modal: Modal) {
         if (
-            fsrsParams($config).toString() === initialParmas.toString()
+            fsrsParams($config).toString() === initialParams.toString()
         ) {
             modal?.show();
         } else {

--- a/ts/routes/deck-options/FsrsOptions.svelte
+++ b/ts/routes/deck-options/FsrsOptions.svelte
@@ -53,6 +53,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     let desiredRetentionFocused = false;
     let desiredRetentionEverFocused = false;
     let optimized = false;
+    const initialParmas = [...fsrsParams($config)];
     $: if (desiredRetentionFocused) {
         desiredRetentionEverFocused = true;
     }
@@ -338,6 +339,17 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         state.save(UpdateDeckConfigsMode.COMPUTE_ALL_PARAMS);
     }
 
+    function showSimulatorModal(modal: Modal) {
+        if (
+            initialParmas.length === 0 ||
+            fsrsParams($config).toString() === initialParmas.toString()
+        ) {
+            modal?.show();
+        } else {
+            alert(tr.deckConfigFsrsSimulateSavePreset());
+        }
+    }
+
     let simulatorModal: Modal;
     let workloadModal: Modal;
 </script>
@@ -368,7 +380,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     class="btn btn-primary"
     on:click={() => {
         simulateFsrsRequest.reviewLimit = 9999;
-        workloadModal?.show();
+        showSimulatorModal(workloadModal);
     }}
 >
     {tr.deckConfigFsrsDesiredRetentionHelpMeDecideExperimental()}
@@ -455,7 +467,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 <hr />
 
 <div class="m-1">
-    <button class="btn btn-primary" on:click={() => simulatorModal?.show()}>
+    <button class="btn btn-primary" on:click={() => showSimulatorModal(simulatorModal)}>
         {tr.deckConfigFsrsSimulatorExperimental()}
     </button>
 </div>


### PR DESCRIPTION
fixes #4064

This will prevent users from running the simulator after optimizing, before saving the preset.