### PR TITLE
Prevent clipping for QPushButton:default:hover

### DIFF
--- a/qt/aqt/stylesheets.py
+++ b/qt/aqt/stylesheets.py
@@ -180,7 +180,7 @@ class CustomStyles:
     QPushButton {{
         margin: 1px;
     }}
-    QPushButton:focus {{
+    QPushButton:focus, QPushButton:default:hover {{
         border: 2px solid {tm.var(colors.BORDER_FOCUS)};
         outline: none;
         margin: 0px;
@@ -198,9 +198,6 @@ class CustomStyles:
                 tm.var(colors.BUTTON_GRADIENT_END),
             )
         };
-    }}
-    QPushButton:default:hover {{
-        border-width: 2px;
     }}
     QPushButton:pressed,
     QPushButton:checked,


### PR DESCRIPTION
Should fix the issue reported at: https://github.com/ankitects/anki/pull/4201#issuecomment-3262286135

Before:

<img width="465" height="45" alt="image" src="https://github.com/user-attachments/assets/67ae0e39-0916-49ec-8904-fa2c424e0f8d" />

After:

<img width="471" height="45" alt="image" src="https://github.com/user-attachments/assets/fec8b34a-06c8-4e5c-9c8f-dca533c25f83" />

<hr>

EDIT: Note that this change causes the border to "grow" outwards rather than inwards. Whether this constitutes an aesthetic regression is probably a matter of personal taste. I slightly prefer the border growing inwards, but as I understand it, this is necessary to prevent the clipping problem. (Unless, of course, we want to make more radical changes to the stylesheet, which I would not be against. I don’t particularly like the 2px border and could live without it entirely.)

The topic I took inspiration from (https://stackoverflow.com/questions/66637388/is-there-a-way-to-change-the-external-border-of-a-qpushbutton) was opened by a user explicitly looking for a way to have the border grow outwards. So, maybe, people like it that way. My suggestion is to test the changes and see how they are received, and adjust later if needed.