### PR TITLE
fix: persist colour picker's custom palette

### DIFF
--- a/proto/anki/frontend.proto
+++ b/proto/anki/frontend.proto
@@ -27,6 +27,9 @@ service FrontendService {
   rpc deckOptionsRequireClose(generic.Empty) returns (generic.Empty);
   // Warns python that the deck option web view is ready to receive requests.
   rpc deckOptionsReady(generic.Empty) returns (generic.Empty);
+
+  // Save colour picker's custom colour palette
+  rpc SaveCustomColours(generic.Empty) returns (generic.Empty);
 }
 
 service BackendFrontendService {}

--- a/qt/aqt/editor.py
+++ b/qt/aqt/editor.py
@@ -151,6 +151,7 @@ class Editor:
         self.add_webview()
         self.setupWeb()
         self.setupShortcuts()
+        self.setupColourPalette()
         gui_hooks.editor_did_init(self)
 
     # Initial setup
@@ -348,6 +349,18 @@ require("anki/ui").loaded.then(() => require("anki/NoteEditor").instances[0].too
             else:
                 keys, fn, _ = row
             QShortcut(QKeySequence(keys), self.widget, activated=fn)  # type: ignore
+
+    def setupColourPalette(self) -> None:
+        assert self.mw.pm.profile is not None
+        if custom_colours := str(
+            self.mw.pm.profile.get("customColorPickerPalette", "")
+        ):
+            for i, colour in enumerate(
+                custom_colours.split(",")[: QColorDialog.customCount()]
+            ):
+                if not QColor.isValidColorName(colour):
+                    break
+                QColorDialog.setCustomColor(i, QColor.fromString(colour))
 
     def _addFocusCheck(self, fn: Callable) -> Callable:
         def checkFocus() -> None:

--- a/qt/aqt/mediasrv.py
+++ b/qt/aqt/mediasrv.py
@@ -599,6 +599,18 @@ def deck_options_ready() -> bytes:
     return b""
 
 
+def save_custom_colours() -> bytes:
+    colours = ",".join(
+        [
+            QColorDialog.customColor(i).name(QColor.NameFormat.HexArgb)
+            for i in range(QColorDialog.customCount())
+        ]
+    )
+    assert aqt.mw.pm.profile is not None
+    aqt.mw.pm.profile["customColorPickerPalette"] = colours
+    return b""
+
+
 post_handler_list = [
     congrats_info,
     get_deck_configs_for_update,
@@ -614,6 +626,7 @@ post_handler_list = [
     search_in_browser,
     deck_options_require_close,
     deck_options_ready,
+    save_custom_colours,
 ]
 
 

--- a/ts/editor/editor-toolbar/ColorPicker.svelte
+++ b/ts/editor/editor-toolbar/ColorPicker.svelte
@@ -4,6 +4,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 -->
 <script lang="ts">
     import Shortcut from "$lib/components/Shortcut.svelte";
+    import { saveCustomColours } from "@generated/backend";
 
     export let keyCombination: string | null = null;
     export let value: string;
@@ -11,7 +12,15 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     let inputRef: HTMLInputElement;
 </script>
 
-<input bind:this={inputRef} tabindex="-1" type="color" bind:value on:input on:change />
+<input
+    bind:this={inputRef}
+    tabindex="-1"
+    type="color"
+    bind:value
+    on:input
+    on:change
+    on:click={() => saveCustomColours({})}
+/>
 
 {#if keyCombination}
     <Shortcut {keyCombination} on:action={() => inputRef.click()} />

--- a/ts/editor/editor-toolbar/HighlightColorButton.svelte
+++ b/ts/editor/editor-toolbar/HighlightColorButton.svelte
@@ -19,6 +19,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     import ColorPicker from "./ColorPicker.svelte";
     import { context as editorToolbarContext } from "./EditorToolbar.svelte";
     import WithColorHelper from "./WithColorHelper.svelte";
+    import { saveCustomColours } from "@generated/backend";
 
     export let color: string;
 
@@ -133,6 +134,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
             on:input={(event) => {
                 color = setColor(event);
                 bridgeCommand(`lastHighlightColor:${color}`);
+                saveCustomColours({});
             }}
             on:change={() => setTextColor()}
         />

--- a/ts/editor/editor-toolbar/TextColorButton.svelte
+++ b/ts/editor/editor-toolbar/TextColorButton.svelte
@@ -22,6 +22,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     import ColorPicker from "./ColorPicker.svelte";
     import { context as editorToolbarContext } from "./EditorToolbar.svelte";
     import WithColorHelper from "./WithColorHelper.svelte";
+    import { saveCustomColours } from "@generated/backend";
 
     export let color: string;
 
@@ -152,6 +153,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
             on:input={(event) => {
                 color = setColor(event);
                 bridgeCommand(`lastTextColor:${color}`);
+                saveCustomColours({});
             }}
             on:change={() => {
                 // Delay added to work around intermittent failures on macOS/Qt6.5


### PR DESCRIPTION
Closes #4233

Custom palette colours are currently reset when anki is restarted. This pr proposes to save them to the current profile. Tested on win 10 and wsl ubuntu

I understand its a qt regression, but without a timeline on when/if it'll get fixed, i reckon its worth handling in anki in the meantime

A quirk with this impl is that (afaik) there is no event for when the picker is closed without a colour being selected. So i've chosen to save the palette when its both opened and when a colour is selected