### PR TITLE
Add safe_rename to handle cross-device file moves (OS error 18)

### DIFF
--- a/rslib/src/media/files.rs
+++ b/rslib/src/media/files.rs
@@ -565,18 +565,18 @@ mod test {
 
     #[test]
     fn safe_rename_moves_file() {
-        let dir = tempdir().unwrap();
-        let src = dir.path().join("test_src.txt");
-        let dst = dir.path().join("test_dst.txt");
+    let dir = tempdir().unwrap();
+    let src = dir.path().join("myfile.txt");
+    let dst = dir.path().join("myfile_trashed.txt");
 
-        fs::write(&src, b"hello world").unwrap();
-        safe_rename(&src, &dst).unwrap();
+    fs::write(&src, b"My test content").unwrap();
+    safe_rename(&src, &dst).unwrap();
 
-        assert!(dst.exists());
-        assert!(!src.exists());
-        let contents = fs::read(&dst).unwrap();
-        assert_eq!(contents, b"hello world");
+    assert!(dst.exists());
+    assert!(!src.exists());
+    let contents = fs::read(&dst).unwrap();
+    assert_eq!(contents, b"My test content");
 
-        fs::remove_file(&dst).unwrap();
+    fs::remove_file(&dst).unwrap();
     }
 }

--- a/rslib/src/media/files.rs
+++ b/rslib/src/media/files.rs
@@ -320,6 +320,18 @@ pub(crate) fn mtime_as_i64<P: AsRef<Path>>(path: P) -> io::Result<i64> {
         .as_millis() as i64)
 }
 
+pub(crate) fn safe_rename(src: &Path, dst: &Path) -> io::Result<()> {
+    match fs::rename(src, dst) {
+        Ok(_) => Ok(()),
+        Err(e) if e.raw_os_error() == Some(18) => {
+            fs::copy(src, dst)?;
+            fs::remove_file(src)?;
+            Ok(())
+        }
+        Err(e) => Err(e),
+    }
+}
+
 pub fn remove_files<S>(media_folder: &Path, files: &[S]) -> Result<()>
 where
     S: AsRef<str> + std::fmt::Debug,
@@ -344,7 +356,7 @@ where
         }
 
         // move file to trash, clobbering any existing file with the same name
-        fs::rename(&src_path, &dst_path)?;
+        safe_rename(&src_path, &dst_path)?;
 
         // mark it as modified, so we can expire it in the future
         let secs = time::SystemTime::now();
@@ -549,5 +561,22 @@ mod test {
             ),
             Cow::<str>::Owned(format!("{}_", " ".repeat(MAX_MEDIA_FILENAME_LENGTH - 2)))
         );
+    }
+
+    #[test]
+    fn safe_rename_moves_file() {
+        let dir = tempdir().unwrap();
+        let src = dir.path().join("test_src.txt");
+        let dst = dir.path().join("test_dst.txt");
+
+        fs::write(&src, b"hello world").unwrap();
+        safe_rename(&src, &dst).unwrap();
+
+        assert!(dst.exists());
+        assert!(!src.exists());
+        let contents = fs::read(&dst).unwrap();
+        assert_eq!(contents, b"hello world");
+
+        fs::remove_file(&dst).unwrap();
     }
 }


### PR DESCRIPTION
I am a student currently taking an open source course and I wanted to contribute with a small change first and get an understanding for how Rust works. The purpose of this PR is to provide a safer file move operation and prevent crashes when files are on different devices. This PR includes the following:

- Added a safe_rename function that handles OS error 18 (Cross-device link) when moving files across different filesystems
- Updated remove_files to use safe_rename instead of fs::rename
- Added a test for safe_rename to ensure the file moves correctly and the content remains intact

I ran into an issue where I couldn’t run the existing tests in the Anki workspace due to dependency conflicts, so I verified the functionality in a separate minimal Rust project to ensure safe_rename works as expected. If you have any suggestions on why these dependency conflicts occur or tips for properly running tests in the workspace, I would greatly appreciate your guidance.

I would also welcome any feedback or suggestions to improve my contribution and learn more. Thank you! :)