### PR TITLE
latex: remove blank lines inside math blocks (fixes #3466)

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -242,6 +242,7 @@ Lee Doughty <32392044+leedoughty@users.noreply.github.com>
 memchr <memchr@proton.me>
 Max Romanowski <maxr777@proton.me>
 Aldlss <ayaldlss@gmail.com>
+Matbe766 <matildabergstrom01@gmail.com>
 
 ********************
 

--- a/rslib/src/latex.rs
+++ b/rslib/src/latex.rs
@@ -79,10 +79,7 @@ pub fn extract_latex(text: &str, svg: bool) -> (Cow<'_, str>, Vec<ExtractedLatex
 
         let fname = fname_for_latex(&latex, svg);
         let img_link = image_link_for_fname(&latex, &fname);
-        extracted.push(ExtractedLatex {
-            fname,
-            latex: latex.into(),
-        });
+        extracted.push(ExtractedLatex { fname, latex });
 
         img_link
     });


### PR DESCRIPTION
Removes `<br>`/`<div>` tags inside math blocks (`[$]`, `[$$]`) instead of turning them into newlines.  
This prevents blank lines that broke environments like `tikzcd`.  
Standard `[latex]` blocks still keep newlines.

Fixes #3466
