### PR TITLE
(UI polish) Improved margins in Card Browser's "Previewer"

### DIFF
--- a/qt/aqt/browser/previewer.py
+++ b/qt/aqt/browser/previewer.py
@@ -81,7 +81,7 @@ class Previewer(QDialog):
         qconnect(self.finished, self._on_finished)
         self.silentlyClose = True
         self.vbox = QVBoxLayout()
-        self.vbox.setContentsMargins(0, 0, 0, 0)
+        self.vbox.setContentsMargins(0, 0, 2, 4)
         self._web: AnkiWebView | None = AnkiWebView(kind=AnkiWebViewKind.PREVIEWER)
         self.vbox.addWidget(self._web)
         self.bbox = QDialogButtonBox()

--- a/qt/aqt/browser/previewer.py
+++ b/qt/aqt/browser/previewer.py
@@ -13,7 +13,7 @@ import aqt.browser
 from anki.cards import Card
 from anki.collection import Config
 from anki.tags import MARKED_TAG
-from aqt import AnkiQt, gui_hooks
+from aqt import AnkiQt, gui_hooks, is_mac
 from aqt.qt import (
     QCheckBox,
     QDialog,
@@ -81,10 +81,15 @@ class Previewer(QDialog):
         qconnect(self.finished, self._on_finished)
         self.silentlyClose = True
         self.vbox = QVBoxLayout()
-        self.vbox.setContentsMargins(0, 0, 2, 4)
+        spacing = 6
+        self.vbox.setContentsMargins(0, 0, 0, 0)
+        self.vbox.setSpacing(spacing)
         self._web: AnkiWebView | None = AnkiWebView(kind=AnkiWebViewKind.PREVIEWER)
         self.vbox.addWidget(self._web)
         self.bbox = QDialogButtonBox()
+        self.bbox.setContentsMargins(
+            spacing, spacing if is_mac else 0, spacing, spacing
+        )
         self.bbox.setLayoutDirection(Qt.LayoutDirection.LeftToRight)
 
         gui_hooks.card_review_webview_did_init(self._web, AnkiWebViewKind.PREVIEWER)


### PR DESCRIPTION
This PR slightly increases the distance between the `Replay`/`Back Only`/`Previous`/`Next` buttons and the lower/right border of the Preview pane. The buttons were previously glued to the window frame. I tried to make the change subtle, yet noticeable.

Tested on Windows 11. 

Before:
<img width="423" height="63" alt="Before" src="https://github.com/user-attachments/assets/9adf3a64-2736-41e5-a63c-40d16cb1b33c" />

After:
<img width="423" height="63" alt="After" src="https://github.com/user-attachments/assets/8f96092d-fdc5-4468-93ab-720ba8d5156e" />