### PR TITLE
Make timebox message translatable with flexible variable order

### DIFF
--- a/ftl/core/studying.ftl
+++ b/ftl/core/studying.ftl
@@ -46,15 +46,14 @@ studying-type-answer-unknown-field = Type answer: unknown field { $val }
 studying-unbury = Unbury
 studying-what-would-you-like-to-unbury = What would you like to unbury?
 studying-you-havent-recorded-your-voice-yet = You haven't recorded your voice yet.
-studying-card-studied-in =
-    { $count ->
-        [one] { $count } card studied in
-       *[other] { $count } cards studied in
-    }
-studying-minute =
-    { $count ->
-        [one] { $count } minute.
-       *[other] { $count } minutes.
+studying-card-studied-in-minute =
+    { $cards ->
+        [one] { $cards } card
+       *[other] { $cards } cards
+    } studied in
+    { $minutes ->
+        [one] { $minutes } minute.
+       *[other] { $minutes } minutes.
     }
 studying-question-time-elapsed = Question time elapsed
 studying-answer-time-elapsed = Answer time elapsed

--- a/ftl/core/studying.ftl
+++ b/ftl/core/studying.ftl
@@ -57,3 +57,16 @@ studying-card-studied-in-minute =
     }
 studying-question-time-elapsed = Question time elapsed
 studying-answer-time-elapsed = Answer time elapsed
+
+## OBSOLETE; you do not need to translate this
+
+studying-card-studied-in =
+    { $count ->
+        [one] { $count } card studied in
+       *[other] { $count } cards studied in
+    }
+studying-minute =
+    { $count ->
+        [one] { $count } minute.
+       *[other] { $count } minutes.
+    }

--- a/qt/aqt/reviewer.py
+++ b/qt/aqt/reviewer.py
@@ -966,11 +966,13 @@ timerStopped = false;
         elapsed = self.mw.col.timeboxReached()
         if elapsed:
             assert not isinstance(elapsed, bool)
-            part1 = tr.studying_card_studied_in(count=elapsed[1])
-            mins = int(round(elapsed[0] / 60))
-            part2 = tr.studying_minute(count=mins)
+            cards_val = elapsed[1]
+            minutes_val = int(round(elapsed[0] / 60))
+            message = tr.studying_card_studied_in_minute(
+                cards=cards_val, minutes=str(minutes_val)
+            )
             fin = tr.studying_finish()
-            diag = askUserDialog(f"{part1} {part2}", [tr.studying_continue(), fin])
+            diag = askUserDialog(message, [tr.studying_continue(), fin])
             diag.setIcon(QMessageBox.Icon.Information)
             if diag.run() == fin:
                 self.mw.moveToState("deckBrowser")

--- a/qt/aqt/reviewer.py
+++ b/qt/aqt/reviewer.py
@@ -17,6 +17,7 @@ import aqt.browser
 import aqt.operations
 from anki.cards import Card, CardId
 from anki.collection import Config, OpChanges, OpChangesWithCount
+from anki.lang import with_collapsed_whitespace
 from anki.scheduler.base import ScheduleCardsAsNew
 from anki.scheduler.v3 import (
     CardAnswer,
@@ -968,8 +969,10 @@ timerStopped = false;
             assert not isinstance(elapsed, bool)
             cards_val = elapsed[1]
             minutes_val = int(round(elapsed[0] / 60))
-            message = tr.studying_card_studied_in_minute(
-                cards=cards_val, minutes=str(minutes_val)
+            message = with_collapsed_whitespace(
+                tr.studying_card_studied_in_minute(
+                    cards=cards_val, minutes=str(minutes_val)
+                )
             )
             fin = tr.studying_finish()
             diag = askUserDialog(message, [tr.studying_continue(), fin])


### PR DESCRIPTION
An example of the timebox message:
<img width="218" height="132" alt="image" src="https://github.com/user-attachments/assets/e8d78034-9045-4b93-b22c-907f4cd62dc5" />


Currently, the timebox dialog message is built from two separate strings (and a space), each containing one variable:
`{ $count } cards studied in` + ` ` + `{ $count } minutes.`
<img width="406" height="117" alt="image" src="https://github.com/user-attachments/assets/43bcbbb0-b80d-4d18-a614-39b6912c1c49" />
<img width="419" height="118" alt="image" src="https://github.com/user-attachments/assets/36bed71a-c028-4ec1-b9b2-d244bec4b9a9" />
As a result, translators cannot flexibly reorder the words of the variables in their translations. 

(In contrast, they can do so for `Studied x cards in y seconds today (z s/card)` on the deck list and the statistics screen.)
<img width="341" height="88" alt="image" src="https://github.com/user-attachments/assets/9a5341e3-cdd4-49a0-848f-72d865c88313" />
<img width="291" height="115" alt="image" src="https://github.com/user-attachments/assets/a7d30302-8793-4826-afdc-e742134ec08f" />
<img width="292" height="109" alt="image" src="https://github.com/user-attachments/assets/21a32c44-96dc-4e2c-9bbf-86971287a0df" />


This PR's commit introduces a single string with both variables for the timebox message, allowing translators to adjust the order for more natural expressions in their languages.
