### PR TITLE
feat: add support for `tag:nc:...` searches

### DIFF
--- a/pylib/tests/test_find.py
+++ b/pylib/tests/test_find.py
@@ -32,6 +32,7 @@ def test_find_cards():
     note = col.newNote()
     note["Front"] = "cat"
     note["Back"] = "sheep"
+    note.tags.append("conjunção größte")
     col.addNote(note)
     catCard = note.cards()[0]
     m = col.models.current()
@@ -68,6 +69,8 @@ def test_find_cards():
     col.tags.bulk_remove(col.db.list("select id from notes"), "foo")
     assert len(col.find_cards("tag:foo")) == 0
     assert len(col.find_cards("tag:bar")) == 5
+    assert len(col.find_cards("tag:conjuncao tag:groste")) == 0
+    assert len(col.find_cards("tag:nc:conjuncao tag:nc:groste")) == 1
     # text searches
     assert len(col.find_cards("cat")) == 2
     assert len(col.find_cards("cat -dog")) == 1

--- a/rslib/src/search/parser.rs
+++ b/rslib/src/search/parser.rs
@@ -392,6 +392,11 @@ fn parse_tag(s: &str) -> ParseResult<'_, SearchNode> {
             tag: unescape_quotes(re),
             mode: FieldSearchMode::Regex,
         }
+    } else if let Some(nc) = s.strip_prefix("nc:") {
+        SearchNode::Tag {
+            tag: unescape(nc)?,
+            mode: FieldSearchMode::NoCombining,
+        }
     } else {
         SearchNode::Tag {
             tag: unescape(s)?,


### PR DESCRIPTION
Noticed while looking at #4312 that support for this was missing, which this pr proposes to add

An integration test seemed out of place in sqlwriter.rs, so i opted to add one in pylib instead