### PR TITLE
Avoid QProgressBar overflow by normalizing to kilobytes (fixes #4341)

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -243,14 +243,11 @@ Lee Doughty <32392044+leedoughty@users.noreply.github.com>
 memchr <memchr@proton.me>
 Max Romanowski <maxr777@proton.me>
 Aldlss <ayaldlss@gmail.com>
-<<<<<<< HEAD
 Hanna Nilsén <hanni614@student.liu.se>
 Elias Johansson Lara <elias.johanssonlara@gmail.com>
 Toby Penner <tobypenner01@gmail.com>
 Danilo Spillebeen <spillebeendanilo@gmail.com>
-Matbe766 <matildabergstrom01@gmail.com
-
->>>>>>> fcd53376f (qt: normalize large progress totals to kilobytes to avoid QProgressBar overflow (#4341); docs: update CONTRIBUTORS)
+Matbe766 <matildabergstrom01@gmail.com>
 
 
 ********************

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -247,6 +247,9 @@ Hanna Nilsén <hanni614@student.liu.se>
 Elias Johansson Lara <elias.johanssonlara@gmail.com>
 Toby Penner <tobypenner01@gmail.com>
 Danilo Spillebeen <spillebeendanilo@gmail.com>
+Matbe766 <matildabergstrom01@gmail.com
+
+>>>>>>> fcd53376f (qt: normalize large progress totals to kilobytes to avoid QProgressBar overflow (#4341); docs: update CONTRIBUTORS)
 
 ********************
 

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -243,6 +243,7 @@ Lee Doughty <32392044+leedoughty@users.noreply.github.com>
 memchr <memchr@proton.me>
 Max Romanowski <maxr777@proton.me>
 Aldlss <ayaldlss@gmail.com>
+<<<<<<< HEAD
 Hanna Nilsén <hanni614@student.liu.se>
 Elias Johansson Lara <elias.johanssonlara@gmail.com>
 Toby Penner <tobypenner01@gmail.com>
@@ -250,6 +251,7 @@ Danilo Spillebeen <spillebeendanilo@gmail.com>
 Matbe766 <matildabergstrom01@gmail.com
 
 >>>>>>> fcd53376f (qt: normalize large progress totals to kilobytes to avoid QProgressBar overflow (#4341); docs: update CONTRIBUTORS)
+
 
 ********************
 

--- a/qt/aqt/progress.py
+++ b/qt/aqt/progress.py
@@ -14,6 +14,8 @@ from aqt.qt import *
 from aqt.qt import sip
 from aqt.utils import disable_help_button, tr
 
+INT32_MAX = 2_147_483_647  # QProgressBar only accepts 32-bit ints
+
 # Progress info
 ##########################################################################
 
@@ -29,6 +31,9 @@ class ProgressManager:
         self._win: ProgressDialog | None = None
         self._levels = 0
         self._backend_timer: QTimer | None = None
+        self._use_kb = (
+            False  # scale raw bytes to kilobytes when totals exceed INT32_MAX
+        )
 
     # Safer timers
     ##########################################################################
@@ -150,8 +155,17 @@ class ProgressManager:
 
         label = label or tr.qt_misc_processing()
         self._win = ProgressDialog(parent)
-        self._win.form.progressBar.setMinimum(min)
-        self._win.form.progressBar.setMaximum(max)
+        # If the total is already known and too large for a 32-bit range,
+        # drive the bar by kilobytes instead of raw bytes (per issue tip).
+        self._use_kb = bool(max and max > INT32_MAX)
+        if self._use_kb:
+            scaled_max = (max + 1023) // 1024  # ceil(bytes/1024) -> kB
+            # scaled_max will be ~2M for a 2 GiB upload; well under INT32
+            self._win.form.progressBar.setRange(0, int(scaled_max))
+        else:
+            self._win.form.progressBar.setMinimum(min)
+            self._win.form.progressBar.setMaximum(max)
+
         self._win.form.progressBar.setTextVisible(False)
         self._win.form.label.setText(label)
         self._win.setWindowTitle(title)
@@ -222,9 +236,31 @@ class ProgressManager:
             self._win.form.label.setText(label)
 
         self._max = max or 0
-        self._win.form.progressBar.setMaximum(self._max)
-        if self._max:
+        # Unknown/zero max -> indeterminate (Qt "busy" mode)
+        if not self._max or self._max <= 0:
+            self._win.form.progressBar.setRange(0, 0)
+            return
+
+        # If max is larger than int32, normalize both value and max to kilobytes
+        if self._max > INT32_MAX:
+            self._use_kb = True
+            # update our internal counter as before (value or auto-increment)
             self._counter = value if value is not None else (self._counter + 1)
+
+            scaled_max = (self._max + 1023) // 1024  # ceil bytes->kB
+            scaled_val = (self._counter + 1023) // 1024
+
+            scaled_val = min(scaled_val, scaled_max)
+
+            # kB are safely within 32-bit limits for realistic uploads
+            self._win.form.progressBar.setRange(0, int(scaled_max))
+            self._win.form.progressBar.setValue(int(scaled_val))
+        else:
+            # Small totals: keep exact byte counts (legacy behavior)
+            self._win.form.progressBar.setRange(0, int(self._max))
+            self._counter = value if value is not None else (self._counter + 1)
+            self._counter = min(self._counter, self._max)
+
             self._win.form.progressBar.setValue(self._counter)
 
     def finish(self) -> None:

--- a/qt/aqt/sync.py
+++ b/qt/aqt/sync.py
@@ -213,22 +213,12 @@ def on_full_sync_timer(mw: aqt.main.AnkiQt, label: str) -> None:
     if sync_progress.transferred == sync_progress.total:
         label = tr.sync_checking()
 
-    INT32_MAX = 2_147_483_647
     total = sync_progress.total
     transferred = sync_progress.transferred
 
-    # Unknown/zero total -> indeterminate spinner (0..0)
-    if not total or total <= 0:
-        value_for_bar = None
-        max_for_bar = 0
-    elif total > INT32_MAX:  # scale to kB if too large for int32
-        max_for_bar = (total + 1023) // 1024
-        value_for_bar = (transferred + 1023) // 1024
-        value_for_bar = min(value_for_bar, max_for_bar)
-    else:
-        # Small totals -> keep exact bytes
-        max_for_bar = total
-        value_for_bar = min(transferred, total)
+    # Scale both to kilobytes with floor division
+    max_for_bar = total // 1024
+    value_for_bar = transferred // 1024
 
     mw.progress.update(
         value=value_for_bar,


### PR DESCRIPTION
When a full one-way upload exceeds 2,147,483,647 bytes, QProgressBar.setMaximum() overflows (int32) and Anki exits with OverflowError.

Fix: If max > INT32_MAX, scale both value and max to kilobytes (ceil division). Small totals keep raw bytes; unknown totals use indeterminate 0..0. Visible labels/UX unchanged—only the internal range/value is scaled.