### PR TITLE
Fix/first and latest review dates should only  consider entries with a rating.

### DIFF
--- a/rslib/src/stats/card.rs
+++ b/rslib/src/stats/card.rs
@@ -76,8 +76,14 @@ impl Collection {
             note_id: card.note_id.into(),
             deck: deck.human_name(),
             added: card.id.as_secs().0,
-            first_review: revlog.first().map(|entry| entry.id.as_secs().0),
-            latest_review: revlog.last().map(|entry| entry.id.as_secs().0),
+            first_review: revlog
+                .iter()
+                .find(|entry| entry.has_rating())
+                .map(|entry| entry.id.as_secs().0),
+            latest_review: revlog
+                .iter()
+                .rfind(|entry| entry.has_rating())
+                .map(|entry| entry.id.as_secs().0),
             due_date: self.due_date(&card)?,
             due_position: self.position(&card),
             interval: card.interval,

--- a/rslib/src/stats/card.rs
+++ b/rslib/src/stats/card.rs
@@ -80,6 +80,7 @@ impl Collection {
                 .iter()
                 .find(|entry| entry.has_rating())
                 .map(|entry| entry.id.as_secs().0),
+            // last_review_time is not used to ensure cram revlogs are included.
             latest_review: revlog
                 .iter()
                 .rfind(|entry| entry.has_rating())


### PR DESCRIPTION
The previous logic may use the date of a rescheduling entry as the latest review, which is not a review.

Before:

<img width="800" height="828" alt="image" src="https://github.com/user-attachments/assets/8724b5ee-2154-4d70-95a6-605b069efa47" />

After:

<img width="800" height="828" alt="image" src="https://github.com/user-attachments/assets/5d9ea334-3bcd-4be3-92c8-4eda3972f92e" />
