### PR TITLE
ci: enforce conventional PR titles via GitHub Action

### DIFF
--- a/.github/workflows/semantic-pr.yml
+++ b/.github/workflows/semantic-pr.yml
@@ -1,0 +1,30 @@
+name: Check PR title (conventional)
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened, ready_for_review]
+
+jobs:
+  semantic:
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            docs
+            style
+            refactor
+            perf
+            test
+            build
+            ci
+            chore
+            revert
+          requireScope: false
+          subjectPattern: '^[^\s].+'
+          wip: true

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -242,6 +242,7 @@ Lee Doughty <32392044+leedoughty@users.noreply.github.com>
 memchr <memchr@proton.me>
 Max Romanowski <maxr777@proton.me>
 Aldlss <ayaldlss@gmail.com>
+Amanda Sternberg <mandis.sternberg@gmail.com>
 
 ********************
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ For more information on building and developing, please see [Development](./docs
 
 Want to contribute to Anki? Check out the [Contribution Guidelines](./docs/contributing.md).
 
+When opening a pull request, please make sure the PR title follows the
+[Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) style.
+Examples:
+    - `feat: add new learning mode`
+    - `fix: avoid crash when merging notetypes`
+
 ### Anki Contributors
 
 [CONTRIBUTORS](./CONTRIBUTORS)


### PR DESCRIPTION
This PR addresses #4322 by introducing a lightweight check to ensure pull request
titles follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) style.

Right now releases take extra time as commit/PR messages need to be reviewed and reformatted manually. Enforcing a simple format (`feat:..`, `fix: ...`, etc.) makes it easier to distinguish features vs bugfixes and enables smoother
changelog/release generation. The PR includes:

- **.github/workflows/semantic-pr.yml:**  Adds a GitHub Action using `amannn/action-semantic-pull-request@v5` to validate PR titles.
-  **README.md:** Added a short note under "Contributing" with examples of valid PR titles.

**Implementation details:**
- Validation is on **PR titles only**, not individual commits, to keep friction low.
- Allowed types: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`, `revert`.
- `requireScope: false` and `wip: true` to allow flexibility.

Closes #4322