### PR TITLE
fix(Occlusion): remember toggle translucency setting

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -246,6 +246,7 @@ Aldlss <ayaldlss@gmail.com>
 Hanna Nilsén <hanni614@student.liu.se>
 Elias Johansson Lara <elias.johanssonlara@gmail.com>
 Toby Penner <tobypenner01@gmail.com>
+Danilo Spillebeen <spillebeendanilo@gmail.com>
 
 ********************
 

--- a/ts/routes/image-occlusion/Toolbar.svelte
+++ b/ts/routes/image-occlusion/Toolbar.svelte
@@ -32,6 +32,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         saveNeededStore,
         opacityStateStore,
     } from "./store";
+    import { get } from "svelte/store";
     import { drawEllipse, drawPolygon, drawRectangle, drawText } from "./tools/index";
     import { makeMaskTransparent, SHAPE_MASK_COLOR } from "./tools/lib";
     import { enableSelectable, stopDraw } from "./tools/lib";
@@ -233,7 +234,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     }
 
     onMount(() => {
-        opacityStateStore.set(maskOpacity);
+        maskOpacity = get(opacityStateStore);
         removeHandlers = singleCallback(
             on(document, "click", onClick),
             on(window, "mousemove", onMousemove),

--- a/ts/routes/image-occlusion/mask-editor.ts
+++ b/ts/routes/image-occlusion/mask-editor.ts
@@ -8,10 +8,22 @@ import { fabric } from "fabric";
 import { get } from "svelte/store";
 
 import { optimumCssSizeForCanvas } from "./canvas-scale";
-import { hideAllGuessOne, notesDataStore, opacityStateStore, saveNeededStore, tagsWritable, textEditingState } from "./store";
+import {
+    hideAllGuessOne,
+    notesDataStore,
+    opacityStateStore,
+    saveNeededStore,
+    tagsWritable,
+    textEditingState,
+} from "./store";
 import Toast from "./Toast.svelte";
 import { addShapesToCanvasFromCloze } from "./tools/add-from-cloze";
-import { enableSelectable, makeMaskTransparent, makeShapesRemainInCanvas, moveShapeToCanvasBoundaries } from "./tools/lib";
+import {
+    enableSelectable,
+    makeMaskTransparent,
+    makeShapesRemainInCanvas,
+    moveShapeToCanvasBoundaries,
+} from "./tools/lib";
 import { modifiedPolygon } from "./tools/tool-polygon";
 import { undoStack } from "./tools/tool-undo-redo";
 import { enablePinchZoom, onResize, setCanvasSize } from "./tools/tool-zoom";

--- a/ts/routes/image-occlusion/mask-editor.ts
+++ b/ts/routes/image-occlusion/mask-editor.ts
@@ -8,10 +8,10 @@ import { fabric } from "fabric";
 import { get } from "svelte/store";
 
 import { optimumCssSizeForCanvas } from "./canvas-scale";
-import { hideAllGuessOne, notesDataStore, saveNeededStore, tagsWritable, textEditingState } from "./store";
+import { hideAllGuessOne, notesDataStore, opacityStateStore, saveNeededStore, tagsWritable, textEditingState } from "./store";
 import Toast from "./Toast.svelte";
 import { addShapesToCanvasFromCloze } from "./tools/add-from-cloze";
-import { enableSelectable, makeShapesRemainInCanvas, moveShapeToCanvasBoundaries } from "./tools/lib";
+import { enableSelectable, makeMaskTransparent, makeShapesRemainInCanvas, moveShapeToCanvasBoundaries } from "./tools/lib";
 import { modifiedPolygon } from "./tools/tool-polygon";
 import { undoStack } from "./tools/tool-undo-redo";
 import { enablePinchZoom, onResize, setCanvasSize } from "./tools/tool-zoom";
@@ -83,6 +83,7 @@ export const setupMaskEditorForEdit = async (
         window.requestAnimationFrame(() => {
             onImageLoaded({ noteId: BigInt(noteId) });
         });
+        if (get(opacityStateStore)) { makeMaskTransparent(canvas, true); }
     };
 
     return canvas;


### PR DESCRIPTION
### Issue
Every time an image with occlusion was added / viewed in the browser the value in the `opacityStateStore` was ignored and reset to the value of `maskOpacity` (false by default) which made the transluency opaque.

=> `opacityStateStore.set(maskOpacity);`

### Proposed Fix
- Retrieve the opacity that was stored in `opacityStateStore` and set the value of ` maskOpacity` accordingly.

- In the card browser, on occlusion image load, check the value of `opacityStateStore` and make the occlusions transparent if needed.

### Changes
- ~2 lines of actual code
- Imports and formatting to pass the ninja tests.

I tested manually and it corresponded to the ideal behavior described in the forum :
The setting is remembered while still being false by default when changing context.

However this approach changes the default behaviour.

Fixes #4357