### PR TITLE
fix(ci): pin cargo-license to 0.7.0

### DIFF
--- a/cargo/licenses.json
+++ b/cargo/licenses.json
@@ -2226,7 +2226,7 @@
   {
     "authors": "Ibraheem Ahmed <ibraheem@ibraheem.ca>",
     "description": "A high performance, zero-copy URL router.",
-    "license": "MIT AND BSD-3-Clause",
+    "license": "BSD-3-Clause AND MIT",
     "license_file": null,
     "name": "matchit",
     "repository": "https://github.com/ibraheemdev/matchit"
@@ -4154,7 +4154,7 @@
   {
     "authors": "David Tolnay <dtolnay@gmail.com>",
     "description": "Determine whether characters have the XID_Start or XID_Continue properties according to Unicode Standard Annex #31",
-    "license": "(MIT OR Apache-2.0) AND Unicode-3.0",
+    "license": "(Apache-2.0 OR MIT) AND Unicode-3.0",
     "license_file": null,
     "name": "unicode-ident",
     "repository": "https://github.com/dtolnay/unicode-ident"

--- a/tools/minilints/src/main.rs
+++ b/tools/minilints/src/main.rs
@@ -255,9 +255,7 @@ fn check_for_unstaged_changes() {
 }
 
 fn generate_licences() -> Result<String> {
-    if which::which("cargo-license").is_err() {
-        Command::run("cargo install cargo-license@0.7.0")?;
-    }
+    Command::run("cargo install cargo-license@0.7.0")?;
     let output = Command::run_with_output([
         "cargo-license",
         "--features",


### PR DESCRIPTION
I unknowingly updated to cargo-license@0.7.0 a few days ago, which now normalises licences properly by [sorting ANDs as well](https://github.com/onur/cargo-license/blob/6ec6d98f31cbe58240b64ee486aa1393660bf6d2/src/lib.rs#L538)

https://github.com/ankitects/anki/pull/4361/commits/33299bc052832d098e1fd352ef29ed1fca869af1 made it so that cargo-license@0.7.0 is only installed if not already present, which means that CI is stuck on an older version (that only sorts ORs) while devs might locally run the latest version when `./check`ing. 

This mismatch means one or the other would complain about licenses.json, which this pr proposes to fix

EDIT: @dae the check updated the ci's version of cargo-licenses, so this pr is essentially a fix for the breakage it caused 😭