### PR TITLE
Colored button borders to prevent Hard misuse

### DIFF
--- a/qt/aqt/data/web/css/reviewer-bottom.scss
+++ b/qt/aqt/data/web/css/reviewer-bottom.scss
@@ -28,6 +28,34 @@ button {
     white-space: nowrap;
     margin: 9px;
     position: relative;
+    border-top-color: color(border-subtle);
+}
+
+.answerButton,
+.answerButton:hover {
+    border-style: solid;
+}
+
+.answerButton:focus {
+    border-style: dashed;
+}
+
+.answerButton,
+.answerButton:hover,
+.answerButton:focus {
+    border-width: 2px;
+}
+
+.answerIncorrect,
+.answerIncorrect:hover,
+.answerIncorrect:focus {
+    border-color: #e01b24;
+}
+
+.answerCorrect,
+.answerCorrect:hover,
+.answerCorrect:focus {
+    border-color: #2ec27e;
 }
 
 .hitem {

--- a/qt/aqt/reviewer.py
+++ b/qt/aqt/reviewer.py
@@ -919,6 +919,12 @@ timerStopped = false;
                 extra = """id="defease" """
             else:
                 extra = ""
+
+            if i == 1:
+                button_class = "answerIncorrect"
+            else:
+                button_class = "answerCorrect"
+
             due = self._buttonTime(i, v3_labels=labels)
             key = (
                 tr.actions_shortcut_key(val=aqt.mw.pm.get_answer_key(i))
@@ -926,9 +932,10 @@ timerStopped = false;
                 else ""
             )
             return """
-<td align=center><button %s title="%s" data-ease="%s" onclick='pycmd("ease%d");'>\
+<td align=center><button %s class="answerButton %s" title="%s" data-ease="%s" onclick='pycmd("ease%d");'>\
 %s%s</button></td>""" % (
                 extra,
+                button_class,
                 key,
                 i,
                 i,


### PR DESCRIPTION
Hard misuse is when users think that Hard = fail even though Hard = pass. I focused on this solution out of many for the following reasons:
1) Works on all devices, no need to worry about desktop vs mobile
2) Doesn't require adding entirely new UI elements
3) Doesn't require bikeshedding wording
4) Doesn't disrupt the existing workflow (uh, studyflow?) of users who are used to 4 buttons 

For the sake of accessibility for colorblind people, in the future a second color scheme can be added in Tools -> Preferences, but that's above my paygrade.

Credit for the code goes to rossgb on Discord (https://github.com/rbrownwsws)