### PR TITLE
Improved error message for importing empty CSV-file

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -26,10 +26,10 @@ GitHub's online interface.
 For users who previously confirmed the license of their contributions on the
 support site, it would be great if you could add your name below as well.
 
-********************
+---
 
 AMBOSS MD Inc. <https://www.amboss.com/>
-Aristotelis P.  <https://glutanimate.com/contact>
+Aristotelis P. <https://glutanimate.com/contact>
 Erez Volk <erez.volk@gmail.com>
 zjosua <zjosua@hotmail.com>
 Yngve Hoiseth <yngve@hoiseth.net>
@@ -160,7 +160,7 @@ Marko Sisovic <msisovic13@gmail.com>
 Viktor Ricci <ricci@primateer.de>
 Harvey Randall <harveyrandall2001@gmail.com>
 Pedro Lameiras <pedrolameiras@tecnico.ulisboa.pt>
-Kai Knoblich  <kai@FreeBSD.org>
+Kai Knoblich <kai@FreeBSD.org>
 Lucas Scharenbroch <lucasscharenbroch@gmail.com>
 Antonio Cavallo <a.cavallo@cavallinux.eu>
 Han Yeong-woo <han@yeongwoo.dev>
@@ -189,7 +189,7 @@ Christian Donat <https://github.com/cdonat2>
 Asuka Minato <https://asukaminato.eu.org>
 Dillon Baldwin <https://github.com/DillBal>
 Voczi <https://github.com/voczi>
-Ben Nguyen <105088397+bpnguyen107@users.noreply.github.com>     
+Ben Nguyen <105088397+bpnguyen107@users.noreply.github.com>  
 Themis Demetriades <themis100@outlook.com>
 Luke Bartholomew <lukesbart@icloud.com>
 Gregory Abrasaldo <degeemon@gmail.com>
@@ -247,8 +247,9 @@ Hanna Nilsén <hanni614@student.liu.se>
 Elias Johansson Lara <elias.johanssonlara@gmail.com>
 Toby Penner <tobypenner01@gmail.com>
 Danilo Spillebeen <spillebeendanilo@gmail.com>
+Josefin Odermalm <112946011+josod827@users.noreply.github.com>
 
-********************
+---
 
 The text of the 3 clause BSD license follows:
 
@@ -258,15 +259,15 @@ Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:
 
 1. Redistributions of source code must retain the above copyright notice, this
-list of conditions and the following disclaimer.
+   list of conditions and the following disclaimer.
 
 2. Redistributions in binary form must reproduce the above copyright notice,
-this list of conditions and the following disclaimer in the documentation
-and/or other materials provided with the distribution.
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
 
 3. Neither the name of the copyright holder nor the names of its contributors
-may be used to endorse or promote products derived from this software without
-specific prior written permission.
+   may be used to endorse or promote products derived from this software without
+   specific prior written permission.
 
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE

--- a/ts/lib/components/ErrorPage.svelte
+++ b/ts/lib/components/ErrorPage.svelte
@@ -2,17 +2,51 @@
 Copyright: Ankitects Pty Ltd and contributors
 License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 -->
+<script context="module" lang="ts">
+    declare function pycmd(cmd: string): void;
+</script>
+
 <script lang="ts">
     export let error: Error;
+
+    function normalizeErrorMessage(message: string): string {
+        return message.replace(/^\d{3}:\s*/, "");
+    }
+
+    function closeWindow() {
+        try {
+            pycmd("close");
+        } catch {
+            history.back();
+        }
+    }
 </script>
 
 <div class="message">
-    {error.message}
+    {normalizeErrorMessage(error.message)}
+</div>
+
+<div class="actions">
+    <button on:click={closeWindow}>Close</button>
 </div>
 
 <style lang="scss">
     .message {
         text-align: center;
         margin: 50px 0 0;
+    }
+
+    .actions {
+        text-align: center;
+        margin-top: 1rem;
+
+        button {
+            padding: 0.5rem 1rem;
+            border: none;
+            border-radius: 4px;
+            background: var(--anki-button-bg, #007acc);
+            color: white;
+            cursor: pointer;
+        }
     }
 </style>

--- a/ts/routes/import-csv/[...path]/+page.svelte
+++ b/ts/routes/import-csv/[...path]/+page.svelte
@@ -4,9 +4,14 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 -->
 <script lang="ts">
     import ImportCsvPage from "../ImportCsvPage.svelte";
+    import ErrorPage from "$lib/components/ErrorPage.svelte";
     import type { PageData } from "./$types";
 
     export let data: PageData;
 </script>
 
-<ImportCsvPage state={data.state} />
+{#if data.initialError}
+    <ErrorPage error={data.initialError} />
+{:else}
+    <ImportCsvPage state={data.state} />
+{/if}

--- a/ts/routes/import-csv/[...path]/+page.ts
+++ b/ts/routes/import-csv/[...path]/+page.ts
@@ -6,14 +6,20 @@ import { ImportCsvState } from "../lib";
 import type { PageLoad } from "./$types";
 
 export const load = (async ({ params }) => {
-    const [notetypes, decks, metadata] = await Promise.all([
-        getNotetypeNames({}),
-        getDeckNames({
-            skipEmptyDefault: false,
-            includeFiltered: false,
-        }),
-        getCsvMetadata({ path: params.path }, { alertOnError: false }),
-    ]);
-    const state = new ImportCsvState(params.path, notetypes, decks, metadata);
-    return { state };
+    try {
+        const [notetypes, decks, metadata] = await Promise.all([
+            getNotetypeNames({}),
+            getDeckNames({
+                skipEmptyDefault: false,
+                includeFiltered: false,
+            }),
+            getCsvMetadata({ path: params.path }, { alertOnError: false }),
+        ]);
+
+        const state = new ImportCsvState(params.path, notetypes, decks, metadata);
+        return { state };
+    } catch (e: any) {
+        const rawMsg = e?.message ?? String(e ?? "");
+        return { initialError: new Error(rawMsg) };
+    }
 }) satisfies PageLoad;


### PR DESCRIPTION
Improves error handling on the import CSV page. It removes the HTTP status code prefix from error messages and makes them more suitable for users, and also adds a Close button.

Fixes #4346

<img width="402" height="428" alt="errormsg_anki" src="https://github.com/user-attachments/assets/65689884-bcb1-45b3-8d18-80406e32e589" />
