### PR TITLE
Fix notetype original_stock_kind using wrong enum

### DIFF
--- a/rslib/src/notetype/stock.rs
+++ b/rslib/src/notetype/stock.rs
@@ -122,7 +122,7 @@ pub(crate) fn basic(tr: &I18n) -> Notetype {
 
 pub(crate) fn basic_typing(tr: &I18n) -> Notetype {
     let mut nt = basic(tr);
-    nt.config.original_stock_kind = StockKind::BasicTyping as i32;
+    nt.config.original_stock_kind = OriginalStockKind::BasicTyping as i32;
     nt.name = tr.notetypes_basic_type_answer_name().into();
     let front = tr.notetypes_front_field();
     let back = tr.notetypes_back_field();
@@ -138,7 +138,7 @@ pub(crate) fn basic_typing(tr: &I18n) -> Notetype {
 
 pub(crate) fn basic_forward_reverse(tr: &I18n) -> Notetype {
     let mut nt = basic(tr);
-    nt.config.original_stock_kind = StockKind::BasicAndReversed as i32;
+    nt.config.original_stock_kind = OriginalStockKind::BasicAndReversed as i32;
     nt.name = tr.notetypes_basic_reversed_name().into();
     let front = tr.notetypes_front_field();
     let back = tr.notetypes_back_field();
@@ -156,7 +156,7 @@ pub(crate) fn basic_forward_reverse(tr: &I18n) -> Notetype {
 
 pub(crate) fn basic_optional_reverse(tr: &I18n) -> Notetype {
     let mut nt = basic_forward_reverse(tr);
-    nt.config.original_stock_kind = StockKind::BasicOptionalReversed as i32;
+    nt.config.original_stock_kind = OriginalStockKind::BasicOptionalReversed as i32;
     nt.name = tr.notetypes_basic_optional_reversed_name().into();
     let addrev = tr.notetypes_add_reverse_field();
     nt.add_field(addrev.as_ref());


### PR DESCRIPTION
## Description
Fixes #4353 - Corrects the enum used when setting `original_stock_kind` for basic notetype variants.

## Problem
The code was using `StockKind` instead of [OriginalStockKind](cci:2://file:///Users/arold0/Github/anki/proto/anki/notetypes.proto:156:2-164:3) when setting the `original_stock_kind` field. These two enums have different numeric values, causing the "Restore to Default" feature to restore the wrong template.

For example:
- `StockKind::BasicTyping` = 3
- When read back as [OriginalStockKind](cci:2://file:///Users/arold0/Github/anki/proto/anki/notetypes.proto:156:2-164:3), value 3 = `BasicOptionalReversed` (not `BasicTyping` which is 4)

This caused the off-by-one behavior reported in the forum.

## Changes
Changed three lines in [rslib/src/notetype/stock.rs](cci:7://file:///Users/arold0/Github/anki/rslib/src/notetype/stock.rs:0:0-0:0) to use [OriginalStockKind](cci:2://file:///Users/arold0/Github/anki/proto/anki/notetypes.proto:156:2-164:3) instead of `StockKind`:
- [basic_typing()](cci:1://file:///Users/arold0/Github/anki/rslib/src/notetype/stock.rs:122:0-136:1)
- [basic_forward_reverse()](cci:1://file:///Users/arold0/Github/anki/rslib/src/notetype/stock.rs:138:0-154:1)
- [basic_optional_reverse()](cci:1://file:///Users/arold0/Github/anki/rslib/src/notetype/stock.rs:156:0-165:1)

## Testing
- All existing tests pass
- The fix matches the solution suggested by @abdnh in the issue