### PR TITLE
feat: show launcher if different version was installed

### DIFF
--- a/qt/launcher/build.rs
+++ b/qt/launcher/build.rs
@@ -7,4 +7,7 @@ fn main() {
             .manifest_required()
             .unwrap();
     }
+    println!("cargo:rerun-if-changed=../../out/buildhash");
+    let buildhash = std::fs::read_to_string("../../out/buildhash").unwrap_or_default();
+    println!("cargo:rustc-env=BUILDHASH={buildhash}");
 }


### PR DESCRIPTION
ref: #4358

This pr proposes to show the launcher whenever its buildhash is different from what was seen previously

A caveat of this approach is that anki must be built in release mode to update the hash even for launcher-only releases. As for package managers, automatic updates used to mean always getting the latest anki, and if users want to continue doing so, it'd have to be via the launcher in any case

But if that's not acceptable, a possible alternative would be to bake `.version` into the launcher and only show it if the installed anki is older and the user hasn't explicitly chosen to keep/use that version