### PR TITLE
fix: make uv use system certstore

### DIFF
--- a/qt/launcher/src/main.rs
+++ b/qt/launcher/src/main.rs
@@ -1013,6 +1013,9 @@ fn uv_command(state: &State) -> Result<Command> {
             .env("UV_DEFAULT_INDEX", &pypi_mirror);
     }
 
+    // have uv use the system certstore instead of webpki-roots'
+    command.env("UV_NATIVE_TLS", "1");
+
     Ok(command)
 }
 


### PR DESCRIPTION
ref: https://forums.ankiweb.net/t/invalid-peer-certificate-issue-with-latest-version/66945?u=llama

uv normally relies on the `webpki-root` crate when loading certs ([docs](https://docs.astral.sh/uv/concepts/authentication/certificates/#tls-certificates)), which doesn't necessarily include custom certs that might be needed when behind a proxy