### PR TITLE
Show text on occlusion cards regardless of occludeInactive

### DIFF
--- a/rslib/src/cloze.rs
+++ b/rslib/src/cloze.rs
@@ -260,7 +260,6 @@ fn reveal_cloze(
             image_occlusion_text,
             question,
             active,
-            cloze_ord,
             &cloze.ordinals,
         ));
         return;
@@ -332,10 +331,9 @@ fn render_image_occlusion(
     text: &str,
     question_side: bool,
     active: bool,
-    ordinal: u16,
     ordinals: &[u16],
 ) -> String {
-    if (question_side && active) || ordinal == 0 {
+    if (question_side && active) || ordinals.contains(&0) {
         format!(
             r#"<div class="cloze" data-ordinal="{}" {}></div>"#,
             ordinals_str(ordinals),

--- a/ts/routes/image-occlusion/review.ts
+++ b/ts/routes/image-occlusion/review.ts
@@ -212,7 +212,7 @@ function drawShapes(
             strokeWidth: properties.activeBorder.width,
         });
     }
-    for (const shape of inactiveShapes.filter((s) => s.occludeInactive || s.ordinal === 0)) {
+    for (const shape of inactiveShapes.filter((s) => s.occludeInactive)) {
         drawShape({
             context,
             size,


### PR DESCRIPTION
Before this change, on an image occlusion card, a text box was visible during editing but not visible during review. This change makes text visible even if other shapes would be hidden.

For me, text doesn't show up when occludeInactive is false (hide one, not hide all)