### PR TITLE
Enable FSRS by default

### DIFF
--- a/proto/anki/config.proto
+++ b/proto/anki/config.proto
@@ -57,6 +57,7 @@ message ConfigKey {
     LOAD_BALANCER_ENABLED = 26;
     FSRS_SHORT_TERM_WITH_STEPS_ENABLED = 27;
     FSRS_LEGACY_EVALUATE = 28;
+    FSRS = 29;
   }
   enum String {
     SET_DUE_BROWSER = 0;

--- a/pylib/tests/shared.py
+++ b/pylib/tests/shared.py
@@ -9,6 +9,7 @@ import tempfile
 import time
 
 from anki.collection import Collection as aopen
+from anki.config import Config
 
 # Between 2-4AM, shift the time back so test assumptions hold.
 lt = time.localtime()
@@ -49,6 +50,8 @@ def getEmptyCol():
     (fd, path) = tempfile.mkstemp(suffix=".anki2")
     shutil.copy(_emptyCol, path)
     col = aopen(path)
+    # Disable FSRS for legacy scheduler tests
+    col.set_config_bool(Config.Bool.FSRS, False, undoable=False)
     return col
 
 

--- a/pylib/tests/test_schedv3.py
+++ b/pylib/tests/test_schedv3.py
@@ -10,6 +10,7 @@ from typing import Dict
 import pytest
 
 from anki import hooks
+from anki.config import Config
 from anki.consts import *
 from anki.lang import without_unicode_isolation
 from anki.scheduler import UnburyDeck
@@ -19,6 +20,8 @@ from tests.shared import getEmptyCol as getEmptyColOrig
 
 def getEmptyCol():
     col = getEmptyColOrig()
+    # Disable FSRS for legacy scheduler tests
+    col.set_config_bool(Config.Bool.FSRS, False, undoable=False)
     return col
 
 

--- a/rslib/src/backend/config.rs
+++ b/rslib/src/backend/config.rs
@@ -40,6 +40,7 @@ impl From<BoolKeyProto> for BoolKey {
             BoolKeyProto::LoadBalancerEnabled => BoolKey::LoadBalancerEnabled,
             BoolKeyProto::FsrsShortTermWithStepsEnabled => BoolKey::FsrsShortTermWithStepsEnabled,
             BoolKeyProto::FsrsLegacyEvaluate => BoolKey::FsrsLegacyEvaluate,
+            BoolKeyProto::Fsrs => BoolKey::Fsrs,
         }
     }
 }

--- a/rslib/src/config/bool.rs
+++ b/rslib/src/config/bool.rs
@@ -79,6 +79,7 @@ impl Collection {
             | BoolKey::RestorePositionReviewer
             | BoolKey::LoadBalancerEnabled
             | BoolKey::FsrsHealthCheck
+            | BoolKey::Fsrs
             | BoolKey::NormalizeNoteText => self.get_config_optional(key).unwrap_or(true),
 
             // other options default to false

--- a/rslib/src/config/schema11.rs
+++ b/rslib/src/config/schema11.rs
@@ -25,6 +25,7 @@ pub(crate) fn schema11_config_as_string(creation_offset: Option<i32>) -> String 
         "schedVer": 2,
         "creationOffset": creation_offset,
         "sched2021": true,
+        "fsrs": true,
     });
     serde_json::to_string(&obj).unwrap()
 }

--- a/rslib/src/deckconfig/update.rs
+++ b/rslib/src/deckconfig/update.rs
@@ -501,7 +501,7 @@ mod test {
             limits: Limits::default(),
             new_cards_ignore_review_limit: false,
             apply_all_parent_limits: false,
-            fsrs: false,
+            fsrs: true,
             fsrs_reschedule: false,
             fsrs_health_check: true,
         };

--- a/rslib/src/scheduler/answering/mod.rs
+++ b/rslib/src/scheduler/answering/mod.rs
@@ -706,6 +706,8 @@ pub(crate) mod test {
     #[test]
     fn state_application() -> Result<()> {
         let mut col = Collection::new();
+        // Disable FSRS for this legacy scheduler test
+        col.set_config_bool(BoolKey::Fsrs, false, false)?;
         if col.timing_today()?.near_cutoff() {
             return Ok(());
         }

--- a/rslib/src/scheduler/queue/builder/mod.rs
+++ b/rslib/src/scheduler/queue/builder/mod.rs
@@ -431,6 +431,8 @@ mod test {
     #[test]
     fn review_queue_building() -> Result<()> {
         let mut col = Collection::new();
+        // Disable FSRS for this legacy scheduler test
+        col.set_config_bool(BoolKey::Fsrs, false, false)?;
 
         let mut deck = col.get_or_create_normal_deck("Default").unwrap();
         let nt = col.get_notetype_by_name("Basic")?.unwrap();

--- a/rslib/src/scheduler/queue/undo.rs
+++ b/rslib/src/scheduler/queue/undo.rs
@@ -100,6 +100,8 @@ mod test {
     fn undo() -> Result<()> {
         // add a note
         let mut col = Collection::new();
+        // Disable FSRS for this legacy scheduler test
+        col.set_config_bool(BoolKey::Fsrs, false, false)?;
         let nid = add_note(&mut col, true)?;
 
         // turn burying and leech suspension on

--- a/ts/routes/deck-options/FsrsOptionsOuter.svelte
+++ b/ts/routes/deck-options/FsrsOptionsOuter.svelte
@@ -96,7 +96,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     />
     <DynamicallySlottable slotHost={Item} {api}>
         <Item>
-            <SwitchRow bind:value={$fsrs} defaultValue={false}>
+            <SwitchRow bind:value={$fsrs} defaultValue={true}>
                 <SettingTitle
                     on:click={() =>
                         openHelpModal(Object.keys(settings).indexOf("fsrs"))}


### PR DESCRIPTION
Make FSRS (Free Spaced Repetition Scheduler) enabled by default for new users and users who haven't explicitly configured it.

Changes:
- Add BoolKey::Fsrs to default-true boolean keys in Rust backend
- Set defaultValue to true for FSRS toggle in deck options UI

close #3616

For AO, please create a new issue to keep track of it.