### PR TITLE
Update VS Code config

### DIFF
--- a/.vscode.dist/tasks.json
+++ b/.vscode.dist/tasks.json
@@ -12,8 +12,7 @@
                 "command": "tools/ninja.bat",
                 "args": [
                     "pylib",
-                    "qt",
-                    "extract:win_amd64_audio"
+                    "qt"
                 ]
             }
         }

--- a/tools/run.py
+++ b/tools/run.py
@@ -5,8 +5,6 @@ import os
 import sys
 
 sys.path.extend(["pylib", "qt", "out/pylib", "out/qt"])
-if sys.platform == "win32":
-    os.environ["PATH"] += ";out\\extracted\\win_amd64_audio"
 
 import aqt
 


### PR DESCRIPTION
This just removes the old `extract:win_amd64_audio` ninja rule from the .vscode.dist