### PR TITLE
(UI polish) Filtered decks: replace maximumSize with sizePolicy in "Limit to" QSpinBox

### DIFF
--- a/qt/aqt/forms/filtered_deck.ui
+++ b/qt/aqt/forms/filtered_deck.ui
@@ -85,11 +85,11 @@
       </item>
       <item row="2" column="2">
        <widget class="QSpinBox" name="limit">
-        <property name="maximumSize">
-         <size>
-          <width>75</width>
-          <height>16777215</height>
-         </size>
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
         </property>
         <property name="minimum">
          <number>1</number>
@@ -168,11 +168,11 @@
       </item>
       <item row="1" column="1">
        <widget class="QSpinBox" name="limit_2">
-        <property name="maximumSize">
-         <size>
-          <width>60</width>
-          <height>16777215</height>
-         </size>
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
         </property>
         <property name="minimum">
          <number>1</number>


### PR DESCRIPTION
**Context**

This PR updates the `Limit` and `Limit_2` `QSpinBox` widgets in the filtered deck creation dialog.
It’s an updated version of a previous PR.

(Note: this still includes the first commit from the original version of the PR. I wasn’t sure whether it’s necessary to remove it or if it just remains for history, since the “Files changed” section now shows only the intended modifications.)

Tested on: Windows 11

**Problem**

Previously, Anki set a fixed maximum width of 60 px for these spin boxes.
This could prevent the full content from being displayed, depending on input length, system font size, or UI scaling.

**Solution**
1. Remove maximumSize. This allows Qt to automatically determine an appropriate width based on the maximum input value.
2. Apply a fixed-size policy. This ensures the spin box doesn’t stretch horizontally when the dialog is resized.

Before:

<img width="475" height="224" alt="image" src="https://github.com/user-attachments/assets/7d147210-68b2-44dc-a6c0-c6e40926c670" />

After: 

<img width="504" height="226" alt="image" src="https://github.com/user-attachments/assets/b01ef2a6-29ff-48b8-94e8-6c0fb514b1a9" />



