### PR TITLE
Fix/FSRS short-term schedule doesn't work with default params

### DIFF
--- a/rslib/src/scheduler/answering/mod.rs
+++ b/rslib/src/scheduler/answering/mod.rs
@@ -488,6 +488,9 @@ impl Collection {
             let params = config.fsrs_params();
             if params.len() >= 19 {
                 params[17] > 0.0 && params[18] > 0.0
+            } else if params.is_empty() {
+                // fallback to true when using default params
+                true
             } else {
                 false
             }


### PR DESCRIPTION
Reproduce steps:

1) Blank out learning steps
2) Use default params
3) Again is 1d for some reason
4) Manually enter

```
0.212, 1.2931, 2.3065, 8.2956,
6.4133, 0.8334, 3.0194, 0.001,
1.8722, 0.1666, 0.796,
1.4835, 0.0614, 0.2629, 1.6483,
0.6014, 1.8729,
0.5425, 0.0912, 0.0658,
0.1542
```
(literally the default parameters)

5) Again is 5.1h, as it should be 

This PR fixed this bug.
