### PR TITLE
feat(launcher): embed python

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -142,7 +142,7 @@ walkdir = "2.5.0"
 which = "8.0.0"
 widestring = "1.1.0"
 winapi = { version = "0.3", features = ["wincon", "winreg"] }
-windows = { version = "0.61.3", features = ["Media_SpeechSynthesis", "Media_Core", "Foundation_Collections", "Storage_Streams", "Win32_System_Console", "Win32_System_Registry", "Win32_System_SystemInformation", "Win32_Foundation", "Win32_UI_Shell", "Wdk_System_SystemServices"] }
+windows = { version = "0.61.3", features = ["Media_SpeechSynthesis", "Media_Core", "Foundation_Collections", "Storage_Streams", "Win32_System_Console", "Win32_System_Registry", "Win32_System_SystemInformation", "Win32_Foundation", "Win32_UI_Shell", "Wdk_System_SystemServices", "Win32_System_LibraryLoader"] }
 wiremock = "0.6.3"
 xz2 = "0.1.7"
 zip = { version = "4.1.0", default-features = false, features = ["deflate", "time"] }

--- a/qt/launcher/Cargo.toml
+++ b/qt/launcher/Cargo.toml
@@ -14,16 +14,13 @@ anki_process.workspace = true
 anyhow.workspace = true
 camino.workspace = true
 dirs.workspace = true
+libc.workspace = true
 locale_config.workspace = true
 serde_json.workspace = true
-
-[target.'cfg(all(unix, not(target_os = "macos")))'.dependencies]
-libc.workspace = true
 
 [target.'cfg(windows)'.dependencies]
 windows.workspace = true
 widestring.workspace = true
-libc.workspace = true
 libc-stdhandle.workspace = true
 
 [[bin]]

--- a/qt/launcher/src/libpython_nix.py
+++ b/qt/launcher/src/libpython_nix.py
@@ -1,0 +1,10 @@
+# Copyright: Ankitects Pty Ltd and contributors
+# License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
+
+import os
+import sysconfig
+
+cfg = sysconfig.get_config_var
+base = cfg("installed_base") or cfg("installed_platbase")
+lib = cfg("LDLIBRARY") or cfg("INSTSONAME")
+print(os.path.join(base, "lib", lib))

--- a/qt/launcher/src/libpython_nix.py
+++ b/qt/launcher/src/libpython_nix.py
@@ -1,10 +1,13 @@
 # Copyright: Ankitects Pty Ltd and contributors
 # License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
+import json
 import os
+import sys
 import sysconfig
 
 cfg = sysconfig.get_config_var
 base = cfg("installed_base") or cfg("installed_platbase")
 lib = cfg("LDLIBRARY") or cfg("INSTSONAME")
-print(os.path.join(base, "lib", lib))
+version = cfg("py_version_nodot")
+print(json.dumps([version, os.path.join(base, "lib", lib), sys.executable]))

--- a/qt/launcher/src/libpython_nix.py
+++ b/qt/launcher/src/libpython_nix.py
@@ -1,13 +1,12 @@
 # Copyright: Ankitects Pty Ltd and contributors
 # License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
-import json
 import os
-import sys
 import sysconfig
 
 cfg = sysconfig.get_config_var
 base = cfg("installed_base") or cfg("installed_platbase")
 lib = cfg("LDLIBRARY") or cfg("INSTSONAME")
 version = cfg("py_version_nodot")
-print(json.dumps([version, os.path.join(base, "lib", lib), sys.executable]))
+print(version)
+print(os.path.join(base, "lib", lib))

--- a/qt/launcher/src/libpython_win.py
+++ b/qt/launcher/src/libpython_win.py
@@ -1,13 +1,12 @@
 # Copyright: Ankitects Pty Ltd and contributors
 # License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
-import json
 import os
-import sys
 import sysconfig
 
 cfg = sysconfig.get_config_var
 base = cfg("installed_base") or cfg("installed_platbase")
 version = cfg("py_version_nodot")
 lib = "python" + version + ".dll"
-print(json.dumps([version, os.path.join(base, lib), sys.executable]))
+print(version)
+print(os.path.join(base, lib))

--- a/qt/launcher/src/libpython_win.py
+++ b/qt/launcher/src/libpython_win.py
@@ -1,10 +1,13 @@
 # Copyright: Ankitects Pty Ltd and contributors
 # License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
+import json
 import os
+import sys
 import sysconfig
 
 cfg = sysconfig.get_config_var
 base = cfg("installed_base") or cfg("installed_platbase")
-lib = "python" + cfg("py_version_nodot") + ".dll"
-print(os.path.join(base, lib))
+version = cfg("py_version_nodot")
+lib = "python" + version + ".dll"
+print(json.dumps([version, os.path.join(base, lib), sys.executable]))

--- a/qt/launcher/src/libpython_win.py
+++ b/qt/launcher/src/libpython_win.py
@@ -1,0 +1,10 @@
+# Copyright: Ankitects Pty Ltd and contributors
+# License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
+
+import os
+import sysconfig
+
+cfg = sysconfig.get_config_var
+base = cfg("installed_base") or cfg("installed_platbase")
+lib = "python" + cfg("py_version_nodot") + ".dll"
+print(os.path.join(base, lib))

--- a/qt/launcher/src/main.rs
+++ b/qt/launcher/src/main.rs
@@ -276,6 +276,9 @@ fn handle_version_install_or_update(state: &State, choice: MainMenuChoice) -> Re
     // Remove sync marker before attempting sync
     let _ = remove_file(&state.sync_complete_marker);
 
+    // clear possibly invalidated libpython path cache
+    let _ = remove_file(&state.libpython_path);
+
     println!("{}\n", state.tr.launcher_updating_anki());
 
     let python_version_trimmed = if state.user_python_version_path.exists() {

--- a/qt/launcher/src/main.rs
+++ b/qt/launcher/src/main.rs
@@ -30,7 +30,7 @@ use crate::platform::get_exe_and_resources_dirs;
 use crate::platform::get_uv_binary_name;
 use crate::platform::launch_anki_normally;
 use crate::platform::respawn_launcher;
-use crate::platform::run_anki_normally;
+use crate::platform::run_anki_embeddedly;
 
 mod platform;
 
@@ -161,7 +161,7 @@ fn run() -> Result<()> {
 
     if !launcher_requested && !pyproject_has_changed && !different_launcher {
         // If no launcher request and venv is already up to date, launch Anki normally
-        if std::env::var("ANKI_LAUNCHER_NO_EMBED").is_ok() || !run_anki_normally(&state) {
+        if std::env::var("ANKI_LAUNCHER_NO_EMBED").is_ok() || !run_anki_embeddedly(&state) {
             let args: Vec<String> = std::env::args().skip(1).collect();
             let cmd = build_python_command(&state, &args)?;
             launch_anki_normally(cmd)?;

--- a/qt/launcher/src/main.rs
+++ b/qt/launcher/src/main.rs
@@ -28,6 +28,7 @@ use crate::platform::get_exe_and_resources_dirs;
 use crate::platform::get_uv_binary_name;
 use crate::platform::launch_anki_normally;
 use crate::platform::respawn_launcher;
+use crate::platform::run_anki_normally;
 
 mod platform;
 
@@ -158,9 +159,11 @@ fn run() -> Result<()> {
 
     if !launcher_requested && !pyproject_has_changed && !different_launcher {
         // If no launcher request and venv is already up to date, launch Anki normally
-        let args: Vec<String> = std::env::args().skip(1).collect();
-        let cmd = build_python_command(&state, &args)?;
-        launch_anki_normally(cmd)?;
+        if std::env::var("ANKI_LAUNCHER_NO_EMBED").is_ok() || !run_anki_normally(&state) {
+            let args: Vec<String> = std::env::args().skip(1).collect();
+            let cmd = build_python_command(&state, &args)?;
+            launch_anki_normally(cmd)?;
+        }
         return Ok(());
     }
 

--- a/qt/launcher/src/main.rs
+++ b/qt/launcher/src/main.rs
@@ -1085,11 +1085,11 @@ fn get_python_env_info(state: &State) -> Result<(String, std::path::PathBuf, CSt
     if let Ok(cached) = read_file(&state.libpython_info) {
         if let Ok(cached) = String::from_utf8(cached) {
             if let Some((version, lib_path)) = cached.split_once('\n') {
-                if let Ok(lib_path) = state.uv_install_root.join(lib_path).canonicalize() {
+                if let Ok(lib_path) = state.uv_install_root.join(lib_path.trim()).canonicalize() {
                     // make sure we're still within AnkiProgramFiles...
                     if lib_path.strip_prefix(&state.uv_install_root).is_ok() {
                         return Ok((
-                            version.to_string(),
+                            version.trim().to_string(),
                             lib_path,
                             CString::new(python_exe.as_os_str().as_encoded_bytes())?,
                         ));
@@ -1124,7 +1124,7 @@ fn get_python_env_info(state: &State) -> Result<(String, std::path::PathBuf, CSt
     let (version, lib_path) = output
         .split_once('\n')
         .ok_or_else(|| anyhow!("invalid libpython info"))?;
-    let lib_path = std::path::PathBuf::from(lib_path);
+    let lib_path = std::path::PathBuf::from(lib_path.trim());
 
     if !lib_path.exists() {
         anyhow::bail!("library path doesn't exist: {lib_path:?}");
@@ -1138,7 +1138,7 @@ fn get_python_env_info(state: &State) -> Result<(String, std::path::PathBuf, CSt
     }
 
     Ok((
-        version.to_owned(),
+        version.trim().to_owned(),
         lib_path,
         CString::new(python_exe.as_os_str().as_encoded_bytes())?,
     ))

--- a/qt/launcher/src/main.rs
+++ b/qt/launcher/src/main.rs
@@ -53,6 +53,7 @@ struct State {
     previous_version: Option<String>,
     resources_dir: std::path::PathBuf,
     venv_folder: std::path::PathBuf,
+    libpython_path: std::path::PathBuf,
     /// system Python + PyQt6 library mode
     system_qt: bool,
 }
@@ -132,6 +133,7 @@ fn run() -> Result<()> {
             && resources_dir.join("system_qt").exists(),
         resources_dir,
         venv_folder: uv_install_root.join(".venv"),
+        libpython_path: uv_install_root.join("libpath"),
     };
 
     // Check for uninstall request from Windows uninstaller

--- a/qt/launcher/src/platform/mod.rs
+++ b/qt/launcher/src/platform/mod.rs
@@ -13,6 +13,9 @@ pub mod windows;
 #[cfg(unix)]
 pub mod nix;
 
+mod py313;
+mod py39;
+
 use std::path::PathBuf;
 
 use anki_process::CommandExt;

--- a/qt/launcher/src/platform/mod.rs
+++ b/qt/launcher/src/platform/mod.rs
@@ -139,3 +139,17 @@ pub fn ensure_os_supported() -> Result<()> {
 
     Ok(())
 }
+
+pub type PyInitializeEx = extern "C" fn(initsigs: std::ffi::c_int);
+pub type PyIsInitialized = extern "C" fn() -> std::ffi::c_int;
+pub type PyRunSimpleString = extern "C" fn(command: *const std::ffi::c_char) -> std::ffi::c_int;
+pub type PyFinalizeEx = extern "C" fn() -> std::ffi::c_int;
+
+#[allow(non_snake_case)]
+struct PyFfi {
+    lib: *mut std::ffi::c_void,
+    Py_InitializeEx: PyInitializeEx,
+    Py_IsInitialized: PyIsInitialized,
+    PyRun_SimpleString: PyRunSimpleString,
+    Py_FinalizeEx: PyFinalizeEx,
+}

--- a/qt/launcher/src/platform/mod.rs
+++ b/qt/launcher/src/platform/mod.rs
@@ -133,10 +133,6 @@ pub fn _run_anki_embeddedly(state: &crate::State) -> Result<()> {
     #[cfg(windows)]
     {
         let console = std::env::var("ANKI_CONSOLE").is_ok();
-        if console {
-            // no pythonw.exe available for us to use
-            ensure_terminal_shown()?;
-        }
         crate::platform::windows::prepare_to_launch_normally();
         // NOTE: without windows_subsystem=console or pythonw,
         // we need to reconnect stdin/stdout/stderr within the interp

--- a/qt/launcher/src/platform/mod.rs
+++ b/qt/launcher/src/platform/mod.rs
@@ -10,6 +10,9 @@ pub mod mac;
 #[cfg(target_os = "windows")]
 pub mod windows;
 
+#[cfg(unix)]
+pub mod nix;
+
 use std::path::PathBuf;
 
 use anki_process::CommandExt;

--- a/qt/launcher/src/platform/mod.rs
+++ b/qt/launcher/src/platform/mod.rs
@@ -113,6 +113,30 @@ pub fn launch_anki_normally(mut cmd: std::process::Command) -> Result<()> {
     Ok(())
 }
 
+pub fn _run_anki_normally(state: &crate::State) -> Result<()> {
+    #[cfg(windows)]
+    {
+        let console = std::env::var("ANKI_CONSOLE").is_ok();
+        if console {
+            // no pythonw.exe available for us to use
+            ensure_terminal_shown()?;
+        }
+        crate::platform::windows::prepare_to_launch_normally();
+        windows::run(state, console)?;
+    }
+    #[cfg(unix)]
+    nix::run(state)?;
+    Ok(())
+}
+
+pub fn run_anki_normally(state: &crate::State) -> bool {
+    if let Err(e) = _run_anki_normally(state) {
+        eprintln!("failed to run as embedded: {e:?}");
+        return false;
+    }
+    true
+}
+
 #[cfg(windows)]
 pub use windows::ensure_terminal_shown;
 

--- a/qt/launcher/src/platform/mod.rs
+++ b/qt/launcher/src/platform/mod.rs
@@ -171,10 +171,24 @@ pub fn ensure_os_supported() -> Result<()> {
     Ok(())
 }
 
-pub type PyInitializeEx = extern "C" fn(initsigs: std::ffi::c_int);
 pub type PyIsInitialized = extern "C" fn() -> std::ffi::c_int;
 pub type PyRunSimpleString = extern "C" fn(command: *const std::ffi::c_char) -> std::ffi::c_int;
 pub type PyFinalizeEx = extern "C" fn() -> std::ffi::c_int;
+pub type PyConfigInitPythonConfig = extern "C" fn(*mut std::ffi::c_void);
+// WARN: py39 and py313's PyStatus are identical
+// check if this remains true in future versions
+pub type PyConfigSetBytesString = extern "C" fn(
+    config: *mut std::ffi::c_void,
+    config_str: *mut *mut libc::wchar_t,
+    str_: *const std::os::raw::c_char,
+) -> py313::PyStatus;
+pub type PyConfigSetBytesArgv = extern "C" fn(
+    config: *mut std::ffi::c_void,
+    argc: isize,
+    argv: *const *mut std::os::raw::c_char,
+) -> py313::PyStatus;
+pub type PyInitializeFromConfig = extern "C" fn(*const std::ffi::c_void) -> py313::PyStatus;
+pub type PyStatusException = extern "C" fn(err: py313::PyStatus) -> std::os::raw::c_int;
 
 #[allow(non_snake_case)]
 struct PyFfi {

--- a/qt/launcher/src/platform/mod.rs
+++ b/qt/launcher/src/platform/mod.rs
@@ -16,6 +16,7 @@ pub mod nix;
 mod py313;
 mod py39;
 
+use std::ffi::CString;
 use std::path::PathBuf;
 
 use anki_process::CommandExt;
@@ -192,11 +193,16 @@ pub type PyStatusException = extern "C" fn(err: py313::PyStatus) -> std::os::raw
 
 #[allow(non_snake_case)]
 struct PyFfi {
+    exec: CString,
     lib: *mut std::ffi::c_void,
-    Py_InitializeEx: PyInitializeEx,
     Py_IsInitialized: PyIsInitialized,
     PyRun_SimpleString: PyRunSimpleString,
     Py_FinalizeEx: PyFinalizeEx,
+    PyConfig_InitPythonConfig: PyConfigInitPythonConfig,
+    PyConfig_SetBytesString: PyConfigSetBytesString,
+    Py_InitializeFromConfig: PyInitializeFromConfig,
+    PyConfig_SetBytesArgv: PyConfigSetBytesArgv,
+    PyStatus_Exception: PyStatusException,
 }
 
 impl PyFfi {

--- a/qt/launcher/src/platform/nix.rs
+++ b/qt/launcher/src/platform/nix.rs
@@ -23,7 +23,7 @@ impl Drop for PyFfi {
 }
 
 macro_rules! load_sym {
-    ($lib:expr, $name:literal) => {{
+    ($lib:expr, $name:expr) => {{
         libc::dlerror();
         let sym = libc::dlsym($lib, $name.as_ptr());
         if sym.is_null() {
@@ -34,9 +34,16 @@ macro_rules! load_sym {
     }};
 }
 
+macro_rules! ffi {
+    ($lib:expr, $exec:expr, $($field:ident),* $(,)?) => {
+        #[allow(clippy::missing_transmute_annotations)] // they're not missing
+        PyFfi { exec: $exec, $($field: load_sym!($lib, ::std::ffi::CString::new(stringify!($field)).unwrap()),)* lib: $lib, }
+    };
+}
+
 impl PyFfi {
     #[allow(non_snake_case)]
-    pub fn load(path: impl AsRef<std::path::Path>) -> Result<Self> {
+    pub fn load(path: impl AsRef<std::path::Path>, exec: CString) -> Result<Self> {
         unsafe {
             libc::dlerror();
             let lib = libc::dlopen(
@@ -48,14 +55,18 @@ impl PyFfi {
                 anyhow::bail!("failed to load library: {dlerror_str}");
             }
 
-            #[allow(clippy::missing_transmute_annotations)] // they're not missing
-            Ok(PyFfi {
-                Py_InitializeEx: load_sym!(lib, c"Py_InitializeEx"),
-                Py_IsInitialized: load_sym!(lib, c"Py_IsInitialized"),
-                PyRun_SimpleString: load_sym!(lib, c"PyRun_SimpleString"),
-                Py_FinalizeEx: load_sym!(lib, c"Py_FinalizeEx"),
+            Ok(ffi!(
                 lib,
-            })
+                exec,
+                Py_IsInitialized,
+                PyRun_SimpleString,
+                Py_FinalizeEx,
+                PyConfig_InitPythonConfig,
+                PyConfig_SetBytesString,
+                Py_InitializeFromConfig,
+                PyConfig_SetBytesArgv,
+                PyStatus_Exception
+            ))
         }
     }
 }

--- a/qt/launcher/src/platform/nix.rs
+++ b/qt/launcher/src/platform/nix.rs
@@ -1,0 +1,104 @@
+// Copyright: Ankitects Pty Ltd and contributors
+// License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
+
+use std::ffi::CStr;
+use std::ffi::CString;
+use std::os::unix::prelude::OsStrExt;
+
+use anki_io::ToUtf8Path;
+use anyhow::anyhow;
+use anyhow::Result;
+
+use crate::get_libpython_path;
+use crate::platform::PyFfi;
+use crate::State;
+
+impl Drop for PyFfi {
+    fn drop(&mut self) {
+        unsafe {
+            (self.Py_FinalizeEx)();
+            libc::dlclose(self.lib)
+        };
+    }
+}
+
+macro_rules! load_sym {
+    ($lib:expr, $name:literal) => {{
+        libc::dlerror();
+        let sym = libc::dlsym($lib, $name.as_ptr());
+        if sym.is_null() {
+            let dlerror_str = CStr::from_ptr(libc::dlerror()).to_str()?;
+            anyhow::bail!("failed to load {}: {dlerror_str}", $name.to_string_lossy());
+        }
+        std::mem::transmute(sym)
+    }};
+}
+
+impl PyFfi {
+    #[allow(non_snake_case)]
+    pub fn load(path: impl AsRef<std::path::Path>) -> Result<Self> {
+        unsafe {
+            libc::dlerror();
+            let lib = libc::dlopen(
+                CString::new(path.as_ref().as_os_str().as_bytes())?.as_ptr(),
+                libc::RTLD_LAZY | libc::RTLD_GLOBAL,
+            );
+            if lib.is_null() {
+                let dlerror_str = CStr::from_ptr(libc::dlerror()).to_str()?;
+                anyhow::bail!("failed to load library: {dlerror_str}");
+            }
+
+            #[allow(clippy::missing_transmute_annotations)] // they're not missing
+            Ok(PyFfi {
+                Py_InitializeEx: load_sym!(lib, c"Py_InitializeEx"),
+                Py_IsInitialized: load_sym!(lib, c"Py_IsInitialized"),
+                PyRun_SimpleString: load_sym!(lib, c"PyRun_SimpleString"),
+                Py_FinalizeEx: load_sym!(lib, c"Py_FinalizeEx"),
+                lib,
+            })
+        }
+    }
+}
+
+pub fn run(state: &State) -> Result<()> {
+    let lib_path = get_libpython_path(state)?;
+
+    // NOTE: activate venv before loading lib
+    let path = std::env::var("PATH")?;
+    let paths = std::env::split_paths(&path);
+    let path = std::env::join_paths(std::iter::once(state.venv_folder.join("bin")).chain(paths))?;
+    std::env::set_var("PATH", path);
+    std::env::set_var("VIRTUAL_ENV", &state.venv_folder);
+    std::env::set_var("PYTHONHOME", "");
+
+    std::env::set_var("ANKI_LAUNCHER", std::env::current_exe()?.utf8()?.as_str());
+    std::env::set_var("ANKI_LAUNCHER_UV", state.uv_path.utf8()?.as_str());
+    std::env::set_var("UV_PROJECT", state.uv_install_root.utf8()?.as_str());
+    std::env::remove_var("SSLKEYLOGFILE");
+
+    let ffi = PyFfi::load(lib_path)?;
+
+    // NOTE: sys.argv would normally be set via PyConfig, but we don't have it here
+    let args: String = std::env::args()
+        .skip(1)
+        .map(|s| format!(r#","{s}""#))
+        .collect();
+
+    // NOTE:
+    // the venv activation script doesn't seem to be
+    // necessary for linux, only PATH and VIRTUAL_ENV
+    // but just call it anyway to have a standard setup
+    let venv_activate_path = state.venv_folder.join("bin/activate_this.py");
+    let venv_activate_path = venv_activate_path
+        .as_os_str()
+        .to_str()
+        .ok_or_else(|| anyhow!("failed to get venv activation script path"))?;
+
+    let preamble = std::ffi::CString::new(format!(
+        r#"import sys, runpy; sys.argv = ['Anki'{args}]; runpy.run_path("{venv_activate_path}")"#,
+    ))?;
+
+    ffi.run(preamble)?;
+
+    Ok(())
+}

--- a/qt/launcher/src/platform/nix.rs
+++ b/qt/launcher/src/platform/nix.rs
@@ -36,7 +36,7 @@ macro_rules! load_sym {
 macro_rules! ffi {
     ($lib:expr, $exec:expr, $($field:ident),* $(,)?) => {
         #[allow(clippy::missing_transmute_annotations)] // they're not missing
-        PyFfi { exec: $exec, $($field: load_sym!($lib, ::std::ffi::CString::new(stringify!($field)).unwrap()),)* lib: $lib, }
+        PyFfi { exec: $exec, $($field: load_sym!($lib, ::std::ffi::CString::new(stringify!($field)).map_err(|_| anyhow::anyhow!("failed to construct symbol CString"))?),)* lib: $lib, }
     };
 }
 

--- a/qt/launcher/src/platform/nix.rs
+++ b/qt/launcher/src/platform/nix.rs
@@ -5,12 +5,9 @@ use std::ffi::CStr;
 use std::ffi::CString;
 use std::os::unix::prelude::OsStrExt;
 
-use anki_io::ToUtf8Path;
 use anyhow::Result;
 
-use crate::get_python_env_info;
 use crate::platform::PyFfi;
-use crate::State;
 
 impl Drop for PyFfi {
     fn drop(&mut self) {
@@ -76,15 +73,4 @@ impl PyFfi {
             ))
         }
     }
-}
-
-pub fn run(state: &State) -> Result<()> {
-    let (version, lib_path, exec) = get_python_env_info(state)?;
-
-    std::env::set_var("ANKI_LAUNCHER", std::env::current_exe()?.utf8()?.as_str());
-    std::env::set_var("ANKI_LAUNCHER_UV", state.uv_path.utf8()?.as_str());
-    std::env::set_var("UV_PROJECT", state.uv_install_root.utf8()?.as_str());
-    std::env::remove_var("SSLKEYLOGFILE");
-
-    PyFfi::load(lib_path, exec)?.run(&version, None)
 }

--- a/qt/launcher/src/platform/py313.rs
+++ b/qt/launcher/src/platform/py313.rs
@@ -1,0 +1,93 @@
+// Copyright: Ankitects Pty Ltd and contributors
+// License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
+
+use libc::wchar_t;
+
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PyStatus {
+    pub _type: ::std::os::raw::c_uint,
+    pub func: *const ::std::os::raw::c_char,
+    pub err_msg: *const ::std::os::raw::c_char,
+    pub exitcode: ::std::os::raw::c_int,
+}
+
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PyWideStringList {
+    pub length: isize,
+    pub items: *mut *mut wchar_t,
+}
+
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PyConfig {
+    pub _config_init: ::std::os::raw::c_int,
+    pub isolated: ::std::os::raw::c_int,
+    pub use_environment: ::std::os::raw::c_int,
+    pub dev_mode: ::std::os::raw::c_int,
+    pub install_signal_handlers: ::std::os::raw::c_int,
+    pub use_hash_seed: ::std::os::raw::c_int,
+    pub hash_seed: ::std::os::raw::c_ulong,
+    pub faulthandler: ::std::os::raw::c_int,
+    pub tracemalloc: ::std::os::raw::c_int,
+    pub perf_profiling: ::std::os::raw::c_int,
+    pub import_time: ::std::os::raw::c_int,
+    pub code_debug_ranges: ::std::os::raw::c_int,
+    pub show_ref_count: ::std::os::raw::c_int,
+    pub dump_refs: ::std::os::raw::c_int,
+    pub dump_refs_file: *mut wchar_t,
+    pub malloc_stats: ::std::os::raw::c_int,
+    pub filesystem_encoding: *mut wchar_t,
+    pub filesystem_errors: *mut wchar_t,
+    pub pycache_prefix: *mut wchar_t,
+    pub parse_argv: ::std::os::raw::c_int,
+    pub orig_argv: PyWideStringList,
+    pub argv: PyWideStringList,
+    pub xoptions: PyWideStringList,
+    pub warnoptions: PyWideStringList,
+    pub site_import: ::std::os::raw::c_int,
+    pub bytes_warning: ::std::os::raw::c_int,
+    pub warn_default_encoding: ::std::os::raw::c_int,
+    pub inspect: ::std::os::raw::c_int,
+    pub interactive: ::std::os::raw::c_int,
+    pub optimization_level: ::std::os::raw::c_int,
+    pub parser_debug: ::std::os::raw::c_int,
+    pub write_bytecode: ::std::os::raw::c_int,
+    pub verbose: ::std::os::raw::c_int,
+    pub quiet: ::std::os::raw::c_int,
+    pub user_site_directory: ::std::os::raw::c_int,
+    pub configure_c_stdio: ::std::os::raw::c_int,
+    pub buffered_stdio: ::std::os::raw::c_int,
+    pub stdio_encoding: *mut wchar_t,
+    pub stdio_errors: *mut wchar_t,
+    #[cfg(windows)]
+    pub legacy_windows_stdio: ::std::os::raw::c_int,
+    pub check_hash_pycs_mode: *mut wchar_t,
+    pub use_frozen_modules: ::std::os::raw::c_int,
+    pub safe_path: ::std::os::raw::c_int,
+    pub int_max_str_digits: ::std::os::raw::c_int,
+    pub cpu_count: ::std::os::raw::c_int,
+    pub pathconfig_warnings: ::std::os::raw::c_int,
+    pub program_name: *mut wchar_t,
+    pub pythonpath_env: *mut wchar_t,
+    pub home: *mut wchar_t,
+    pub platlibdir: *mut wchar_t,
+    pub module_search_paths_set: ::std::os::raw::c_int,
+    pub module_search_paths: PyWideStringList,
+    pub stdlib_dir: *mut wchar_t,
+    pub executable: *mut wchar_t,
+    pub base_executable: *mut wchar_t,
+    pub prefix: *mut wchar_t,
+    pub base_prefix: *mut wchar_t,
+    pub exec_prefix: *mut wchar_t,
+    pub base_exec_prefix: *mut wchar_t,
+    pub skip_source_first_line: ::std::os::raw::c_int,
+    pub run_command: *mut wchar_t,
+    pub run_module: *mut wchar_t,
+    pub run_filename: *mut wchar_t,
+    pub sys_path_0: *mut wchar_t,
+    pub _install_importlib: ::std::os::raw::c_int,
+    pub _init_main: ::std::os::raw::c_int,
+    pub _is_python_build: ::std::os::raw::c_int,
+}

--- a/qt/launcher/src/platform/py39.rs
+++ b/qt/launcher/src/platform/py39.rs
@@ -1,0 +1,75 @@
+// Copyright: Ankitects Pty Ltd and contributors
+// License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
+
+use libc::wchar_t;
+
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PyWideStringList {
+    pub length: ::std::os::raw::c_longlong,
+    pub items: *mut *mut wchar_t,
+}
+
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PyConfig {
+    pub _config_init: ::std::os::raw::c_int,
+    pub isolated: ::std::os::raw::c_int,
+    pub use_environment: ::std::os::raw::c_int,
+    pub dev_mode: ::std::os::raw::c_int,
+    pub install_signal_handlers: ::std::os::raw::c_int,
+    pub use_hash_seed: ::std::os::raw::c_int,
+    pub hash_seed: ::std::os::raw::c_ulong,
+    pub faulthandler: ::std::os::raw::c_int,
+    pub _use_peg_parser: ::std::os::raw::c_int,
+    pub tracemalloc: ::std::os::raw::c_int,
+    pub import_time: ::std::os::raw::c_int,
+    pub show_ref_count: ::std::os::raw::c_int,
+    pub dump_refs: ::std::os::raw::c_int,
+    pub malloc_stats: ::std::os::raw::c_int,
+    pub filesystem_encoding: *mut wchar_t,
+    pub filesystem_errors: *mut wchar_t,
+    pub pycache_prefix: *mut wchar_t,
+    pub parse_argv: ::std::os::raw::c_int,
+    pub argv: PyWideStringList,
+    pub program_name: *mut wchar_t,
+    pub xoptions: PyWideStringList,
+    pub warnoptions: PyWideStringList,
+    pub site_import: ::std::os::raw::c_int,
+    pub bytes_warning: ::std::os::raw::c_int,
+    pub inspect: ::std::os::raw::c_int,
+    pub interactive: ::std::os::raw::c_int,
+    pub optimization_level: ::std::os::raw::c_int,
+    pub parser_debug: ::std::os::raw::c_int,
+    pub write_bytecode: ::std::os::raw::c_int,
+    pub verbose: ::std::os::raw::c_int,
+    pub quiet: ::std::os::raw::c_int,
+    pub user_site_directory: ::std::os::raw::c_int,
+    pub configure_c_stdio: ::std::os::raw::c_int,
+    pub buffered_stdio: ::std::os::raw::c_int,
+    pub stdio_encoding: *mut wchar_t,
+    pub stdio_errors: *mut wchar_t,
+    #[cfg(windows)]
+    pub legacy_windows_stdio: ::std::os::raw::c_int,
+    pub check_hash_pycs_mode: *mut wchar_t,
+    pub pathconfig_warnings: ::std::os::raw::c_int,
+    pub pythonpath_env: *mut wchar_t,
+    pub home: *mut wchar_t,
+    pub module_search_paths_set: ::std::os::raw::c_int,
+    pub module_search_paths: PyWideStringList,
+    pub executable: *mut wchar_t,
+    pub base_executable: *mut wchar_t,
+    pub prefix: *mut wchar_t,
+    pub base_prefix: *mut wchar_t,
+    pub exec_prefix: *mut wchar_t,
+    pub base_exec_prefix: *mut wchar_t,
+    pub platlibdir: *mut wchar_t,
+    pub skip_source_first_line: ::std::os::raw::c_int,
+    pub run_command: *mut wchar_t,
+    pub run_module: *mut wchar_t,
+    pub run_filename: *mut wchar_t,
+    pub _install_importlib: ::std::os::raw::c_int,
+    pub _init_main: ::std::os::raw::c_int,
+    pub _isolated_interpreter: ::std::os::raw::c_int,
+    pub _orig_argv: PyWideStringList,
+}

--- a/qt/launcher/src/platform/windows.rs
+++ b/qt/launcher/src/platform/windows.rs
@@ -297,7 +297,10 @@ macro_rules! load_sym {
 macro_rules! ffi {
     ($lib:expr, $exec:expr, $($field:ident),* $(,)?) => {
         #[allow(clippy::missing_transmute_annotations)] // they're not missing
-        PyFfi { exec: $exec, $($field: load_sym!($lib, ::std::ffi::CString::new(stringify!($field)).unwrap()),)* lib: $lib.0, }
+        PyFfi { exec: $exec, $($field: {
+            let sym = ::std::ffi::CString::new(stringify!($field)).map_err(|_| anyhow::anyhow!("failed to construct symbol CString"))?;
+            load_sym!($lib, sym)
+        },)* lib: $lib.0, }
     };
 }
 


### PR DESCRIPTION
Closes #4151

Looked into why embedding statically/dynamically python would need version-scoped installers, and found that [PyConfig's layout](https://github.com/PyO3/pyo3/blob/67da00d07da5a5755344d101663e69e9209554bb/pyo3-ffi/src/cpython/initconfig.rs#L82) depends on the targetted version. If we went that route, we could use pyembed (of the dead pyoxidizer family) or pyo3 and link against a specific version

Instead, i've opted to link against libpython at runtime, using the venv bin* to get the libpath for the currently selected version (3.9/3.13 etc.), using the [venv activation script](https://virtualenv.pypa.io/en/legacy/userguide.html#using-virtualenv-without-bin-python) to setup up `sys.path`, `sys.prefix` etc, and only relying on the 3.x stable api and [The Very High Level Layer](https://docs.python.org/3/c-api/veryhigh.html#the-very-high-level-layer) to setup and start the interpreter. If it fails, it'll fallback to the usual launch method of spawning the venv bin

Wasn't able to find any examples of run-time linking python, but i did see a mention in the [python manual](https://github.com/python/cpython/blob/b3a38438d83245e52dff80f348c7fde539333cea/Doc/faq/windows.rst#how-can-i-embed-python-into-a-windows-application) so we're not doing anything untoward here (hopefully)

Portability: this Just Works™ on my wsl ubuntu and win10 machines (after wrestling with the quirks of 3.9 and 3.13 on each platform), but i've not been able to test on macs

Overhead: once on first-startup to get and cache libpython's path, and none as far as i can tell on runtime

*this may seem weird but there's precedence: pyo3 [invokes](https://github.com/PyO3/pyo3/blob/67da00d07da5a5755344d101663e69e9209554bb/pyo3-build-config/src/impl_.rs#L210) python in build scripts
