### PR TITLE
feat(tts): fallback to Apple Samantha voice for TTS on macOS

### DIFF
--- a/qt/aqt/tts.py
+++ b/qt/aqt/tts.py
@@ -98,10 +98,7 @@ class TTSPlayer:
         # (for example, Apple Samantha) with rank of -50
         for avail in avail_voices:
             if avail.lang == tag.lang:
-                if (
-                    avail.lang == "en_US"
-                    and avail.name == "Apple_Samantha_(English_(US))"
-                ):
+                if avail.lang == "en_US" and avail.name.startswith("Apple_Samantha"):
                     return TTSVoiceMatch(voice=avail, rank=-50)
 
         # if no requested or preferred voices match, we fall back on


### PR DESCRIPTION
As raised in https://github.com/ankitects/anki/issues/4406 - On macOS 26 when a voice is not provided for TTS, it falls back to a "zombie" sounding voice.

This PR implements the suggested changed raised by BenJamesBen here: https://forums.ankiweb.net/t/tts-switched-to-wrong-voice-macos-ios-update/66687/29 - improving TTS by adding a preferred fallback voice (Apple Samantha) for US English language cards.

With this change, if no requested voices match, the system will now select Apple Samantha (English US) as the preferred fallback with a rank of -50. If no preferred voices match, it falls back to the first available voice for the language, rank -100.

**Before:**

https://github.com/user-attachments/assets/eef7da55-2875-475f-8873-5b19e8338501



**After:**

https://github.com/user-attachments/assets/31c91f11-65ce-4989-baba-b4d1bab6159f

