### PR TITLE
Svelte5 migrate dispatch

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -255,6 +255,7 @@ Ranjit Odedra <ranjitodedra.dev@gmail.com>
 Eltaurus <https://github.com/Eltaurus-Lt>
 jariji
 Francisco Esteva <fr.esteva@duocuc.cl>
+AmandaSternberg-creator <amandasternberg2001@gmail.com>
 
 ********************
 

--- a/ts/lib/tag-editor/tag-options-button/TagAddButton.svelte
+++ b/ts/lib/tag-editor/tag-options-button/TagAddButton.svelte
@@ -5,7 +5,6 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 <script lang="ts">
     import * as tr from "@generated/ftl";
     import { getPlatformString } from "@tslib/shortcuts";
-    import { createEventDispatcher } from "svelte";
 
     import Icon from "$lib/components/Icon.svelte";
     import IconConstrain from "$lib/components/IconConstrain.svelte";
@@ -16,10 +15,10 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
     export let keyCombination: string;
 
-    const dispatch = createEventDispatcher<{ tagappend: null }>();
+    export let onTagAppend: (() => void) | undefined;
 
     function appendTag() {
-        dispatch("tagappend");
+    if (onTagAppend) onTagAppend();
     }
 </script>
 
@@ -43,7 +42,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     </span>
 </div>
 
-<Shortcut {keyCombination} on:action={() => dispatch("tagappend")} />
+<Shortcut {keyCombination} on:action={appendTag} />
 
 <style lang="scss">
     .tag-add-button {

--- a/ts/lib/tag-editor/tag-options-button/TagAddButton.svelte
+++ b/ts/lib/tag-editor/tag-options-button/TagAddButton.svelte
@@ -18,7 +18,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     export let onTagAppend: (() => void) | undefined;
 
     function appendTag() {
-    if (onTagAppend) onTagAppend();
+        if (onTagAppend) onTagAppend();
     }
 </script>
 

--- a/ts/lib/tag-editor/tag-options-button/TagAddButton.svelte
+++ b/ts/lib/tag-editor/tag-options-button/TagAddButton.svelte
@@ -18,7 +18,9 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     export let onTagAppend: (() => void) | undefined;
 
     function appendTag() {
-        if (onTagAppend) onTagAppend();
+        if (onTagAppend) { 
+            onTagAppend();
+        }
     }
 </script>
 

--- a/ts/lib/tag-editor/tag-options-button/TagAddButton.svelte
+++ b/ts/lib/tag-editor/tag-options-button/TagAddButton.svelte
@@ -18,7 +18,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     export let onTagAppend: (() => void) | undefined;
 
     function appendTag() {
-    if (onTagAppend){ 
+        if (onTagAppend) {
             onTagAppend();
         }
     }

--- a/ts/lib/tag-editor/tag-options-button/TagOptionsButton.svelte
+++ b/ts/lib/tag-editor/tag-options-button/TagOptionsButton.svelte
@@ -21,7 +21,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         {#if tagsSelected}
             <TagsSelectedButton on:tagselectall on:tagcopy on:tagdelete />
         {:else}
-            <TagAddButton on:tagappend {keyCombination} />
+            <TagAddButton {keyCombination} />
         {/if}
     {/key}
 </div>

--- a/ts/lib/tag-editor/tag-options-button/TagOptionsButton.svelte
+++ b/ts/lib/tag-editor/tag-options-button/TagOptionsButton.svelte
@@ -21,7 +21,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         {#if tagsSelected}
             <TagsSelectedButton on:tagselectall on:tagcopy on:tagdelete />
         {:else}
-            <TagAddButton {keyCombination} />
+            <TagAddButton {keyCombination} onTagAppend={() => {}} />
         {/if}
     {/key}
 </div>


### PR DESCRIPTION
Hi,
I started exploring this, but I don’t expect so much of it since Daimen hasn’t given the go-ahead and some related PRs (#4029, #4289) might need to be merged first.

However, I set up a proposal for how we could adadress the deprecated createEventDispatcher usage in Svelte components (#4408). In this PR I refactored one component (TagAddButton.svelte) to use a callback prop (onTagAppend) instead of dispatching "tagappend" events and updated the parent accordingly.

This PR is intended as a starting point only. Any thoughts or suggestions are highly appreciated before I continue!
Thanks :)