### PR TITLE
fix(reviewer/card): Implement night mode styles in reviewer.scss

### DIFF
--- a/ts/reviewer/reviewer.scss
+++ b/ts/reviewer/reviewer.scss
@@ -23,7 +23,7 @@ body {
 
 // explicit nightMode definition required
 // to override default .card styling
-body.nightMode {
+body.nightMode * {
     background-color: var(--canvas);
     color: var(--fg);
 }


### PR DESCRIPTION

<img width="2345" height="1524" alt="Group 590" src="https://github.com/user-attachments/assets/53d3146c-1a91-4f3e-93a0-6a2848cf4342" />

---

On macOS, dark mode isn’t supported in some places. I’ve put up with this issue for a long time, so I decided to try fixing it. (Maybe this is the reason—at least it works fine on my local setup and now supports dark mode.)

(I like Anki, 