### PR TITLE
fix: ensure cloze deletions do not place non-breaking spaces inside the cloze

### DIFF
--- a/ts/lib/tslib/wrap.ts
+++ b/ts/lib/tslib/wrap.ts
@@ -4,7 +4,12 @@
 import { getRange, getSelection } from "./cross-browser";
 
 function wrappedExceptForWhitespace(text: string, front: string, back: string): string {
-    const match = text.match(/^(\s*)([^]*?)(\s*)$/)!;
+    const normalizedText = text
+        .replace(/&nbsp;/g, " ")
+        .replace(/&#160;/g, " ")
+        .replace(/\u00A0/g, " ");
+
+    const match = normalizedText.match(/^(\s*)([^]*?)(\s*)$/)!;
     return match[1] + front + match[2] + back + match[3];
 }
 


### PR DESCRIPTION
Fixes: https://github.com/ankitects/anki/issues/4445

Previously, when creating cloze deletions from text copied within Anki, any non-breaking spaces were ending up inside the cloze. This meant the next word would get attached directly to the cloze, like {{c1::word }}next, instead of having the space outside where it belongs e.g. {{c1::word}} next. Further information can be found in [this post](https://forums.ankiweb.net/t/cloze-deletion-bug-in-add-window-when-using-ctrl-shift-with-internal-text/67534).

With this change, all non-breaking whitespaces are consistently placed outside the cloze deletion, matching the behaviour when typing or pasting from external sources.