### PR TITLE
Add headers to deleted.txt to detect Note Type and GUID

### DIFF
--- a/qt/aqt/main.py
+++ b/qt/aqt/main.py
@@ -1643,7 +1643,9 @@ title="{}" {}>{}</button>""".format(
         existed = os.path.exists(path)
         with open(path, "ab") as f:
             if not existed:
-                f.write(b"nid\tmid\tfields\n")
+                f.write(b"#guid column:1\n")
+                f.write(b"#notetype column:2\n")
+                f.write(b"#nid\tmid\tfields\n")
             for id, mid, flds in col.db.execute(
                 f"select id, mid, flds from notes where id in {ids2str(nids)}"
             ):


### PR DESCRIPTION
Hi

A very minor change.

I was reviewing the Anki Manual and noted that there is a somewhat outdated [section](https://docs.ankiweb.net/backups.html#deletion-log):
> [...] please note the import feature only supports a single note type at one time [...]

This PR adds headers to `deleted.txt` to allow for easy import:
```
#guid column:1
#notetype column:2
```

If undesired, will close this PR.

If accepted, I can update https://docs.ankiweb.net/backups.html#deletion-log

Other option is to explain to the user to add the said headers to the top of `deleted.txt`.

Whichever you feel is better.


Harvey
