### PR TITLE
Make grade_now() easier to use for add-ons

### DIFF
--- a/qt/aqt/browser/browser.py
+++ b/qt/aqt/browser/browser.py
@@ -1133,15 +1133,16 @@ class Browser(QMainWindow):
             (4, tr.studying_easy()),
         ]:
             btn = QPushButton(label)
+
+            def cb(ease: int) -> None:
+                grade_now(
+                    parent=self, card_ids=self.selected_cards(), ease=ease
+                ).run_in_background()
+                dialog.accept()
+
             qconnect(
                 btn.clicked,
-                functools.partial(
-                    grade_now,
-                    parent=self,
-                    card_ids=self.selected_cards(),
-                    ease=ease,
-                    dialog=dialog,
-                ),
+                functools.partial(cb, ease=ease),
             )
             if key := aqt.mw.pm.get_answer_key(ease):
                 QShortcut(key, dialog, activated=btn.click)  # type: ignore

--- a/qt/aqt/operations/scheduling.py
+++ b/qt/aqt/operations/scheduling.py
@@ -70,8 +70,7 @@ def grade_now(
     parent: QWidget,
     card_ids: Sequence[CardId],
     ease: int,
-    dialog: QDialog,
-) -> None:
+) -> CollectionOp[OpChanges]:
     if ease == 1:
         rating = CardAnswer.AGAIN
     elif ease == 2:
@@ -80,7 +79,7 @@ def grade_now(
         rating = CardAnswer.GOOD
     else:
         rating = CardAnswer.EASY
-    CollectionOp(
+    return CollectionOp(
         parent,
         lambda col: col._backend.grade_now(
             card_ids=card_ids,
@@ -90,8 +89,7 @@ def grade_now(
         lambda _: tooltip(
             tr.scheduling_graded_cards_done(cards=len(card_ids)), parent=parent
         )
-    ).run_in_background()
-    dialog.accept()
+    )
 
 
 def forget_cards(


### PR DESCRIPTION
The grade_now() operation was taking a QDialog argument, which makes it hard to use in add-ons.