### PR TITLE
Use macos_helper.disable_appnap at startup

### DIFF
--- a/qt/aqt/main.py
+++ b/qt/aqt/main.py
@@ -48,6 +48,7 @@ from anki.utils import (
     split_fields,
 )
 from aqt import gui_hooks
+from aqt._macos_helper import macos_helper
 from aqt.addons import DownloadLogEntry, check_and_prompt_for_updates, show_log_to_user
 from aqt.dbcheck import check_db
 from aqt.debug_console import show_debug_console
@@ -1718,6 +1719,9 @@ title="{}" {}>{}</button>""".format(
             self.hideMenuAccels = True
             self.maybeHideAccelerators()
             self.hideStatusTips()
+            # prevent App Nap from suspending Anki in the background
+            if macos_helper:
+                macos_helper.disable_appnap()
         elif is_win:
             self._setupWin32()
 


### PR DESCRIPTION
Hello @dae 

I'm on the latest beta and I tried the solution to disable the appnap quoted [here](https://forums.ankiweb.net/t/recent-anki-updates-bundle-id-change-disabling-app-nap-macos-anki-connect/65550/7?u=sound)

But apparently, after reading more, it doesn't really get preserved through executions

> You'll want to make sure to keep a strong reference to the token returned by `-[NSProcessInfo beginActivityWithOptions: reason:]`, because App Nap may resume again automatically when the token is deallocated.
[Prevent App Nap Programmatically](https://lapcatsoftware.com/articles/prevent-app-nap.html)


I added the call to disable_appnap() in the qt/aqt/main.py, rebuild the library and run the app with the Dock, because with the terminal `./run` I think it doesn't get to sleep.

Now it seems to be running OK.

Is it OK for you to enable it by default ?