### PR TITLE
Allow 10% as minimum Desired Retention

### DIFF
--- a/rslib/src/deckconfig/mod.rs
+++ b/rslib/src/deckconfig/mod.rs
@@ -296,7 +296,7 @@ pub(crate) fn ensure_deck_config_values_valid(config: &mut DeckConfigInner) {
     ensure_f32_valid(
         &mut config.desired_retention,
         default.desired_retention,
-        0.7,
+        0.1,
         0.99,
     );
     ensure_f32_valid(

--- a/rslib/src/deckconfig/service.rs
+++ b/rslib/src/deckconfig/service.rs
@@ -127,7 +127,7 @@ impl crate::services::DeckConfigService for Collection {
 
         config.deck_size = guard.cards;
 
-        let costs = (70u32..=99u32)
+        let costs = (10u32..=99u32)
             .into_par_iter()
             .map(|dr| {
                 Ok((

--- a/rslib/src/scheduler/fsrs/retention.rs
+++ b/rslib/src/scheduler/fsrs/retention.rs
@@ -36,7 +36,7 @@ impl Collection {
                 Some(cards),
                 None,
             )?
-            .clamp(0.7, 0.95))
+            .clamp(0.1, 0.99))
     }
 
     pub fn get_optimal_retention_parameters(

--- a/ts/routes/deck-options/FsrsOptions.svelte
+++ b/ts/routes/deck-options/FsrsOptions.svelte
@@ -356,7 +356,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         <SpinBoxFloatRow
             bind:value={effectiveDesiredRetention}
             defaultValue={defaults.desiredRetention}
-            min={0.7}
+            min={0.1}
             max={0.99}
             percentage={true}
             bind:focused={desiredRetentionFocused}

--- a/ts/routes/deck-options/SimulatorModal.svelte
+++ b/ts/routes/deck-options/SimulatorModal.svelte
@@ -361,7 +361,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
                     <SpinBoxFloatRow
                         bind:value={simulateFsrsRequest.desiredRetention}
                         defaultValue={$config.desiredRetention}
-                        min={0.7}
+                        min={0.1}
                         max={0.99}
                         percentage={true}
                     >


### PR DESCRIPTION
Hello,

While I don't think going lower than a certain level is necessarily always a good idea, recently a lot of discussions shown that R ranges from 40-70% might in fact be the "best" in terms on knolwedge maintained vs time spent reviewing.

It does actually work OK, some workload ratio for certain low DR seems to display NaN which could be improved later, but for now I'd already like to open the discussion about allowing this or not.

Personally I'm running a 65% DR deck for now and I don't really have much to complain, so I don't really locking the option to users is really worth it, especially when there's some pretty intense warning when they do so.

https://github.com/user-attachments/assets/ee1cc5e0-3bc6-4c40-ac6a-5b32ed703d40

