### PR TITLE
Fix rounded corners on FSRS Simulator modal

### DIFF
--- a/ts/routes/deck-options/SimulatorModal.svelte
+++ b/ts/routes/deck-options/SimulatorModal.svelte
@@ -623,6 +623,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     .modal {
         background-color: rgba(0, 0, 0, 0.5);
         --bs-modal-margin: 0;
+        --bs-modal-border-radius: 0;
     }
 
     .svg-container {


### PR DESCRIPTION
Fixes the rounded outline on the FSRS Simulator modal by setting `--bs-modal-border-radius: 0`.

This addresses the first part of #4168. The graph font size was intentionally left unchanged as it appears to be designed for accessibility/responsive purposes (discussed in the issue comments).

Before : 
<img width="92" height="78" alt="before" src="https://github.com/user-attachments/assets/133a5149-d61f-41c7-ac80-94df5116c0a2" />

After : 
<img width="98" height="111" alt="after" src="https://github.com/user-attachments/assets/250e843f-efb0-4b71-99c1-8de544521497" />


