### PR TITLE
Docs: Add tip to disable "check on save" in Rust analyzer on low-end machines

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -16,6 +16,3 @@ rustflags = ["-C", "target-feature=+crt-static"]
 
 [target.x86_64-pc-windows-msvc]
 linker = "rust-lld"
-
-[build]
-target-dir = "out/rust"

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -16,3 +16,6 @@ rustflags = ["-C", "target-feature=+crt-static"]
 
 [target.x86_64-pc-windows-msvc]
 linker = "rust-lld"
+
+[build]
+target-dir = "out/rust"

--- a/docs-site/developers/development.mdx
+++ b/docs-site/developers/development.mdx
@@ -164,6 +164,19 @@ If you invoke Rust outside of the build scripts (eg by running cargo, or
 with Rust Analyzer), output files will go into `target/` unless you have
 overriden the default output location.
 
+## Storage and Performance
+
+Most editors use rust-analyzer for Rust support, which runs `cargo check` in the
+background whenever you save a file, so that problems are surfaced before you try to
+build. This is useful, but on lower-end machines, it can noticeably increase disk
+usage and CPU load. If that's a problem for you, consider disabling "check on save"
+(e.g. set `rust-analyzer.checkOnSave` to `false` in VS Code) as a trade-off — you'll
+lose real-time error checking, but rust-analyzer can still be used for code completion,
+go-to-definition, etc.
+
+If you chose to disable "check on save" and don't run `cargo` commands manually, you
+may delete the `target/` folder (if any) as that's no longer used.
+
 ## IDEs
 
 Please see [this separate page](./editing) for setting up an editor/IDE.

--- a/docs/development.md
+++ b/docs/development.md
@@ -158,9 +158,10 @@ other builds on your system may use as well. If you wish to clear up those cache
 they can be found in `~/.rustup`, `~/.cargo` and `~/.cache/{yarn,pip}`. On
 Windows, Yarn cache can be found in `%LOCALAPPDATA%\Yarn`.
 
-If you invoke Rust outside of the build scripts (eg by running cargo, or
-with Rust Analyzer), output files will go into `target/` unless you have
-overriden the default output location.
+With previous versions, if you invoked Rust outside of the build scripts (e.g., by
+running cargo, or with Rust Analyzer), output files would go into `target/` unless
+you had overridden the default output location. If you are up-to-date with the
+current main branch, you may want to delete the `target/` folder.
 
 ## IDEs
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -158,10 +158,22 @@ other builds on your system may use as well. If you wish to clear up those cache
 they can be found in `~/.rustup`, `~/.cargo` and `~/.cache/{yarn,pip}`. On
 Windows, Yarn cache can be found in `%LOCALAPPDATA%\Yarn`.
 
-With previous versions, if you invoked Rust outside of the build scripts (e.g., by
-running cargo, or with Rust Analyzer), output files would go into `target/` unless
-you had overridden the default output location. If you are up-to-date with the
-current main branch, you may want to delete the `target/` folder.
+If you invoke Rust outside of the build scripts (eg by running cargo, or
+with Rust Analyzer), output files will go into `target/` unless you have
+overriden the default output location.
+
+## Storage and Performance
+
+Most editors use rust-analyzer for Rust support, which runs `cargo check` in the
+background whenever you save a file, so that problems are surfaced before you try to
+build. This is useful, but on lower-end machines, it can noticeably increase disk
+usage and CPU load. If that's a problem for you, consider disabling "check on save"
+(e.g. set `rust-analyzer.checkOnSave` to `false` in VS Code) as a trade-off — you'll
+lose real-time error checking, but rust-analyzer can still be used for code completion,
+go-to-definition, etc.
+
+If you chose to disable "check on save" and don't run `cargo` commands manually, you
+may delete the `target/` folder (if any) as that's no longer used.
 
 ## IDEs
 


### PR DESCRIPTION
Anki's build scripts (ninja) set CARGO_TARGET_DIR for their own execution. But, when running cargo commands directly (like cargo check), those commands don't inherit that environment variable and use the default target/ directory instead, leading to duplicate builds.

After this change, all cargo commands (check, build, test, etc.) will use the same cache, saving storage space.