### PR TITLE
Handle OpChanges in TS backend calls

### DIFF
--- a/proto/anki/collection.proto
+++ b/proto/anki/collection.proto
@@ -78,6 +78,10 @@ message OpChangesOnly {
   collection.OpChanges changes = 1;
 }
 
+message NestedOpChanges {
+  OpChangesOnly changes = 1;
+}
+
 message OpChangesWithCount {
   OpChanges changes = 1;
   uint32 count = 2;

--- a/pylib/anki/collection.py
+++ b/pylib/anki/collection.py
@@ -35,6 +35,7 @@ Preferences = config_pb2.Preferences
 UndoStatus = collection_pb2.UndoStatus
 OpChanges = collection_pb2.OpChanges
 OpChangesOnly = collection_pb2.OpChangesOnly
+NestedOpChanges = collection_pb2.NestedOpChanges
 OpChangesWithCount = collection_pb2.OpChangesWithCount
 OpChangesWithId = collection_pb2.OpChangesWithId
 OpChangesAfterUndo = collection_pb2.OpChangesAfterUndo

--- a/qt/aqt/mediasrv.py
+++ b/qt/aqt/mediasrv.py
@@ -16,6 +16,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from errno import EPROTOTYPE
 from http import HTTPStatus
+from typing import Any
 
 import flask
 import flask_cors
@@ -28,7 +29,13 @@ import aqt
 import aqt.main
 import aqt.operations
 from anki import hooks
-from anki.collection import OpChanges, OpChangesOnly, Progress, SearchNode
+from anki.collection import (
+    NestedOpChanges,
+    OpChanges,
+    OpChangesOnly,
+    Progress,
+    SearchNode,
+)
 from anki.decks import UpdateDeckConfigs
 from anki.scheduler.v3 import SchedulingStatesWithContext, SetSchedulingStatesRequest
 from anki.utils import dev_mode
@@ -707,7 +714,28 @@ def raw_backend_request(endpoint: str) -> Callable[[], bytes]:
 
     assert hasattr(RustBackend, f"{endpoint}_raw")
 
-    return lambda: getattr(aqt.mw.col._backend, f"{endpoint}_raw")(request.data)
+    def wrapped() -> bytes:
+        output = getattr(aqt.mw.col._backend, f"{endpoint}_raw")(request.data)
+        if op_changes_type := int(request.headers.get("Anki-Op-Changes", "0")):
+            op_message_types = (OpChanges, OpChangesOnly, NestedOpChanges)
+            try:
+                response = op_message_types[op_changes_type - 1]()
+                response.ParseFromString(output)
+                changes: Any = response
+                for _ in range(op_changes_type - 1):
+                    changes = changes.changes
+            except IndexError:
+                raise ValueError(f"unhandled op changes level: {op_changes_type}")
+
+            def handle_on_main() -> None:
+                handler = aqt.mw.app.activeWindow()
+                on_op_finished(aqt.mw, changes, handler)
+
+            aqt.mw.taskman.run_on_main(handle_on_main)
+
+        return output
+
+    return wrapped
 
 
 # all methods in here require a collection

--- a/qt/aqt/webview.py
+++ b/qt/aqt/webview.py
@@ -12,14 +12,16 @@ from collections.abc import Callable, Sequence
 from enum import Enum
 from typing import TYPE_CHECKING, Any, Type, cast
 
+from google.protobuf.json_format import MessageToDict
 from typing_extensions import TypedDict, Unpack
 
 import anki
 import anki.lang
 from anki._legacy import deprecated
 from anki.lang import is_rtl
-from anki.utils import hmr_mode, is_lin, is_mac, is_win
+from anki.utils import hmr_mode, is_lin, is_mac, is_win, to_json_bytes
 from aqt import colors, gui_hooks
+from aqt.operations import OpChanges
 from aqt.qt import *
 from aqt.qt import sip
 from aqt.theme import theme_manager
@@ -382,6 +384,7 @@ class AnkiWebView(QWebEngineView):
         self._filterSet = False
         gui_hooks.theme_did_change.append(self.on_theme_did_change)
         gui_hooks.body_classes_need_update.append(self.on_body_classes_need_update)
+        gui_hooks.operation_did_execute.append(self.on_operation_did_execute)
 
         qconnect(self.loadFinished, self._on_load_finished)
 
@@ -911,6 +914,7 @@ html {{ {font} }}
 
         gui_hooks.theme_did_change.remove(self.on_theme_did_change)
         gui_hooks.body_classes_need_update.remove(self.on_body_classes_need_update)
+        gui_hooks.operation_did_execute.remove(self.on_operation_did_execute)
         # defer page cleanup so that in-flight requests have a chance to complete first
         # https://forums.ankiweb.net/t/error-when-exiting-browsing-when-the-software-is-installed-in-the-path-c-program-files-anki/38363
         mw.progress.single_shot(5000, lambda: mw.mediaServer.clear_page_html(id(self)))
@@ -950,6 +954,17 @@ html {{ {font} }}
         )
         self.eval(
             f"""document.body.classList.toggle("reduce-motion", {json.dumps(mw.pm.reduce_motion())}); """
+        )
+
+    def on_operation_did_execute(
+        self, changes: OpChanges, handler: object | None
+    ) -> None:
+        if handler is self.parentWidget():
+            return
+
+        changes_json = to_json_bytes(MessageToDict(changes)).decode()
+        self.eval(
+            f"if(globalThis.anki && globalThis.anki.onOperationDidExecute) globalThis.anki.onOperationDidExecute({changes_json})"
         )
 
     @deprecated(info="use theme_manager.qcolor() instead")

--- a/ts/lib/generated/post.ts
+++ b/ts/lib/generated/post.ts
@@ -11,11 +11,12 @@ export async function postProto<T>(
     input: { toBinary(): Uint8Array; getType(): { typeName: string } },
     outputType: { fromBinary(arr: Uint8Array): T },
     options: PostProtoOptions = {},
+    opChangesType = 0,
 ): Promise<T> {
     try {
         const inputBytes = input.toBinary();
         const path = `/_anki/${method}`;
-        const outputBytes = await postProtoInner(path, inputBytes);
+        const outputBytes = await postProtoInner(path, inputBytes, opChangesType);
         return outputType.fromBinary(outputBytes);
     } catch (err) {
         const { alertOnError = true } = options;
@@ -26,11 +27,12 @@ export async function postProto<T>(
     }
 }
 
-async function postProtoInner(url: string, body: Uint8Array): Promise<Uint8Array> {
+async function postProtoInner(url: string, body: Uint8Array, opChangesType: number): Promise<Uint8Array> {
     const result = await fetch(url, {
         method: "POST",
         headers: {
             "Content-Type": "application/binary",
+            "Anki-Op-Changes": opChangesType.toString(),
         },
         body,
     });

--- a/ts/lib/tslib/operations.ts
+++ b/ts/lib/tslib/operations.ts
@@ -1,0 +1,20 @@
+// Copyright: Ankitects Pty Ltd and contributors
+// License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
+
+import type { OpChanges } from "@generated/anki/collection_pb";
+
+type OperationHandler = (changes: Partial<OpChanges>) => void;
+const handlers: OperationHandler[] = [];
+
+export function registerOperationHandler(handler: (changes: Partial<OpChanges>) => void): void {
+    handlers.push(handler);
+}
+
+function onOperationDidExecute(changes: Partial<OpChanges>): void {
+    for (const handler of handlers) {
+        handler(changes);
+    }
+}
+
+globalThis.anki = globalThis.anki || {};
+globalThis.anki.onOperationDidExecute = onOperationDidExecute;


### PR DESCRIPTION
Most TS backend calls that return OpChanges are currently not reflected in UI undo status. This provides a generic solution to extract OpChanges from responses (with handling for nesting).

The `registerOperationHandler` TS function was also added to allow Svelte pages to register operation handlers and react to changes in other screens.


This solution is already used in #4029 and will probably be useful for #4289