### PR TITLE
Add strikethrough button in editor toolbar

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -261,6 +261,7 @@ defkorean <https://github.com/defkorean>
 Michael Lappas <https://github.com/michaellappas>
 Brett Schwartz <brettschwartz871@gmail.com>
 Lovro Boban <lovro.boban@hotmail.com>
+Elie Carrot <eyh.carrot@gmail.com>
 
 ********************
 

--- a/ftl/core/editing.ftl
+++ b/ftl/core/editing.ftl
@@ -46,6 +46,7 @@ editing-remove-formatting = Remove formatting
 editing-restore-original-size = Restore original size
 editing-select-remove-formatting = Select formatting to remove
 editing-show-duplicates = Show Duplicates
+editing-strikethrough-text = Strikethrough text
 editing-subscript = Subscript
 editing-superscript = Superscript
 editing-tags = Tags

--- a/ts/editor/editor-toolbar/InlineButtons.svelte
+++ b/ts/editor/editor-toolbar/InlineButtons.svelte
@@ -11,6 +11,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     import HighlightColorButton from "./HighlightColorButton.svelte";
     import ItalicButton from "./ItalicButton.svelte";
     import RemoveFormatButton from "./RemoveFormatButton.svelte";
+    import StrikethroughButton from "./StrikethroughButton.svelte";
     import SubscriptButton from "./SubscriptButton.svelte";
     import SuperscriptButton from "./SuperscriptButton.svelte";
     import TextColorButton from "./TextColorButton.svelte";
@@ -33,7 +34,8 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         <ButtonGroup>
             <BoldButton --border-left-radius="5px" />
             <ItalicButton />
-            <UnderlineButton --border-right-radius="5px" />
+            <UnderlineButton />
+            <StrikethroughButton --border-right-radius="5px" />
         </ButtonGroup>
     </Item>
 

--- a/ts/editor/editor-toolbar/StrikethroughButton.svelte
+++ b/ts/editor/editor-toolbar/StrikethroughButton.svelte
@@ -23,7 +23,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     {matcher}
     key="strikethrough"
     tooltip={tr.editingStrikethroughText()}
-    keyCombination="Control+Shift+S"
+    keyCombination="Control+Alt+X"
 >
     <Icon icon={strikethroughIcon} />
 </TextAttributeButton>

--- a/ts/editor/editor-toolbar/StrikethroughButton.svelte
+++ b/ts/editor/editor-toolbar/StrikethroughButton.svelte
@@ -1,0 +1,29 @@
+<!--
+Copyright: Ankitects Pty Ltd and contributors
+License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
+-->
+<script lang="ts">
+    import * as tr from "@generated/ftl";
+
+    import Icon from "$lib/components/Icon.svelte";
+    import { strikethroughIcon } from "$lib/components/icons";
+    import type { MatchType } from "$lib/domlib/surround";
+
+    import TextAttributeButton from "./TextAttributeButton.svelte";
+
+    function matcher(element: HTMLElement | SVGElement, match: MatchType): void {
+        if (element.tagName === "S") {
+            return match.remove();
+        }
+    }
+</script>
+
+<TextAttributeButton
+    tagName="s"
+    {matcher}
+    key="strikethrough"
+    tooltip={tr.editingStrikethroughText()}
+    keyCombination="Control+Shift+S"
+>
+    <Icon icon={strikethroughIcon} />
+</TextAttributeButton>

--- a/ts/lib/components/icons.ts
+++ b/ts/lib/components/icons.ts
@@ -181,10 +181,10 @@ import Bold_ from "bootstrap-icons/icons/type-bold.svg?component";
 import bold_ from "bootstrap-icons/icons/type-bold.svg?url";
 import Italic_ from "bootstrap-icons/icons/type-italic.svg?component";
 import italic_ from "bootstrap-icons/icons/type-italic.svg?url";
-import Underline_ from "bootstrap-icons/icons/type-underline.svg?component";
-import underline_ from "bootstrap-icons/icons/type-underline.svg?url";
 import Strikethrough_ from "bootstrap-icons/icons/type-strikethrough.svg?component";
 import strikethrough_ from "bootstrap-icons/icons/type-strikethrough.svg?url";
+import Underline_ from "bootstrap-icons/icons/type-underline.svg?component";
+import underline_ from "bootstrap-icons/icons/type-underline.svg?url";
 
 import IncrementCloze_ from "../../icons/contain-plus.svg?component";
 import incrementCloze_ from "../../icons/contain-plus.svg?url";

--- a/ts/lib/components/icons.ts
+++ b/ts/lib/components/icons.ts
@@ -183,6 +183,8 @@ import Italic_ from "bootstrap-icons/icons/type-italic.svg?component";
 import italic_ from "bootstrap-icons/icons/type-italic.svg?url";
 import Underline_ from "bootstrap-icons/icons/type-underline.svg?component";
 import underline_ from "bootstrap-icons/icons/type-underline.svg?url";
+import Strikethrough_ from "bootstrap-icons/icons/type-strikethrough.svg?component";
+import strikethrough_ from "bootstrap-icons/icons/type-strikethrough.svg?url";
 
 import IncrementCloze_ from "../../icons/contain-plus.svg?component";
 import incrementCloze_ from "../../icons/contain-plus.svg?url";
@@ -248,6 +250,7 @@ export const justifyRightIcon = { url: justifyRight_, component: JustifyRight_ }
 export const boldIcon = { url: bold_, component: Bold_ };
 export const italicIcon = { url: italic_, component: Italic_ };
 export const underlineIcon = { url: underline_, component: Underline_ };
+export const strikethroughIcon = { url: strikethrough_, component: Strikethrough_ };
 export const deleteIcon = { url: delete_, component: Delete_ };
 export const inlineIcon = { url: inline_, component: Inline_ };
 export const blockIcon = { url: block_, component: Block_ };


### PR DESCRIPTION
# Changes

- icon.ts to use strikethrough bootstrap icons
- Copy and adapt `UnderlineButton.svelte` to `Strikethrough.svelte`.

  It seems that a shortcut is obligatory so I use `Ctrl+Alt+X`.
  Note : in GDoc, it's `Alt+Shift+5` ; in Word, it's `Ctrl+Shift+X` ; but both are already used. (And in LibreOffice there is not.)

- Add this button next to the underlined button in `InlineButtons.svelte`
- Add (English) legend in `ftl/core/editing.ftl`
- And my name on Contributors

# Screenshot

<img width="480" height="270" alt="image" src="https://github.com/user-attachments/assets/e9bdcd84-3dd6-46b4-8eb6-d76227389260" />

# Tests

- Manual test with `./run`
- Ran `./ninja check`
- Tried successfully `./tools/runopt` and `./tools/build`

---

Note: As you can see from my poor English, I don't use AI anywhere.
      And I don't know if I should add (unit) tests, but I don't see too many.
