### PR TITLE
Constrain simulator graph width to fix oversized text

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -125,6 +125,7 @@ XeR <github.com/XeR>
 mgrottenthaler <github.com/mgrottenthaler>
 Austin Siew <github.com/Aquafina-water-bottle>
 Joel Koen <mail@joelkoen.com>
+Christos Longros <chris.longros@gmail.com>
 Christopher Woggon <christopher.woggon@gmail.com>
 Kavel Rao <github.com/kavelrao>
 Ben Yip <github.com/bennyyip>

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -934,9 +934,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.10.1"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "bytesize"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ axum-client-ip = "1.1.3"
 axum-extra = { version = "0.10.1", features = ["typed-header"] }
 bitflags = "2.9.1"
 blake3 = "1.8.2"
-bytes = "1.10.1"
+bytes = "1.11.1"
 camino = "1.1.10"
 chrono = { version = "0.4.41", default-features = false, features = ["std", "clock"] }
 clap = { version = "4.5.40", features = ["derive"] }

--- a/ts/routes/deck-options/SimulatorModal.svelte
+++ b/ts/routes/deck-options/SimulatorModal.svelte
@@ -625,7 +625,10 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         --bs-modal-margin: 0;
     }
 
+
     .svg-container {
+        max-width: 800px;
+        margin: 0 auto;
         width: 100%;
         /* Account for modal header, controls, etc */
         max-height: max(calc(100vh - 400px), 200px);


### PR DESCRIPTION
Partial fix for #4168 (complements #4535 which addresses the border-radius)

The FSRS simulator modal uses `max-width: 100vw`, causing the SVG graph to stretch across the full viewport. Since text inside the SVG scales with the viewBox, axis labels and legend text appear disproportionately large compared to surrounding UI elements.

This adds `max-width: 800px` to `.svg-container`, keeping the graph at a readable size consistent with the statistics page graphs.

Before/after screenshots to follow in comments.