### PR TITLE
Fix MacOS memory leak

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -263,6 +263,7 @@ Michael Lappas <https://github.com/michaellappas>
 Brett Schwartz <brettschwartz871@gmail.com>
 Lovro Boban <lovro.boban@hotmail.com>
 Yuuki Gabriele Patriarca <yuukigpatriarca@gmail.com>
+David Moran <morandavid575@gmail.com>
 SecretX <https://github.com/SecretX33>
 
 ********************

--- a/qt/aqt/__init__.py
+++ b/qt/aqt/__init__.py
@@ -563,6 +563,17 @@ def setupGL(pm: aqt.profiles.ProfileManager) -> None:
     elif driver == VideoDriver.Direct3D:
         QQuickWindow.setGraphicsApi(QSGRendererInterface.GraphicsApi.Direct3D11)
 
+    if is_mac:
+        # Fix macOS memory leak: WebEngine's Metal compositing accumulates shader
+        # pipeline states in MTLCompilerFSCache indefinitely (~500ms/cycle at idle).
+        # Forcing CPU compositing stops this cache growth.
+        flag = "--disable-gpu-compositing"
+        env_key = "QTWEBENGINE_CHROMIUM_FLAGS"
+
+        existing = os.environ.get(env_key, "")
+        if flag not in existing.split():
+            os.environ[env_key] = f"{existing} {flag}".strip()
+
 
 PROFILE_CODE = os.environ.get("ANKI_PROFILE_CODE")
 


### PR DESCRIPTION
## Fix macOS memory growth caused by unbounded Metal shader cache accumulation in QtWebEngine compositor

### Problem

<img width="709" height="109" alt="image" src="https://github.com/user-attachments/assets/09c8ad96-767a-4766-b7a1-34643eacbeba" />


Forum discussion from over a year ago: https://forums.ankiweb.net/t/memory-leak-over-time/50931/32

On macOS, Anki's memory footprint grows continuously while the application is idle — typically several MB per minute — and never recovers - memory could reach 20 to 30 gigs after a week or so. This behavior was observed via macOS Activity Monitor and confirmed with Instruments.

Initial investigation ruled out the obvious candidates:

- Python `tracemalloc` found no growing Python allocations
- `leaks` found no unreachable objects — the memory is reachable, not leaked in the traditional sense
- Reducing timer frequency had no effect
- The `QtWebEngineProcess` helper process was stable; growth was entirely in the main Python process


### Root Cause (confirmed via Instruments → Allocations + Call Tree)

<img width="755" height="113" alt="image" src="https://github.com/user-attachments/assets/e8760043-66a3-4409-a748-2e2aa3843fe1" />
<img width="581" height="212" alt="image" src="https://github.com/user-attachments/assets/4901e6b0-af3a-405b-9158-2d09374fc35d" />

Every second, Qt's scene graph fires a render-sync timer, which calls into `RenderWidgetHostViewQtDelegateItem` — QtWebEngine's internal QML item that composites web content using OpenGL. On each sync it allocates a new `QOpenGLFramebufferObject` rather than reusing the existing one.

Each new FBO has a different geometry identity, so Apple's OpenGL→Metal translation layer (`GLDContextRec::buildPipelineState`) compiles a fresh Metal shader pipeline state for it via `AGXG15XFamilyDevice::newRenderPipelineStateWithDescriptor`. The compiled pipeline state is inserted into `MTLCompilerFSCache::getElement` — a cache that is reachable and therefore not flagged as a leak, but that grows without bound for the lifetime of the process.

**Full call chain:**
```
QTimerInfoList::activateTimers
→ QQuickWidget::event
→ QQuickRenderControl::sync
→ RenderWidgetHostViewQtDelegateItem::updatePaintNode
→ QOpenGLFramebufferObject::QOpenGLFramebufferObject   ← new FBO every 500ms
→ glDrawArrays → GLDContextRec::buildPipelineState
→ AGXG15XFamilyDevice::newRenderPipelineStateWithDescriptor
→ MTLCompilerFSCache::getElement                       ← accumulates forever
```

This is a Qt/Chromium interaction bug specific to the macOS OpenGL→Metal compatibility layer; it does not affect Linux or Windows.

### Fix

Set `--disable-gpu-compositing` in `QTWEBENGINE_CHROMIUM_FLAGS` on macOS (in `setupGL()`, `qt/aqt/__init__.py`). This switches Chromium's page compositor from GPU mode (which creates FBOs on every render sync) to CPU/software mode (a plain bitmap uploaded as a texture). No `QOpenGLFramebufferObject` is created, no Metal pipeline states are compiled, and `MTLCompilerFSCache` never grows.

The flag is appended to any existing value of `QTWEBENGINE_CHROMIUM_FLAGS` rather than overwriting it, so user-set or developer flags (e.g. `--remote-allow-origins`) are preserved.

<!-- Screenshot 3: Allocations timeline after fix — flat line -->

### Confirmation of fix

Anki running for 8 hours:
<img width="663" height="42" alt="image" src="https://github.com/user-attachments/assets/6b14cab5-ccfe-4cd2-9db8-472b486cff08" />


### Trade-off

CPU compositing means Chromium composites page layers on the CPU (Skia) rather than the GPU. Web content renders identically; CSS animations and video still work. For Anki's workload — card text, LaTeX images, simple SVG — this is indistinguishable in practice.

If visible degradation is ever reported, the fallback `--use-angle=swiftshader` provides a software GPU path instead.