### PR TITLE
Update AV_TAGS regex

### DIFF
--- a/rslib/src/text.rs
+++ b/rslib/src/text.rs
@@ -154,11 +154,6 @@ static AV_TAGS: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(
         r"(?xs)
             \[sound:(.+?)\]     # 1 - the filename in a sound tag
-            |
-            \[anki:tts\]
-                \[(.*?)\]       # 2 - arguments to tts call
-                (.*?)           # 3 - field text
-            \[/anki:tts\]
             ",
     )
     .unwrap()


### PR DESCRIPTION
The AV_TAGS regex matches an old format of the `anki:tts` tag (`[anki:tts][lang=en_US]` rather than `[anki:tts lang=en_US]`). It was originally updated when the feature got introduced in https://github.com/ankitects/anki/commit/0942ffbff6cd08dbc83e64c79b4027e6cff43adb but then was never adjusted to reflect later changes to the syntax.
I removed it from the pattern rather than updating it to match, because AV_TAGS is only used for matching filenames nowadays (stripping is handled by a different module).