### PR TITLE
Handle Briefcase file associations

### DIFF
--- a/qt/installer/pyproject.toml.template
+++ b/qt/installer/pyproject.toml.template
@@ -115,3 +115,27 @@ supported = false
 
 [tool.briefcase.app.anki.web]
 supported = false
+
+[tool.briefcase.app.anki.document_type.apkg]
+description = "Anki deck package"
+extension = "apkg"
+icon = "resources/anki"
+mime_type = "application/x-apkg"
+url = "https://docs.ankiweb.net/exporting.html#deck-apkg"
+macOS.CFBundleTypeRole = "Editor"
+
+[tool.briefcase.app.anki.document_type.colpkg]
+description = "Anki collection package"
+extension = "colpkg"
+icon = "resources/anki"
+mime_type = "application/x-colpkg"
+url = "https://docs.ankiweb.net/exporting.html#collection-colpkg"
+macOS.CFBundleTypeRole = "Editor"
+
+[tool.briefcase.app.anki.document_type.ankiaddon]
+description = "Anki add-on"
+extension = "ankiaddon"
+icon = "resources/anki"
+mime_type = "application/x-ankiaddon"
+url = "https://addon-docs.ankiweb.net/sharing.html"
+macOS.CFBundleTypeRole = "Editor"


### PR DESCRIPTION
This registers Anki's file associations (.apkg, .colpkg, .ankiaddon) for the Briefcase installer.

## How to test

- Build installer `./ninja installer`.
- Install package under `./out/installer/dist`.
-  Download and confirm the following sample files are associated with Anki on your system: https://gofile.io/d/snFa5x

## Issues

File associations don't appear to be supported for Linux packages unfortunately. I'll create an issue to discuss if we should try to support Linux system packages at all.

-----

Closes #4597