### PR TITLE
Add Briefcase app permissions

### DIFF
--- a/qt/installer/pyproject.toml.template
+++ b/qt/installer/pyproject.toml.template
@@ -30,6 +30,7 @@ universal_build = true
 min_os_version = "12.0"
 entitlement."com.apple.security.cs.disable-executable-page-protection" = true
 entitlement."com.apple.security.cs.allow-dyld-environment-variables" = true
+entitlement."com.apple.security.device.audio-input" = true
 
 [tool.briefcase.app.anki.linux]
 requires = [


### PR DESCRIPTION
This adds app permissions (e.g. microphone) for the Briefcase installer, along with required macOS entitlements.

## How to test

- Build installer: `./ninja installer`.
- Install package under `./out/installer/dist`.
- On macOS, open Anki, open the editor by clicking on the Add button, then press F5 to test audio recording. You should see a prompt to give Anki permission to access your microphone. Before this PR, the app would simply crash with a long error traceback.

----

Closes #4600