### PR TITLE
Set up Briefcase code signing and notarization

### DIFF
--- a/qt/tools/build_installer.py
+++ b/qt/tools/build_installer.py
@@ -76,6 +76,7 @@ def main(aqt_wheel: str, anki_wheel: str, out_dir: Path) -> None:
             "-m",
             "briefcase",
             "package",
+            "--log",
             *identity_args,
         ],
         cwd=out_dir,


### PR DESCRIPTION
## Changes

This adds a basic setup for code signing and macOS notarization for the Briefcase installer. Platform-specific logic is handled by Briefcase, so this just passes the `--identity` argument to the `package` command if the `SIGN_IDENTITY` environment variable is defined.

## How to test

You can test this using a self-signed certificate.

### Windows

Run the following PowerShell script:
```pwsh
$params = @{
    DnsName = 'apps.ankiweb.net'
    CertStoreLocation = 'Cert:\CurrentUser\My'
    HashAlgorithm = 'sha256'
    Type = 'CodeSigningCert'
}
$cert = New-SelfSignedCertificate @params
$thumbprint = $cert.Thumbprint
Write-Host $thumbprint
$env:SIGN_IDENTITY=$thumbprint

./tools/ninja installer

Remove-Item Cert:\CurrentUser\My\$thumbprint
```

This generates a certificate and build a signed installer using it. To confirm the certificate is used, Right-click on the resulting Anki-25.9.2.msi, click Properties, go to the Digital Signatures tab and confirm the signature is displayed:

<img width="405" height="566" alt="image" src="https://github.com/user-attachments/assets/02cc9fda-ba6f-4a55-8143-d33019a89920" />

### macOS

You'll need to disable notarization for testing using a self-signed certificate. Apply the following change:
```diff
diff --git a/qt/tools/build_installer.py b/qt/tools/build_installer.py
index b572c720a..43c057be6 100644
--- a/qt/tools/build_installer.py
+++ b/qt/tools/build_installer.py
@@ -77,6 +77,7 @@ def main(aqt_wheel: str, anki_wheel: str, out_dir: Path) -> None:
             "briefcase",
             "package",
             *identity_args,
+            "--no-notarize",
         ],
         cwd=out_dir,
     )
```


Then run the following Bash script (you might be prompted to enter your password multiple times in a GUI and the terminal):

```bash
#!/bin/bash
set -e

TEAM_ID="ANKIDEV001"
CERT_NAME="apps.ankiweb.net (${TEAM_ID})"
KEYCHAIN="$HOME/Library/Keychains/login.keychain-db"
rm -f /tmp/sign_key.anki.* /tmp/sign_cert.anki.*
TMP_KEY=$(mktemp /tmp/sign_key.anki.pem)
TMP_CERT=$(mktemp /tmp/sign_cert.anki.pem)
TMP_P12=$(mktemp /tmp/sign_cert.anki.p12)

cleanup() {
    security delete-certificate -c "$CERT_NAME" "$KEYCHAIN" 2>/dev/null || true
    rm -f "$TMP_KEY" "$TMP_CERT" "$TMP_P12"
}
trap cleanup EXIT

# Create self-signed code signing certificate
openssl req -x509 -newkey rsa:2048 \
    -keyout "$TMP_KEY" \
    -out "$TMP_CERT" \
    -days 1 -nodes \
    -subj "/CN=${CERT_NAME}" \
    -addext "keyUsage=critical,digitalSignature" \
    -addext "extendedKeyUsage=codeSigning"

# Export to PKCS12 and import into keychain
P12_PASS="temp"
openssl pkcs12 -export -legacy -out "$TMP_P12" -inkey "$TMP_KEY" -in "$TMP_CERT" -passout pass:"$P12_PASS"
security import "$TMP_P12" -k "$KEYCHAIN" -P "$P12_PASS" -T /usr/bin/codesign

# Trust the certificate for code signing
security add-trusted-cert -r trustRoot -p codeSign -k "$KEYCHAIN" "$TMP_CERT"

# Allow codesign to access the key without prompting.
# You'll be prompted once here for your keychain (Mac login) password.
security set-key-partition-list -S apple-tool:,apple: -s "$KEYCHAIN"

export SIGN_IDENTITY="$CERT_NAME"
echo "$SIGN_IDENTITY"

./ninja installer
```

To confirm the certificate is used, run the following command:
```
codesign --display --verbose=4 ./out/installer/build/anki/macos/app/Anki.app
```

For a signed binary, you should at least these two fields:
```
Signature size=1759
Authority=apps.ankiweb.net (ANKIDEV001)
```

For an unsigned binary, you should see `Signature=adhoc`.

----

Closes #4614
