### PR TITLE
Increase media sync batch limits

### DIFF
--- a/rslib/src/sync/media/database/client/mod.rs
+++ b/rslib/src/sync/media/database/client/mod.rs
@@ -348,6 +348,7 @@ mod test {
     use crate::media::files::sha1_of_data;
     use crate::media::MediaManager;
     use crate::sync::media::database::client::MediaEntry;
+    use crate::sync::media::MAX_MEDIA_FILES_IN_ZIP;
 
     #[test]
     fn database() -> Result<()> {
@@ -376,7 +377,10 @@ mod test {
             ctx.set_entry(&entry)?;
             assert_eq!(ctx.get_entry("test.mp3")?.unwrap(), entry);
 
-            assert_eq!(ctx.get_pending_uploads(25)?, vec![entry]);
+            assert_eq!(
+                ctx.get_pending_uploads(MAX_MEDIA_FILES_IN_ZIP as u32)?,
+                vec![entry]
+            );
 
             let mut meta = ctx.get_meta()?;
             assert_eq!(meta.folder_mtime, 0);

--- a/rslib/src/sync/media/database/server/entry/download.rs
+++ b/rslib/src/sync/media/database/server/entry/download.rs
@@ -59,3 +59,75 @@ impl ServerMediaDatabase {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use axum::http::StatusCode;
+    use tempfile::tempdir;
+
+    use super::*;
+    use crate::sync::media::zip::UploadedChange;
+    use crate::sync::media::zip::UploadedChangeKind;
+
+    fn add_files(db: &mut ServerMediaDatabase, count: usize, size: usize) {
+        db.with_transaction(|db, meta| {
+            for idx in 0..count {
+                db.register_uploaded_change(
+                    meta,
+                    UploadedChange {
+                        nfc_filename: format!("file-{idx}.txt"),
+                        kind: UploadedChangeKind::AddOrReplace {
+                            nonempty_data: vec![idx as u8; size],
+                            sha1: vec![idx as u8; 20],
+                        },
+                    },
+                )?;
+            }
+            Ok(())
+        })
+        .unwrap();
+    }
+
+    fn filenames(count: usize) -> Vec<String> {
+        (0..count).map(|idx| format!("file-{idx}.txt")).collect()
+    }
+
+    fn new_db() -> (tempfile::TempDir, ServerMediaDatabase) {
+        let dir = tempdir().unwrap();
+        let db = ServerMediaDatabase::new(&dir.path().join("server.db")).unwrap();
+        (dir, db)
+    }
+
+    #[test]
+    fn download_allows_batches_larger_than_legacy_limit() {
+        let (_dir, mut db) = new_db();
+        add_files(&mut db, 30, 1);
+
+        assert!(30 <= MAX_MEDIA_FILES_IN_ZIP);
+        let entries = db.get_entries_for_download(&filenames(30)).unwrap();
+        assert_eq!(entries.len(), 30);
+    }
+
+    #[test]
+    fn download_rejects_requests_over_batch_limit() {
+        let (_dir, db) = new_db();
+        let err = db
+            .get_entries_for_download(&filenames(MAX_MEDIA_FILES_IN_ZIP + 1))
+            .unwrap_err();
+        assert_eq!(err.code, StatusCode::BAD_REQUEST);
+        assert_eq!(err.context, "too many files requested");
+    }
+
+    #[test]
+    fn download_truncates_after_configured_zip_target() {
+        let (_dir, mut db) = new_db();
+        let file_size = 1024 * 1024;
+        let expected_entries = (MEDIA_SYNC_TARGET_ZIP_BYTES / file_size) + 1;
+        add_files(&mut db, expected_entries + 1, file_size);
+
+        let entries = db
+            .get_entries_for_download(&filenames(expected_entries + 1))
+            .unwrap();
+        assert_eq!(entries.len(), expected_entries);
+    }
+}

--- a/rslib/src/sync/media/mod.rs
+++ b/rslib/src/sync/media/mod.rs
@@ -26,7 +26,7 @@ pub const MAX_MEDIA_FILENAME_LENGTH_SERVER: usize = 255;
 /// Media syncing does not support files over 100MiB.
 pub static MAX_INDIVIDUAL_MEDIA_FILE_SIZE: usize = 100 * 1024 * 1024;
 
-pub static MAX_MEDIA_FILES_IN_ZIP: usize = 25;
+pub static MAX_MEDIA_FILES_IN_ZIP: usize = 100;
 
 /// If reached, no further files are placed into the zip.
-pub static MEDIA_SYNC_TARGET_ZIP_BYTES: usize = (2.5 * 1024.0 * 1024.0) as usize;
+pub static MEDIA_SYNC_TARGET_ZIP_BYTES: usize = 10 * 1024 * 1024;

--- a/rslib/src/sync/media/tests.rs
+++ b/rslib/src/sync/media/tests.rs
@@ -28,6 +28,7 @@ use crate::sync::media::sanity::MediaSanityCheckResponse;
 use crate::sync::media::sanity::SanityCheckRequest;
 use crate::sync::media::syncer::MediaSyncer;
 use crate::sync::media::zip::zip_files_for_upload;
+use crate::sync::media::MAX_MEDIA_FILES_IN_ZIP;
 use crate::sync::request::IntoSyncRequest;
 use crate::sync::request::SyncRequest;
 use crate::sync::version::SyncVersion;
@@ -288,6 +289,48 @@ async fn parallel_requests() -> Result<()> {
             fs::read_to_string(media2.media_folder.join("diff")).unwrap(),
             "1"
         );
+        Ok(())
+    })
+    .await
+}
+
+#[tokio::test]
+async fn large_media_batch_roundtrip() -> Result<()> {
+    with_active_server(|client| async move {
+        let ctx = SyncTestContext::new(client.clone());
+        let media2 = ctx.media2();
+        ctx.sync_media1().await?;
+
+        let file_count = 30;
+        assert!(file_count <= MAX_MEDIA_FILES_IN_ZIP);
+        let entries: Vec<_> = (0..file_count)
+            .map(|idx| {
+                (
+                    format!("file-{idx}.txt"),
+                    Some(format!("data-{idx}").into_bytes()),
+                )
+            })
+            .collect();
+        let zip_data = zip_files_for_upload(entries.clone())?;
+        client
+            .upload_changes(SyncRequest::from_data(
+                zip_data,
+                ctx.client.sync_key.clone(),
+                String::new(),
+                IpAddr::from([0, 0, 0, 0]),
+                SyncVersion::latest(),
+            ))
+            .await?;
+
+        ctx.sync_media2().await?;
+
+        for (filename, data) in entries {
+            assert_eq!(
+                fs::read(media2.media_folder.join(filename)).unwrap(),
+                data.unwrap()
+            );
+        }
+
         Ok(())
     })
     .await

--- a/rslib/src/sync/media/upload.rs
+++ b/rslib/src/sync/media/upload.rs
@@ -110,3 +110,32 @@ pub fn gather_zip_data_for_upload(
 
     Ok(Some(entries))
 }
+
+#[cfg(test)]
+mod tests {
+    use tempfile::tempdir;
+
+    use super::*;
+    use crate::media::MediaManager;
+    use crate::sync::media::MAX_MEDIA_FILES_IN_ZIP;
+
+    #[test]
+    fn gather_zip_data_handles_batches_larger_than_legacy_limit() -> Result<()> {
+        let dir = tempdir()?;
+        let media_dir = dir.path().join("media");
+        let media_db = dir.path().join("media.db");
+        let mgr = MediaManager::new(&media_dir, &media_db)?;
+
+        for idx in 0..30 {
+            mgr.add_file(&format!("file-{idx}.txt"), b"x")?;
+        }
+
+        assert!(30 <= MAX_MEDIA_FILES_IN_ZIP);
+        let pending = mgr.db.get_pending_uploads(30)?;
+        let gathered = gather_zip_data_for_upload(&mgr.db, &mgr.media_folder, &pending)?
+            .expect("test media entries should be readable");
+        assert_eq!(gathered.len(), 30);
+
+        Ok(())
+    }
+}

--- a/rslib/src/sync/media/zip.rs
+++ b/rslib/src/sync/media/zip.rs
@@ -16,6 +16,7 @@ use crate::media::files::sha1_of_data;
 use crate::prelude::*;
 use crate::sync::media::MAX_INDIVIDUAL_MEDIA_FILE_SIZE;
 use crate::sync::media::MAX_MEDIA_FILENAME_LENGTH_SERVER;
+use crate::sync::media::MAX_MEDIA_FILES_IN_ZIP;
 
 pub struct ZipFileMetadata {
     pub filename: String,
@@ -99,7 +100,7 @@ pub fn unzip_and_validate_files(zip_data: &[u8]) -> Result<Vec<UploadedChange>> 
     // meta map first, limited to a reasonable size
     let meta_file = zip.by_name("_meta")?;
     let entries: Vec<UploadEntry> = serde_json::from_reader(meta_file.take(50 * 1024))?;
-    if entries.len() > 25 {
+    if entries.len() > MAX_MEDIA_FILES_IN_ZIP {
         invalid_input!("too many files in zip");
     }
 
@@ -154,4 +155,37 @@ pub fn unzip_and_validate_files(zip_data: &[u8]) -> Result<Vec<UploadedChange>> 
 struct UploadEntry {
     actual_filename: String,
     filename_in_zip: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::error::AnkiError;
+
+    fn upload_entries(count: usize) -> Vec<(String, Option<Vec<u8>>)> {
+        (0..count)
+            .map(|idx| (format!("file-{idx}.txt"), Some(vec![idx as u8])))
+            .collect()
+    }
+
+    #[test]
+    fn accepts_batches_up_to_configured_limit() -> Result<()> {
+        let zip = zip_files_for_upload(upload_entries(MAX_MEDIA_FILES_IN_ZIP))?;
+        let changes = unzip_and_validate_files(&zip)?;
+        assert_eq!(changes.len(), MAX_MEDIA_FILES_IN_ZIP);
+        Ok(())
+    }
+
+    #[test]
+    fn rejects_batches_over_configured_limit() -> Result<()> {
+        let zip = zip_files_for_upload(upload_entries(MAX_MEDIA_FILES_IN_ZIP + 1))?;
+        let err = unzip_and_validate_files(&zip)
+            .err()
+            .expect("zip with too many entries should be rejected");
+        assert!(matches!(
+            err,
+            AnkiError::InvalidInput { source } if source.message == "too many files in zip"
+        ));
+        Ok(())
+    }
 }


### PR DESCRIPTION
## Problem

Media sync currently limits each batch to 25 files and targets about 2.5 MiB per zip.

For large collections with lots of small media files, that leads to more upload/download round trips than necessary, which slows sync down.

## Changes

This bumps the batch limit to 100 files and the target zip size to 10 MiB.

The server-side zip validation now accepts the larger batches as well, and I added coverage around batch construction, download truncation, zip validation, and a 30-file roundtrip test.

The sync pipeline is still sequential; this just lets each request carry more work.

Closes #4467
