### PR TITLE
fix: card text invisible in dark/night mode

### DIFF
--- a/ts/reviewer/index.ts
+++ b/ts/reviewer/index.ts
@@ -86,6 +86,18 @@ function replaceScript(oldScript: HTMLScriptElement): Promise<void> {
     });
 }
 
+function stripInlineColors(element: Element): void {
+    for (const el of element.querySelectorAll("[style]")) {
+        const style = (el as HTMLElement).style;
+        if (style.color) {
+            style.removeProperty("color");
+        }
+        if (style.backgroundColor) {
+            style.removeProperty("background-color");
+        }
+    }
+}
+
 async function setInnerHTML(element: Element, html: string): Promise<void> {
     for (const oldVideo of element.getElementsByTagName("video")) {
         oldVideo.pause();
@@ -98,6 +110,10 @@ async function setInnerHTML(element: Element, html: string): Promise<void> {
     }
 
     element.innerHTML = html;
+
+    if (document.body.classList.contains("nightMode")) {
+        stripInlineColors(element);
+    }
 
     for (const oldScript of element.getElementsByTagName("script")) {
         await replaceScript(oldScript);

--- a/ts/reviewer/reviewer.scss
+++ b/ts/reviewer/reviewer.scss
@@ -22,8 +22,8 @@ body {
 }
 
 // explicit nightMode definition required
-// to override default .card styling
-body.nightMode {
+// to override default .card styling injected via inline <style> tags
+body.nightMode.card {
     background-color: var(--canvas);
     color: var(--fg);
 }


### PR DESCRIPTION
## Linked issue (required)

Refs: card content with inline styles not visible in night mode

## Summary / motivation (required)

Card text is invisible in dark/night mode due to two issues:

1. **CSS specificity**: The `.card { color: black; background-color: white; }` from notetype CSS (injected via inline `<style>` tags in `#qa`) overrides `body.nightMode` due to equal specificity and later source order. Fixed by increasing selector to `body.nightMode.card`.

2. **Inline style colors**: Card content pasted from websites contains hardcoded inline `style="color: rgb(36,41,46)"` which no CSS rule can override. Added `stripInlineColors()` to remove inline `color` and `background-color` from elements inside `#qa` when in night mode.

## Steps to reproduce (required, use N/A if not applicable)

1. Enable dark mode on macOS (System Settings > Appearance > Dark)
2. Create a card by pasting content from a website (e.g. GitHub/Wikipedia) that includes inline styles
3. Review the card — text is nearly invisible (dark text on dark background)

## How to test (required)

### Checklist (minimum)

- [x] I ran `./ninja check` or an equivalent relevant check locally.
- [ ] I added or updated tests when the change is non-trivial or behavior changed.

### Details

1. `./check` passes — all Rust, Python, TypeScript/Svelte checks green
2. Manual verification via `QTWEBENGINE_REMOTE_DEBUGGING=9222 ./run`:
   - Inspected `#qa` innerHTML — inline `color` stripped from `<h3>` elements
   - Verified `getComputedStyle(document.body).color` = `rgb(252, 252, 252)` (light)
   - Verified `getComputedStyle(document.body).backgroundColor` = `rgb(44, 44, 44)` (dark)
   - Verified `getComputedStyle(h3).color` = `rgb(252, 252, 252)` (inherits from body)

## Before / after behavior (optional)

**Before**: Card text uses hardcoded dark colors (black or near-black) on dark background — unreadable.
**After**: Inline colors stripped in night mode; text inherits `var(--fg)` from body — clearly visible.

## Risk / compatibility / migration (optional)

- Cards with **intentionally** colored inline text (not from paste) will lose those colors in night mode. This is an acceptable tradeoff since inline colors from paste are far more common and almost never dark-mode-aware.
- Class-based colors (`.cloze`, `.typeGood`, `.typeBad`, etc.) are unaffected.

## UI evidence (required for visual changes; otherwise N/A)

Verified via CDP remote debugging — card text color changes from `rgb(36, 41, 46)` to `rgb(252, 252, 252)` in night mode.

## Scope

- [x] This PR is focused on one change (no unrelated edits).