### PR TITLE
FSRS Sync Reconciliation Mechanism

### DIFF
--- a/docs/FSRS_AUTO_OPTIMIZE.md
+++ b/docs/FSRS_AUTO_OPTIMIZE.md
@@ -1,0 +1,269 @@
+# FSRS Auto Optimize
+
+## Constraints
+
+- Auto-optimize is not only "save new FSRS params".
+- When deck config changes are applied, Anki may recompute memory state for affected cards.
+- That recomputation rewrites `cards.data` and bumps card `mtime`.
+- `cards.data` stores FSRS memory state plus desired retention and decay.
+- Deck config params and card rows do not sync as one unit.
+- Deck configs merge by config `mtime`.
+- Cards merge later as whole rows by card `mtime`.
+- This means two devices can produce different FSRS state for the same card even if they eventually agree on the preset params.
+
+## Main Risk
+
+The dangerous case is not only:
+
+- optimize on device A
+- optimize on device B
+
+It is also:
+
+- review on device A
+- auto-optimize on device B before sync
+- sync both devices later
+
+In that case, device B can compute memory state from incomplete review history.
+During sync, revlogs are merged before cards, but card FSRS state is not recomputed after revlog merge.
+If device B's card row has the newer `mtime`, it can win even though its FSRS state was computed without the latest review.
+
+## Related Code
+
+### Optimization / FSRS update path
+
+- Deck options UI:
+  - `ts/routes/deck-options/FsrsOptions.svelte`
+- Deck config update and recompute trigger:
+  - `rslib/src/deckconfig/update.rs`
+- Memory-state recomputation:
+  - `rslib/src/scheduler/fsrs/memory_state.rs`
+- FSRS param computation:
+  - `rslib/src/scheduler/fsrs/params.rs`
+- Card FSRS serialization in `cards.data`:
+  - `rslib/src/storage/card/data.rs`
+
+### Sync path
+
+- Normal sync flow:
+  - `rslib/src/sync/collection/normal.rs`
+- Unchunked change merge for deck configs:
+  - `rslib/src/sync/collection/changes.rs`
+- Chunk merge for revlogs/cards/notes:
+  - `rslib/src/sync/collection/chunks.rs`
+- Sync sanity check:
+  - `rslib/src/sync/collection/sanity.rs`
+
+## Important Current Behavior
+
+### Deck options UI
+
+`Optimize Current Preset` computes new params into the deck options form state.
+It does not by itself rewrite cards immediately.
+The card rewrite happens when the deck config changes are saved and `update_memory_state()` runs.
+
+`Optimize All Presets` goes through the bulk update path and then the same recompute machinery.
+
+### Deck config apply path
+
+When deck configs are updated, Anki checks whether FSRS-related inputs changed:
+
+- params
+- desired retention
+- easy days when rescheduling is enabled
+- FSRS enabled/disabled
+
+If yes, it queues decks for memory-state recomputation.
+
+### Memory-state update path
+
+`update_memory_state()`:
+
+- gathers revlog history for the searched cards
+- computes new memory state
+- stores `memory_state`, `desired_retention`, and `decay` on cards
+- optionally reschedules cards
+- saves each card through `update_card_inner()`
+
+That save bumps card `mtime` and marks the card as sync-relevant.
+
+### Sync merge path
+
+The sync logic currently:
+
+- merges revlogs
+- merges cards
+- keeps the newer card row based on `mtime` / pending sync state
+
+Card merge is a whole-row overwrite, not a field-wise FSRS merge.
+So the winner card row brings its own `data`, interval, due, and other card state with it.
+
+## How Conflicts Happen
+
+### Scenario 1: review on one device, optimize on another
+
+1. Device A reviews a card but has not synced yet.
+2. Device B auto-optimizes and recomputes that card's FSRS state without seeing A's review.
+3. Device B saves newer card data and newer `mtime`.
+4. Sync merges revlogs first, so the review eventually exists everywhere.
+5. Sync then merges cards by `mtime`, and B's stale FSRS state can win.
+
+Result:
+
+- final revlog history may be complete
+- final card FSRS state may still be stale
+
+### Scenario 2: both devices optimize
+
+1. Device A optimizes with one visible review set.
+2. Device B optimizes with another visible review set.
+3. Both rewrite overlapping cards.
+4. Sync picks card winners by `mtime`.
+
+Result:
+
+- preset params may converge
+- card-level FSRS state may still depend on whichever device wrote last
+
+### Scenario 3: config and cards disagree after sync
+
+Deck configs sync in the unchunked phase.
+Cards sync in the chunked phase.
+So it is possible to end with:
+
+- params from one side
+- card FSRS state computed using older params or older review history from the other side
+
+## Revlog Table Approach
+
+The revlog idea is attractive because it would give optimization-related events timestamps.
+But by itself it does not look sufficient.
+
+Reasons:
+
+- current FSRS history building filters to entries that have a rating and affect scheduling
+- manual/rescheduled-style entries are treated specially
+- entries with no rating do not currently participate as normal FSRS review history
+
+So adding a virtual revlog entry alone does not automatically fix stale memory-state resolution.
+
+At minimum, a revlog-based approach would still need post-sync recomputation for affected cards.
+
+## Current Read
+
+The safer direction looks closer to:
+
+- detect cards whose FSRS-relevant data may conflict during sync
+- finish merging revlogs and other sync data
+- recompute FSRS state and interval for those specific cards after sync data is complete
+
+That matches the concern that the winning card row may not include all reviews even when the final merged revlog does.
+
+## When To Reconcile
+
+The important nuance is that reconciliation must consider:
+
+- data that was just synced down from the other side
+- data that already exists locally but is still pending upload
+
+So the reconcile step should not run while applying each incoming card row.
+It should run after remote data has been merged into the local collection, but before local pending card chunks are gathered and uploaded.
+
+In the current normal sync flow, the intended place is conceptually:
+
+1. deletions
+2. unchunked changes, including deck configs
+3. remote chunks merged into local DB
+4. FSRS reconcile pass for affected cards
+5. gather local pending chunks and upload them
+
+This matters because, at that point:
+
+- remote revlogs have already been inserted locally
+- local pending revlogs are also already present locally
+- merged deck config state is available locally
+- recomputed card state can become the version that gets uploaded in the same sync
+
+If reconciliation happens too early:
+
+- later incoming card merges can overwrite it
+- it may compute from incomplete merged state
+- it may miss deck-config changes that arrived earlier in the sync
+
+## Detect vs Recompute
+
+It likely makes sense to separate:
+
+- detection of cards that need FSRS reconciliation
+- actual recomputation of those cards
+
+Detection can happen during merge when a remote card overlaps a local pending card and FSRS-relevant data differs.
+But recomputation should wait until the remote merge phase is complete.
+
+So the sync code likely wants a temporary set such as:
+
+- `cards_needing_fsrs_reconcile`
+
+That set can be populated during incoming merge, then processed once after remote chunks are done.
+
+## Why Not Recompute During Card Merge
+
+`add_or_update_card_if_newer()` is a reasonable place to detect candidates.
+It is not a good place to recompute them.
+
+Reasons:
+
+- it runs card-by-card
+- revlogs and other related rows may still be mid-merge
+- later incoming rows may still change the final local state
+
+So:
+
+- detect during card merge
+- recompute after remote merge is complete
+
+## Test Strategy
+
+The best test shape is an integration test using the existing two-device sync harness in:
+
+- `rslib/src/sync/collection/tests.rs`
+
+Useful scenarios:
+
+### Scenario A
+
+- create shared starting state
+- full upload from `col1`
+- full download into `col2`
+- review card on `col1`
+- optimize / recompute on `col2`
+- sync `col1`
+- sync `col2`
+- assert final card state is based on full merged review history
+
+### Scenario B
+
+- shared starting state
+- optimize on both sides with different visible review history
+- sync both sides
+- assert no stale card FSRS state remains
+
+### Scenario C
+
+- change params on one side
+- keep overlapping card updates on the other side
+- sync both sides
+- assert final params and per-card FSRS state are consistent
+
+## First Test To Build Later
+
+The first regression test should model:
+
+- review on device A
+- optimize on device B before sync
+- sync both devices
+
+That is the clearest case where:
+
+- all revlogs can be present after sync
+- but the kept card state can still be computed from incomplete history

--- a/docs/FSRS_SYNC_RECONCILE_IMPLEMENTATION.md
+++ b/docs/FSRS_SYNC_RECONCILE_IMPLEMENTATION.md
@@ -528,20 +528,20 @@ cargo fmt --all
 
 The current sync reconciliation coverage is:
 
-| Test                                                             | What it proves                                                                                                     |
-| ---------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
-| `fsrs_stale_card_state_is_reconciled_during_sync`                | One device reviews, the other recomputes stale FSRS state, and sync converges to merged truth.                    |
-| `fsrs_metadata_conflict_is_reconciled_without_rescheduling`      | FSRS-only metadata conflicts are repaired without changing `due` or `interval`.                                   |
-| `fsrs_itemless_card_state_is_cleared_during_sync`                | Itemless reconciliation clears stale FSRS fields and refreshes retention/decay metadata.                          |
-| `fsrs_conflicts_are_reconciled_per_preset`                       | Cards from different presets/configs are reconciled with the correct config grouping.                              |
-| `fsrs_reconciliation_uses_original_deck_for_filtered_cards`      | Filtered-deck metadata reconciliation resolves through `original_or_current_deck_id()`.                           |
-| `fsrs_reconciliation_respects_deck_overrides_within_one_preset`  | Two decks sharing one preset still get their own deck-level desired retention override in the same batch.         |
-| `fsrs_mixed_schedule_and_metadata_conflicts_reconcile_selectively` | In one preset batch, one card can be rescheduled while another only gets metadata repair.                       |
-| `fsrs_filtered_card_schedule_conflict_uses_original_deck`        | Filtered-deck schedule reconciliation uses the home deck and updates the home-deck schedule through `original_due`. |
-| `fsrs_state_is_recomputed_from_reviews_on_both_devices`          | The same card reviewed on both devices before sync is recomputed from the merged review history.                  |
+| Test                                                               | What it proves                                                                                                      |
+|--------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------|
+| `fsrs_stale_card_state_is_reconciled_during_sync`                  | One device reviews, the other recomputes stale FSRS state, and sync converges to merged truth.                      |
+| `fsrs_metadata_conflict_is_reconciled_without_rescheduling`        | FSRS-only metadata conflicts are repaired without changing `due` or `interval`.                                     |
+| `fsrs_itemless_card_state_is_cleared_during_sync`                  | Itemless reconciliation clears stale FSRS fields and refreshes retention/decay metadata.                            |
+| `fsrs_conflicts_are_reconciled_per_preset`                         | Cards from different presets/configs are reconciled with the correct config grouping.                               |
+| `fsrs_reconciliation_uses_original_deck_for_filtered_cards`        | Filtered-deck metadata reconciliation resolves through `original_or_current_deck_id()`.                             |
+| `fsrs_reconciliation_respects_deck_overrides_within_one_preset`    | Two decks sharing one preset still get their own deck-level desired retention override in the same batch.           |
+| `fsrs_mixed_schedule_and_metadata_conflicts_reconcile_selectively` | In one preset batch, one card can be rescheduled while another only gets metadata repair.                           |
+| `fsrs_filtered_card_schedule_conflict_uses_original_deck`          | Filtered-deck schedule reconciliation uses the home deck and updates the home-deck schedule through `original_due`. |
+| `fsrs_state_is_recomputed_from_reviews_on_both_devices`            | The same card reviewed on both devices before sync is recomputed from the merged review history.                    |
 
 Related base FSRS behavior already covered outside sync:
 
-| Test                       | What it proves                                                                    |
-| -------------------------- | --------------------------------------------------------------------------------- |
-| `no_req_clears_fsrs_data`  | The memory-state update path clears FSRS data when no FSRS request is provided.   |
+| Test                      | What it proves                                                                  |
+| ------------------------- | ------------------------------------------------------------------------------- |
+| `no_req_clears_fsrs_data` | The memory-state update path clears FSRS data when no FSRS request is provided. |

--- a/docs/FSRS_SYNC_RECONCILE_IMPLEMENTATION.md
+++ b/docs/FSRS_SYNC_RECONCILE_IMPLEMENTATION.md
@@ -366,7 +366,7 @@ Why this is necessary:
 - The guard conditions prevent the reconcile pass from inventing schedule changes for cards that should not be rescheduled at all.
 - The logic uses merged review timing and the recomputed memory state, so the resulting interval is based on the final post-sync view rather than either stale pre-sync row.
 
-## 10. The Test Covers The Real Failure Shape
+## 10. The Tests Cover The Reconciliation Matrix
 
 File:
 
@@ -422,20 +422,126 @@ async fn fsrs_stale_card_state_is_reconciled_during_sync() -> Result<()> {
 
 Why this is necessary:
 
-- This is the actual bug shape we care about:
+- The original stale-state case is still the core failure shape:
   - device A reviews
   - device B recomputes stale FSRS state without that review
   - sync must converge onto the merged truth
-- The test does not only check `cards.data`; it also checks `last_review_time`, `interval`, and `due`, because stale FSRS state can surface in multiple stored fields.
-- Using the real sync harness is important here because the ordering of merge and upload phases is exactly what the implementation relies on.
+- The coverage was then expanded to protect the other non-obvious branches in the implementation:
+  - metadata-only conflicts that must not reschedule
+  - itemless reconciliation
+  - per-preset grouping
+  - filtered-deck reconciliation via `original_or_current_deck_id()`
+  - deck-level desired retention overrides within one preset batch
+  - mixed batches where one card needs schedule reconciliation and another only needs metadata reconciliation
+  - same-card reviews on both devices before sync, which must rebuild memory state from the merged review history
+- Using the real sync harness is important because the ordering of merge and upload phases is exactly what the implementation relies on.
+
+Code:
+
+```rust
+#[tokio::test]
+async fn fsrs_state_is_recomputed_from_reviews_on_both_devices() -> Result<()> {
+    // ...
+    col1.answer_good();
+    // ...
+    col2.answer_easy();
+
+    let out = ctx.normal_sync(&mut col1).await;
+    assert_eq!(out.required, SyncActionRequired::NoChanges);
+    let out = ctx.normal_sync(&mut col2).await;
+    assert_eq!(out.required, SyncActionRequired::NoChanges);
+
+    let merged_card = col2.storage.get_card(card_id)?.unwrap();
+    let pre_converged_card = col1.storage.get_card(card_id)?.unwrap();
+    assert_eq!(col2.storage.get_revlog_entries_for_card(card_id)?.len(), 3);
+    assert_eq!(col1.storage.get_revlog_entries_for_card(card_id)?.len(), 2);
+    assert!(
+        merged_card.memory_state != pre_converged_card.memory_state
+            || merged_card.last_review_time != pre_converged_card.last_review_time
+            || merged_card.interval != pre_converged_card.interval
+            || merged_card.due != pre_converged_card.due
+    );
+
+    let out = ctx.normal_sync(&mut col1).await;
+    assert_eq!(out.required, SyncActionRequired::NoChanges);
+    // both sides now converge onto the merged-history state
+}
+```
+
+Why this is necessary:
+
+- This is the strongest remaining correctness case for the reconciliation design.
+- It proves the implementation is not only repairing stale `card.data`; it is also handling the case where both devices independently add new reviews to the same card before syncing.
+- The intermediate assertion intentionally checks that the second syncing device moves to merged-history state before the first device has caught up.
+
+## 11. Add Minimal Debug Logging For Operability
+
+Files:
+
+- `rslib/src/sync/collection/normal.rs`
+- `rslib/src/scheduler/fsrs/memory_state.rs`
+
+Code:
+
+```rust
+debug!(
+    cards = cards_needing_fsrs_reconcile.len(),
+    schedule_cards = cards_needing_fsrs_reconcile
+        .values()
+        .filter(|&&needs_schedule_reconcile| needs_schedule_reconcile)
+        .count(),
+    "reconciling fsrs state"
+);
+```
+
+```rust
+debug!(
+    config_id = config_id.0,
+    cards = card_ids.len(),
+    cards_with_items = items.len(),
+    itemless_cards = cards_without_items.len(),
+    schedule_cards = schedule_reconcile_cards.len(),
+    "recomputing fsrs state after sync"
+);
+```
+
+Why this is necessary:
+
+- The sync path is hard to reason about from user reports alone.
+- These logs give just enough signal to answer:
+  - was FSRS reconciliation triggered at all?
+  - how many cards needed full schedule repair?
+  - how were the cards split by config and itemless/itemful paths?
+- The logging stays intentionally aggregate-only. It avoids per-card noise and does not add new behavior.
 
 ## Verified Commands
 
 These are the targeted checks that were run after the change:
 
 ```bash
-cargo test -p anki fsrs_stale_card_state -- --nocapture
-cargo test -p anki sync_roundtrip -- --nocapture
+cargo test -p anki fsrs_ -- --nocapture
 cargo test -p anki sync::collection::tests -- --nocapture
 cargo fmt --all
 ```
+
+## Test Matrix
+
+The current sync reconciliation coverage is:
+
+| Test | What it proves |
+| --- | --- |
+| `fsrs_stale_card_state_is_reconciled_during_sync` | One device reviews, the other recomputes stale FSRS state, and sync converges to merged truth. |
+| `fsrs_metadata_conflict_is_reconciled_without_rescheduling` | FSRS-only metadata conflicts are repaired without changing `due` or `interval`. |
+| `fsrs_itemless_card_state_is_cleared_during_sync` | Itemless reconciliation clears stale FSRS fields and refreshes retention/decay metadata. |
+| `fsrs_conflicts_are_reconciled_per_preset` | Cards from different presets/configs are reconciled with the correct config grouping. |
+| `fsrs_reconciliation_uses_original_deck_for_filtered_cards` | Filtered-deck metadata reconciliation resolves through `original_or_current_deck_id()`. |
+| `fsrs_reconciliation_respects_deck_overrides_within_one_preset` | Two decks sharing one preset still get their own deck-level desired retention override in the same batch. |
+| `fsrs_mixed_schedule_and_metadata_conflicts_reconcile_selectively` | In one preset batch, one card can be rescheduled while another only gets metadata repair. |
+| `fsrs_filtered_card_schedule_conflict_uses_original_deck` | Filtered-deck schedule reconciliation uses the home deck and updates the home-deck schedule through `original_due`. |
+| `fsrs_state_is_recomputed_from_reviews_on_both_devices` | The same card reviewed on both devices before sync is recomputed from the merged review history. |
+
+Related base FSRS behavior already covered outside sync:
+
+| Test | What it proves |
+| --- | --- |
+| `no_req_clears_fsrs_data` | The memory-state update path clears FSRS data when no FSRS request is provided. |

--- a/docs/FSRS_SYNC_RECONCILE_IMPLEMENTATION.md
+++ b/docs/FSRS_SYNC_RECONCILE_IMPLEMENTATION.md
@@ -528,20 +528,20 @@ cargo fmt --all
 
 The current sync reconciliation coverage is:
 
-| Test | What it proves |
-| --- | --- |
-| `fsrs_stale_card_state_is_reconciled_during_sync` | One device reviews, the other recomputes stale FSRS state, and sync converges to merged truth. |
-| `fsrs_metadata_conflict_is_reconciled_without_rescheduling` | FSRS-only metadata conflicts are repaired without changing `due` or `interval`. |
-| `fsrs_itemless_card_state_is_cleared_during_sync` | Itemless reconciliation clears stale FSRS fields and refreshes retention/decay metadata. |
-| `fsrs_conflicts_are_reconciled_per_preset` | Cards from different presets/configs are reconciled with the correct config grouping. |
-| `fsrs_reconciliation_uses_original_deck_for_filtered_cards` | Filtered-deck metadata reconciliation resolves through `original_or_current_deck_id()`. |
-| `fsrs_reconciliation_respects_deck_overrides_within_one_preset` | Two decks sharing one preset still get their own deck-level desired retention override in the same batch. |
-| `fsrs_mixed_schedule_and_metadata_conflicts_reconcile_selectively` | In one preset batch, one card can be rescheduled while another only gets metadata repair. |
-| `fsrs_filtered_card_schedule_conflict_uses_original_deck` | Filtered-deck schedule reconciliation uses the home deck and updates the home-deck schedule through `original_due`. |
-| `fsrs_state_is_recomputed_from_reviews_on_both_devices` | The same card reviewed on both devices before sync is recomputed from the merged review history. |
+| Test                                                             | What it proves                                                                                                     |
+| ---------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| `fsrs_stale_card_state_is_reconciled_during_sync`                | One device reviews, the other recomputes stale FSRS state, and sync converges to merged truth.                    |
+| `fsrs_metadata_conflict_is_reconciled_without_rescheduling`      | FSRS-only metadata conflicts are repaired without changing `due` or `interval`.                                   |
+| `fsrs_itemless_card_state_is_cleared_during_sync`                | Itemless reconciliation clears stale FSRS fields and refreshes retention/decay metadata.                          |
+| `fsrs_conflicts_are_reconciled_per_preset`                       | Cards from different presets/configs are reconciled with the correct config grouping.                              |
+| `fsrs_reconciliation_uses_original_deck_for_filtered_cards`      | Filtered-deck metadata reconciliation resolves through `original_or_current_deck_id()`.                           |
+| `fsrs_reconciliation_respects_deck_overrides_within_one_preset`  | Two decks sharing one preset still get their own deck-level desired retention override in the same batch.         |
+| `fsrs_mixed_schedule_and_metadata_conflicts_reconcile_selectively` | In one preset batch, one card can be rescheduled while another only gets metadata repair.                       |
+| `fsrs_filtered_card_schedule_conflict_uses_original_deck`        | Filtered-deck schedule reconciliation uses the home deck and updates the home-deck schedule through `original_due`. |
+| `fsrs_state_is_recomputed_from_reviews_on_both_devices`          | The same card reviewed on both devices before sync is recomputed from the merged review history.                  |
 
 Related base FSRS behavior already covered outside sync:
 
-| Test | What it proves |
-| --- | --- |
-| `no_req_clears_fsrs_data` | The memory-state update path clears FSRS data when no FSRS request is provided. |
+| Test                       | What it proves                                                                    |
+| -------------------------- | --------------------------------------------------------------------------------- |
+| `no_req_clears_fsrs_data`  | The memory-state update path clears FSRS data when no FSRS request is provided.   |

--- a/docs/FSRS_SYNC_RECONCILE_IMPLEMENTATION.md
+++ b/docs/FSRS_SYNC_RECONCILE_IMPLEMENTATION.md
@@ -529,7 +529,7 @@ cargo fmt --all
 The current sync reconciliation coverage is:
 
 | Test                                                               | What it proves                                                                                                      |
-|--------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------|
+| ------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------- |
 | `fsrs_stale_card_state_is_reconciled_during_sync`                  | One device reviews, the other recomputes stale FSRS state, and sync converges to merged truth.                      |
 | `fsrs_metadata_conflict_is_reconciled_without_rescheduling`        | FSRS-only metadata conflicts are repaired without changing `due` or `interval`.                                     |
 | `fsrs_itemless_card_state_is_cleared_during_sync`                  | Itemless reconciliation clears stale FSRS fields and refreshes retention/decay metadata.                            |

--- a/docs/FSRS_SYNC_RECONCILE_IMPLEMENTATION.md
+++ b/docs/FSRS_SYNC_RECONCILE_IMPLEMENTATION.md
@@ -1,0 +1,441 @@
+# FSRS Sync Reconcile Implementation
+
+This note explains the first sync-safety implementation for FSRS.
+
+The goal of this change is narrow:
+
+- detect when a local pending card and an incoming remote card disagree on FSRS-relevant state
+- finish merging remote data first
+- recompute affected cards from merged local truth
+- upload the reconciled card as a normal pending sync change
+
+This does **not** change the `cards.data` format.
+
+## 1. Reconcile In The Right Sync Phase
+
+File:
+
+- `rslib/src/sync/collection/normal.rs`
+
+Code:
+
+```rust
+async fn normal_sync_inner(&mut self, mut state: ClientSyncState) -> error::Result<SyncOutput> {
+    let mut cards_needing_fsrs_reconcile = HashMap::new();
+
+    self.progress
+        .update(false, |p| p.stage = SyncStage::Syncing)?;
+
+    debug!("start");
+    self.start_and_process_deletions(&state).await?;
+    debug!("unchunked changes");
+    self.process_unchunked_changes(&state).await?;
+    debug!("begin stream from server");
+    self.process_chunks_from_server(&state, &mut cards_needing_fsrs_reconcile)
+        .await?;
+    debug!(
+        cards = cards_needing_fsrs_reconcile.len(),
+        "reconciling fsrs state"
+    );
+    self.col
+        .reconcile_fsrs_state_after_sync(cards_needing_fsrs_reconcile)?;
+    debug!("begin stream to server");
+    self.send_chunks_to_server(&state).await?;
+```
+
+Why this is necessary:
+
+- The reconcile pass must run **after** remote revlogs and card rows have been merged locally.
+- It must also run **before** local chunks are gathered for upload.
+- That is the only point where the local DB can see both:
+  - just-downloaded remote history
+  - still-pending local history
+- This avoids trusting either stale pre-sync card row as the final truth.
+
+## 2. Detect Candidates During Remote Card Merge
+
+File:
+
+- `rslib/src/sync/collection/chunks.rs`
+
+Code:
+
+```rust
+fn merge_cards(
+    &self,
+    entries: Vec<CardEntry>,
+    pending_usn: Usn,
+    cards_needing_fsrs_reconcile: &mut HashMap<CardId, bool>,
+) -> Result<()> {
+    for entry in entries {
+        self.add_or_update_card_if_newer(entry, pending_usn, cards_needing_fsrs_reconcile)?;
+    }
+    Ok(())
+}
+
+fn add_or_update_card_if_newer(
+    &self,
+    entry: CardEntry,
+    pending_usn: Usn,
+    cards_needing_fsrs_reconcile: &mut HashMap<CardId, bool>,
+) -> Result<()> {
+    let proceed = if let Some(existing_card) = self.storage.get_card(entry.id)? {
+        if existing_card.usn.is_pending_sync(pending_usn)
+            && card_needs_fsrs_reconcile(&existing_card, &entry)
+        {
+            cards_needing_fsrs_reconcile
+                .entry(entry.id)
+                .and_modify(|should_reschedule| {
+                    *should_reschedule |= card_schedule_differs(&existing_card, &entry)
+                })
+                .or_insert_with(|| card_schedule_differs(&existing_card, &entry));
+        }
+        !existing_card.usn.is_pending_sync(pending_usn) || existing_card.mtime < entry.mtime
+    } else {
+        true
+    };
+    if proceed {
+        let card = entry.into();
+        self.storage.add_or_update_card(&card)?;
+    }
+    Ok(())
+}
+```
+
+Why this is necessary:
+
+- Detection belongs in the incoming card merge path because that is where both versions are visible at once.
+- The condition is intentionally limited to **locally pending** cards, because that is the case where we know the local side still has unsynced state that can conflict with the incoming remote row.
+- The `bool` in the map is used to remember whether schedule fields also diverged, so later reconciliation knows whether interval/due needs to be recomputed as well.
+- The code still preserves the existing winner rule for the raw row merge. The reconcile pass is a follow-up correction, not a replacement for the current sync protocol.
+
+## 3. Define What Counts As An FSRS-Relevant Conflict
+
+File:
+
+- `rslib/src/sync/collection/chunks.rs`
+
+Code:
+
+```rust
+fn card_needs_fsrs_reconcile(existing: &Card, incoming: &CardEntry) -> bool {
+    let incoming_data = CardData::from_str(&incoming.data);
+    let incoming_has_fsrs = incoming_data.memory_state().is_some()
+        || incoming_data.fsrs_desired_retention.is_some()
+        || incoming_data.decay.is_some()
+        || existing.memory_state.is_some()
+        || existing.desired_retention.is_some()
+        || existing.decay.is_some();
+
+    incoming_has_fsrs
+        && (existing.memory_state != incoming_data.memory_state()
+            || existing.desired_retention != incoming_data.fsrs_desired_retention
+            || existing.decay != incoming_data.decay
+            || existing.last_review_time != incoming_data.last_review_time
+            || card_schedule_differs(existing, incoming))
+}
+```
+
+Why this is necessary:
+
+- We do not want to reconcile every overlapping card update.
+- We only care about cards that are already carrying FSRS-derived state or whose FSRS-derived state clearly diverges.
+- `last_review_time` is included because it affects FSRS behavior and can become stale independently of raw memory state values.
+- Schedule differences are included because stale FSRS state is not only about `cards.data`; it can also show up as wrong interval or due values.
+
+## 4. Group Reconciliation By Current Deck Config
+
+File:
+
+- `rslib/src/scheduler/fsrs/memory_state.rs`
+
+Code:
+
+```rust
+pub(crate) fn reconcile_fsrs_state_after_sync(
+    &mut self,
+    cards_needing_fsrs_reconcile: HashMap<CardId, bool>,
+) -> Result<()> {
+    if cards_needing_fsrs_reconcile.is_empty() || !self.get_config_bool(BoolKey::Fsrs) {
+        return Ok(());
+    }
+
+    let mut card_ids_by_config: HashMap<DeckConfigId, Vec<CardId>> = HashMap::new();
+    let mut deck_desired_retention: HashMap<DeckId, f32> = HashMap::new();
+    for &card_id in cards_needing_fsrs_reconcile.keys() {
+        let card = self.storage.get_card(card_id)?.or_not_found(card_id)?;
+        let deck_id = card.original_or_current_deck_id();
+        let deck = self.get_deck(deck_id)?.or_not_found(deck_id)?;
+        let config_id = deck.config_id().or_invalid("home deck is filtered")?;
+        card_ids_by_config
+            .entry(config_id)
+            .or_default()
+            .push(card_id);
+        if let Ok(normal) = deck.normal() {
+            if let Some(desired_retention) = normal.desired_retention {
+                deck_desired_retention.insert(deck_id, desired_retention);
+            }
+        }
+    }
+```
+
+Why this is necessary:
+
+- Reconciliation must use the **current deck config** that the card belongs to after merge, not the config that either side happened to use before sync.
+- Grouping by config lets the implementation reuse the existing batch FSRS logic instead of recomputing card-by-card with duplicated setup.
+- `original_or_current_deck_id()` matters because filtered-deck cards still need to resolve through their home deck config.
+- Deck-specific desired retention is collected separately so the recompute uses the actual effective retention for each card.
+
+## 5. Rebuild From Merged Local Revlogs
+
+File:
+
+- `rslib/src/scheduler/fsrs/memory_state.rs`
+
+Code:
+
+```rust
+let timing = self.timing_today()?;
+let usn = self.usn()?;
+for (config_id, card_ids) in card_ids_by_config {
+    let config = self
+        .storage
+        .get_deck_config(config_id)?
+        .or_not_found(config_id)?;
+    let revlog =
+        self.revlog_for_srs(SearchNode::CardIds(comma_separated_ids(&card_ids)))?;
+    let fsrs = FSRS::new(Some(config.fsrs_params()))?;
+    let last_revlog_info = get_last_revlog_info(&revlog);
+    let items = fsrs_items_for_memory_states(
+        &fsrs,
+        revlog,
+        timing.next_day_at,
+        config.inner.historical_retention,
+        ignore_revlogs_before_ms_from_config(&config)?,
+    )?;
+```
+
+Why this is necessary:
+
+- This is the core of the approach: do not trust either old card row, just rebuild from the merged local revlog/config state.
+- The code uses the same FSRS item builder as the existing memory-state update flow. That keeps behavior aligned with the rest of the codebase.
+- `get_last_revlog_info()` is captured once here because later steps need consistent review timing for both `last_review_time` and optional rescheduling.
+
+## 6. Preserve Existing FSRS Semantics For Itemless Cards
+
+File:
+
+- `rslib/src/scheduler/fsrs/memory_state.rs`
+
+Code:
+
+```rust
+fn reconcile_itemless_cards_after_sync(
+    &mut self,
+    cards: Vec<CardId>,
+    last_revlog_info: &HashMap<CardId, LastRevlogInfo>,
+    mut set_decay_and_desired_retention: impl FnMut(&mut Card),
+    usn: Usn,
+) -> Result<()> {
+    for card_id in cards {
+        let mut card = self.storage.get_card(card_id)?.or_not_found(card_id)?;
+        set_decay_and_desired_retention(&mut card);
+        card.memory_state = None;
+        card.last_review_time = last_revlog_info
+            .get(&card_id)
+            .and_then(|info| info.last_reviewed_at);
+        self.update_reconciled_card_after_sync(&mut card, usn)?;
+    }
+    Ok(())
+}
+```
+
+Why this is necessary:
+
+- Cards without a valid FSRS item still need their derived metadata refreshed.
+- In particular, `decay`, `desired_retention`, and `last_review_time` can still be stale even when `memory_state` remains `None`.
+- This mirrors the existing distinction in the FSRS update code between cards that produce an item and cards that do not.
+
+## 7. Write Back Without Using Undo-Oriented Update Paths
+
+File:
+
+- `rslib/src/scheduler/fsrs/memory_state.rs`
+
+Code:
+
+```rust
+fn update_reconciled_card_after_sync(&mut self, card: &mut Card, usn: Usn) -> Result<()> {
+    card.set_modified(usn);
+    self.storage.update_card(card)
+}
+```
+
+Why this is necessary:
+
+- Sync is already running inside its own transaction and is not an undoable UI operation.
+- Reusing `update_card_inner()` here would drag the reconcile step through the normal undo-oriented card update path.
+- This helper keeps the intended sync behavior:
+  - bump card `mtime`
+  - mark it with the current sync USN
+  - persist it directly
+
+## 8. Only Reschedule When The Conflict Included Schedule Fields
+
+File:
+
+- `rslib/src/scheduler/fsrs/memory_state.rs`
+
+Code:
+
+```rust
+let schedule_reconcile_cards: HashSet<_> = card_ids
+    .iter()
+    .copied()
+    .filter(|card_id| {
+        cards_needing_fsrs_reconcile
+            .get(card_id)
+            .copied()
+            .unwrap_or_default()
+    })
+    .collect();
+```
+
+```rust
+if schedule_reconcile_cards.contains(&card_id) {
+    self.reschedule_reconciled_card_after_sync(
+        &mut card,
+        fsrs,
+        last_revlog_info.get(&card_id),
+        timing,
+        max_interval,
+    )?;
+}
+```
+
+Why this is necessary:
+
+- Not every FSRS conflict means the card’s due/interval needs to change.
+- Separating “FSRS metadata differs” from “schedule-relevant fields differ” avoids gratuitous interval churn.
+- This keeps the first implementation narrower and reduces the chance of changing scheduling when the only stale fields were in `cards.data`.
+
+## 9. Reuse Existing Rescheduling Logic Shape
+
+File:
+
+- `rslib/src/scheduler/fsrs/memory_state.rs`
+
+Code:
+
+```rust
+fn reschedule_reconciled_card_after_sync(
+    &mut self,
+    card: &mut Card,
+    fsrs: &FSRS,
+    last_revlog_info: Option<&LastRevlogInfo>,
+    timing: SchedTimingToday,
+    max_interval: u32,
+) -> Result<()> {
+    let Some(last_info) = last_revlog_info else {
+        return Ok(());
+    };
+    let Some(last_review) = last_info.last_reviewed_at else {
+        return Ok(());
+    };
+    if !(card.ctype == CardType::Review && card.queue != CardQueue::Suspended) {
+        return Ok(());
+    };
+    // ...
+    let interval = fsrs.next_interval(
+        Some(
+            card.memory_state
+                .expect("memory state set before rescheduling")
+                .stability,
+        ),
+        card.desired_retention
+            .expect("desired retention set before rescheduling"),
+        0,
+    );
+    // ...
+}
+```
+
+Why this is necessary:
+
+- The reschedule behavior needs to stay aligned with the existing FSRS update path as much as possible.
+- The guard conditions prevent the reconcile pass from inventing schedule changes for cards that should not be rescheduled at all.
+- The logic uses merged review timing and the recomputed memory state, so the resulting interval is based on the final post-sync view rather than either stale pre-sync row.
+
+## 10. The Test Covers The Real Failure Shape
+
+File:
+
+- `rslib/src/sync/collection/tests.rs`
+
+Code:
+
+```rust
+#[tokio::test]
+async fn fsrs_stale_card_state_is_reconciled_during_sync() -> Result<()> {
+    // ...
+    col1.answer_good();
+
+    let config = col2.get_deck_config(DeckConfigId(1), false)?.unwrap();
+    let request = UpdateMemoryStateRequest {
+        params: config.fsrs_params().clone(),
+        preset_desired_retention: config.inner.desired_retention,
+        historical_retention: config.inner.historical_retention,
+        max_interval: config.inner.maximum_review_interval,
+        reschedule: false,
+        deck_desired_retention: HashMap::new(),
+    };
+    col2.transact(Op::UpdateDeckConfig, |col| {
+        col.update_memory_state(vec![UpdateMemoryStateEntry {
+            req: Some(request),
+            search: SearchNode::CardIds(card_id.to_string()),
+            ignore_before,
+        }])?;
+        Ok(())
+    })?;
+
+    let stale_card = col2.storage.get_card(card_id)?.unwrap();
+    let reviewed_card = col1.storage.get_card(card_id)?.unwrap();
+    assert!(
+        stale_card.memory_state != reviewed_card.memory_state
+            || stale_card.last_review_time != reviewed_card.last_review_time
+            || stale_card.interval != reviewed_card.interval
+            || stale_card.due != reviewed_card.due
+    );
+
+    let out = ctx.normal_sync(&mut col1).await;
+    assert_eq!(out.required, SyncActionRequired::NoChanges);
+    let out = ctx.normal_sync(&mut col2).await;
+    assert_eq!(out.required, SyncActionRequired::NoChanges);
+
+    let reconciled_card = col2.storage.get_card(card_id)?.unwrap();
+    let reviewed_card = col1.storage.get_card(card_id)?.unwrap();
+    assert_eq!(reconciled_card.memory_state, reviewed_card.memory_state);
+    assert_eq!(reconciled_card.last_review_time, reviewed_card.last_review_time);
+    assert_eq!(reconciled_card.interval, reviewed_card.interval);
+    assert_eq!(reconciled_card.due, reviewed_card.due);
+```
+
+Why this is necessary:
+
+- This is the actual bug shape we care about:
+  - device A reviews
+  - device B recomputes stale FSRS state without that review
+  - sync must converge onto the merged truth
+- The test does not only check `cards.data`; it also checks `last_review_time`, `interval`, and `due`, because stale FSRS state can surface in multiple stored fields.
+- Using the real sync harness is important here because the ordering of merge and upload phases is exactly what the implementation relies on.
+
+## Verified Commands
+
+These are the targeted checks that were run after the change:
+
+```bash
+cargo test -p anki fsrs_stale_card_state -- --nocapture
+cargo test -p anki sync_roundtrip -- --nocapture
+cargo test -p anki sync::collection::tests -- --nocapture
+cargo fmt --all
+```

--- a/rslib/src/scheduler/fsrs/memory_state.rs
+++ b/rslib/src/scheduler/fsrs/memory_state.rs
@@ -2,6 +2,7 @@
 // License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
 use std::collections::HashMap;
+use std::collections::HashSet;
 
 use anki_proto::scheduler::ComputeMemoryStateResponse;
 use fsrs::FSRSItem;
@@ -22,9 +23,11 @@ use crate::scheduler::answering::get_fuzz_seed;
 use crate::scheduler::fsrs::params::reviews_for_fsrs;
 use crate::scheduler::fsrs::params::Params;
 use crate::scheduler::states::fuzz::with_review_fuzz;
+use crate::scheduler::SchedTimingToday;
 use crate::search::Negated;
 use crate::search::SearchNode;
 use crate::search::StateKind;
+use crate::storage::comma_separated_ids;
 
 #[derive(Debug, Clone, Copy, Default)]
 pub struct ComputeMemoryProgress {
@@ -264,6 +267,107 @@ impl Collection {
         Ok(())
     }
 
+    pub(crate) fn reconcile_fsrs_state_after_sync(
+        &mut self,
+        cards_needing_fsrs_reconcile: HashMap<CardId, bool>,
+    ) -> Result<()> {
+        if cards_needing_fsrs_reconcile.is_empty() || !self.get_config_bool(BoolKey::Fsrs) {
+            return Ok(());
+        }
+
+        let mut card_ids_by_config: HashMap<DeckConfigId, Vec<CardId>> = HashMap::new();
+        let mut deck_desired_retention: HashMap<DeckId, f32> = HashMap::new();
+        for &card_id in cards_needing_fsrs_reconcile.keys() {
+            let card = self.storage.get_card(card_id)?.or_not_found(card_id)?;
+            let deck_id = card.original_or_current_deck_id();
+            let deck = self.get_deck(deck_id)?.or_not_found(deck_id)?;
+            let config_id = deck.config_id().or_invalid("home deck is filtered")?;
+            card_ids_by_config
+                .entry(config_id)
+                .or_default()
+                .push(card_id);
+            if let Ok(normal) = deck.normal() {
+                if let Some(desired_retention) = normal.desired_retention {
+                    deck_desired_retention.insert(deck_id, desired_retention);
+                }
+            }
+        }
+
+        let timing = self.timing_today()?;
+        let usn = self.usn()?;
+        for (config_id, card_ids) in card_ids_by_config {
+            let config = self
+                .storage
+                .get_deck_config(config_id)?
+                .or_not_found(config_id)?;
+            let revlog =
+                self.revlog_for_srs(SearchNode::CardIds(comma_separated_ids(&card_ids)))?;
+            let fsrs = FSRS::new(Some(config.fsrs_params()))?;
+            let last_revlog_info = get_last_revlog_info(&revlog);
+            let items = fsrs_items_for_memory_states(
+                &fsrs,
+                revlog,
+                timing.next_day_at,
+                config.inner.historical_retention,
+                ignore_revlogs_before_ms_from_config(&config)?,
+            )?;
+
+            let (items, cards_without_items): (Vec<(CardId, FsrsItemForMemoryState)>, Vec<CardId>) =
+                items.into_iter().partition_map(|(card_id, item)| {
+                    if let Some(item) = item {
+                        Either::Left((card_id, item))
+                    } else {
+                        Either::Right(card_id)
+                    }
+                });
+
+            let decay = get_decay_from_params(config.fsrs_params());
+            let schedule_reconcile_cards: HashSet<_> = card_ids
+                .iter()
+                .copied()
+                .filter(|card_id| {
+                    cards_needing_fsrs_reconcile
+                        .get(card_id)
+                        .copied()
+                        .unwrap_or_default()
+                })
+                .collect();
+
+            self.reconcile_itemless_cards_after_sync(
+                cards_without_items,
+                &last_revlog_info,
+                |card: &mut Card| {
+                    let deck_id = card.original_or_current_deck_id();
+                    let desired_retention = *deck_desired_retention
+                        .get(&deck_id)
+                        .unwrap_or(&config.inner.desired_retention);
+                    card.desired_retention = Some(desired_retention);
+                    card.decay = Some(decay);
+                },
+                usn,
+            )?;
+            self.reconcile_cards_with_items_after_sync(
+                items,
+                &fsrs,
+                &last_revlog_info,
+                &schedule_reconcile_cards,
+                timing,
+                config.inner.maximum_review_interval,
+                |card: &mut Card| {
+                    let deck_id = card.original_or_current_deck_id();
+                    let desired_retention = *deck_desired_retention
+                        .get(&deck_id)
+                        .unwrap_or(&config.inner.desired_retention);
+                    card.desired_retention = Some(desired_retention);
+                    card.decay = Some(decay);
+                },
+                usn,
+            )?;
+        }
+
+        Ok(())
+    }
+
     fn create_progress_closure(&self, item_count: usize) -> Result<impl FnMut() -> Result<()>> {
         let mut progress = self.new_progress_handler::<ComputeMemoryProgress>();
         progress.update(false, |s| {
@@ -286,6 +390,30 @@ impl Collection {
             card.clear_fsrs_data();
             self.update_card_inner(&mut card, original, usn)?;
             on_updated_card()?
+        }
+        Ok(())
+    }
+
+    fn update_reconciled_card_after_sync(&mut self, card: &mut Card, usn: Usn) -> Result<()> {
+        card.set_modified(usn);
+        self.storage.update_card(card)
+    }
+
+    fn reconcile_itemless_cards_after_sync(
+        &mut self,
+        cards: Vec<CardId>,
+        last_revlog_info: &HashMap<CardId, LastRevlogInfo>,
+        mut set_decay_and_desired_retention: impl FnMut(&mut Card),
+        usn: Usn,
+    ) -> Result<()> {
+        for card_id in cards {
+            let mut card = self.storage.get_card(card_id)?.or_not_found(card_id)?;
+            set_decay_and_desired_retention(&mut card);
+            card.memory_state = None;
+            card.last_review_time = last_revlog_info
+                .get(&card_id)
+                .and_then(|info| info.last_reviewed_at);
+            self.update_reconciled_card_after_sync(&mut card, usn)?;
         }
         Ok(())
     }
@@ -354,6 +482,142 @@ impl Collection {
                 on_updated_card()?;
             }
         }
+        Ok(())
+    }
+
+    fn reconcile_cards_with_items_after_sync(
+        &mut self,
+        items: Vec<(CardId, FsrsItemForMemoryState)>,
+        fsrs: &FSRS,
+        last_revlog_info: &HashMap<CardId, LastRevlogInfo>,
+        schedule_reconcile_cards: &HashSet<CardId>,
+        timing: SchedTimingToday,
+        max_interval: u32,
+        mut set_decay_and_desired_retention: impl FnMut(&mut Card),
+        usn: Usn,
+    ) -> Result<()> {
+        const FSRS_BATCH_SIZE: usize = 1000;
+
+        let mut to_update = Vec::new();
+        let mut fsrs_items = Vec::new();
+        let mut starting_states = Vec::new();
+
+        for (card_id, item) in items.into_iter() {
+            to_update.push(card_id);
+            fsrs_items.push(item.item);
+            starting_states.push(item.starting_state);
+        }
+
+        let mut p = permutation::sort_unstable_by_key(&fsrs_items, |item| item.reviews.len());
+        p.apply_slice_in_place(&mut to_update);
+        p.apply_slice_in_place(&mut fsrs_items);
+        p.apply_slice_in_place(&mut starting_states);
+
+        for ((to_update, fsrs_items), starting_states) in to_update
+            .chunk_into_vecs(FSRS_BATCH_SIZE)
+            .zip_eq(fsrs_items.chunk_into_vecs(FSRS_BATCH_SIZE))
+            .zip_eq(starting_states.chunk_into_vecs(FSRS_BATCH_SIZE))
+        {
+            let memory_states = fsrs.memory_state_batch(fsrs_items, starting_states)?;
+
+            for (card_id, memory_state) in to_update.into_iter().zip_eq(memory_states) {
+                let mut card = self.storage.get_card(card_id)?.or_not_found(card_id)?;
+                set_decay_and_desired_retention(&mut card);
+                card.memory_state = Some(memory_state.into());
+                card.last_review_time = last_revlog_info
+                    .get(&card_id)
+                    .and_then(|info| info.last_reviewed_at);
+                if schedule_reconcile_cards.contains(&card_id) {
+                    self.reschedule_reconciled_card_after_sync(
+                        &mut card,
+                        fsrs,
+                        last_revlog_info.get(&card_id),
+                        timing,
+                        max_interval,
+                    )?;
+                }
+                self.update_reconciled_card_after_sync(&mut card, usn)?;
+            }
+        }
+
+        Ok(())
+    }
+
+    fn reschedule_reconciled_card_after_sync(
+        &mut self,
+        card: &mut Card,
+        fsrs: &FSRS,
+        last_revlog_info: Option<&LastRevlogInfo>,
+        timing: SchedTimingToday,
+        max_interval: u32,
+    ) -> Result<()> {
+        let Some(last_info) = last_revlog_info else {
+            return Ok(());
+        };
+        let Some(last_review) = last_info.last_reviewed_at else {
+            return Ok(());
+        };
+        if !(card.ctype == CardType::Review && card.queue != CardQueue::Suspended) {
+            return Ok(());
+        }
+
+        let deck = self
+            .get_deck(card.original_or_current_deck_id())?
+            .or_not_found(card.original_or_current_deck_id())?;
+        let deckconfig_id = deck.config_id().or_invalid("home deck is filtered")?;
+        let days_elapsed = timing.next_day_at.elapsed_days_since(last_review) as i32;
+        let min_interval = |interval: u32| {
+            let previous_interval = last_info.previous_interval.unwrap_or(0);
+            if interval > previous_interval {
+                previous_interval + 1
+            } else {
+                0
+            }
+            .max(1)
+        };
+        let interval = fsrs.next_interval(
+            Some(
+                card.memory_state
+                    .expect("memory state set before rescheduling")
+                    .stability,
+            ),
+            card.desired_retention
+                .expect("desired retention set before rescheduling"),
+            0,
+        );
+        let mut rescheduler = if self.get_config_bool(BoolKey::LoadBalancerEnabled) {
+            Some(Rescheduler::new(self)?)
+        } else {
+            None
+        };
+        card.interval = rescheduler
+            .as_mut()
+            .and_then(|r| {
+                r.find_interval(
+                    interval,
+                    min_interval(interval as u32),
+                    max_interval,
+                    days_elapsed as u32,
+                    deckconfig_id,
+                    get_fuzz_seed(card, true),
+                )
+            })
+            .unwrap_or_else(|| {
+                with_review_fuzz(
+                    card.get_fuzz_factor(true),
+                    interval,
+                    min_interval(interval as u32),
+                    max_interval,
+                )
+            });
+
+        let due = if card.original_due != 0 {
+            &mut card.original_due
+        } else {
+            &mut card.due
+        };
+        *due = (timing.days_elapsed as i32) - days_elapsed + card.interval as i32;
+
         Ok(())
     }
 

--- a/rslib/src/scheduler/fsrs/memory_state.rs
+++ b/rslib/src/scheduler/fsrs/memory_state.rs
@@ -12,6 +12,7 @@ use fsrs::FSRS5_DEFAULT_DECAY;
 use fsrs::FSRS6_DEFAULT_DECAY;
 use itertools::Either;
 use itertools::Itertools;
+use tracing::debug;
 
 use super::params::ignore_revlogs_before_ms_from_config;
 use super::rescheduler::Rescheduler;
@@ -332,6 +333,14 @@ impl Collection {
                         .unwrap_or_default()
                 })
                 .collect();
+            debug!(
+                config_id = config_id.0,
+                cards = card_ids.len(),
+                cards_with_items = items.len(),
+                itemless_cards = cards_without_items.len(),
+                schedule_cards = schedule_reconcile_cards.len(),
+                "recomputing fsrs state after sync"
+            );
 
             self.reconcile_itemless_cards_after_sync(
                 cards_without_items,

--- a/rslib/src/sync/collection/chunks.rs
+++ b/rslib/src/sync/collection/chunks.rs
@@ -5,6 +5,7 @@ use itertools::Itertools;
 use serde::Deserialize;
 use serde::Serialize;
 use serde_tuple::Serialize_tuple;
+use std::collections::HashMap;
 use tracing::debug;
 
 use crate::card::Card;
@@ -90,6 +91,7 @@ impl NormalSyncer<'_> {
     pub(in crate::sync) async fn process_chunks_from_server(
         &mut self,
         state: &ClientSyncState,
+        cards_needing_fsrs_reconcile: &mut HashMap<CardId, bool>,
     ) -> Result<()> {
         loop {
             let chunk = self.server.chunk(EmptyInput::request()).await?.json()?;
@@ -107,7 +109,8 @@ impl NormalSyncer<'_> {
             })?;
 
             let done = chunk.done;
-            self.col.apply_chunk(chunk, state.pending_usn)?;
+            self.col
+                .apply_chunk(chunk, state.pending_usn, cards_needing_fsrs_reconcile)?;
 
             self.progress.check_cancelled()?;
 
@@ -159,9 +162,14 @@ impl Collection {
     /// pending_usn is used to decide whether the local objects are newer.
     /// If the provided objects are not modified locally, the USN inside
     /// the individual objects is used.
-    pub(in crate::sync) fn apply_chunk(&mut self, chunk: Chunk, pending_usn: Usn) -> Result<()> {
+    pub(in crate::sync) fn apply_chunk(
+        &mut self,
+        chunk: Chunk,
+        pending_usn: Usn,
+        cards_needing_fsrs_reconcile: &mut HashMap<CardId, bool>,
+    ) -> Result<()> {
         self.merge_revlog(chunk.revlog)?;
-        self.merge_cards(chunk.cards, pending_usn)?;
+        self.merge_cards(chunk.cards, pending_usn, cards_needing_fsrs_reconcile)?;
         self.merge_notes(chunk.notes, pending_usn)
     }
 
@@ -172,15 +180,35 @@ impl Collection {
         Ok(())
     }
 
-    fn merge_cards(&self, entries: Vec<CardEntry>, pending_usn: Usn) -> Result<()> {
+    fn merge_cards(
+        &self,
+        entries: Vec<CardEntry>,
+        pending_usn: Usn,
+        cards_needing_fsrs_reconcile: &mut HashMap<CardId, bool>,
+    ) -> Result<()> {
         for entry in entries {
-            self.add_or_update_card_if_newer(entry, pending_usn)?;
+            self.add_or_update_card_if_newer(entry, pending_usn, cards_needing_fsrs_reconcile)?;
         }
         Ok(())
     }
 
-    fn add_or_update_card_if_newer(&self, entry: CardEntry, pending_usn: Usn) -> Result<()> {
+    fn add_or_update_card_if_newer(
+        &self,
+        entry: CardEntry,
+        pending_usn: Usn,
+        cards_needing_fsrs_reconcile: &mut HashMap<CardId, bool>,
+    ) -> Result<()> {
         let proceed = if let Some(existing_card) = self.storage.get_card(entry.id)? {
+            if existing_card.usn.is_pending_sync(pending_usn)
+                && card_needs_fsrs_reconcile(&existing_card, &entry)
+            {
+                cards_needing_fsrs_reconcile
+                    .entry(entry.id)
+                    .and_modify(|should_reschedule| {
+                        *should_reschedule |= card_schedule_differs(&existing_card, &entry)
+                    })
+                    .or_insert_with(|| card_schedule_differs(&existing_card, &entry));
+            }
             !existing_card.usn.is_pending_sync(pending_usn) || existing_card.mtime < entry.mtime
         } else {
             true
@@ -308,6 +336,33 @@ impl Collection {
     }
 }
 
+fn card_needs_fsrs_reconcile(existing: &Card, incoming: &CardEntry) -> bool {
+    let incoming_data = CardData::from_str(&incoming.data);
+    let incoming_has_fsrs = incoming_data.memory_state().is_some()
+        || incoming_data.fsrs_desired_retention.is_some()
+        || incoming_data.decay.is_some()
+        || existing.memory_state.is_some()
+        || existing.desired_retention.is_some()
+        || existing.decay.is_some();
+
+    incoming_has_fsrs
+        && (existing.memory_state != incoming_data.memory_state()
+            || existing.desired_retention != incoming_data.fsrs_desired_retention
+            || existing.decay != incoming_data.decay
+            || existing.last_review_time != incoming_data.last_review_time
+            || card_schedule_differs(existing, incoming))
+}
+
+fn card_schedule_differs(existing: &Card, incoming: &CardEntry) -> bool {
+    existing.deck_id != incoming.did
+        || existing.ctype != incoming.ctype
+        || existing.queue != incoming.queue
+        || existing.due != incoming.due
+        || existing.interval != incoming.ivl
+        || existing.original_due != incoming.odue
+        || existing.original_deck_id != incoming.odid
+}
+
 impl From<CardEntry> for Card {
     fn from(e: CardEntry) -> Self {
         let data = CardData::from_str(&e.data);
@@ -411,7 +466,7 @@ pub fn server_apply_chunk(
     col: &mut Collection,
     state: &mut ServerSyncState,
 ) -> Result<()> {
-    col.apply_chunk(req.chunk, state.client_usn)
+    col.apply_chunk(req.chunk, state.client_usn, &mut HashMap::new())
 }
 
 impl Usn {

--- a/rslib/src/sync/collection/chunks.rs
+++ b/rslib/src/sync/collection/chunks.rs
@@ -1,11 +1,12 @@
 // Copyright: Ankitects Pty Ltd and contributors
 // License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
+use std::collections::HashMap;
+
 use itertools::Itertools;
 use serde::Deserialize;
 use serde::Serialize;
 use serde_tuple::Serialize_tuple;
-use std::collections::HashMap;
 use tracing::debug;
 
 use crate::card::Card;

--- a/rslib/src/sync/collection/normal.rs
+++ b/rslib/src/sync/collection/normal.rs
@@ -134,6 +134,10 @@ impl NormalSyncer<'_> {
             .await?;
         debug!(
             cards = cards_needing_fsrs_reconcile.len(),
+            schedule_cards = cards_needing_fsrs_reconcile
+                .values()
+                .filter(|&&needs_schedule_reconcile| needs_schedule_reconcile)
+                .count(),
             "reconciling fsrs state"
         );
         self.col

--- a/rslib/src/sync/collection/normal.rs
+++ b/rslib/src/sync/collection/normal.rs
@@ -2,6 +2,7 @@
 // License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
 use reqwest::Client;
+use std::collections::HashMap;
 use tracing::debug;
 
 use crate::collection::Collection;
@@ -119,6 +120,8 @@ impl NormalSyncer<'_> {
     /// Sync. Caller must have created a transaction, and should call
     /// abort on failure.
     async fn normal_sync_inner(&mut self, mut state: ClientSyncState) -> error::Result<SyncOutput> {
+        let mut cards_needing_fsrs_reconcile = HashMap::new();
+
         self.progress
             .update(false, |p| p.stage = SyncStage::Syncing)?;
 
@@ -127,7 +130,14 @@ impl NormalSyncer<'_> {
         debug!("unchunked changes");
         self.process_unchunked_changes(&state).await?;
         debug!("begin stream from server");
-        self.process_chunks_from_server(&state).await?;
+        self.process_chunks_from_server(&state, &mut cards_needing_fsrs_reconcile)
+            .await?;
+        debug!(
+            cards = cards_needing_fsrs_reconcile.len(),
+            "reconciling fsrs state"
+        );
+        self.col
+            .reconcile_fsrs_state_after_sync(cards_needing_fsrs_reconcile)?;
         debug!("begin stream to server");
         self.send_chunks_to_server(&state).await?;
 

--- a/rslib/src/sync/collection/normal.rs
+++ b/rslib/src/sync/collection/normal.rs
@@ -1,8 +1,9 @@
 // Copyright: Ankitects Pty Ltd and contributors
 // License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
-use reqwest::Client;
 use std::collections::HashMap;
+
+use reqwest::Client;
 use tracing::debug;
 
 use crate::collection::Collection;

--- a/rslib/src/sync/collection/tests.rs
+++ b/rslib/src/sync/collection/tests.rs
@@ -8,6 +8,7 @@ use std::future::Future;
 use std::sync::LazyLock;
 
 use axum::http::StatusCode;
+use fsrs::DEFAULT_PARAMETERS;
 use reqwest::Client;
 use reqwest::Url;
 use serde_json::json;
@@ -29,6 +30,7 @@ use crate::collection::CollectionBuilder;
 use crate::config::BoolKey;
 use crate::deckconfig::DeckConfig;
 use crate::decks::DeckKind;
+use crate::decks::NativeDeckName;
 use crate::error::SyncError;
 use crate::error::SyncErrorKind;
 use crate::log::set_global_logger;
@@ -563,6 +565,554 @@ async fn fsrs_itemless_card_state_is_cleared_during_sync() -> Result<()> {
         // reschedule the card.
         assert_eq!(reconciled_card.due, stale_card.due);
         assert_eq!(reconciled_card.interval, stale_card.interval);
+
+        Ok(())
+    })
+    .await
+}
+
+#[tokio::test]
+async fn fsrs_conflicts_are_reconciled_per_preset() -> Result<()> {
+    with_active_server(|client| async move {
+        let ctx = SyncTestContext::new(client);
+
+        let mut col1 = ctx.col1();
+        col1.set_config_bool(BoolKey::Fsrs, true, false)?;
+
+        let mut config1 = col1.get_deck_config(DeckConfigId(1), false)?.unwrap();
+        config1.inner.desired_retention = 0.81;
+        config1.inner.fsrs_params_6 = DEFAULT_PARAMETERS.into();
+        col1.add_or_update_deck_config(&mut config1)?;
+
+        let mut config2 = DeckConfig {
+            name: "fsrs second config".into(),
+            ..Default::default()
+        };
+        config2.inner.desired_retention = 0.93;
+        config2.inner.fsrs_params_6 = DEFAULT_PARAMETERS.into();
+        config2.inner.fsrs_params_6[20] = 0.21;
+        col1.add_or_update_deck_config(&mut config2)?;
+
+        let mut deck2 = col1.get_or_create_normal_deck("fsrs second deck")?;
+        if let DeckKind::Normal(deck) = &mut deck2.kind {
+            deck.config_id = config2.id.0;
+        }
+        col1.add_or_update_deck(&mut deck2)?;
+
+        let nt = col1.get_notetype_by_name("Basic")?.unwrap();
+        let mut note1 = nt.new_note();
+        note1.set_field(0, "fsrs-preset-1")?;
+        col1.add_note(&mut note1, DeckId(1))?;
+        col1.set_current_deck(DeckId(1))?;
+        let card1 = col1.answer_easy().card_id;
+
+        let mut note2 = nt.new_note();
+        note2.set_field(0, "fsrs-preset-2")?;
+        col1.add_note(&mut note2, deck2.id)?;
+        col1.set_current_deck(deck2.id)?;
+        let card2 = col1.answer_easy().card_id;
+
+        sync_fsrs_collections(&ctx, col1).await?;
+
+        let mut col1 = ctx.col1();
+        let mut col2 = ctx.col2();
+
+        // Recompute both cards on the source side using different presets so
+        // reconciliation has to group by config instead of treating all cards
+        // as if they shared one FSRS setup.
+        let config1 = col1.get_deck_config(DeckConfigId(1), false)?.unwrap();
+        let config2 = col1.get_deck_config(config2.id, false)?.unwrap();
+        let ignore_before1 = ignore_revlogs_before_ms_from_config(&config1)?;
+        let ignore_before2 = ignore_revlogs_before_ms_from_config(&config2)?;
+        col1.transact(Op::UpdateDeckConfig, |col| {
+            col.update_memory_state(vec![
+                UpdateMemoryStateEntry {
+                    req: Some(UpdateMemoryStateRequest {
+                        params: config1.fsrs_params().clone(),
+                        preset_desired_retention: config1.inner.desired_retention,
+                        historical_retention: config1.inner.historical_retention,
+                        max_interval: config1.inner.maximum_review_interval,
+                        reschedule: false,
+                        deck_desired_retention: HashMap::new(),
+                    }),
+                    search: SearchNode::CardIds(card1.to_string()),
+                    ignore_before: ignore_before1,
+                },
+                UpdateMemoryStateEntry {
+                    req: Some(UpdateMemoryStateRequest {
+                        params: config2.fsrs_params().clone(),
+                        preset_desired_retention: config2.inner.desired_retention,
+                        historical_retention: config2.inner.historical_retention,
+                        max_interval: config2.inner.maximum_review_interval,
+                        reschedule: false,
+                        deck_desired_retention: HashMap::new(),
+                    }),
+                    search: SearchNode::CardIds(card2.to_string()),
+                    ignore_before: ignore_before2,
+                },
+            ])?;
+            Ok(())
+        })?;
+        let out = ctx.normal_sync(&mut col1).await;
+        assert_eq!(out.required, SyncActionRequired::NoChanges);
+
+        // Make the destination side newer so the stale cards stay local and
+        // must be repaired by the post-sync reconciliation pass.
+        col2.get_and_update_card(card1, |card| {
+            card.memory_state = Some(FsrsMemoryState {
+                stability: card.memory_state.unwrap().stability + 1.0,
+                difficulty: card.memory_state.unwrap().difficulty,
+            });
+            card.desired_retention = Some(0.99);
+            card.decay = Some(0.11);
+            Ok(())
+        })?;
+        col2.get_and_update_card(card2, |card| {
+            card.memory_state = Some(FsrsMemoryState {
+                stability: card.memory_state.unwrap().stability + 2.0,
+                difficulty: card.memory_state.unwrap().difficulty,
+            });
+            card.desired_retention = Some(0.77);
+            card.decay = Some(0.31);
+            Ok(())
+        })?;
+
+        let out = ctx.normal_sync(&mut col2).await;
+        assert_eq!(out.required, SyncActionRequired::NoChanges);
+
+        let synced_card1 = col1.storage.get_card(card1)?.unwrap();
+        let synced_card2 = col1.storage.get_card(card2)?.unwrap();
+        let reconciled_card1 = col2.storage.get_card(card1)?.unwrap();
+        let reconciled_card2 = col2.storage.get_card(card2)?.unwrap();
+        assert_eq!(reconciled_card1.memory_state, synced_card1.memory_state);
+        assert_eq!(reconciled_card2.memory_state, synced_card2.memory_state);
+        assert_eq!(
+            reconciled_card1.desired_retention,
+            Some(config1.inner.desired_retention)
+        );
+        assert_eq!(
+            reconciled_card2.desired_retention,
+            Some(config2.inner.desired_retention)
+        );
+        assert!(
+            (reconciled_card1.decay.unwrap() - get_decay_from_params(config1.fsrs_params())).abs()
+                < 0.001
+        );
+        assert!(
+            (reconciled_card2.decay.unwrap() - get_decay_from_params(config2.fsrs_params())).abs()
+                < 0.001
+        );
+        assert_ne!(
+            reconciled_card1.desired_retention,
+            reconciled_card2.desired_retention
+        );
+        assert_ne!(reconciled_card1.decay, reconciled_card2.decay);
+
+        Ok(())
+    })
+    .await
+}
+
+#[tokio::test]
+async fn fsrs_reconciliation_uses_original_deck_for_filtered_cards() -> Result<()> {
+    with_active_server(|client| async move {
+        let ctx = SyncTestContext::new(client);
+
+        let mut col1 = ctx.col1();
+        col1.set_config_bool(BoolKey::Fsrs, true, false)?;
+
+        let mut home_deck = col1.get_or_create_normal_deck("fsrs home deck")?;
+        home_deck.normal_mut().unwrap().desired_retention = Some(0.84);
+        col1.add_or_update_deck(&mut home_deck)?;
+
+        let nt = col1.get_notetype_by_name("Basic")?.unwrap();
+        let mut note = nt.new_note();
+        note.set_field(0, "fsrs-filtered-home")?;
+        col1.add_note(&mut note, home_deck.id)?;
+        col1.set_current_deck(home_deck.id)?;
+        let card_id = col1.answer_easy().card_id;
+
+        sync_fsrs_collections(&ctx, col1).await?;
+
+        let mut col1 = ctx.col1();
+        let mut col2 = ctx.col2();
+
+        // Refresh the source card so the server has a pending card change,
+        // then create a newer local filtered-deck variant on the other side.
+        let config = col1.get_deck_config(DeckConfigId(1), false)?.unwrap();
+        let ignore_before = ignore_revlogs_before_ms_from_config(&config)?;
+        col1.transact(Op::UpdateDeckConfig, |col| {
+            col.update_memory_state(vec![UpdateMemoryStateEntry {
+                req: Some(UpdateMemoryStateRequest {
+                    params: config.fsrs_params().clone(),
+                    preset_desired_retention: config.inner.desired_retention,
+                    historical_retention: config.inner.historical_retention,
+                    max_interval: config.inner.maximum_review_interval,
+                    reschedule: false,
+                    deck_desired_retention: HashMap::from([(home_deck.id, 0.84)]),
+                }),
+                search: SearchNode::CardIds(card_id.to_string()),
+                ignore_before,
+            }])?;
+            Ok(())
+        })?;
+        let out = ctx.normal_sync(&mut col1).await;
+        assert_eq!(out.required, SyncActionRequired::NoChanges);
+
+        let mut filtered_deck = Deck::new_filtered();
+        filtered_deck.name = NativeDeckName::from_native_str("fsrs filtered");
+        {
+            let filtered = filtered_deck.filtered_mut()?;
+            filtered.reschedule = false;
+            filtered.search_terms[0].search = format!("cid:{}", card_id.0);
+        }
+        col2.add_or_update_deck(&mut filtered_deck)?;
+        assert_eq!(col2.rebuild_filtered_deck(filtered_deck.id)?.output, 1);
+        let stale_card = col2.get_and_update_card(card_id, |card| {
+            card.memory_state = Some(FsrsMemoryState {
+                stability: card.memory_state.unwrap().stability + 1.5,
+                difficulty: card.memory_state.unwrap().difficulty,
+            });
+            card.desired_retention = Some(0.99);
+            card.decay = Some(0.12);
+            Ok(())
+        })?;
+        assert_eq!(stale_card.deck_id, filtered_deck.id);
+        assert_eq!(stale_card.original_deck_id, home_deck.id);
+
+        let out = ctx.normal_sync(&mut col2).await;
+        assert_eq!(out.required, SyncActionRequired::NoChanges);
+
+        let reconciled_card = col2.storage.get_card(card_id)?.unwrap();
+        let synced_card = col1.storage.get_card(card_id)?.unwrap();
+        assert_eq!(reconciled_card.deck_id, filtered_deck.id);
+        assert_eq!(reconciled_card.original_deck_id, home_deck.id);
+        assert_eq!(reconciled_card.memory_state, synced_card.memory_state);
+        assert_eq!(reconciled_card.desired_retention, Some(0.84));
+        assert_eq!(
+            reconciled_card.last_review_time,
+            synced_card.last_review_time
+        );
+
+        Ok(())
+    })
+    .await
+}
+
+#[tokio::test]
+async fn fsrs_reconciliation_respects_deck_overrides_within_one_preset() -> Result<()> {
+    with_active_server(|client| async move {
+        let ctx = SyncTestContext::new(client);
+
+        let mut col1 = ctx.col1();
+        col1.set_config_bool(BoolKey::Fsrs, true, false)?;
+
+        let mut shared_config = col1.get_deck_config(DeckConfigId(1), false)?.unwrap();
+        shared_config.inner.desired_retention = 0.89;
+        shared_config.inner.fsrs_params_6 = DEFAULT_PARAMETERS.into();
+        col1.add_or_update_deck_config(&mut shared_config)?;
+
+        let mut deck1 = col1.get_or_create_normal_deck("fsrs override deck 1")?;
+        deck1.normal_mut().unwrap().desired_retention = Some(0.82);
+        col1.add_or_update_deck(&mut deck1)?;
+
+        let mut deck2 = col1.get_or_create_normal_deck("fsrs override deck 2")?;
+        deck2.normal_mut().unwrap().desired_retention = Some(0.95);
+        col1.add_or_update_deck(&mut deck2)?;
+
+        let nt = col1.get_notetype_by_name("Basic")?.unwrap();
+        let mut note1 = nt.new_note();
+        note1.set_field(0, "fsrs-override-1")?;
+        col1.add_note(&mut note1, deck1.id)?;
+        col1.set_current_deck(deck1.id)?;
+        let card1 = col1.answer_easy().card_id;
+
+        let mut note2 = nt.new_note();
+        note2.set_field(0, "fsrs-override-2")?;
+        col1.add_note(&mut note2, deck2.id)?;
+        col1.set_current_deck(deck2.id)?;
+        let card2 = col1.answer_easy().card_id;
+
+        sync_fsrs_collections(&ctx, col1).await?;
+
+        let mut col1 = ctx.col1();
+        let mut col2 = ctx.col2();
+
+        let config = col1.get_deck_config(DeckConfigId(1), false)?.unwrap();
+        let ignore_before = ignore_revlogs_before_ms_from_config(&config)?;
+        // Both cards share the same preset, so reconciliation will process
+        // them together and must still apply the deck-level desired retention
+        // override for each home deck.
+        col1.transact(Op::UpdateDeckConfig, |col| {
+            col.update_memory_state(vec![UpdateMemoryStateEntry {
+                req: Some(UpdateMemoryStateRequest {
+                    params: config.fsrs_params().clone(),
+                    preset_desired_retention: config.inner.desired_retention,
+                    historical_retention: config.inner.historical_retention,
+                    max_interval: config.inner.maximum_review_interval,
+                    reschedule: false,
+                    deck_desired_retention: HashMap::from([(deck1.id, 0.82), (deck2.id, 0.95)]),
+                }),
+                search: SearchNode::CardIds(format!("{},{}", card1.0, card2.0)),
+                ignore_before,
+            }])?;
+            Ok(())
+        })?;
+        let out = ctx.normal_sync(&mut col1).await;
+        assert_eq!(out.required, SyncActionRequired::NoChanges);
+
+        col2.get_and_update_card(card1, |card| {
+            card.memory_state = Some(FsrsMemoryState {
+                stability: card.memory_state.unwrap().stability + 1.0,
+                difficulty: card.memory_state.unwrap().difficulty,
+            });
+            card.desired_retention = Some(0.99);
+            card.decay = Some(0.11);
+            Ok(())
+        })?;
+        col2.get_and_update_card(card2, |card| {
+            card.memory_state = Some(FsrsMemoryState {
+                stability: card.memory_state.unwrap().stability + 1.5,
+                difficulty: card.memory_state.unwrap().difficulty,
+            });
+            card.desired_retention = Some(0.77);
+            card.decay = Some(0.31);
+            Ok(())
+        })?;
+
+        let out = ctx.normal_sync(&mut col2).await;
+        assert_eq!(out.required, SyncActionRequired::NoChanges);
+
+        let reconciled_card1 = col2.storage.get_card(card1)?.unwrap();
+        let reconciled_card2 = col2.storage.get_card(card2)?.unwrap();
+        let synced_card1 = col1.storage.get_card(card1)?.unwrap();
+        let synced_card2 = col1.storage.get_card(card2)?.unwrap();
+        assert_eq!(reconciled_card1.memory_state, synced_card1.memory_state);
+        assert_eq!(reconciled_card2.memory_state, synced_card2.memory_state);
+        assert_eq!(reconciled_card1.desired_retention, Some(0.82));
+        assert_eq!(reconciled_card2.desired_retention, Some(0.95));
+        assert_ne!(
+            reconciled_card1.desired_retention,
+            reconciled_card2.desired_retention
+        );
+        assert!(
+            (reconciled_card1.decay.unwrap() - get_decay_from_params(config.fsrs_params())).abs()
+                < 0.001
+        );
+        assert!(
+            (reconciled_card2.decay.unwrap() - get_decay_from_params(config.fsrs_params())).abs()
+                < 0.001
+        );
+
+        Ok(())
+    })
+    .await
+}
+
+#[tokio::test]
+async fn fsrs_mixed_schedule_and_metadata_conflicts_reconcile_selectively() -> Result<()> {
+    with_active_server(|client| async move {
+        let ctx = SyncTestContext::new(client);
+
+        let mut col1 = ctx.col1();
+        col1.set_config_bool(BoolKey::Fsrs, true, false)?;
+
+        let mut metadata_deck = col1.get_or_create_normal_deck("fsrs metadata deck")?;
+        metadata_deck.normal_mut().unwrap().desired_retention = Some(0.83);
+        col1.add_or_update_deck(&mut metadata_deck)?;
+
+        let nt = col1.get_notetype_by_name("Basic")?.unwrap();
+        let mut note1 = nt.new_note();
+        note1.set_field(0, "fsrs-mixed-schedule")?;
+        col1.add_note(&mut note1, DeckId(1))?;
+        col1.set_current_deck(DeckId(1))?;
+        let card1 = col1.answer_easy().card_id;
+
+        let mut note2 = nt.new_note();
+        note2.set_field(0, "fsrs-mixed-metadata")?;
+        col1.add_note(&mut note2, metadata_deck.id)?;
+        col1.set_current_deck(metadata_deck.id)?;
+        let card2 = col1.answer_easy().card_id;
+
+        sync_fsrs_collections(&ctx, col1).await?;
+
+        let mut col1 = ctx.col1();
+        let mut col2 = ctx.col2();
+
+        std::thread::sleep(std::time::Duration::from_millis(1100));
+
+        // Card 1 gets a new review on the source side, so its schedule needs
+        // to be recomputed from merged history. Card 2 only gets a metadata
+        // refresh using the same preset and should keep its existing schedule.
+        col1.storage
+            .db
+            .execute("update cards set due = 0 where id = ?", [card1])?;
+        col1.set_current_deck(DeckId(1))?;
+        col1.clear_study_queues();
+        col1.answer_good();
+
+        let config = col1.get_deck_config(DeckConfigId(1), false)?.unwrap();
+        let ignore_before = ignore_revlogs_before_ms_from_config(&config)?;
+        col1.transact(Op::UpdateDeckConfig, |col| {
+            col.update_memory_state(vec![UpdateMemoryStateEntry {
+                req: Some(UpdateMemoryStateRequest {
+                    params: config.fsrs_params().clone(),
+                    preset_desired_retention: config.inner.desired_retention,
+                    historical_retention: config.inner.historical_retention,
+                    max_interval: config.inner.maximum_review_interval,
+                    reschedule: false,
+                    deck_desired_retention: HashMap::from([(metadata_deck.id, 0.83)]),
+                }),
+                search: SearchNode::CardIds(card2.to_string()),
+                ignore_before,
+            }])?;
+            Ok(())
+        })?;
+
+        let stale_card1 = col2.get_and_update_card(card1, |card| {
+            card.memory_state = Some(FsrsMemoryState {
+                stability: card.memory_state.unwrap().stability + 1.0,
+                difficulty: card.memory_state.unwrap().difficulty,
+            });
+            card.interval += 1;
+            card.due += 1;
+            card.desired_retention = Some(0.99);
+            card.decay = Some(0.11);
+            Ok(())
+        })?;
+        let stale_card2 = col2.get_and_update_card(card2, |card| {
+            card.memory_state = Some(FsrsMemoryState {
+                stability: card.memory_state.unwrap().stability + 1.5,
+                difficulty: card.memory_state.unwrap().difficulty,
+            });
+            card.desired_retention = Some(0.97);
+            card.decay = Some(0.12);
+            Ok(())
+        })?;
+
+        let reviewed_card = col1.storage.get_card(card1)?.unwrap();
+        let refreshed_card = col1.storage.get_card(card2)?.unwrap();
+        assert!(
+            stale_card1.interval != reviewed_card.interval || stale_card1.due != reviewed_card.due
+        );
+        assert_eq!(stale_card2.interval, refreshed_card.interval);
+        assert_eq!(stale_card2.due, refreshed_card.due);
+
+        let out = ctx.normal_sync(&mut col1).await;
+        assert_eq!(out.required, SyncActionRequired::NoChanges);
+        let out = ctx.normal_sync(&mut col2).await;
+        assert_eq!(out.required, SyncActionRequired::NoChanges);
+
+        let reconciled_card1 = col2.storage.get_card(card1)?.unwrap();
+        let reconciled_card2 = col2.storage.get_card(card2)?.unwrap();
+        let synced_card1 = col1.storage.get_card(card1)?.unwrap();
+        let synced_card2 = col1.storage.get_card(card2)?.unwrap();
+        assert_eq!(reconciled_card1.memory_state, synced_card1.memory_state);
+        assert_eq!(
+            reconciled_card1.last_review_time,
+            synced_card1.last_review_time
+        );
+        assert_eq!(reconciled_card1.interval, synced_card1.interval);
+        assert_eq!(reconciled_card1.due, synced_card1.due);
+
+        assert_eq!(reconciled_card2.memory_state, synced_card2.memory_state);
+        assert_eq!(
+            reconciled_card2.desired_retention,
+            synced_card2.desired_retention
+        );
+        assert_eq!(
+            reconciled_card2.last_review_time,
+            synced_card2.last_review_time
+        );
+        // Card 2 was only marked for metadata reconciliation, so its schedule
+        // should remain untouched even though it was processed in the same
+        // preset batch as card 1.
+        assert_eq!(reconciled_card2.interval, stale_card2.interval);
+        assert_eq!(reconciled_card2.due, stale_card2.due);
+
+        Ok(())
+    })
+    .await
+}
+
+#[tokio::test]
+async fn fsrs_filtered_card_schedule_conflict_uses_original_deck() -> Result<()> {
+    with_active_server(|client| async move {
+        let ctx = SyncTestContext::new(client);
+
+        let mut col1 = ctx.col1();
+        col1.set_config_bool(BoolKey::Fsrs, true, false)?;
+
+        let mut home_deck = col1.get_or_create_normal_deck("fsrs filtered schedule home")?;
+        home_deck.normal_mut().unwrap().desired_retention = Some(0.84);
+        col1.add_or_update_deck(&mut home_deck)?;
+
+        let nt = col1.get_notetype_by_name("Basic")?.unwrap();
+        let mut note = nt.new_note();
+        note.set_field(0, "fsrs-filtered-schedule")?;
+        col1.add_note(&mut note, home_deck.id)?;
+        col1.set_current_deck(home_deck.id)?;
+        let card_id = col1.answer_easy().card_id;
+
+        sync_fsrs_collections(&ctx, col1).await?;
+
+        let mut col1 = ctx.col1();
+        let mut col2 = ctx.col2();
+
+        std::thread::sleep(std::time::Duration::from_millis(1100));
+
+        col1.storage
+            .db
+            .execute("update cards set due = 0 where id = ?", [card_id])?;
+        col1.set_current_deck(home_deck.id)?;
+        col1.clear_study_queues();
+        col1.answer_good();
+
+        let mut filtered_deck = Deck::new_filtered();
+        filtered_deck.name = NativeDeckName::from_native_str("fsrs filtered schedule");
+        {
+            let filtered = filtered_deck.filtered_mut()?;
+            filtered.reschedule = false;
+            filtered.search_terms[0].search = format!("cid:{}", card_id.0);
+        }
+        col2.add_or_update_deck(&mut filtered_deck)?;
+        assert_eq!(col2.rebuild_filtered_deck(filtered_deck.id)?.output, 1);
+        let stale_card = col2.get_and_update_card(card_id, |card| {
+            card.memory_state = Some(FsrsMemoryState {
+                stability: card.memory_state.unwrap().stability + 1.5,
+                difficulty: card.memory_state.unwrap().difficulty,
+            });
+            card.interval += 1;
+            card.original_due += 1;
+            card.desired_retention = Some(0.99);
+            card.decay = Some(0.12);
+            Ok(())
+        })?;
+        assert_eq!(stale_card.deck_id, filtered_deck.id);
+        assert_eq!(stale_card.original_deck_id, home_deck.id);
+
+        let reviewed_card = col1.storage.get_card(card_id)?.unwrap();
+        assert!(
+            stale_card.interval != reviewed_card.interval
+                || stale_card.original_due != reviewed_card.due
+        );
+
+        let out = ctx.normal_sync(&mut col1).await;
+        assert_eq!(out.required, SyncActionRequired::NoChanges);
+        let out = ctx.normal_sync(&mut col2).await;
+        assert_eq!(out.required, SyncActionRequired::NoChanges);
+
+        let reconciled_card = col2.storage.get_card(card_id)?.unwrap();
+        let synced_card = col1.storage.get_card(card_id)?.unwrap();
+        assert_eq!(reconciled_card.deck_id, filtered_deck.id);
+        assert_eq!(reconciled_card.original_deck_id, home_deck.id);
+        assert_eq!(reconciled_card.memory_state, synced_card.memory_state);
+        assert_eq!(reconciled_card.desired_retention, Some(0.84));
+        assert_eq!(reconciled_card.interval, synced_card.interval);
+        assert_eq!(reconciled_card.original_due, synced_card.due);
+        // The filtered deck position should remain local to the filtered deck;
+        // only the home-deck schedule is updated through original_due.
+        assert_eq!(reconciled_card.due, stale_card.due);
 
         Ok(())
     })

--- a/rslib/src/sync/collection/tests.rs
+++ b/rslib/src/sync/collection/tests.rs
@@ -24,6 +24,7 @@ use wiremock::MockServer;
 use wiremock::ResponseTemplate;
 
 use crate::card::CardQueue;
+use crate::card::FsrsMemoryState;
 use crate::collection::CollectionBuilder;
 use crate::config::BoolKey;
 use crate::deckconfig::DeckConfig;
@@ -35,6 +36,9 @@ use crate::notetype::all_stock_notetypes;
 use crate::ops::Op;
 use crate::prelude::*;
 use crate::revlog::RevlogEntry;
+use crate::revlog::RevlogId;
+use crate::revlog::RevlogReviewKind;
+use crate::scheduler::fsrs::memory_state::get_decay_from_params;
 use crate::scheduler::fsrs::memory_state::UpdateMemoryStateEntry;
 use crate::scheduler::fsrs::memory_state::UpdateMemoryStateRequest;
 use crate::scheduler::fsrs::params::ignore_revlogs_before_ms_from_config;
@@ -396,6 +400,176 @@ async fn fsrs_stale_card_state_is_reconciled_during_sync() -> Result<()> {
 }
 
 #[tokio::test]
+async fn fsrs_metadata_conflict_is_reconciled_without_rescheduling() -> Result<()> {
+    with_active_server(|client| async move {
+        let ctx = SyncTestContext::new(client);
+
+        let mut col1 = ctx.col1();
+        col1.set_config_bool(BoolKey::Fsrs, true, false)?;
+        let nt = col1.get_notetype_by_name("Basic")?.unwrap();
+        let mut note = nt.new_note();
+        note.set_field(0, "fsrs-metadata")?;
+        col1.add_note(&mut note, DeckId(1))?;
+        let card_id = col1.answer_easy().card_id;
+
+        sync_fsrs_collections(&ctx, col1).await?;
+
+        let mut col1 = ctx.col1();
+        let mut col2 = ctx.col2();
+
+        // Recompute FSRS metadata on col1 with a different desired retention,
+        // but without rescheduling. This gives us a conflict where only
+        // FSRS-derived card fields should be reconciled.
+        let mut deck = (*col1.get_deck(DeckId(1))?.unwrap()).clone();
+        deck.normal_mut().unwrap().desired_retention = Some(0.83);
+        col1.add_or_update_deck(&mut deck)?;
+
+        let config = col1.get_deck_config(DeckConfigId(1), false)?.unwrap();
+        let ignore_before = ignore_revlogs_before_ms_from_config(&config)?;
+        let request = UpdateMemoryStateRequest {
+            params: config.fsrs_params().clone(),
+            preset_desired_retention: config.inner.desired_retention,
+            historical_retention: config.inner.historical_retention,
+            max_interval: config.inner.maximum_review_interval,
+            reschedule: false,
+            deck_desired_retention: HashMap::from([(DeckId(1), 0.83)]),
+        };
+        col1.transact(Op::UpdateDeckConfig, |col| {
+            col.update_memory_state(vec![UpdateMemoryStateEntry {
+                req: Some(request),
+                search: SearchNode::CardIds(card_id.to_string()),
+                ignore_before,
+            }])?;
+            Ok(())
+        })?;
+
+        // Simulate the other device holding stale FSRS data while the
+        // scheduling fields still match the current review history.
+        let stale_card = col2.get_and_update_card(card_id, |card| {
+            card.memory_state = Some(FsrsMemoryState {
+                stability: card.memory_state.unwrap().stability + 1.0,
+                difficulty: card.memory_state.unwrap().difficulty,
+            });
+            card.desired_retention = Some(0.97);
+            card.decay = Some(0.12);
+            Ok(())
+        })?;
+        let updated_card = col1.storage.get_card(card_id)?.unwrap();
+        assert_eq!(stale_card.interval, updated_card.interval);
+        assert_eq!(stale_card.due, updated_card.due);
+        assert_ne!(stale_card.memory_state, updated_card.memory_state);
+        assert_ne!(stale_card.desired_retention, updated_card.desired_retention);
+
+        let out = ctx.normal_sync(&mut col1).await;
+        assert_eq!(out.required, SyncActionRequired::NoChanges);
+        let out = ctx.normal_sync(&mut col2).await;
+        assert_eq!(out.required, SyncActionRequired::NoChanges);
+
+        let reconciled_card = col2.storage.get_card(card_id)?.unwrap();
+        let synced_card = col1.storage.get_card(card_id)?.unwrap();
+        assert_eq!(reconciled_card.memory_state, synced_card.memory_state);
+        assert_eq!(
+            reconciled_card.desired_retention,
+            synced_card.desired_retention
+        );
+        assert_eq!(reconciled_card.decay, synced_card.decay);
+        assert_eq!(
+            reconciled_card.last_review_time,
+            synced_card.last_review_time
+        );
+        // Because only FSRS metadata diverged, reconciliation should not
+        // rewrite the schedule.
+        assert_eq!(reconciled_card.interval, stale_card.interval);
+        assert_eq!(reconciled_card.due, stale_card.due);
+
+        Ok(())
+    })
+    .await
+}
+
+#[tokio::test]
+async fn fsrs_itemless_card_state_is_cleared_during_sync() -> Result<()> {
+    with_active_server(|client| async move {
+        let ctx = SyncTestContext::new(client);
+
+        let mut col1 = ctx.col1();
+        col1.set_config_bool(BoolKey::Fsrs, true, false)?;
+        let nt = col1.get_notetype_by_name("Basic")?.unwrap();
+        let mut note = nt.new_note();
+        note.set_field(0, "fsrs-itemless")?;
+        col1.add_note(&mut note, DeckId(1))?;
+        let card_id = col1.search_cards(note.id, SortMode::NoOrder)?[0];
+
+        sync_fsrs_collections(&ctx, col1).await?;
+
+        let mut col1 = ctx.col1();
+        let mut col2 = ctx.col2();
+
+        // A manual-only revlog makes the card show up in the merged history
+        // while still producing no FSRS item, which exercises the itemless
+        // reconciliation path.
+        col1.get_and_update_card(card_id, |card| {
+            card.due += 7;
+            Ok(())
+        })?;
+        col1.storage.add_revlog_entry(
+            &RevlogEntry {
+                id: RevlogId::new(),
+                cid: card_id,
+                usn: col1.usn()?,
+                button_chosen: 0,
+                interval: 0,
+                last_interval: 0,
+                ease_factor: 2500,
+                taken_millis: 0,
+                review_kind: RevlogReviewKind::Manual,
+            },
+            true,
+        )?;
+        col2.get_and_update_card(card_id, |card| {
+            card.memory_state = Some(FsrsMemoryState {
+                stability: 7.0,
+                difficulty: 4.0,
+            });
+            card.desired_retention = Some(0.72);
+            card.decay = Some(0.34);
+            card.last_review_time = Some(TimestampSecs(123));
+            Ok(())
+        })?;
+
+        // Confirm the local side really carries stale FSRS state before sync.
+        let stale_card = col2.storage.get_card(card_id)?.unwrap();
+        assert!(stale_card.memory_state.is_some());
+        assert!(stale_card.last_review_time.is_some());
+
+        let out = ctx.normal_sync(&mut col1).await;
+        assert_eq!(out.required, SyncActionRequired::NoChanges);
+        let out = ctx.normal_sync(&mut col2).await;
+        assert_eq!(out.required, SyncActionRequired::NoChanges);
+
+        let reconciled_card = col2.storage.get_card(card_id)?.unwrap();
+        let config = col2.get_deck_config(DeckConfigId(1), false)?.unwrap();
+        assert_eq!(reconciled_card.memory_state, None);
+        assert_eq!(reconciled_card.last_review_time, None);
+        assert_eq!(
+            reconciled_card.desired_retention,
+            Some(config.inner.desired_retention)
+        );
+        assert!(
+            (reconciled_card.decay.unwrap() - get_decay_from_params(config.fsrs_params())).abs()
+                < 0.001
+        );
+        // Itemless reconciliation clears FSRS-derived fields, but it does not
+        // reschedule the card.
+        assert_eq!(reconciled_card.due, stale_card.due);
+        assert_eq!(reconciled_card.interval, stale_card.interval);
+
+        Ok(())
+    })
+    .await
+}
+
+#[tokio::test]
 async fn sanity_check_should_roll_back_and_force_full_sync() -> Result<()> {
     with_active_server(|client| async move {
         let ctx = SyncTestContext::new(client);
@@ -677,6 +851,28 @@ async fn upload_download(ctx: &SyncTestContext) -> Result<()> {
     );
 
     // fetch so we're in sync
+    ctx.full_download(col2).await;
+
+    Ok(())
+}
+
+async fn sync_fsrs_collections(ctx: &SyncTestContext, mut col1: Collection) -> Result<()> {
+    let out = ctx.normal_sync(&mut col1).await;
+    assert!(matches!(
+        out.required,
+        SyncActionRequired::FullSyncRequired { .. }
+    ));
+    ctx.full_upload(col1).await;
+
+    let mut col2 = ctx.col2();
+    let out = ctx.normal_sync(&mut col2).await;
+    assert_eq!(
+        out.required,
+        SyncActionRequired::FullSyncRequired {
+            upload_ok: false,
+            download_ok: true,
+        }
+    );
     ctx.full_download(col2).await;
 
     Ok(())

--- a/rslib/src/sync/collection/tests.rs
+++ b/rslib/src/sync/collection/tests.rs
@@ -1120,6 +1120,84 @@ async fn fsrs_filtered_card_schedule_conflict_uses_original_deck() -> Result<()>
 }
 
 #[tokio::test]
+async fn fsrs_state_is_recomputed_from_reviews_on_both_devices() -> Result<()> {
+    with_active_server(|client| async move {
+        let ctx = SyncTestContext::new(client);
+
+        let mut col1 = ctx.col1();
+        col1.set_config_bool(BoolKey::Fsrs, true, false)?;
+        let nt = col1.get_notetype_by_name("Basic")?.unwrap();
+        let mut note = nt.new_note();
+        note.set_field(0, "fsrs-dual-review")?;
+        col1.add_note(&mut note, DeckId(1))?;
+        let card_id = col1.answer_easy().card_id;
+
+        sync_fsrs_collections(&ctx, col1).await?;
+
+        let mut col1 = ctx.col1();
+        let mut col2 = ctx.col2();
+
+        std::thread::sleep(std::time::Duration::from_millis(1100));
+        col1.storage
+            .db
+            .execute("update cards set due = 0 where id = ?", [card_id])?;
+        col1.clear_study_queues();
+        col1.answer_good();
+
+        std::thread::sleep(std::time::Duration::from_millis(1100));
+        col2.storage
+            .db
+            .execute("update cards set due = 0 where id = ?", [card_id])?;
+        col2.clear_study_queues();
+        col2.answer_easy();
+
+        let local_card1 = col1.storage.get_card(card_id)?.unwrap();
+        let local_card2 = col2.storage.get_card(card_id)?.unwrap();
+        assert!(
+            local_card1.memory_state != local_card2.memory_state
+                || local_card1.last_review_time != local_card2.last_review_time
+                || local_card1.interval != local_card2.interval
+                || local_card1.due != local_card2.due
+        );
+        assert_eq!(col1.storage.get_revlog_entries_for_card(card_id)?.len(), 2);
+        assert_eq!(col2.storage.get_revlog_entries_for_card(card_id)?.len(), 2);
+
+        let out = ctx.normal_sync(&mut col1).await;
+        assert_eq!(out.required, SyncActionRequired::NoChanges);
+        let out = ctx.normal_sync(&mut col2).await;
+        assert_eq!(out.required, SyncActionRequired::NoChanges);
+
+        let merged_card = col2.storage.get_card(card_id)?.unwrap();
+        let pre_converged_card = col1.storage.get_card(card_id)?.unwrap();
+        assert_eq!(col2.storage.get_revlog_entries_for_card(card_id)?.len(), 3);
+        assert_eq!(col1.storage.get_revlog_entries_for_card(card_id)?.len(), 2);
+        // After device 2 syncs, it has seen both review streams and should no
+        // longer match device 1's still-local-only card state.
+        assert!(
+            merged_card.memory_state != pre_converged_card.memory_state
+                || merged_card.last_review_time != pre_converged_card.last_review_time
+                || merged_card.interval != pre_converged_card.interval
+                || merged_card.due != pre_converged_card.due
+        );
+
+        let out = ctx.normal_sync(&mut col1).await;
+        assert_eq!(out.required, SyncActionRequired::NoChanges);
+
+        let synced_card1 = col1.storage.get_card(card_id)?.unwrap();
+        let synced_card2 = col2.storage.get_card(card_id)?.unwrap();
+        assert_eq!(col1.storage.get_revlog_entries_for_card(card_id)?.len(), 3);
+        assert_eq!(col2.storage.get_revlog_entries_for_card(card_id)?.len(), 3);
+        assert_eq!(synced_card1.memory_state, synced_card2.memory_state);
+        assert_eq!(synced_card1.last_review_time, synced_card2.last_review_time);
+        assert_eq!(synced_card1.interval, synced_card2.interval);
+        assert_eq!(synced_card1.due, synced_card2.due);
+
+        Ok(())
+    })
+    .await
+}
+
+#[tokio::test]
 async fn sanity_check_should_roll_back_and_force_full_sync() -> Result<()> {
     with_active_server(|client| async move {
         let ctx = SyncTestContext::new(client);

--- a/rslib/src/sync/collection/tests.rs
+++ b/rslib/src/sync/collection/tests.rs
@@ -3,6 +3,7 @@
 
 #![cfg(test)]
 
+use std::collections::HashMap;
 use std::future::Future;
 use std::sync::LazyLock;
 
@@ -24,14 +25,20 @@ use wiremock::ResponseTemplate;
 
 use crate::card::CardQueue;
 use crate::collection::CollectionBuilder;
+use crate::config::BoolKey;
 use crate::deckconfig::DeckConfig;
 use crate::decks::DeckKind;
 use crate::error::SyncError;
 use crate::error::SyncErrorKind;
 use crate::log::set_global_logger;
 use crate::notetype::all_stock_notetypes;
+use crate::ops::Op;
 use crate::prelude::*;
 use crate::revlog::RevlogEntry;
+use crate::scheduler::fsrs::memory_state::UpdateMemoryStateEntry;
+use crate::scheduler::fsrs::memory_state::UpdateMemoryStateRequest;
+use crate::scheduler::fsrs::params::ignore_revlogs_before_ms_from_config;
+use crate::search::SearchNode;
 use crate::search::SortMode;
 use crate::sync::collection::graves::ApplyGravesRequest;
 use crate::sync::collection::meta::MetaRequest;
@@ -281,6 +288,108 @@ async fn sync_roundtrip() -> Result<()> {
         let ctx = SyncTestContext::new(client);
         upload_download(&ctx).await?;
         regular_sync(&ctx).await?;
+        Ok(())
+    })
+    .await
+}
+
+#[tokio::test]
+async fn fsrs_stale_card_state_is_reconciled_during_sync() -> Result<()> {
+    with_active_server(|client| async move {
+        let ctx = SyncTestContext::new(client);
+
+        let mut col1 = ctx.col1();
+        col1.set_config_bool(BoolKey::Fsrs, true, false)?;
+        let nt = col1.get_notetype_by_name("Basic")?.unwrap();
+        let mut note = nt.new_note();
+        note.set_field(0, "fsrs")?;
+        col1.add_note(&mut note, DeckId(1))?;
+        let card_id = col1.answer_easy().card_id;
+
+        let out = ctx.normal_sync(&mut col1).await;
+        assert!(matches!(
+            out.required,
+            SyncActionRequired::FullSyncRequired { .. }
+        ));
+        ctx.full_upload(col1).await;
+
+        let mut col2 = ctx.col2();
+        let out = ctx.normal_sync(&mut col2).await;
+        assert_eq!(
+            out.required,
+            SyncActionRequired::FullSyncRequired {
+                upload_ok: false,
+                download_ok: true,
+            }
+        );
+        ctx.full_download(col2).await;
+
+        let mut col1 = ctx.col1();
+        let mut col2 = ctx.col2();
+
+        std::thread::sleep(std::time::Duration::from_millis(1100));
+        col1.storage
+            .db
+            .execute("update cards set due = 0 where id = ?", [card_id])?;
+        col1.clear_study_queues();
+        col1.answer_good();
+
+        std::thread::sleep(std::time::Duration::from_millis(1));
+
+        let config = col2.get_deck_config(DeckConfigId(1), false)?.unwrap();
+        let ignore_before = ignore_revlogs_before_ms_from_config(&config)?;
+        let request = UpdateMemoryStateRequest {
+            params: config.fsrs_params().clone(),
+            preset_desired_retention: config.inner.desired_retention,
+            historical_retention: config.inner.historical_retention,
+            max_interval: config.inner.maximum_review_interval,
+            reschedule: false,
+            deck_desired_retention: HashMap::new(),
+        };
+        col2.transact(Op::UpdateDeckConfig, |col| {
+            col.update_memory_state(vec![UpdateMemoryStateEntry {
+                req: Some(request),
+                search: SearchNode::CardIds(card_id.to_string()),
+                ignore_before,
+            }])?;
+            Ok(())
+        })?;
+
+        let stale_card = col2.storage.get_card(card_id)?.unwrap();
+        let reviewed_card = col1.storage.get_card(card_id)?.unwrap();
+        assert!(
+            stale_card.memory_state != reviewed_card.memory_state
+                || stale_card.last_review_time != reviewed_card.last_review_time
+                || stale_card.interval != reviewed_card.interval
+                || stale_card.due != reviewed_card.due
+        );
+
+        let out = ctx.normal_sync(&mut col1).await;
+        assert_eq!(out.required, SyncActionRequired::NoChanges);
+        let out = ctx.normal_sync(&mut col2).await;
+        assert_eq!(out.required, SyncActionRequired::NoChanges);
+
+        let reconciled_card = col2.storage.get_card(card_id)?.unwrap();
+        let reviewed_card = col1.storage.get_card(card_id)?.unwrap();
+        assert_eq!(reconciled_card.memory_state, reviewed_card.memory_state);
+        assert_eq!(
+            reconciled_card.last_review_time,
+            reviewed_card.last_review_time
+        );
+        assert_eq!(reconciled_card.interval, reviewed_card.interval);
+        assert_eq!(reconciled_card.due, reviewed_card.due);
+
+        let out = ctx.normal_sync(&mut col1).await;
+        assert_eq!(out.required, SyncActionRequired::NoChanges);
+        let synced_card = col1.storage.get_card(card_id)?.unwrap();
+        assert_eq!(synced_card.memory_state, reconciled_card.memory_state);
+        assert_eq!(
+            synced_card.last_review_time,
+            reconciled_card.last_review_time
+        );
+        assert_eq!(synced_card.interval, reconciled_card.interval);
+        assert_eq!(synced_card.due, reconciled_card.due);
+
         Ok(())
     })
     .await


### PR DESCRIPTION
Hello,

Initially it was aimed to be about automatic optimization. But after some brainstorming and exploring the codebase with codex, we kinda came to the realization that Automatic Optimzation would be much simpler if FSRS related parameters, data, ... were simply reconciled nicely when syncing to ankiweb instead of forcing full sync either way.

So instead of discussing AO, this PR aims simple to discuss FSRS Sync Reconciliations.

I'm not 100% confident if all tests cover all the subcases, but for now I think it's a good discussion base.

This PR include some docs file I can remove later if it's redundant, but I kinda like to have those for now as a way to show some code changed and why, especially because I used mainly codex to alter the code.
Due to the nature of the PR (being heavily made by LLM), feel free to challenge any part you think should be revisited.