### PR TITLE
fix: clear retained underline typing style after deleting all text

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -274,6 +274,7 @@ Daniel Pechersky <danny.pechersky@gmail.com>
 fernandolins <1887601+fernandolins@users.noreply.github.com>
 Christos Longros <chris.longros@gmail.com> 
 Maskady <florent.tout@gmail.com>
+Nicola <nicoladicrescenzo04@icloud.com>
 
 ********************
 

--- a/ts/lib/sveltelib/input-handler.test.ts
+++ b/ts/lib/sveltelib/input-handler.test.ts
@@ -1,0 +1,74 @@
+// Copyright: Ankitects Pty Ltd and contributors
+// License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, test } from "vitest";
+
+import { getSelection } from "@tslib/cross-browser";
+
+import useInputHandler from "./input-handler";
+
+function setSelection(element: HTMLElement, offset: number): void {
+    const selection = getSelection(element)!;
+    const range = new Range();
+
+    range.setStart(element, offset);
+    range.collapse(true);
+
+    selection.removeAllRanges();
+    selection.addRange(range);
+}
+
+describe("input handler", () => {
+    afterEach(() => {
+        document.body.replaceChildren();
+        getSelection(document.body)?.removeAllRanges();
+    });
+
+    test("resets caret to the start of an empty editor after delete input", () => {
+        const element = document.createElement("div");
+        element.innerHTML = "<br>";
+        document.body.appendChild(element);
+
+        const [, setupHandler] = useInputHandler();
+        const { destroy } = setupHandler(element);
+
+        setSelection(element, 1);
+        element.dispatchEvent(
+            new InputEvent("input", {
+                bubbles: true,
+                inputType: "deleteContentBackward",
+            }),
+        );
+
+        const selection = getSelection(element)!;
+        expect(selection.anchorNode).toBe(element);
+        expect(selection.anchorOffset).toBe(0);
+
+        destroy();
+    });
+
+    test("does not reset caret for insert input", () => {
+        const element = document.createElement("div");
+        element.innerHTML = "<br>";
+        document.body.appendChild(element);
+
+        const [, setupHandler] = useInputHandler();
+        const { destroy } = setupHandler(element);
+
+        setSelection(element, 1);
+        element.dispatchEvent(
+            new InputEvent("input", {
+                bubbles: true,
+                inputType: "insertText",
+                data: "a",
+            }),
+        );
+
+        const selection = getSelection(element)!;
+        expect(selection.anchorNode).toBe(element);
+        expect(selection.anchorOffset).toBe(1);
+
+        destroy();
+    });
+});

--- a/ts/lib/sveltelib/input-handler.ts
+++ b/ts/lib/sveltelib/input-handler.ts
@@ -46,6 +46,41 @@ export interface InputHandlerAPI {
     readonly specialKey: HandlerList<SpecialKeyParams>;
 }
 
+function elementHasOnlyLineBreak(element: Element): boolean {
+    return element.childNodes.length === 1
+        && element.firstChild instanceof HTMLBRElement
+        && element.textContent?.length === 0;
+}
+
+function resetSelectionToStart(element: Element): void {
+    const selection = getSelection(element);
+
+    if (!selection) {
+        return;
+    }
+
+    const range = new Range();
+    range.setStart(element, 0);
+    range.collapse(true);
+
+    selection.removeAllRanges();
+    selection.addRange(range);
+}
+
+function clearTypingStyleAfterDelete(element: Element, event: Event): void {
+    if (
+        !(event instanceof InputEvent)
+        || !event.inputType.startsWith("delete")
+        || !elementHasOnlyLineBreak(element)
+    ) {
+        return;
+    }
+
+    // Chromium keeps the last inline typing style after deleting the final
+    // formatted character. Resetting the caret clears that hidden state.
+    resetSelectionToStart(element);
+}
+
 /**
  * An interface that allows Svelte components to attach event listeners via triggers.
  * They will be attached to the component(s) that install the manager.
@@ -91,6 +126,7 @@ function useInputHandler(): [InputHandlerAPI, SetupInputHandlerAction] {
     }
 
     async function onInput(this: Element, event: Event): Promise<void> {
+        clearTypingStyleAfterDelete(this, event);
         await afterInput.dispatch({ event });
     }
 


### PR DESCRIPTION
## Linked issue (required)

Fixes #1809

## Summary / motivation (required)

This PR fixes a bug in the note editor where underline formatting could remain
implicitly active after deleting all text in a field.

In Chromium, deleting the final formatted character can leave the previous
inline typing style active internally. This caused newly typed text to become
underlined again even though the underline button no longer appeared active.

The fix resets the caret/selection when a delete leaves the editor empty, so
new input starts from a neutral state.

## Steps to reproduce (required, use N/A if not applicable)

1. Open Add Cards or edit an existing note.
2. Enable underline.
3. Type some text.
4. Delete all text in the field.
5. Type again.

## How to test (required)

### Checklist (minimum)

- [x] I ran `./ninja check` or an equivalent relevant check locally.
- [x] I added or updated tests when the change is non-trivial or behavior changed.

### Details

Checks run locally:
- `./ninja check:svelte`
- `./yarn vitest:once lib/sveltelib/input-handler.test.ts`
- `./check`

Manual verification:
- Reproduced the issue in the editor before the fix.
- After the fix, typing in an empty field after deleting all underlined text no
  longer reapplies underline unexpectedly.

## Before / after behavior (optional)

Before:
- After enabling underline, typing, and deleting all text, newly typed text
  could still become underlined unexpectedly.

After:
- When deleting all text from the field, the hidden retained typing style is
  cleared, and newly typed text is inserted without underline unless the user
  enables it again.

## Risk / compatibility / migration (optional)

Low risk. The change is limited to delete events that leave the editor in its
empty `<br>` state, and a regression test was added for the behavior.

## UI evidence (required for visual changes; otherwise N/A)

N/A

## Scope

- [x] This PR is focused on one change (no unrelated edits).
