### PR TITLE
Chore: add Dependabot config with monthly grouped updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,49 @@
+version: 2
+
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      rust-minor-patch:
+        applies-to: version-updates
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+    commit-message:
+      prefix: "chore(deps)"
+
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      js-minor-patch:
+        applies-to: version-updates
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+    commit-message:
+      prefix: "chore(deps)"
+
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      python-minor-patch:
+        applies-to: version-updates
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+    commit-message:
+      prefix: "chore(deps)"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      actions:
+        applies-to: version-updates
+        patterns: ["*"]
+    commit-message:
+      prefix: "chore(ci)"


### PR DESCRIPTION
## Linked issue (required)

Partially related to #4722 

## Summary/motivation (required)

Weekly (by default), Dependabot checks for updates and opens a PR for each dependency update. This generates numerous PRs that require human review time and GitHub Actions overhead.

By adding the Dependabot configuration file, we changed the frequency to monthly and grouped the PRs by ecosystem.

## Scope

This PR does:

- [x] Fewer open dependency PRs (minor/patch grouped per ecosystem)
- [x] Less CI / GitHub Actions churn (monthly cadence + fewer PRs)
- [x] Clearer review queue (updates batched by Rust / JS / Python / Actions)

This PR does not:

❌ Group major version bumps (still separate PRs)
❌ Shorten individual CI runs
