### PR TITLE
chore(ci): raise dependabot open-pull-requests-limit to 3

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,8 @@ updates:
     schedule:
       interval: "monthly"
     open-pull-requests-limit: 3
+    cooldown:
+      default-days: 7
     groups:
       rust-minor-patch:
         applies-to: version-updates
@@ -19,6 +21,8 @@ updates:
     schedule:
       interval: "monthly"
     open-pull-requests-limit: 3
+    cooldown:
+      default-days: 7
     groups:
       js-minor-patch:
         applies-to: version-updates
@@ -32,6 +36,8 @@ updates:
     schedule:
       interval: "monthly"
     open-pull-requests-limit: 3
+    cooldown:
+      default-days: 7
     groups:
       python-minor-patch:
         applies-to: version-updates
@@ -45,6 +51,8 @@ updates:
     schedule:
       interval: "monthly"
     open-pull-requests-limit: 3
+    cooldown:
+      default-days: 7
     groups:
       actions:
         applies-to: version-updates

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,7 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    open-pull-requests-limit: 3
     groups:
       rust-minor-patch:
         applies-to: version-updates
@@ -17,6 +18,7 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    open-pull-requests-limit: 3
     groups:
       js-minor-patch:
         applies-to: version-updates
@@ -29,6 +31,7 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    open-pull-requests-limit: 3
     groups:
       python-minor-patch:
         applies-to: version-updates
@@ -41,6 +44,7 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    open-pull-requests-limit: 3
     groups:
       actions:
         applies-to: version-updates

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5684,9 +5684,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",


### PR DESCRIPTION
## What
- Set `open-pull-requests-limit` to **3** for each `package-ecosystem` in [`.github/dependabot.yml`](.github/dependabot.yml) so we allow a few more concurrent Dependabot version-update PRs per stack while still bounding review load.

## Why
- A slightly higher cap lets more ecosystems progress in parallel when the queue is healthy, without going back to the default (5) or an unbounded backlog of open PRs.