### PR TITLE
fix: use correct type annotation on `Collection.add_notes`

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -274,6 +274,7 @@ Daniel Pechersky <danny.pechersky@gmail.com>
 fernandolins <1887601+fernandolins@users.noreply.github.com>
 Christos Longros <chris.longros@gmail.com> 
 Maskady <florent.tout@gmail.com>
+Jeremy Fleischman <jeremyfleischman@gmail.com>
 
 ********************
 

--- a/pylib/anki/collection.py
+++ b/pylib/anki/collection.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Generator, Iterable, Sequence
+from collections.abc import Generator, Sequence
 from typing import Any, Literal, Union, cast
 
 from anki import (
@@ -534,7 +534,7 @@ class Collection(DeprecatedNamesMixin):
         note.id = NoteId(out.note_id)
         return out.changes
 
-    def add_notes(self, requests: Iterable[AddNoteRequest]) -> OpChanges:
+    def add_notes(self, requests: Sequence[AddNoteRequest]) -> OpChanges:
         for request in requests:
             hooks.note_will_be_added(self, request.note, request.deck_id)
         out = self._backend.add_notes(


### PR DESCRIPTION
## Linked issue (required)

This is so minor I opted not to create an issue first. Hope that's ok!

## Summary / motivation (required)

`add_notes` loops over the given `requests` 3 times. The previous type annotation (`Iterable`) allows for things like generators, which can only be iterated over one time.

## Steps to reproduce (required, use N/A if not applicable)

N/A

## How to test (required)

Advice appreciated here!

### Checklist (minimum)

- [x] I ran `./ninja check` or an equivalent relevant check locally.
- [x] I added or updated tests when the change is non-trivial or behavior changed.

### Details

N/A

## Before / after behavior (optional)

N/A

## Risk / compatibility / migration (optional)

N/A

## UI evidence (required for visual changes; otherwise N/A)

N/A

## Scope

- [x] This PR is focused on one change (no unrelated edits).
