### PR TITLE
docs: add warning to `add_deck` that you must refetch after adding

### DIFF
--- a/pylib/anki/decks.py
+++ b/pylib/anki/decks.py
@@ -168,6 +168,7 @@ class DeckManager(DeprecatedNamesMixin):
         return self.col._backend.new_deck()
 
     def add_deck(self, deck: Deck) -> OpChangesWithId:
+        "Deck needs to be fetched from DB after adding."
         return self.col._backend.add_deck(message=deck)
 
     def new_deck_legacy(self, filtered: bool) -> DeckDict:


### PR DESCRIPTION
This cost me an embarrassing amount of time, because the legacy `add_*` methods do not behave this way. Not sure if this comment would have helped me, but it can't hurt!

See relevant forum discussion:
<https://forums.ankiweb.net/t/anki-decks-deckmanager-add-deck-does-not-update-the-decks-id/69563>.