### PR TITLE
fix: Sign Windows Anki.exe before MSI packaging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -237,10 +237,11 @@ jobs:
           name: wheels-macos-intel
           path: out/wheels/anki-*.whl
 
-  build-windows:
+  build-and-sign-windows:
     needs: prepare
     runs-on: windows-latest
     timeout-minutes: 90
+    environment: ${{ inputs['skip-signing'] != true && 'release' || '' }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -249,9 +250,78 @@ jobs:
       - name: Setup build environment
         uses: ./.github/actions/setup-anki
 
-      - name: Build installer
+      # --- Signed path (4 phases) ---
+
+      # Phase 1: Create + Build via ninja (no package yet)
+      - name: Build app
+        if: inputs['skip-signing'] != true
+        run: tools\build-installer.bat
+        env:
+          BRIEFCASE_STOP_BEFORE_PACKAGE: "1"
+
+      # Phase 2: Sign the exe via Azure Trusted Signing
+      - name: Azure login
+        if: inputs['skip-signing'] != true
+        uses: azure/login@v3
+        with:
+          creds: '{"clientId":"${{ secrets.AZURE_CLIENT_ID }}","clientSecret":"${{ secrets.AZURE_CLIENT_SECRET }}","subscriptionId":"${{ secrets.AZURE_SUBSCRIPTION_ID }}","tenantId":"${{ secrets.AZURE_TENANT_ID }}"}'
+
+      - name: Sign app binary
+        if: inputs['skip-signing'] != true
+        uses: azure/artifact-signing-action@v1
+        with:
+          endpoint: https://eus.codesigning.azure.net/
+          signing-account-name: anki-signing
+          certificate-profile-name: ${{ secrets.AZURE_CERT_PROFILE_NAME }}
+          files: ${{ github.workspace }}\out\installer\build\anki\windows\app\src\Anki.exe
+          file-digest: SHA256
+          timestamp-rfc3161: http://timestamp.acs.microsoft.com
+          timestamp-digest: SHA256
+
+      - name: Verify app binary signature
+        if: inputs['skip-signing'] != true
+        shell: pwsh
+        run: |
+          $sig = Get-AuthenticodeSignature "out\installer\build\anki\windows\app\src\Anki.exe"
+          if ($sig.Status -ne "Valid") {
+            Write-Error "Anki.exe signature status: $($sig.Status)"
+            exit 1
+          }
+          Write-Host "Anki.exe signed successfully: $($sig.SignerCertificate.Subject)"
+
+      # Phase 3: Package the signed binary into MSI (bypass ninja)
+      - name: Package signed installer
+        if: inputs['skip-signing'] != true
+        shell: pwsh
+        run: >
+          .\out\pyenv\scripts\python.exe qt\tools\build_installer.py
+          --version ${{ needs.prepare.outputs.pep440_version }}
+          --aqt_wheel _
+          --anki_wheel _
+          --out_dir out\installer
+        env:
+          BRIEFCASE_PACKAGE_ONLY: "1"
+
+      # Phase 4: Sign the MSI
+      - name: Sign MSI
+        if: inputs['skip-signing'] != true
+        uses: azure/artifact-signing-action@v1
+        with:
+          endpoint: https://eus.codesigning.azure.net/
+          signing-account-name: anki-signing
+          certificate-profile-name: ${{ secrets.AZURE_CERT_PROFILE_NAME }}
+          files-folder: out/installer/dist/
+          files-folder-filter: msi
+          file-digest: SHA256
+          timestamp-rfc3161: http://timestamp.acs.microsoft.com
+          timestamp-digest: SHA256
+
+      # --- Unsigned fallback ---
+      - name: Build unsigned installer
+        if: inputs['skip-signing'] == true
         run: tools\build-installer.bat
 
+      # --- Artifacts (both paths) ---
       - uses: actions/upload-artifact@v4
         with:
           name: installer-windows
@@ -339,46 +409,8 @@ jobs:
           name: installer-linux-arm
           path: out/installer/dist/
 
-  sign-windows:
-    if: inputs['skip-signing'] != true
-    needs: build-windows
-    runs-on: windows-2022
-    environment: release
-    permissions:
-      contents: read
-    steps:
-      - name: Download Windows artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: installer-windows
-          path: dist/
-
-      - name: Azure login
-        uses: azure/login@v3
-        with:
-          creds: '{"clientId":"${{ secrets.AZURE_CLIENT_ID }}","clientSecret":"${{ secrets.AZURE_CLIENT_SECRET }}","subscriptionId":"${{ secrets.AZURE_SUBSCRIPTION_ID }}","tenantId":"${{ secrets.AZURE_TENANT_ID }}"}'
-
-      - name: Sign Windows installer
-        uses: azure/artifact-signing-action@v1
-        with:
-          endpoint: https://eus.codesigning.azure.net/
-          signing-account-name: anki-signing
-          certificate-profile-name: ${{ secrets.AZURE_CERT_PROFILE_NAME }}
-          files-folder: dist/
-          files-folder-filter: msi
-          file-digest: SHA256
-          timestamp-rfc3161: http://timestamp.acs.microsoft.com
-          timestamp-digest: SHA256
-
-      - name: Re-upload signed artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: installer-windows
-          path: dist/
-          overwrite: true
-
   release:
-    needs: [prepare, build-and-sign-mac, build-and-sign-mac-intel, sign-windows, build-linux-x86, build-linux-arm-wheels, build-linux-arm-installer]
+    needs: [prepare, build-and-sign-mac, build-and-sign-mac-intel, build-and-sign-windows, build-linux-x86, build-linux-arm-wheels, build-linux-arm-installer]
     if: >-
       ${{ always()
       && inputs.publish == 'release'
@@ -388,7 +420,7 @@ jobs:
       && needs.build-linux-x86.result == 'success'
       && needs.build-linux-arm-wheels.result == 'success'
       && needs.build-linux-arm-installer.result == 'success'
-      && needs.sign-windows.result == 'success'
+      && needs.build-and-sign-windows.result == 'success'
       }}
     runs-on: ubuntu-latest
     environment: release
@@ -425,14 +457,14 @@ jobs:
           RELEASE_SHA: ${{ github.sha }}
 
   publish-testpypi:
-    needs: [prepare, build-and-sign-mac, build-and-sign-mac-intel, build-windows, build-linux-x86, build-linux-arm-wheels, build-linux-arm-installer]
+    needs: [prepare, build-and-sign-mac, build-and-sign-mac-intel, build-and-sign-windows, build-linux-x86, build-linux-arm-wheels, build-linux-arm-installer]
     if: >-
       ${{ always()
       && inputs.publish != 'none'
       && needs.prepare.result == 'success'
       && needs.build-and-sign-mac.result == 'success'
       && needs.build-and-sign-mac-intel.result == 'success'
-      && needs.build-windows.result == 'success'
+      && needs.build-and-sign-windows.result == 'success'
       && needs.build-linux-x86.result == 'success'
       && needs.build-linux-arm-wheels.result == 'success'
       && needs.build-linux-arm-installer.result == 'success'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -300,6 +300,18 @@ jobs:
           timestamp-rfc3161: http://timestamp.acs.microsoft.com
           timestamp-digest: SHA256
 
+      - name: Verify MSI signature
+        if: inputs['skip-signing'] != true
+        shell: pwsh
+        run: |
+          $msi = Get-ChildItem "out/installer/dist/*.msi" | Select-Object -First 1
+          $sig = Get-AuthenticodeSignature $msi.FullName
+          if ($sig.Status -ne "Valid") {
+            Write-Error "MSI signature status: $($sig.Status)"
+            exit 1
+          }
+          Write-Host "MSI signed successfully: $($sig.SignerCertificate.Subject)"
+
       - uses: actions/upload-artifact@v4
         with:
           name: installer-windows

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -250,16 +250,9 @@ jobs:
       - name: Setup build environment
         uses: ./.github/actions/setup-anki
 
-      # --- Signed path (4 phases) ---
-
-      # Phase 1: Create + Build via ninja (no package yet)
       - name: Build app
-        if: inputs['skip-signing'] != true
-        run: tools\build-installer.bat
-        env:
-          BRIEFCASE_STOP_BEFORE_PACKAGE: "1"
+        run: tools\ninja installer:build
 
-      # Phase 2: Sign the exe via Azure Trusted Signing
       - name: Azure login
         if: inputs['skip-signing'] != true
         uses: azure/login@v3
@@ -289,20 +282,9 @@ jobs:
           }
           Write-Host "Anki.exe signed successfully: $($sig.SignerCertificate.Subject)"
 
-      # Phase 3: Package the signed binary into MSI (bypass ninja)
-      - name: Package signed installer
-        if: inputs['skip-signing'] != true
-        shell: pwsh
-        run: >
-          .\out\pyenv\scripts\python.exe qt\tools\build_installer.py
-          --version ${{ needs.prepare.outputs.pep440_version }}
-          --aqt_wheel _
-          --anki_wheel _
-          --out_dir out\installer
-        env:
-          BRIEFCASE_PACKAGE_ONLY: "1"
+      - name: Package installer
+        run: tools\ninja installer:package
 
-      # Phase 4: Sign the MSI
       - name: Sign MSI
         if: inputs['skip-signing'] != true
         uses: azure/artifact-signing-action@v1
@@ -316,12 +298,6 @@ jobs:
           timestamp-rfc3161: http://timestamp.acs.microsoft.com
           timestamp-digest: SHA256
 
-      # --- Unsigned fallback ---
-      - name: Build unsigned installer
-        if: inputs['skip-signing'] == true
-        run: tools\build-installer.bat
-
-      # --- Artifacts (both paths) ---
       - uses: actions/upload-artifact@v4
         with:
           name: installer-windows

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -266,6 +266,8 @@ jobs:
           endpoint: https://eus.codesigning.azure.net/
           signing-account-name: anki-signing
           certificate-profile-name: ${{ secrets.AZURE_CERT_PROFILE_NAME }}
+          # Path derived from Briefcase conventions + qt/installer/app/pyproject.toml.template:
+          # {out_dir}/build/{app_name}/{platform}/{output_format}/{packaging_root}/{formal_name}.exe
           files: ${{ github.workspace }}\out\installer\build\anki\windows\app\src\Anki.exe
           file-digest: SHA256
           timestamp-rfc3161: http://timestamp.acs.microsoft.com

--- a/build/configure/src/installer.rs
+++ b/build/configure/src/installer.rs
@@ -11,13 +11,13 @@ use ninja_gen::Build;
 
 use crate::anki_version;
 
-pub struct BuildInstaller {
-    pub version: String,
+struct BuildCommand {
+    version: String,
 }
 
-impl BuildAction for BuildInstaller {
+impl BuildAction for BuildCommand {
     fn command(&self) -> &str {
-        "$pyenv_bin $script --version $version --aqt_wheel $aqt_wheel --anki_wheel $anki_wheel --out_dir $out"
+        "$pyenv_bin $script --version $version build --aqt_wheel $aqt_wheel --anki_wheel $anki_wheel"
     }
 
     fn files(&mut self, build: &mut impl FilesHandle) {
@@ -43,7 +43,25 @@ impl BuildAction for BuildInstaller {
                 glob!["qt/installer/**"]
             ],
         );
-        build.add_outputs("out", vec!["installer"]);
+        build.add_output_stamp("installer/briefcase.build.stamp");
+    }
+}
+
+struct PackageCommand {
+    version: String,
+}
+
+impl BuildAction for PackageCommand {
+    fn command(&self) -> &str {
+        "$pyenv_bin $script --version $version package"
+    }
+
+    fn files(&mut self, build: &mut impl FilesHandle) {
+        build.add_inputs("pyenv_bin", inputs![":pyenv:bin"]);
+        build.add_inputs("script", inputs!["qt/tools/build_installer.py"]);
+        build.add_variable("version", &self.version);
+        build.add_inputs("", inputs![":installer:build",]);
+        build.add_output_stamp("installer/briefcase.package.stamp");
     }
 }
 
@@ -62,11 +80,14 @@ pub fn build_installer(build: &mut Build) -> Result<()> {
             offline_build: false,
         },
     )?;
+    let version = anki_version();
     build.add_action(
-        "installer:dist",
-        BuildInstaller {
-            version: anki_version(),
+        "installer:build",
+        BuildCommand {
+            version: version.clone(),
         },
     )?;
+    build.add_action("installer:package", PackageCommand { version })?;
+
     Ok(())
 }

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -34,15 +34,13 @@ flowchart TD
 
     prepare --> mac["build-and-sign-mac<br/>🍎 ARM"]
     prepare --> macint["build-and-sign-mac-intel<br/>🍎 Intel"]
-    prepare --> win[build-windows<br/>🪟]
+    prepare --> win["build-and-sign-windows<br/>🪟🔏 Azure"]
     prepare --> lin[build-linux<br/>🐧 x86]
     prepare --> linarm[build-linux-arm<br/>🐧 ARM]
 
-    win --> signwin["sign-windows<br/>🔏 Azure"]
-
     mac --> release
     macint --> release
-    signwin --> release
+    win --> release
     lin --> release
     linarm --> release
 
@@ -67,7 +65,6 @@ flowchart TD
     style win fill:#2d333b,stroke:#e5c07b,color:#adbac7
     style lin fill:#2d333b,stroke:#e5c07b,color:#adbac7
     style linarm fill:#2d333b,stroke:#e5c07b,color:#adbac7
-    style signwin fill:#2d333b,stroke:#c678dd,color:#adbac7
     style release fill:#2d333b,stroke:#7ee787,color:#adbac7
     style testpypi fill:#2d333b,stroke:#7ee787,color:#adbac7
     style pypi fill:#2d333b,stroke:#7ee787,color:#adbac7
@@ -95,9 +92,9 @@ The release workflow uses GitHub
 as manual approval gates. Jobs that access signing credentials or publish
 artifacts require a reviewer to approve the deployment before they run:
 
-- **`release`** — Required by the macOS signing jobs, Windows signing job,
-  the GitHub release job, and PyPI publishing. Protects code-signing secrets
-  and prevents accidental public releases.
+- **`release`** — Required by the macOS signing jobs, Windows build-and-sign
+  job, the GitHub release job, and PyPI publishing. Protects code-signing
+  secrets and prevents accidental public releases.
 - **`testpypi`** — Required by the TestPyPI publishing job. Allows test
   uploads to be gated separately from production releases.
 

--- a/qt/tools/build_installer.py
+++ b/qt/tools/build_installer.py
@@ -32,62 +32,98 @@ def get_briefcase_template_path() -> Path | None:
 
 
 def main(version: str, aqt_wheel: str, anki_wheel: str, out_dir: Path) -> None:
-    shutil.rmtree(out_dir, ignore_errors=True)
-    shutil.copytree(app_dir, out_dir)
+    package_only = os.environ.get("BRIEFCASE_PACKAGE_ONLY") == "1"
+    stop_before_package = os.environ.get("BRIEFCASE_STOP_BEFORE_PACKAGE") == "1"
 
-    if sys.platform == "linux":
-        subprocess.check_call(
-            [
-                sys.executable,
-                "-m",
-                "PyInstaller",
-                "-y",
-                out_dir / "pyinstaller.spec",
-                "--distpath",
-                out_dir / "dist",
-                "--workpath",
-                out_dir / "build",
-            ]
+    if package_only and stop_before_package:
+        raise SystemExit(
+            "BRIEFCASE_PACKAGE_ONLY and BRIEFCASE_STOP_BEFORE_PACKAGE "
+            "are mutually exclusive"
         )
-        dist_dir = out_dir / "dist" / "anki"
-        scripts_dir = installer_dir / "linux-scripts"
-        for file in scripts_dir.iterdir():
-            if file.name == "build.sh":
-                continue
-            dest_file = dist_dir / file.name
-            shutil.copy2(file, dest_file)
 
-        print("Building zip...", file=sys.stderr)
+    if not package_only:
+        shutil.rmtree(out_dir, ignore_errors=True)
+        shutil.copytree(app_dir, out_dir)
+
+        if sys.platform == "linux":
+            subprocess.check_call(
+                [
+                    sys.executable,
+                    "-m",
+                    "PyInstaller",
+                    "-y",
+                    out_dir / "pyinstaller.spec",
+                    "--distpath",
+                    out_dir / "dist",
+                    "--workpath",
+                    out_dir / "build",
+                ]
+            )
+            dist_dir = out_dir / "dist" / "anki"
+            scripts_dir = installer_dir / "linux-scripts"
+            for file in scripts_dir.iterdir():
+                if file.name == "build.sh":
+                    continue
+                dest_file = dist_dir / file.name
+                shutil.copy2(file, dest_file)
+
+            print("Building zip...", file=sys.stderr)
+            subprocess.check_call(
+                [
+                    "bash",
+                    (scripts_dir / "build.sh").absolute().as_posix(),
+                    version,
+                    dist_dir.absolute().as_posix(),
+                ],
+                cwd=out_dir,
+            )
+            return
+
+        aqt_wheel = normalize_wheel_path(out_dir, aqt_wheel)
+        anki_wheel = normalize_wheel_path(out_dir, anki_wheel)
+        template_path = get_briefcase_template_path()
+        template = (
+            f'template = "{template_path.absolute().as_posix()}"'
+            if template_path
+            else ""
+        )
+        template = env.get_template("pyproject.toml.template").render(
+            aqt_wheel=aqt_wheel,
+            anki_wheel=anki_wheel,
+            version=version,
+            template=template,
+        )
+        (out_dir / "pyproject.toml").write_text(template, encoding="utf-8")
+        shutil.copy("LICENSE", out_dir / "LICENSE")
+        (out_dir / "CHANGELOG").write_text(
+            "Please see https://apps.ankiweb.net/", encoding="utf-8"
+        )
+
+    if stop_before_package:
         subprocess.check_call(
-            [
-                "bash",
-                (scripts_dir / "build.sh").absolute().as_posix(),
-                version,
-                dist_dir.absolute().as_posix(),
-            ],
+            [sys.executable, "-m", "briefcase", "create", "--log"],
             cwd=out_dir,
         )
+        subprocess.check_call(
+            [sys.executable, "-m", "briefcase", "build", "--log"],
+            cwd=out_dir,
+        )
+        exe_path = out_dir / "build" / "anki" / "windows" / "app" / "src" / "Anki.exe"
+        if not exe_path.exists():
+            raise SystemExit(f"Build did not produce expected binary: {exe_path}")
         return
 
-    aqt_wheel = normalize_wheel_path(out_dir, aqt_wheel)
-    anki_wheel = normalize_wheel_path(out_dir, anki_wheel)
-    template_path = get_briefcase_template_path()
-    template = (
-        f'template = "{template_path.absolute().as_posix()}"' if template_path else ""
-    )
-    template = env.get_template("pyproject.toml.template").render(
-        aqt_wheel=aqt_wheel,
-        anki_wheel=anki_wheel,
-        version=version,
-        template=template,
-    )
-    (out_dir / "pyproject.toml").write_text(template, encoding="utf-8")
-    shutil.copy("LICENSE", out_dir / "LICENSE")
-    (out_dir / "CHANGELOG").write_text(
-        "Please see https://apps.ankiweb.net/", encoding="utf-8"
-    )
-    identity = os.environ.get("SIGN_IDENTITY")
-    identity_args = ["--identity", identity] if identity else ["--adhoc-sign"]
+    if package_only:
+        exe_path = out_dir / "build" / "anki" / "windows" / "app" / "src" / "Anki.exe"
+        if not exe_path.exists():
+            raise SystemExit(f"Expected signed binary not found: {exe_path}")
+
+    if package_only:
+        identity_args = ["--adhoc-sign"]
+    else:
+        identity = os.environ.get("SIGN_IDENTITY")
+        identity_args = ["--identity", identity] if identity else ["--adhoc-sign"]
+
     subprocess.check_call(
         [
             sys.executable,

--- a/qt/tools/build_installer.py
+++ b/qt/tools/build_installer.py
@@ -15,7 +15,7 @@ import jinja2
 
 installer_dir = Path("qt/installer")
 app_dir = installer_dir / "app"
-out_dir = Path("out/installer").absolute()
+out_dir = Path("out/installer").resolve()
 env = jinja2.Environment(loader=jinja2.FileSystemLoader(app_dir))
 
 

--- a/qt/tools/build_installer.py
+++ b/qt/tools/build_installer.py
@@ -15,7 +15,7 @@ import jinja2
 
 installer_dir = Path("qt/installer")
 app_dir = installer_dir / "app"
-out_dir = Path("out/installer")
+out_dir = Path("out/installer").absolute()
 env = jinja2.Environment(loader=jinja2.FileSystemLoader(app_dir))
 
 

--- a/qt/tools/build_installer.py
+++ b/qt/tools/build_installer.py
@@ -15,7 +15,13 @@ import jinja2
 
 installer_dir = Path("qt/installer")
 app_dir = installer_dir / "app"
+out_dir = Path("out/installer")
+out_dir.mkdir(exist_ok=True)
 env = jinja2.Environment(loader=jinja2.FileSystemLoader(app_dir))
+
+
+def use_briefcase() -> bool:
+    return sys.platform in ("win32", "darwin")
 
 
 def normalize_wheel_path(out_dir: Path, path: str) -> str:
@@ -31,99 +37,93 @@ def get_briefcase_template_path() -> Path | None:
     return None
 
 
-def main(version: str, aqt_wheel: str, anki_wheel: str, out_dir: Path) -> None:
-    package_only = os.environ.get("BRIEFCASE_PACKAGE_ONLY") == "1"
-    stop_before_package = os.environ.get("BRIEFCASE_STOP_BEFORE_PACKAGE") == "1"
+def build_pyinstaller() -> None:
+    subprocess.check_call(
+        [
+            sys.executable,
+            "-m",
+            "PyInstaller",
+            "-y",
+            out_dir / "pyinstaller.spec",
+            "--distpath",
+            out_dir / "dist",
+            "--workpath",
+            out_dir / "build",
+        ]
+    )
 
-    if package_only and stop_before_package:
-        raise SystemExit(
-            "BRIEFCASE_PACKAGE_ONLY and BRIEFCASE_STOP_BEFORE_PACKAGE "
-            "are mutually exclusive"
-        )
 
-    if not package_only:
-        shutil.rmtree(out_dir, ignore_errors=True)
-        shutil.copytree(app_dir, out_dir)
+def package_pyinstaller(version: str) -> None:
+    dist_dir = out_dir / "dist" / "anki"
+    scripts_dir = installer_dir / "linux-scripts"
+    for file in scripts_dir.iterdir():
+        if file.name == "build.sh":
+            continue
+        dest_file = dist_dir / file.name
+        shutil.copy2(file, dest_file)
 
-        if sys.platform == "linux":
-            subprocess.check_call(
-                [
-                    sys.executable,
-                    "-m",
-                    "PyInstaller",
-                    "-y",
-                    out_dir / "pyinstaller.spec",
-                    "--distpath",
-                    out_dir / "dist",
-                    "--workpath",
-                    out_dir / "build",
-                ]
-            )
-            dist_dir = out_dir / "dist" / "anki"
-            scripts_dir = installer_dir / "linux-scripts"
-            for file in scripts_dir.iterdir():
-                if file.name == "build.sh":
-                    continue
-                dest_file = dist_dir / file.name
-                shutil.copy2(file, dest_file)
+    print("Building zip...", file=sys.stderr)
+    subprocess.check_call(
+        [
+            "bash",
+            (scripts_dir / "build.sh").absolute().as_posix(),
+            version,
+            dist_dir.absolute().as_posix(),
+        ],
+        cwd=out_dir,
+    )
 
-            print("Building zip...", file=sys.stderr)
-            subprocess.check_call(
-                [
-                    "bash",
-                    (scripts_dir / "build.sh").absolute().as_posix(),
-                    version,
-                    dist_dir.absolute().as_posix(),
-                ],
-                cwd=out_dir,
-            )
-            return
 
-        aqt_wheel = normalize_wheel_path(out_dir, aqt_wheel)
-        anki_wheel = normalize_wheel_path(out_dir, anki_wheel)
-        template_path = get_briefcase_template_path()
-        template = (
-            f'template = "{template_path.absolute().as_posix()}"'
-            if template_path
-            else ""
-        )
-        template = env.get_template("pyproject.toml.template").render(
-            aqt_wheel=aqt_wheel,
-            anki_wheel=anki_wheel,
-            version=version,
-            template=template,
-        )
-        (out_dir / "pyproject.toml").write_text(template, encoding="utf-8")
-        shutil.copy("LICENSE", out_dir / "LICENSE")
-        (out_dir / "CHANGELOG").write_text(
-            "Please see https://apps.ankiweb.net/", encoding="utf-8"
-        )
+def build(args: argparse.Namespace) -> None:
+    version = args.version
+    shutil.copytree(app_dir, out_dir, dirs_exist_ok=True)
 
-    win_exe_path = out_dir / "build" / "anki" / "windows" / "app" / "src" / "Anki.exe"
-
-    if stop_before_package:
-        subprocess.check_call(
-            [sys.executable, "-m", "briefcase", "create", "--log"],
-            cwd=out_dir,
-        )
-        subprocess.check_call(
-            [sys.executable, "-m", "briefcase", "build", "--log"],
-            cwd=out_dir,
-        )
-        if not win_exe_path.exists():
-            raise SystemExit(f"Build did not produce expected binary: {win_exe_path}")
+    if not use_briefcase():
+        build_pyinstaller()
         return
 
-    if package_only:
-        if not win_exe_path.exists():
-            raise SystemExit(f"Expected signed binary not found: {win_exe_path}")
-        # CI signs the exe externally then calls package-only; briefcase's own
-        # signing is not needed, so use --adhoc-sign to skip it.
-        identity_args = ["--adhoc-sign"]
-    else:
-        identity = os.environ.get("SIGN_IDENTITY")
-        identity_args = ["--identity", identity] if identity else ["--adhoc-sign"]
+    aqt_wheel = normalize_wheel_path(out_dir, args.aqt_wheel)
+    anki_wheel = normalize_wheel_path(out_dir, args.anki_wheel)
+    template_path = get_briefcase_template_path()
+    template = (
+        f'template = "{template_path.absolute().as_posix()}"' if template_path else ""
+    )
+    template = env.get_template("pyproject.toml.template").render(
+        aqt_wheel=aqt_wheel,
+        anki_wheel=anki_wheel,
+        version=version,
+        template=template,
+    )
+    (out_dir / "pyproject.toml").write_text(template, encoding="utf-8")
+    shutil.copy("LICENSE", out_dir / "LICENSE")
+    (out_dir / "CHANGELOG").write_text(
+        "Please see https://apps.ankiweb.net/", encoding="utf-8"
+    )
+    subprocess.check_call(
+        [
+            sys.executable,
+            "-m",
+            "briefcase",
+            "build",
+            "--update",
+            "--update-requirements",
+            "--update-resources",
+            "--update-support",
+            "--log",
+        ],
+        cwd=out_dir,
+    )
 
+
+def package(args: argparse.Namespace) -> None:
+    version = args.version
+
+    if not use_briefcase():
+        package_pyinstaller(version)
+        return
+
+    identity = os.environ.get("SIGN_IDENTITY")
+    identity_args = ["--identity", identity] if identity else ["--adhoc-sign"]
     subprocess.check_call(
         [
             sys.executable,
@@ -148,16 +148,17 @@ def main(version: str, aqt_wheel: str, anki_wheel: str, out_dir: Path) -> None:
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Build the Briefcase installer.")
     parser.add_argument("--version", help="Anki version")
-    parser.add_argument("--aqt_wheel", help="Path to the aqt wheel file")
-    parser.add_argument("--anki_wheel", help="Path to the anki wheel file")
-    parser.add_argument(
-        "--out_dir",
-        type=Path,
-        help="Output directory for the Briefcase app",
-    )
+    subparsers = parser.add_subparsers(help="Briefcase command (build/package)")
+    build_parser = subparsers.add_parser("build", help="Compile/build app")
+    build_parser.add_argument("--aqt_wheel", help="Path to the aqt wheel file")
+    build_parser.add_argument("--anki_wheel", help="Path to the anki wheel file")
+    build_parser.set_defaults(func=build)
+    package_parser = subparsers.add_parser("package", help="Package installer")
+    package_parser.set_defaults(func=package)
+
     return parser.parse_args()
 
 
 if __name__ == "__main__":
     args = parse_args()
-    main(args.version, args.aqt_wheel, args.anki_wheel, args.out_dir)
+    args.func(args)

--- a/qt/tools/build_installer.py
+++ b/qt/tools/build_installer.py
@@ -121,6 +121,7 @@ def package(args: argparse.Namespace) -> None:
         package_pyinstaller(version)
         return
 
+    shutil.rmtree(out_dir / "dist", ignore_errors=True)
     identity = os.environ.get("SIGN_IDENTITY")
     identity_args = ["--identity", identity] if identity else ["--adhoc-sign"]
     subprocess.check_call(

--- a/qt/tools/build_installer.py
+++ b/qt/tools/build_installer.py
@@ -99,6 +99,8 @@ def main(version: str, aqt_wheel: str, anki_wheel: str, out_dir: Path) -> None:
             "Please see https://apps.ankiweb.net/", encoding="utf-8"
         )
 
+    win_exe_path = out_dir / "build" / "anki" / "windows" / "app" / "src" / "Anki.exe"
+
     if stop_before_package:
         subprocess.check_call(
             [sys.executable, "-m", "briefcase", "create", "--log"],
@@ -108,17 +110,15 @@ def main(version: str, aqt_wheel: str, anki_wheel: str, out_dir: Path) -> None:
             [sys.executable, "-m", "briefcase", "build", "--log"],
             cwd=out_dir,
         )
-        exe_path = out_dir / "build" / "anki" / "windows" / "app" / "src" / "Anki.exe"
-        if not exe_path.exists():
-            raise SystemExit(f"Build did not produce expected binary: {exe_path}")
+        if not win_exe_path.exists():
+            raise SystemExit(f"Build did not produce expected binary: {win_exe_path}")
         return
 
     if package_only:
-        exe_path = out_dir / "build" / "anki" / "windows" / "app" / "src" / "Anki.exe"
-        if not exe_path.exists():
-            raise SystemExit(f"Expected signed binary not found: {exe_path}")
-
-    if package_only:
+        if not win_exe_path.exists():
+            raise SystemExit(f"Expected signed binary not found: {win_exe_path}")
+        # CI signs the exe externally then calls package-only; briefcase's own
+        # signing is not needed, so use --adhoc-sign to skip it.
         identity_args = ["--adhoc-sign"]
     else:
         identity = os.environ.get("SIGN_IDENTITY")

--- a/qt/tools/build_installer.py
+++ b/qt/tools/build_installer.py
@@ -16,7 +16,6 @@ import jinja2
 installer_dir = Path("qt/installer")
 app_dir = installer_dir / "app"
 out_dir = Path("out/installer")
-out_dir.mkdir(exist_ok=True)
 env = jinja2.Environment(loader=jinja2.FileSystemLoader(app_dir))
 
 
@@ -161,4 +160,5 @@ def parse_args() -> argparse.Namespace:
 
 if __name__ == "__main__":
     args = parse_args()
+    out_dir.mkdir(exist_ok=True)
     args.func(args)

--- a/qt/tools/build_installer.py
+++ b/qt/tools/build_installer.py
@@ -24,7 +24,7 @@ def use_briefcase() -> bool:
 
 
 def normalize_wheel_path(out_dir: Path, path: str) -> str:
-    path = Path(path).relative_to(out_dir.parent).as_posix()
+    path = Path(path).absolute().relative_to(out_dir.parent).as_posix()
     return f"../{path}"
 
 


### PR DESCRIPTION
## Summary

- Add two-phase build support to `build_installer.py` via `BRIEFCASE_STOP_BEFORE_PACKAGE` and `BRIEFCASE_PACKAGE_ONLY` env vars, allowing CI to sign `Anki.exe` between the build and package steps
- Merge `build-windows` + `sign-windows` into a single `build-and-sign-windows` job that signs both `Anki.exe` (via Azure Trusted Signing) and the MSI wrapper
- Previously only the MSI was signed; the installed `Anki.exe` was unsigned

### How it works

1. **Build** — `briefcase create` + `briefcase build` via ninja (stops before packaging)
2. **Sign exe** — Azure Trusted Signing signs `Anki.exe` directly
3. **Package** — `briefcase package --adhoc-sign` wraps the already-signed exe into an MSI (bypasses ninja, calls `build_installer.py` directly since ninja would skip the already-built target)
4. **Sign MSI** — Azure Trusted Signing signs the MSI

The unsigned fallback (`skip-signing: true`) is preserved. macOS and Linux paths are unaffected.

## Test plan

- [ ] Trigger release workflow with `skip-signing: true` — verify unsigned build succeeds (same as before)
- [ ] Trigger release workflow with `skip-signing: false` — verify `Verify app binary signature` step passes
- [ ] Download signed MSI → install → check `Anki.exe` Properties → Digital Signatures tab shows valid signature
- [ ] Verify macOS builds still work (no env vars set in those jobs)