### PR TITLE
Implements Numerical search and ranges

### DIFF
--- a/rslib/src/search/mod.rs
+++ b/rslib/src/search/mod.rs
@@ -477,4 +477,56 @@ mod test {
             );
         }
     }
+
+    #[test]
+    fn numeric_field_search_uses_named_field_not_sort_field() -> Result<()> {
+        let mut col = Collection::new();
+        let mut nt = col.get_notetype_by_name("Basic")?.unwrap().as_ref().clone();
+        nt.add_field("Frequency");
+        col.update_notetype(&mut nt, false)?;
+
+        let nt = col.get_notetype_by_name("Basic")?.unwrap();
+        assert_ne!(nt.config.sort_field_idx, 2);
+
+        let mut add_note = |front: &str, frequency: &str| -> Result<NoteId> {
+            let mut note = nt.new_note();
+            note.set_field(0, front)?;
+            note.set_field(2, frequency)?;
+            col.add_note(&mut note, DeckId(1))?;
+            Ok(note.id)
+        };
+
+        let lower_bound = add_note("lower bound", "500")?;
+        let in_range = add_note("in range", "550")?;
+        let upper_bound = add_note("upper bound", "600")?;
+        let too_high = add_note("too high", "1500")?;
+        let not_numeric = add_note("not numeric", "abc")?;
+
+        let mut ids = col.search_notes("Frequency>500 Frequency<600", SortMode::NoOrder)?;
+        ids.sort();
+        assert_eq!(ids, vec![in_range]);
+
+        let ids = col.search_notes("Frequency<600", SortMode::NoOrder)?;
+        assert!(ids.contains(&lower_bound));
+        assert!(!ids.contains(&upper_bound));
+        assert!(!ids.contains(&too_high));
+        assert!(!ids.contains(&not_numeric));
+
+        let mut ids = col.search_notes("Frequency:[500,600]", SortMode::NoOrder)?;
+        ids.sort();
+        assert_eq!(ids, vec![lower_bound, in_range, upper_bound]);
+
+        let mut ids = col.search_notes("Frequency:[500,600[", SortMode::NoOrder)?;
+        ids.sort();
+        assert_eq!(ids, vec![lower_bound, in_range]);
+
+        let mut ids = col.search_notes("Frequency:]500,600]", SortMode::NoOrder)?;
+        ids.sort();
+        assert_eq!(ids, vec![in_range, upper_bound]);
+
+        let ids = col.search_notes("Frequency:]500,600[", SortMode::NoOrder)?;
+        assert_eq!(ids, vec![in_range]);
+
+        Ok(())
+    }
 }

--- a/rslib/src/search/mod.rs
+++ b/rslib/src/search/mod.rs
@@ -477,4 +477,42 @@ mod test {
             );
         }
     }
+
+    #[test]
+    fn numeric_field_search_uses_named_field_not_sort_field() -> Result<()> {
+        let mut col = Collection::new();
+        let mut nt = col.get_notetype_by_name("Basic")?.unwrap().as_ref().clone();
+        nt.add_field("Frequency");
+        col.update_notetype(&mut nt, false)?;
+
+        let nt = col.get_notetype_by_name("Basic")?.unwrap();
+        assert_ne!(nt.config.sort_field_idx, 2);
+
+        for frequency in ["499", "500", "550", "600", "1500", "abc"] {
+            let mut note = nt.new_note();
+            note.set_field(0, "not numeric")?;
+            note.set_field(2, frequency)?;
+            col.add_note(&mut note, DeckId(1))?;
+        }
+
+        let mut matching_frequencies = |query: &str| -> Result<Vec<String>> {
+            let mut ids = col.search_notes(query, SortMode::NoOrder)?;
+            ids.sort();
+            ids.into_iter()
+                .map(|id| Ok(col.storage.get_note(id)?.unwrap().fields()[2].clone()))
+                .collect()
+        };
+
+        assert_eq!(
+            matching_frequencies("Frequency>500 Frequency<600")?,
+            ["550"]
+        );
+        assert_eq!(matching_frequencies("Frequency<500")?, ["499"]);
+        assert_eq!(matching_frequencies("Frequency<=500")?, ["499", "500"]);
+        assert_eq!(matching_frequencies("Frequency=500")?, ["500"]);
+        assert_eq!(matching_frequencies("Frequency>=600")?, ["600", "1500"]);
+        assert_eq!(matching_frequencies("Frequency>600")?, ["1500"]);
+
+        Ok(())
+    }
 }

--- a/rslib/src/search/parser.rs
+++ b/rslib/src/search/parser.rs
@@ -75,6 +75,18 @@ pub enum SearchNode {
         text: String,
         mode: FieldSearchMode,
     },
+    NumericField {
+        field: String,
+        operator: String,
+        value: f64,
+    },
+    NumericFieldRange {
+        field: String,
+        min: f64,
+        max: f64,
+        min_inclusive: bool,
+        max_inclusive: bool,
+    },
     AddedInDays(u32),
     EditedInDays(u32),
     CardTemplate(TemplateKind),
@@ -346,10 +358,34 @@ fn search_node_for_text(s: &str) -> ParseResult<'_, SearchNode> {
     .parse(s)
     .map_err(|_: nom::Err<ParseError>| parse_failure(s, FailKind::MissingKey))?;
     if tail.is_empty() {
-        Ok(SearchNode::UnqualifiedText(unescape(head)?))
+        if let Some(node) = parse_numeric_field_comparison(head)? {
+            Ok(node)
+        } else {
+            Ok(SearchNode::UnqualifiedText(unescape(head)?))
+        }
     } else {
         search_node_for_text_with_argument(head, &tail[1..])
     }
+}
+
+fn parse_numeric_field_comparison(s: &str) -> ParseResult<'_, Option<SearchNode>> {
+    static RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"^(.+?)(<=|>=|<|>)(.+)$").unwrap());
+    let Some(caps) = RE.captures(s) else {
+        return Ok(None);
+    };
+
+    let field = caps.get(1).unwrap().as_str();
+    let operator = caps.get(2).unwrap().as_str();
+    let value = match caps.get(3).unwrap().as_str().parse::<f64>() {
+        Ok(value) if value.is_finite() => value,
+        _ => return Ok(None),
+    };
+
+    Ok(Some(SearchNode::NumericField {
+        field: unescape(field)?,
+        operator: operator.into(),
+        value,
+    }))
 }
 
 /// Convert a colon-separated key/val pair into the relevant search type.
@@ -382,8 +418,45 @@ fn search_node_for_text_with_argument<'a>(
         "has-cd" => SearchNode::CustomData(unescape(val)?),
         "preset" => SearchNode::Preset(val.into()),
         // anything else is a field search
-        _ => parse_single_field(key, val)?,
+        _ => parse_numeric_field_range(key, val)?.unwrap_or(parse_single_field(key, val)?),
     })
+}
+
+fn parse_numeric_field_range<'a>(
+    key: &'a str,
+    val: &'a str,
+) -> ParseResult<'a, Option<SearchNode>> {
+    let Some(left_bracket) = val.as_bytes().first() else {
+        return Ok(None);
+    };
+    let Some(right_bracket) = val.as_bytes().last() else {
+        return Ok(None);
+    };
+    if !matches!(left_bracket, b'[' | b']') || !matches!(right_bracket, b'[' | b']') {
+        return Ok(None);
+    }
+
+    let inner = &val[1..val.len() - 1];
+    let Some((min, max)) = inner.split_once(',') else {
+        return Ok(None);
+    };
+    let Ok(min) = min.trim().parse::<f64>() else {
+        return Ok(None);
+    };
+    let Ok(max) = max.trim().parse::<f64>() else {
+        return Ok(None);
+    };
+    if !min.is_finite() || !max.is_finite() {
+        return Ok(None);
+    }
+
+    Ok(Some(SearchNode::NumericFieldRange {
+        field: unescape(key)?,
+        min,
+        max,
+        min_inclusive: *left_bracket == b'[',
+        max_inclusive: *right_bracket == b']',
+    }))
 }
 
 fn parse_tag(s: &str) -> ParseResult<'_, SearchNode> {
@@ -857,6 +930,42 @@ mod test {
                 field: "foo".into(),
                 text: "bar".into(),
                 mode: FieldSearchMode::NoCombining,
+            })]
+        );
+        assert_eq!(
+            parse("Frequency>500 Frequency<1500")?,
+            vec![
+                Search(NumericField {
+                    field: "Frequency".into(),
+                    operator: ">".into(),
+                    value: 500.0,
+                }),
+                And,
+                Search(NumericField {
+                    field: "Frequency".into(),
+                    operator: "<".into(),
+                    value: 1500.0,
+                })
+            ]
+        );
+        assert_eq!(
+            parse("Frequency:[500,600[")?,
+            vec![Search(NumericFieldRange {
+                field: "Frequency".into(),
+                min: 500.0,
+                max: 600.0,
+                min_inclusive: true,
+                max_inclusive: false,
+            })]
+        );
+        assert_eq!(
+            parse("Frequency:]500,600]")?,
+            vec![Search(NumericFieldRange {
+                field: "Frequency".into(),
+                min: 500.0,
+                max: 600.0,
+                min_inclusive: false,
+                max_inclusive: true,
             })]
         );
 

--- a/rslib/src/search/parser.rs
+++ b/rslib/src/search/parser.rs
@@ -75,6 +75,11 @@ pub enum SearchNode {
         text: String,
         mode: FieldSearchMode,
     },
+    NumericField {
+        field: String,
+        operator: String,
+        value: f64,
+    },
     AddedInDays(u32),
     EditedInDays(u32),
     CardTemplate(TemplateKind),
@@ -346,10 +351,34 @@ fn search_node_for_text(s: &str) -> ParseResult<'_, SearchNode> {
     .parse(s)
     .map_err(|_: nom::Err<ParseError>| parse_failure(s, FailKind::MissingKey))?;
     if tail.is_empty() {
-        Ok(SearchNode::UnqualifiedText(unescape(head)?))
+        if let Some(node) = parse_numeric_field_comparison(head)? {
+            Ok(node)
+        } else {
+            Ok(SearchNode::UnqualifiedText(unescape(head)?))
+        }
     } else {
         search_node_for_text_with_argument(head, &tail[1..])
     }
+}
+
+fn parse_numeric_field_comparison(s: &str) -> ParseResult<'_, Option<SearchNode>> {
+    static RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"^(.+?)(<=|>=|=|<|>)(.+)$").unwrap());
+    let Some(caps) = RE.captures(s) else {
+        return Ok(None);
+    };
+
+    let field = caps.get(1).unwrap().as_str();
+    let operator = caps.get(2).unwrap().as_str();
+    let value = match caps.get(3).unwrap().as_str().parse::<f64>() {
+        Ok(value) if value.is_finite() => value,
+        _ => return Ok(None),
+    };
+
+    Ok(Some(SearchNode::NumericField {
+        field: unescape(field)?,
+        operator: operator.into(),
+        value,
+    }))
 }
 
 /// Convert a colon-separated key/val pair into the relevant search type.
@@ -859,6 +888,16 @@ mod test {
                 mode: FieldSearchMode::NoCombining,
             })]
         );
+        for operator in ["<", "<=", "=", ">=", ">"] {
+            assert_eq!(
+                parse(&format!("Frequency{operator}500"))?,
+                vec![Search(NumericField {
+                    field: "Frequency".into(),
+                    operator: operator.into(),
+                    value: 500.0,
+                })]
+            );
+        }
 
         // escaping is independent of quotation
         assert_eq!(

--- a/rslib/src/search/sqlwriter.rs
+++ b/rslib/src/search/sqlwriter.rs
@@ -142,6 +142,26 @@ impl SqlWriter<'_> {
             SearchNode::SingleField { field, text, mode } => {
                 self.write_field(&norm(field), &self.norm_note(text), *mode)?
             }
+            SearchNode::NumericField {
+                field,
+                operator,
+                value,
+            } => {
+                let comparisons = [(operator.as_str(), *value)];
+                self.write_numeric_field(&norm(field), &comparisons)?
+            }
+            SearchNode::NumericFieldRange {
+                field,
+                min,
+                max,
+                min_inclusive,
+                max_inclusive,
+            } => {
+                let min_op = if *min_inclusive { ">=" } else { ">" };
+                let max_op = if *max_inclusive { "<=" } else { "<" };
+                let comparisons = [(min_op, *min), (max_op, *max)];
+                self.write_numeric_field(&norm(field), &comparisons)?
+            }
             SearchNode::Duplicates { notetype_id, text } => {
                 self.write_dupe(*notetype_id, &self.norm_note(text))?
             }
@@ -729,6 +749,40 @@ impl SqlWriter<'_> {
         Ok(())
     }
 
+    fn write_numeric_field(&mut self, field_name: &str, comparisons: &[(&str, f64)]) -> Result<()> {
+        let field_indices_by_notetype = self.fields_indices_by_notetype(field_name)?;
+        if field_indices_by_notetype.is_empty() {
+            write!(self.sql, "false").unwrap();
+            return Ok(());
+        }
+
+        self.args
+            .push(r"^[+-]?(?:[0-9]+(?:\.[0-9]*)?|\.[0-9]+)(?:[eE][+-]?[0-9]+)?$".into());
+        let arg_idx = self.args.len();
+
+        let all_notetype_clauses = field_indices_by_notetype
+            .iter()
+            .map(|(mid, field_indices)| {
+                let field_clauses = field_indices
+                    .iter()
+                    .map(|idx| {
+                        let field = format!("trim(field_at_index(n.flds, {idx}))");
+                        let comparisons = comparisons
+                            .iter()
+                            .map(|(op, value)| format!("cast({field} as real) {op} {value}"))
+                            .join(" and ");
+                        format!("({field} regexp ?{arg_idx} and {comparisons})")
+                    })
+                    .join(" or ");
+                format!("(n.mid = {mid} and ({field_clauses}))")
+            })
+            .join(" or ");
+
+        write!(self.sql, "({all_notetype_clauses})").unwrap();
+
+        Ok(())
+    }
+
     fn num_fields_and_fields_indices_by_notetype(
         &mut self,
         field_name: &str,
@@ -1095,6 +1149,8 @@ impl SearchNode {
 
             SearchNode::UnqualifiedText(_) => RequiredTable::Notes,
             SearchNode::SingleField { .. } => RequiredTable::Notes,
+            SearchNode::NumericField { .. } => RequiredTable::Notes,
+            SearchNode::NumericFieldRange { .. } => RequiredTable::Notes,
             SearchNode::Tag { .. } => RequiredTable::Notes,
             SearchNode::Duplicates { .. } => RequiredTable::Notes,
             SearchNode::Regex(_) => RequiredTable::Notes,

--- a/rslib/src/search/sqlwriter.rs
+++ b/rslib/src/search/sqlwriter.rs
@@ -142,6 +142,11 @@ impl SqlWriter<'_> {
             SearchNode::SingleField { field, text, mode } => {
                 self.write_field(&norm(field), &self.norm_note(text), *mode)?
             }
+            SearchNode::NumericField {
+                field,
+                operator,
+                value,
+            } => self.write_numeric_field(&norm(field), operator, *value)?,
             SearchNode::Duplicates { notetype_id, text } => {
                 self.write_dupe(*notetype_id, &self.norm_note(text))?
             }
@@ -729,6 +734,38 @@ impl SqlWriter<'_> {
         Ok(())
     }
 
+    fn write_numeric_field(&mut self, field_name: &str, operator: &str, value: f64) -> Result<()> {
+        let field_indices_by_notetype = self.fields_indices_by_notetype(field_name)?;
+        if field_indices_by_notetype.is_empty() {
+            write!(self.sql, "false").unwrap();
+            return Ok(());
+        }
+
+        self.args
+            .push(r"^[+-]?(?:[0-9]+(?:\.[0-9]*)?|\.[0-9]+)(?:[eE][+-]?[0-9]+)?$".into());
+        let arg_idx = self.args.len();
+
+        let all_notetype_clauses = field_indices_by_notetype
+            .iter()
+            .map(|(mid, field_indices)| {
+                let field_clauses = field_indices
+                    .iter()
+                    .map(|idx| {
+                        let field = format!("trim(field_at_index(n.flds, {idx}))");
+                        format!(
+                            "({field} regexp ?{arg_idx} and cast({field} as real) {operator} {value})"
+                        )
+                    })
+                    .join(" or ");
+                format!("(n.mid = {mid} and ({field_clauses}))")
+            })
+            .join(" or ");
+
+        write!(self.sql, "({all_notetype_clauses})").unwrap();
+
+        Ok(())
+    }
+
     fn num_fields_and_fields_indices_by_notetype(
         &mut self,
         field_name: &str,
@@ -1095,6 +1132,7 @@ impl SearchNode {
 
             SearchNode::UnqualifiedText(_) => RequiredTable::Notes,
             SearchNode::SingleField { .. } => RequiredTable::Notes,
+            SearchNode::NumericField { .. } => RequiredTable::Notes,
             SearchNode::Tag { .. } => RequiredTable::Notes,
             SearchNode::Duplicates { .. } => RequiredTable::Notes,
             SearchNode::Regex(_) => RequiredTable::Notes,

--- a/rslib/src/search/writer.rs
+++ b/rslib/src/search/writer.rs
@@ -71,6 +71,25 @@ fn write_search_node(node: &SearchNode) -> String {
     match node {
         UnqualifiedText(s) => maybe_quote(&s.replace(':', "\\:")),
         SingleField { field, text, mode } => write_single_field(field, text, *mode),
+        NumericField {
+            field,
+            operator,
+            value,
+        } => maybe_quote(&format!("{}{operator}{value}", field.replace(':', "\\:"))),
+        NumericFieldRange {
+            field,
+            min,
+            max,
+            min_inclusive,
+            max_inclusive,
+        } => {
+            let left = if *min_inclusive { "[" } else { "]" };
+            let right = if *max_inclusive { "]" } else { "[" };
+            maybe_quote(&format!(
+                "{}:{left}{min},{max}{right}",
+                field.replace(':', "\\:")
+            ))
+        }
         AddedInDays(u) => format!("added:{u}"),
         EditedInDays(u) => format!("edited:{u}"),
         IntroducedInDays(u) => format!("introduced:{u}"),
@@ -240,6 +259,15 @@ mod test {
         assert_eq!(r#""aNd" "oR""#, normalize_search(r#""aNd" "oR""#).unwrap());
         // normalize numbers
         assert_eq!("prop:ease>1", normalize_search("prop:ease>1.0").unwrap());
+        assert_eq!(
+            "Frequency>500",
+            normalize_search("Frequency>500.0").unwrap()
+        );
+        assert_eq!(
+            "Frequency:[500,600[",
+            normalize_search("Frequency:[500.0,600.0[").unwrap()
+        );
+        assert_eq!(r"foo\:bar>5", normalize_search(r"foo\:bar>5").unwrap());
     }
 
     #[test]

--- a/rslib/src/search/writer.rs
+++ b/rslib/src/search/writer.rs
@@ -71,6 +71,11 @@ fn write_search_node(node: &SearchNode) -> String {
     match node {
         UnqualifiedText(s) => maybe_quote(&s.replace(':', "\\:")),
         SingleField { field, text, mode } => write_single_field(field, text, *mode),
+        NumericField {
+            field,
+            operator,
+            value,
+        } => maybe_quote(&format!("{}{operator}{value}", field.replace(':', "\\:"))),
         AddedInDays(u) => format!("added:{u}"),
         EditedInDays(u) => format!("edited:{u}"),
         IntroducedInDays(u) => format!("introduced:{u}"),
@@ -240,6 +245,15 @@ mod test {
         assert_eq!(r#""aNd" "oR""#, normalize_search(r#""aNd" "oR""#).unwrap());
         // normalize numbers
         assert_eq!("prop:ease>1", normalize_search("prop:ease>1.0").unwrap());
+        assert_eq!(
+            "Frequency>500",
+            normalize_search("Frequency>500.0").unwrap()
+        );
+        assert_eq!(
+            "Frequency=500",
+            normalize_search("Frequency=500.0").unwrap()
+        );
+        assert_eq!(r"foo\:bar>5", normalize_search(r"foo\:bar>5").unwrap());
     }
 
     #[test]


### PR DESCRIPTION
Hello, I ported back to anki main branch this feature from my fork I think other people might enjoy,

It allows to search on numerical fields like this : `Frequency>500, Frequency<600`.

I also added a range filter, something like `Frequency:[500,600[` (include, exclusive, can be swapped).

The code was generated by Codex (5.5 High) and reviewed by me. There's a backward compatibility risk if people had queries like "Frequency>600" in the past (that would I guess match if there's content where there's Frequency>600 in it ?), but I think the impact is so small it's OK to keep this syntax.

A few posts asked for this in the past 
- https://forums.ankiweb.net/t/allow-for-in-search/9888/3
- https://www.reddit.com/r/Anki/comments/8u6ksr/is_it_possible_to_search_in_a_numeric_range_of_a/

