### PR TITLE
docs: add contributing guidelines for add-ons, linked issues, and AI-assisted PRs

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -16,6 +16,16 @@ issue tracker, please reach out on the forums before you begin work, so we can l
 you know whether they're likely to be accepted or not. When you spent a bunch of time
 on a PR that ends up getting rejected, it's no fun for either you or us.
 
+## Consider an Add-on First
+
+Before submitting a PR for a new feature, please consider whether it could be
+implemented as an add-on instead. We aim to keep the core Anki codebase lean
+and maintainable. Many great ideas are better served as add-ons, where they
+can iterate faster and serve specific user needs without affecting all users.
+
+See the [Add-on API documentation](https://addon-docs.ankiweb.net/) for
+guidance on building add-ons.
+
 ## Refactoring
 
 Please avoid PRs that focus on refactoring. Every PR has a cost to review, and a chance

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -26,6 +26,15 @@ can iterate faster and serve specific user needs without affecting all users.
 See the [Add-on API documentation](https://addon-docs.ankiweb.net/) for
 guidance on building add-ons.
 
+## Linked Issues
+
+Every pull request, except hotfixes and dependency updates, must be linked
+to an existing open issue. If no issue exists, please open one to describe
+the problem before submitting a PR. This helps us ensure we're solving the
+right problems and prevents wasted effort on both sides.
+
+PRs without a linked issue may be automatically closed after a short period.
+
 ## Refactoring
 
 Please avoid PRs that focus on refactoring. Every PR has a cost to review, and a chance

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -143,6 +143,17 @@ Please don't make a pull request for a bunch of unrelated changes, as they are
 difficult to review and will be rejected - split them up into separate
 requests instead.
 
+## AI-Assisted Contributions
+
+Using AI tools to help write or review code is permitted. However, you must
+understand every change you submit. If you cannot explain what your changes
+do and how they interact with the rest of the system, your PR will be closed.
+
+Please review AI-generated code carefully before submitting. PRs that appear
+to have been submitted without human review — e.g., irrelevant code, duplicate
+logic, or comments that don't match the implementation — may be closed without
+further discussion.
+
 ## License
 
 Please add yourself to the [CONTRIBUTORS](./CONTRIBUTORS) file in your first pull request.


### PR DESCRIPTION
## Summary / motivation (required)

Adds three new sections to `docs/contributing.md` to address recurring pain points in PR reviews:

- **Consider an Add-on First**: encourages contributors to explore the add-on API before proposing core features, to keep the codebase lean.
- **Linked Issues**: makes it explicit that every non-trivial PR must be linked to an open issue, with a note that unlinked PRs may be auto-closed.
- **AI-Assisted Contributions**: sets expectations for AI-generated code: it's allowed, but contributors must understand and review every change they submit.

### Details

Read `docs/contributing.md` and verify the three new sections render correctly and are consistent in tone with the existing content.
