### PR TITLE
fix: Prevent easy days from being set while touchscreen scrolling

### DIFF
--- a/ts/routes/deck-options/EasyDaysInput.svelte
+++ b/ts/routes/deck-options/EasyDaysInput.svelte
@@ -2,9 +2,10 @@
 Copyright: Ankitects Pty Ltd and contributors
 License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 -->
-<script>
+<script lang="ts">
     import * as tr from "@generated/ftl";
     import Item from "$lib/components/Item.svelte";
+    import { onMount } from "svelte";
 
     const easyDays = [
         tr.deckConfigEasyDaysMonday(),
@@ -17,10 +18,45 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     ];
 
     export let values = [0, 0, 0, 0, 0, 0, 0];
+
+    let startY = 0;
+    let originalValues = [...values];
+
+    function handleTouchStart(): void {
+        startY = window.scrollY;
+        originalValues = [...values];
+    }
+
+    function handleTouchEnd(): void {
+        const deltaY = Math.abs(window.scrollY - startY);
+        if (deltaY > 1) {
+            // If the screen has scrolled
+            values = [...originalValues];
+        }
+    }
+
+    function onInput(event: Event, index: number): void {
+        values[index] = parseFloat((event.target as HTMLInputElement).value);
+    }
+
+    let touchDivRef: HTMLDivElement | null = null;
+
+    // Todo: Use on:touchstart. For some reason it doesn't work when added to the div in the markup, but works when added manually here.
+    onMount(() => {
+        touchDivRef?.addEventListener("touchstart", handleTouchStart, {
+            passive: true,
+        });
+        touchDivRef?.addEventListener("touchend", handleTouchEnd, { passive: true });
+
+        return () => {
+            touchDivRef?.removeEventListener("touchstart", handleTouchStart);
+            touchDivRef?.removeEventListener("touchend", handleTouchEnd);
+        };
+    });
 </script>
 
 <Item>
-    <div class="container">
+    <div class="container" bind:this={touchDivRef}>
         <div class="easy-days-settings">
             <span></span>
             <span class="header min-col">{tr.deckConfigEasyDaysMinimum()}</span>
@@ -31,8 +67,9 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
                 <span class="day">{day}</span>
                 <div class="input-container">
                     <input
+                        on:input={(e) => onInput(e, index)}
                         type="range"
-                        bind:value={values[index]}
+                        value={values[index]}
                         step={0.5}
                         max={1.0}
                         min={0.0}
@@ -86,6 +123,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     .easy-days-settings input[type="range"] {
         width: 100%;
         cursor: pointer;
+        touch-action: auto;
     }
 
     .day {


### PR DESCRIPTION
<!--
Title (for the Pull Request title field at the top):
Use a short prefix so the change type is obvious. You do not need to repeat it in the body below.

Examples:
- fix: — bugfix
- feat: — feature
- refactor: — internal change without user-facing feature
- docs: — documentation only
- chore: — tooling, CI, deps, build housekeeping
- test: — tests only
-->

## Linked issue (required)

<!-- Fixes #123 / Closes #123 / Refs #123 -->

closes https://github.com/ankidroid/Anki-Android/issues/20929

## Summary / motivation (required)

<!-- What this PR does and why. For larger changes, add enough context for reviewers. -->
People inadvertently set their easy days without noticing while scrolling on mobile. See [this forum post]( https://forums.ankiweb.net/t/deck-options-easy-days-switch-triggered-when-scrolling/63854/9).

This resets the easy days to their original values if the user has scrolled while they are being set.

## Steps to reproduce (required, use N/A if not applicable)

<!-- Steps to reproduce: how to trigger the bug in the broken state (the "before").
 - Mainly for bugfixes;
    - For bugs: numbered steps before the fix. For non-bugs: write N/A.
 - use N/A for features, refactors, docs, chore, etc.
-->
N/A
## How to test (required)

<!--- How to test: how you verified the change (checks, unit tests, manual steps, edge cases — the "after" or general validation). --->

I used `ANKI_API_HOST=0.0.0.0 ./run` and browsed to `http://(host-ip-address):40000/deck-options/1` on a mobile device

@david-allison would you mind testing this in AnkiDroid?

### Checklist (minimum)

- [X] I ran `./ninja check` or an equivalent relevant check locally.
- [ ] I added or updated tests when the change is non-trivial or behavior changed.

### Details

<!-- Commands, manual steps, edge cases, and what you observed -->
There was a weird issue with `on:touchstart` not working and I had to manually add an event handler which is a little annoying.

## Before / after behavior (optional)

<!-- For bugfixes: behavior before vs after. For other types: N/A or a short note. -->

## Risk / compatibility / migration (optional)

<!-- Breaking changes, rollout notes, or N/A for small / low-risk PRs -->

## UI evidence (required for visual changes; otherwise N/A)

<!-- Screenshot or short video -->

## Scope

- [X] This PR is focused on one change (no unrelated edits).
