### PR TITLE
fix:  Use floats when displaying card intervals

### DIFF
--- a/proto/anki/stats.proto
+++ b/proto/anki/stats.proto
@@ -32,13 +32,13 @@ message CardStatsResponse {
     RevlogEntry.ReviewKind review_kind = 2;
     uint32 button_chosen = 3;
     // seconds
-    uint32 interval = 4;
+    float interval = 4;
     // per mill
     uint32 ease = 5;
     float taken_secs = 6;
     optional cards.FsrsMemoryState memory_state = 7;
     // seconds
-    uint32 last_interval = 8;
+    float last_interval = 8;
   }
   repeated StatsRevlogEntry revlog = 1;
   int64 card_id = 2;

--- a/rslib/src/browser_table.rs
+++ b/rslib/src/browser_table.rs
@@ -604,7 +604,7 @@ impl RowContext {
             "".into()
         } else {
             time_span(
-                (intervals.iter().sum::<f32>() * 86400.0 / (intervals.len() as f32)) as f32,
+                intervals.iter().sum::<f32>() * 86400.0 / (intervals.len() as f32),
                 &self.tr,
                 false,
             )

--- a/rslib/src/browser_table.rs
+++ b/rslib/src/browser_table.rs
@@ -594,17 +594,17 @@ impl RowContext {
                 CardType::Review | CardType::Relearn => (),
             }
         }
-        let intervals: Vec<u32> = self
+        let intervals: Vec<f32> = self
             .cards
             .iter()
             .filter(|c| matches!(c.ctype, CardType::Review | CardType::Relearn))
-            .map(|c| c.interval)
+            .map(|c| c.interval as f32)
             .collect();
         if intervals.is_empty() {
             "".into()
         } else {
             time_span(
-                (intervals.iter().sum::<u32>() * 86400 / (intervals.len() as u32)) as f32,
+                (intervals.iter().sum::<f32>() * 86400.0 / (intervals.len() as f32)) as f32,
                 &self.tr,
                 false,
             )

--- a/rslib/src/revlog/mod.rs
+++ b/rslib/src/revlog/mod.rs
@@ -80,7 +80,7 @@ impl RevlogEntry {
         if self.interval > 0 {
             self.interval as f32 * 86_400.0
         } else {
-            self.interval as f32 * -1.0
+            -(self.interval as f32)
         }
     }
 
@@ -88,7 +88,7 @@ impl RevlogEntry {
         if self.last_interval > 0 {
             self.last_interval as f32 * 86_400.0
         } else {
-            self.last_interval as f32 * -1.0
+            -(self.last_interval as f32)
         }
     }
 

--- a/rslib/src/revlog/mod.rs
+++ b/rslib/src/revlog/mod.rs
@@ -76,22 +76,20 @@ pub enum RevlogReviewKind {
 }
 
 impl RevlogEntry {
-    pub(crate) fn interval_secs(&self) -> u32 {
-        u32::try_from(if self.interval > 0 {
-            self.interval.saturating_mul(86_400)
+    pub(crate) fn interval_secs(&self) -> f32 {
+        if self.interval > 0 {
+            self.interval as f32 * 86_400.0
         } else {
-            self.interval.saturating_mul(-1)
-        })
-        .unwrap()
+            self.interval as f32 * -1.0
+        }
     }
 
-    pub(crate) fn last_interval_secs(&self) -> u32 {
-        u32::try_from(if self.last_interval > 0 {
-            self.last_interval.saturating_mul(86_400)
+    pub(crate) fn last_interval_secs(&self) -> f32 {
+        if self.last_interval > 0 {
+            self.last_interval as f32 * 86_400.0
         } else {
-            self.last_interval.saturating_mul(-1)
-        })
-        .unwrap()
+            self.last_interval as f32 * -1.0
+        }
     }
 
     /// Returns true if this entry represents a reset operation.


### PR DESCRIPTION
<!--
Title (for the Pull Request title field at the top):
Use a short prefix so the change type is obvious. You do not need to repeat it in the body below.

Examples:
- fix: — bugfix
- feat: — feature
- refactor: — internal change without user-facing feature
- docs: — documentation only
- chore: — tooling, CI, deps, build housekeeping
- test: — tests only
-->

## Linked issue (required)

fixes #4787
<!-- Fixes #123 / Closes #123 / Refs #123 -->

## Summary / motivation (required)

While it is impossible during normal use to get an interval greater than 10 years due to the max_interval. By using set date you can get a larger interval which is then displayed incorrectly. By using a float to store the second values instead of a u32, we can display higher values (although the day interval is still constrained by u32).
<!-- What this PR does and why. For larger changes, add enough context for reviewers. -->

## Steps to reproduce (required, use N/A if not applicable)

<!-- Steps to reproduce: how to trigger the bug in the broken state (the "before").
 - Mainly for bugfixes;
    - For bugs: numbered steps before the fix. For non-bugs: write N/A.
 - use N/A for features, refactors, docs, chore, etc.
-->

1. use set interval with a massive number
2. check the 
3.

## How to test (required)

<!--- How to test: how you verified the change (checks, unit tests, manual steps, edge cases — the "after" or general validation). --->
Follow the steps to reproduce. The number will display as the actual interval in all instances.

### Checklist (minimum)

- [X] I ran `./ninja check` or an equivalent relevant check locally.
- [ ] I added or updated tests when the change is non-trivial or behavior changed.

### Details

<!-- Commands, manual steps, edge cases, and what you observed -->

## Before / after behavior (optional)

<img width="1073" height="783" alt="image" src="https://github.com/user-attachments/assets/8c0b785a-9a0c-4deb-af2c-5c5d33879940" />
<img width="1073" height="783" alt="image" src="https://github.com/user-attachments/assets/58db3060-68d0-45bb-91d6-935d35d0ffa5" />


<!-- For bugfixes: behavior before vs after. For other types: N/A or a short note. -->

## Risk / compatibility / migration (optional)

<!-- Breaking changes, rollout notes, or N/A for small / low-risk PRs -->
Since the value is at max MAX_u32 * 86_400 maybe we should use a u64 instead? largely a moot point as accuracy doesn't matter for the time display functions.

## UI evidence (required for visual changes; otherwise N/A)

<!-- Screenshot or short video -->

## Scope

- [X] This PR is focused on one change (no unrelated edits).
