### PR TITLE
feat: Enable Windows ARM64 support for Briefcase

### DIFF
--- a/.github/actions/setup-anki/action.yml
+++ b/.github/actions/setup-anki/action.yml
@@ -49,11 +49,17 @@ runs:
 
     - name: Install rsync (Windows)
       if: runner.os == 'Windows'
+      id: setup-msys2
       uses: msys2/setup-msys2@v2
       with:
         update: false
         install: rsync
-        path-type: minimal
+
+    - name: Add MSYS2 usr/bin to PATH (Windows)
+      if: runner.os == 'Windows'
+      shell: pwsh
+      run: |
+        "${{ steps.setup-msys2.outputs.msys2-location }}\usr\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
     # Reads toolchain version from rust-toolchain.toml automatically.
     - name: Install Rust toolchain

--- a/.github/actions/setup-anki/action.yml
+++ b/.github/actions/setup-anki/action.yml
@@ -49,10 +49,11 @@ runs:
 
     - name: Install rsync (Windows)
       if: runner.os == 'Windows'
-      shell: bash
-      run: |
-        /c/msys64/usr/bin/pacman.exe -Sy --noconfirm rsync
-        echo "C:\msys64\usr\bin" >> "$GITHUB_PATH"
+      uses: msys2/setup-msys2@v2
+      with:
+        update: false
+        install: rsync
+        path-type: minimal
 
     # Reads toolchain version from rust-toolchain.toml automatically.
     - name: Install Rust toolchain

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -362,6 +362,162 @@ jobs:
           name: wheels-windows
           path: out/wheels/anki-*.whl
 
+  # Windows ARM uses a 4-job chain because azure/artifact-signing-action does not
+  # support ARM runners: build on ARM → sign EXE on x64 → package MSI on ARM → sign MSI on x64.
+  build-windows-arm:
+    needs: prepare
+    runs-on: windows-11-arm
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.sha }}
+
+      - name: Setup build environment
+        uses: ./.github/actions/setup-anki
+
+      - name: Build app
+        run: tools\ninja installer:build
+
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: logs-installer-windows-arm
+          path: out/installer/logs/
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: build-windows-arm
+          path: |
+            out/installer/
+            !out/installer/logs/
+
+      - name: Build wheels
+        run: tools\ninja wheels:anki
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: wheels-windows-arm
+          path: out/wheels/anki-*.whl
+
+  sign-exe-windows-arm:
+    needs: [prepare, build-windows-arm]
+    runs-on: windows-latest
+    timeout-minutes: 15
+    environment: ${{ inputs.sign == true && 'release' || '' }}
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: build-windows-arm
+          path: out/installer/
+
+      - name: Azure login
+        if: inputs.sign == true
+        uses: azure/login@v3
+        with:
+          creds: '{"clientId":"${{ secrets.AZURE_CLIENT_ID }}","clientSecret":"${{ secrets.AZURE_CLIENT_SECRET }}","subscriptionId":"${{ secrets.AZURE_SUBSCRIPTION_ID }}","tenantId":"${{ secrets.AZURE_TENANT_ID }}"}'
+
+      - name: Sign app binary
+        if: inputs.sign == true
+        uses: azure/artifact-signing-action@v1
+        with:
+          endpoint: https://eus.codesigning.azure.net/
+          signing-account-name: anki-signing
+          certificate-profile-name: ${{ secrets.AZURE_CERT_PROFILE_NAME }}
+          files: ${{ github.workspace }}\out\installer\build\anki\windows\app\src\Anki.exe
+          file-digest: SHA256
+          timestamp-rfc3161: http://timestamp.acs.microsoft.com
+          timestamp-digest: SHA256
+
+      - name: Verify app binary signature
+        if: inputs.sign == true
+        shell: pwsh
+        run: |
+          $sig = Get-AuthenticodeSignature "out\installer\build\anki\windows\app\src\Anki.exe"
+          if ($sig.Status -ne "Valid") {
+            Write-Error "Anki.exe signature status: $($sig.Status)"
+            exit 1
+          }
+          Write-Host "Anki.exe signed successfully: $($sig.SignerCertificate.Subject)"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: signed-build-windows-arm
+          path: out/installer/
+
+  package-windows-arm:
+    needs: [prepare, build-windows-arm, sign-exe-windows-arm]
+    runs-on: windows-11-arm
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.sha }}
+
+      - name: Setup build environment
+        uses: ./.github/actions/setup-anki
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: signed-build-windows-arm
+          path: out/installer/
+
+      - name: Package installer
+        run: |
+          tools\ninja pyenv
+          out\pyenv\scripts\python.exe qt\tools\build_installer.py --version ${{ needs.prepare.outputs.pep440_version }} package
+      - uses: actions/upload-artifact@v4
+        with:
+          name: unsigned-installer-windows-arm
+          path: out/installer/dist/
+
+  sign-msi-windows-arm:
+    needs: [prepare, package-windows-arm]
+    runs-on: windows-latest
+    timeout-minutes: 15
+    environment: ${{ inputs.sign == true && 'release' || '' }}
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: unsigned-installer-windows-arm
+          path: dist/
+
+      - name: Azure login
+        if: inputs.sign == true
+        uses: azure/login@v3
+        with:
+          creds: '{"clientId":"${{ secrets.AZURE_CLIENT_ID }}","clientSecret":"${{ secrets.AZURE_CLIENT_SECRET }}","subscriptionId":"${{ secrets.AZURE_SUBSCRIPTION_ID }}","tenantId":"${{ secrets.AZURE_TENANT_ID }}"}'
+
+      - name: Sign MSI
+        if: inputs.sign == true
+        uses: azure/artifact-signing-action@v1
+        with:
+          endpoint: https://eus.codesigning.azure.net/
+          signing-account-name: anki-signing
+          certificate-profile-name: ${{ secrets.AZURE_CERT_PROFILE_NAME }}
+          files-folder: dist/
+          files-folder-filter: msi
+          file-digest: SHA256
+          timestamp-rfc3161: http://timestamp.acs.microsoft.com
+          timestamp-digest: SHA256
+
+      - name: Verify MSI signature
+        if: inputs.sign == true
+        shell: pwsh
+        run: |
+          $msi = Get-ChildItem "dist/*.msi" | Select-Object -First 1
+          $sig = Get-AuthenticodeSignature $msi.FullName
+          if ($sig.Status -ne "Valid") {
+            Write-Error "MSI signature status: $($sig.Status)"
+            exit 1
+          }
+          Write-Host "MSI signed successfully: $($sig.SignerCertificate.Subject)"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: installer-windows-arm
+          path: dist/
+
   # Linux x86 and ARM are kept as separate jobs rather than a matrix because the ARM
   # build requires different runners for wheels vs installer: ubuntu-22.04
   # for wheels (to target glibc 2.35) and ubuntu-24.04-arm for the installer (the Qt wheels require it).
@@ -456,7 +612,7 @@ jobs:
           path: out/installer/dist/
 
   release:
-    needs: [prepare, build-and-sign-mac, build-and-sign-mac-intel, build-and-sign-windows, build-linux-x86, build-linux-arm-wheels, build-linux-arm-installer]
+    needs: [prepare, build-and-sign-mac, build-and-sign-mac-intel, build-and-sign-windows, sign-msi-windows-arm, build-linux-x86, build-linux-arm-wheels, build-linux-arm-installer]
     if: >-
       ${{ always()
       && inputs['draft-release'] == true
@@ -467,6 +623,7 @@ jobs:
       && needs.build-linux-arm-wheels.result == 'success'
       && needs.build-linux-arm-installer.result == 'success'
       && needs.build-and-sign-windows.result == 'success'
+      && needs.sign-msi-windows-arm.result == 'success'
       }}
     runs-on: ubuntu-latest
     environment: release
@@ -503,7 +660,7 @@ jobs:
           RELEASE_SHA: ${{ github.sha }}
 
   publish-testpypi:
-    needs: [prepare, build-and-sign-mac, build-and-sign-mac-intel, build-and-sign-windows, build-linux-x86, build-linux-arm-wheels]
+    needs: [prepare, build-and-sign-mac, build-and-sign-mac-intel, build-and-sign-windows, build-windows-arm, build-linux-x86, build-linux-arm-wheels]
     if: >-
       ${{ always()
       && (inputs['publish-testpypi'] == true || inputs['publish-pypi'] == true)
@@ -511,6 +668,7 @@ jobs:
       && needs.build-and-sign-mac.result == 'success'
       && needs.build-and-sign-mac-intel.result == 'success'
       && needs.build-and-sign-windows.result == 'success'
+      && needs.build-windows-arm.result == 'success'
       && needs.build-linux-x86.result == 'success'
       && needs.build-linux-arm-wheels.result == 'success'
       }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -382,7 +382,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: logs-installer-windows-arm
+          name: logs-installer-windows-arm-build
           path: out/installer/logs/
 
       - uses: actions/upload-artifact@v4
@@ -466,6 +466,13 @@ jobs:
         run: |
           tools\ninja pyenv
           out\pyenv\scripts\python.exe qt\tools\build_installer.py --version ${{ needs.prepare.outputs.pep440_version }} package
+
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: logs-installer-windows-arm-package
+          path: out/installer/logs/
+
       - uses: actions/upload-artifact@v4
         with:
           name: unsigned-installer-windows-arm

--- a/build/configure/src/main.rs
+++ b/build/configure/src/main.rs
@@ -24,7 +24,6 @@ use ninja_gen::protobuf::check_proto;
 use ninja_gen::protobuf::setup_protoc;
 use ninja_gen::python::setup_uv;
 use ninja_gen::Build;
-use platform::overriden_python_venv_platform;
 use pylib::build_pylib;
 use pylib::check_pylib;
 use python::check_python;
@@ -50,10 +49,7 @@ fn main() -> Result<()> {
     check_proto(build, inputs![glob!["proto/**/*.proto"]])?;
 
     if env::var("OFFLINE_BUILD").is_err() {
-        setup_uv(
-            build,
-            overriden_python_venv_platform().unwrap_or(build.host_platform),
-        )?;
+        setup_uv(build, build.host_platform)?;
     }
     setup_venv(build)?;
 

--- a/build/configure/src/platform.rs
+++ b/build/configure/src/platform.rs
@@ -10,17 +10,7 @@ pub fn overriden_rust_target_triple() -> Option<&'static str> {
     overriden_python_wheel_platform().map(|p| p.as_rust_triple())
 }
 
-/// Usually None to use the host architecture, except on Windows which
-/// always uses x86_64, since WebEngine is unavailable for ARM64.
-pub fn overriden_python_venv_platform() -> Option<Platform> {
-    if cfg!(target_os = "windows") {
-        Some(Platform::WindowsX64)
-    } else {
-        None
-    }
-}
-
-/// Like [`overriden_python_venv_platform`], but:
+/// Usually None to use the host architecture, but:
 /// If MAC_X86 is set, an X86 wheel will be built on macOS ARM.
 /// If LIN_ARM64 is set, an ARM64 wheel will be built on Linux AMD64.
 pub fn overriden_python_wheel_platform() -> Option<Platform> {
@@ -29,6 +19,6 @@ pub fn overriden_python_wheel_platform() -> Option<Platform> {
     } else if env::var("LIN_ARM64").is_ok() {
         Some(Platform::LinuxArm)
     } else {
-        overriden_python_venv_platform()
+        None
     }
 }

--- a/build/ninja_gen/src/python.rs
+++ b/build/ninja_gen/src/python.rs
@@ -153,7 +153,14 @@ impl BuildAction for PythonEnvironment {
                     read_file(".python-version").expect("No .python-version in cwd");
                 let python_version_str =
                     String::from_utf8(python_version).expect("Invalid UTF-8 in .python-version");
-                python_version_str.trim().to_string()
+                let version = python_version_str.trim();
+                // On Windows ARM64, uv defaults to x64 interpreters
+                // (astral-sh/uv#12906), so request the native build explicitly.
+                if cfg!(all(windows, target_arch = "aarch64")) {
+                    format!("cpython-{version}-windows-aarch64-none")
+                } else {
+                    version.to_string()
+                }
             });
             build.add_variable("python", python);
             build.add_variable("extra_args", self.extra_args);

--- a/qt/pyproject.toml
+++ b/qt/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
 
 [project.optional-dependencies]
 audio = [
-  "anki-audio==0.1.0; sys.platform == 'win32' and platform_machine == 'x86_64' or sys.platform == 'darwin'",
+  "anki-audio==0.1.0; (sys.platform == 'win32' and platform_machine == 'AMD64') or sys.platform == 'darwin'",
 ]
 qt = [
   "pyqt6==6.11.0",

--- a/qt/pyproject.toml
+++ b/qt/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
 
 [project.optional-dependencies]
 audio = [
-  "anki-audio==0.1.0; sys.platform == 'win32' or sys.platform == 'darwin'",
+  "anki-audio==0.1.0; sys.platform == 'win32' and platform_machine == 'x86_64' or sys.platform == 'darwin'",
 ]
 qt = [
   "pyqt6==6.11.0",

--- a/qt/tools/build_installer.py
+++ b/qt/tools/build_installer.py
@@ -105,7 +105,7 @@ def package(args: argparse.Namespace) -> None:
     )
     platform_suffix = ""
     if sys.platform == "win32":
-        arch ="arm64" if platform.machine() == "ARM64" else "x64"
+        arch = "arm64" if platform.machine() == "ARM64" else "x64"
         platform_suffix = f"-win-{arch}"
     elif sys.platform == "darwin":
         arch = "apple" if platform.machine() == "arm64" else "intel"

--- a/qt/tools/build_installer.py
+++ b/qt/tools/build_installer.py
@@ -105,7 +105,8 @@ def package(args: argparse.Namespace) -> None:
     )
     platform_suffix = ""
     if sys.platform == "win32":
-        platform_suffix = "-windows"
+        arch ="arm64" if platform.machine() == "ARM64" else "x64"
+        platform_suffix = f"-win-{arch}"
     elif sys.platform == "darwin":
         arch = "apple" if platform.machine() == "arm64" else "intel"
         platform_suffix = f"-mac-{arch}"

--- a/rslib/src/backend/github.rs
+++ b/rslib/src/backend/github.rs
@@ -27,32 +27,14 @@ const LATEST_RELEASE_URL: &str = "https://api.github.com/repos/ankitects/anki/re
 
 // NOTE: must match platform suffixes in build_installer.py
 fn get_platform_suffix() -> Option<&'static str> {
-    if cfg!(target_os = "windows") {
-        if cfg!(target_arch = "aarch64") {
-            Some("-win-arm64")
-        } else if cfg!(target_arch = "x86_64") {
-            Some("-win-x64")
-        } else {
-            None
-        }
-    } else if cfg!(target_os = "macos") {
-        if cfg!(target_arch = "aarch64") {
-            Some("-mac-apple")
-        } else if cfg!(target_arch = "x86_64") {
-            Some("-mac-intel")
-        } else {
-            None
-        }
-    } else if cfg!(target_os = "linux") {
-        if cfg!(target_arch = "aarch64") {
-            Some("-linux-aarch64")
-        } else if cfg!(target_arch = "x86_64") {
-            Some("-linux-x86_64")
-        } else {
-            None
-        }
-    } else {
-        None
+    match (std::env::consts::OS, std::env::consts::ARCH) {
+        ("windows", "x86_64") => Some("-win-x64"),
+        ("windows", "aarch64") => Some("-win-arm64"),
+        ("macos", "x86_64") => Some("-mac-intel"),
+        ("macos", "aarch64") => Some("-mac-apple"),
+        ("linux", "x86_64") => Some("-linux-x86_64"),
+        ("linux", "aarch64") => Some("-linux-aarch64"),
+        _ => None,
     }
 }
 

--- a/rslib/src/backend/github.rs
+++ b/rslib/src/backend/github.rs
@@ -25,9 +25,16 @@ use crate::updates::DownloadUpdateProgress;
 const ALL_RELEASES_URL: &str = "https://api.github.com/repos/ankitects/anki/releases";
 const LATEST_RELEASE_URL: &str = "https://api.github.com/repos/ankitects/anki/releases/latest";
 
+// NOTE: must match platform suffixes in build_installer.py
 fn get_platform_suffix() -> Option<&'static str> {
     if cfg!(target_os = "windows") {
-        Some("-windows")
+        if cfg!(target_arch = "aarch64") {
+            Some("-win-arm64")
+        } else if cfg!(target_arch = "x86_64") {
+            Some("-win-x64")
+        } else {
+            None
+        }
     } else if cfg!(target_os = "macos") {
         if cfg!(target_arch = "aarch64") {
             Some("-mac-apple")

--- a/uv.lock
+++ b/uv.lock
@@ -197,7 +197,7 @@ dependencies = [
 
 [package.optional-dependencies]
 audio = [
-    { name = "anki-audio", marker = "sys_platform == 'darwin' or sys_platform == 'win32' or (extra == 'extra-3-aqt-qt' and extra == 'extra-3-aqt-qt610') or (extra == 'extra-3-aqt-qt' and extra == 'extra-3-aqt-qt68') or (extra == 'extra-3-aqt-qt' and extra == 'extra-3-aqt-qt69') or (extra == 'extra-3-aqt-qt610' and extra == 'extra-3-aqt-qt68') or (extra == 'extra-3-aqt-qt610' and extra == 'extra-3-aqt-qt69') or (extra == 'extra-3-aqt-qt68' and extra == 'extra-3-aqt-qt69')" },
+    { name = "anki-audio", marker = "(platform_machine == 'x86_64' and sys_platform == 'win32') or (platform_machine != 'x86_64' and extra == 'extra-3-aqt-qt' and extra == 'extra-3-aqt-qt610') or (platform_machine != 'x86_64' and extra == 'extra-3-aqt-qt' and extra == 'extra-3-aqt-qt68') or (platform_machine != 'x86_64' and extra == 'extra-3-aqt-qt' and extra == 'extra-3-aqt-qt69') or (platform_machine != 'x86_64' and extra == 'extra-3-aqt-qt610' and extra == 'extra-3-aqt-qt68') or (platform_machine != 'x86_64' and extra == 'extra-3-aqt-qt610' and extra == 'extra-3-aqt-qt69') or (platform_machine != 'x86_64' and extra == 'extra-3-aqt-qt68' and extra == 'extra-3-aqt-qt69') or sys_platform == 'darwin' or (sys_platform != 'win32' and extra == 'extra-3-aqt-qt' and extra == 'extra-3-aqt-qt610') or (sys_platform != 'win32' and extra == 'extra-3-aqt-qt' and extra == 'extra-3-aqt-qt68') or (sys_platform != 'win32' and extra == 'extra-3-aqt-qt' and extra == 'extra-3-aqt-qt69') or (sys_platform != 'win32' and extra == 'extra-3-aqt-qt610' and extra == 'extra-3-aqt-qt68') or (sys_platform != 'win32' and extra == 'extra-3-aqt-qt610' and extra == 'extra-3-aqt-qt69') or (sys_platform != 'win32' and extra == 'extra-3-aqt-qt68' and extra == 'extra-3-aqt-qt69')" },
 ]
 qt = [
     { name = "pyqt6", version = "6.11.0", source = { registry = "https://pypi.org/simple" } },
@@ -230,7 +230,7 @@ qt69 = [
 
 [package.metadata]
 requires-dist = [
-    { name = "anki-audio", marker = "(sys_platform == 'darwin' and extra == 'audio') or (sys_platform == 'win32' and extra == 'audio')", specifier = "==0.1.0" },
+    { name = "anki-audio", marker = "(platform_machine == 'x86_64' and sys_platform == 'win32' and extra == 'audio') or (sys_platform == 'darwin' and extra == 'audio')", specifier = "==0.1.0" },
     { name = "anki-mac-helper", marker = "sys_platform == 'darwin'", specifier = ">=0.1.1" },
     { name = "beautifulsoup4" },
     { name = "flask" },

--- a/uv.lock
+++ b/uv.lock
@@ -197,7 +197,7 @@ dependencies = [
 
 [package.optional-dependencies]
 audio = [
-    { name = "anki-audio", marker = "(platform_machine == 'x86_64' and sys_platform == 'win32') or (platform_machine != 'x86_64' and extra == 'extra-3-aqt-qt' and extra == 'extra-3-aqt-qt610') or (platform_machine != 'x86_64' and extra == 'extra-3-aqt-qt' and extra == 'extra-3-aqt-qt68') or (platform_machine != 'x86_64' and extra == 'extra-3-aqt-qt' and extra == 'extra-3-aqt-qt69') or (platform_machine != 'x86_64' and extra == 'extra-3-aqt-qt610' and extra == 'extra-3-aqt-qt68') or (platform_machine != 'x86_64' and extra == 'extra-3-aqt-qt610' and extra == 'extra-3-aqt-qt69') or (platform_machine != 'x86_64' and extra == 'extra-3-aqt-qt68' and extra == 'extra-3-aqt-qt69') or sys_platform == 'darwin' or (sys_platform != 'win32' and extra == 'extra-3-aqt-qt' and extra == 'extra-3-aqt-qt610') or (sys_platform != 'win32' and extra == 'extra-3-aqt-qt' and extra == 'extra-3-aqt-qt68') or (sys_platform != 'win32' and extra == 'extra-3-aqt-qt' and extra == 'extra-3-aqt-qt69') or (sys_platform != 'win32' and extra == 'extra-3-aqt-qt610' and extra == 'extra-3-aqt-qt68') or (sys_platform != 'win32' and extra == 'extra-3-aqt-qt610' and extra == 'extra-3-aqt-qt69') or (sys_platform != 'win32' and extra == 'extra-3-aqt-qt68' and extra == 'extra-3-aqt-qt69')" },
+    { name = "anki-audio", marker = "(platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine != 'AMD64' and extra == 'extra-3-aqt-qt' and extra == 'extra-3-aqt-qt610') or (platform_machine != 'AMD64' and extra == 'extra-3-aqt-qt' and extra == 'extra-3-aqt-qt68') or (platform_machine != 'AMD64' and extra == 'extra-3-aqt-qt' and extra == 'extra-3-aqt-qt69') or (platform_machine != 'AMD64' and extra == 'extra-3-aqt-qt610' and extra == 'extra-3-aqt-qt68') or (platform_machine != 'AMD64' and extra == 'extra-3-aqt-qt610' and extra == 'extra-3-aqt-qt69') or (platform_machine != 'AMD64' and extra == 'extra-3-aqt-qt68' and extra == 'extra-3-aqt-qt69') or sys_platform == 'darwin' or (sys_platform != 'win32' and extra == 'extra-3-aqt-qt' and extra == 'extra-3-aqt-qt610') or (sys_platform != 'win32' and extra == 'extra-3-aqt-qt' and extra == 'extra-3-aqt-qt68') or (sys_platform != 'win32' and extra == 'extra-3-aqt-qt' and extra == 'extra-3-aqt-qt69') or (sys_platform != 'win32' and extra == 'extra-3-aqt-qt610' and extra == 'extra-3-aqt-qt68') or (sys_platform != 'win32' and extra == 'extra-3-aqt-qt610' and extra == 'extra-3-aqt-qt69') or (sys_platform != 'win32' and extra == 'extra-3-aqt-qt68' and extra == 'extra-3-aqt-qt69')" },
 ]
 qt = [
     { name = "pyqt6", version = "6.11.0", source = { registry = "https://pypi.org/simple" } },
@@ -230,7 +230,7 @@ qt69 = [
 
 [package.metadata]
 requires-dist = [
-    { name = "anki-audio", marker = "(platform_machine == 'x86_64' and sys_platform == 'win32' and extra == 'audio') or (sys_platform == 'darwin' and extra == 'audio')", specifier = "==0.1.0" },
+    { name = "anki-audio", marker = "(platform_machine == 'AMD64' and sys_platform == 'win32' and extra == 'audio') or (sys_platform == 'darwin' and extra == 'audio')", specifier = "==0.1.0" },
     { name = "anki-mac-helper", marker = "sys_platform == 'darwin'", specifier = ">=0.1.1" },
     { name = "beautifulsoup4" },
     { name = "flask" },


### PR DESCRIPTION
## Linked issue

#4678

## Summary

This enables native Windows ARM64 builds for Briefcase. Depends on #4797

## How to test

- Run `./tools/ninja installer` in a Windows ARM64 machine.
- Check the architecture of the installer under `./out/installer/dist` by going to Properties > Compatibility and confirming emulation settings are disabled.
- Install the package and confirm Anki.exe is a native binary.
- Open Anki, go to the [debug console](https://docs.ankiweb.net/misc.html#debug-console) and run the following code to check the architecture of the Python build:
```python
import platform

print(platform.machine(), platform.python_compiler())
```
