### PR TITLE
Fix audio package publishing

### DIFF
--- a/.github/workflows/publish-audio-package.yml
+++ b/.github/workflows/publish-audio-package.yml
@@ -22,6 +22,8 @@ on:
 
 env:
   RELEASE: 2
+  N2_OUTPUT_PROGRESS: "1"
+  N2_OUTPUT_SUCCESS: "1"
 
 jobs:
   prepare:

--- a/.github/workflows/publish-audio-package.yml
+++ b/.github/workflows/publish-audio-package.yml
@@ -54,11 +54,11 @@ jobs:
             needs_signing: true
           - runner: windows-latest
             artifact: wheel-windows-x64
-            build_cmd: ./ninja audio_wheel
+            build_cmd: tools\ninja audio_wheel
             needs_signing: false
           - runner: windows-11-arm
             artifact: wheel-windows-arm
-            build_cmd: ./ninja audio_wheel
+            build_cmd: tools\ninja audio_wheel
             needs_signing: false
     runs-on: ${{ matrix.runner }}
     environment: ${{ matrix.needs_signing && inputs.sign-macos == true && 'release' || '' }}

--- a/build/configure/src/audio.rs
+++ b/build/configure/src/audio.rs
@@ -30,11 +30,11 @@ fn mpv_archive(platform: Platform) -> OnlineArchive {
 fn lame_archive(platform: Platform) -> OnlineArchive {
     match platform {
         Platform::WindowsX64 => OnlineArchive {
-            url: "https://www.rarewares.org/files/mp3/lame3.100-64-20200409.zip",
+            url: "https://github.com/ankitects/anki-bundle-extras/releases/download/anki-2026-05-08/lame3.100-64-20200409.zip",
             sha256: "59ea16ac74afb04f8ed9f33f75618e4e7e5b3e1ea53f5d751e3834e99f58ba6d",
         },
         Platform::WindowsArm => OnlineArchive {
-            url: "https://www.rarewares.org/files/mp3/lame-3.100-ARM64.zip",
+            url: "https://github.com/ankitects/anki-bundle-extras/releases/download/anki-2026-05-08/lame-3.100-ARM64.zip",
             sha256: "b1868219b9c9f38f83834b2e6a69c616cabfe6658f5d05c26ac371f39afdac5d",
         },
         _ => unreachable!(),

--- a/build/configure/src/audio.rs
+++ b/build/configure/src/audio.rs
@@ -35,7 +35,7 @@ fn lame_archive(platform: Platform) -> OnlineArchive {
         },
         Platform::WindowsArm => OnlineArchive {
             url: "https://github.com/ankitects/anki-bundle-extras/releases/download/anki-2026-05-08/lame-3.100-ARM64.zip",
-            sha256: "b1868219b9c9f38f83834b2e6a69c616cabfe6658f5d05c26ac371f39afdac5d",
+            sha256: "03ecceab5d4f408b0f919b4618947a7731b5bd1f297fba52914bfb6eeae187fb",
         },
         _ => unreachable!(),
     }

--- a/qt/audio/build.sh
+++ b/qt/audio/build.sh
@@ -9,13 +9,15 @@ fi
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 OUTPUT_DIR="$SCRIPT_DIR/../../out/extracted"
+BREW_PREFIX="$(brew --prefix)"
+BREW_REPO="$(brew --repository)"
 
 brew install dylibbundler
 brew install lame
 if [ "$(brew list --full-name | grep ankitects/audio/mpv)" = "" ]; then
     brew uninstall mpv || true
     brew tap-new ankitects/audio || true
-    cp "$SCRIPT_DIR/mpv.rb" /opt/homebrew/Library/Taps/ankitects/homebrew-audio/Formula/
+    cp "$SCRIPT_DIR/mpv.rb" "$BREW_REPO/Library/Taps/ankitects/homebrew-audio/Formula/"
     brew install ankitects/audio/mpv
 fi
 
@@ -23,13 +25,13 @@ rm -rf "$OUTPUT_DIR/mpv"
 mkdir -p "$OUTPUT_DIR/mpv"
 pushd "$OUTPUT_DIR/mpv"
 mkdir libs
-cp /opt/homebrew/bin/mpv .
+cp "$BREW_PREFIX/bin/mpv" .
 dylibbundler -x mpv -d libs -p @executable_path/libs/ -b
 popd
 
 rm -rf "$OUTPUT_DIR/lame"
 mkdir -p "$OUTPUT_DIR/lame"
-cp /opt/homebrew/bin/lame "$OUTPUT_DIR/lame/" && chmod u+w "$OUTPUT_DIR/lame/lame"
+cp "$BREW_PREFIX/bin/lame" "$OUTPUT_DIR/lame/" && chmod u+w "$OUTPUT_DIR/lame/lame"
 
 if [ -n "${SIGN_IDENTITY:-}" ]; then
     find "$OUTPUT_DIR/mpv/libs" -name "*.dylib" -exec \

--- a/qt/audio/hatch_build.py
+++ b/qt/audio/hatch_build.py
@@ -44,6 +44,8 @@ class CustomBuildHook(BuildHookInterface):
                 mpv_dir / "vulkan-1.dll",
                 lame_dir / "lame.exe",
                 lame_dir / "lame_enc.dll",
+                lame_dir / "libmp3lame-0.dll",
+                lame_dir / "libiconv-2.dll",
             ]
             lib_files = []
         else:

--- a/qt/audio/mpv.rb
+++ b/qt/audio/mpv.rb
@@ -65,8 +65,6 @@ class Mpv < Formula
     depends_on "zlib-ng-compat"
   end
 
-  conflicts_with cask: "stolendata-mpv", because: "both install `mpv` binaries"
-
   def install
     # LANG is unset by default on macOS and causes issues when calling getlocale
     # or getdefaultlocale in docutils. Force the default c/posix locale since

--- a/qt/audio/mpv.rb
+++ b/qt/audio/mpv.rb
@@ -65,6 +65,8 @@ class Mpv < Formula
     depends_on "zlib-ng-compat"
   end
 
+  conflicts_with cask: "stolendata-mpv", because: "both install `mpv` binaries"
+
   def install
     # LANG is unset by default on macOS and causes issues when calling getlocale
     # or getdefaultlocale in docutils. Force the default c/posix locale since


### PR DESCRIPTION
A follow-up to #4664

Last run: https://github.com/ankitects/anki/actions/runs/25575366970

Confirmed macOS signing is set up correctly by extracting the wheels and running `codesign -dvvv` on the mpv/lame binaries.