### PR TITLE
ci: require release environment approval for Linux build jobs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -532,6 +532,7 @@ jobs:
     needs: prepare
     runs-on: ubuntu-22.04
     timeout-minutes: 90
+    environment: ${{ inputs.sign == true && 'release' || '' }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -570,6 +571,7 @@ jobs:
     needs: prepare
     runs-on: ubuntu-22.04
     timeout-minutes: 90
+    environment: ${{ inputs.sign == true && 'release' || '' }}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/cargo/licenses.json
+++ b/cargo/licenses.json
@@ -2597,7 +2597,7 @@
     "license": "Apache-2.0",
     "license_file": null,
     "name": "openssl",
-    "repository": "https://github.com/sfackler/rust-openssl"
+    "repository": "https://github.com/rust-openssl/rust-openssl"
   },
   {
     "authors": null,
@@ -2621,7 +2621,7 @@
     "license": "MIT",
     "license_file": null,
     "name": "openssl-sys",
-    "repository": "https://github.com/sfackler/rust-openssl"
+    "repository": "https://github.com/rust-openssl/rust-openssl"
   },
   {
     "authors": "Simon Ochsenreither <simon@ochsenreither.de>",


### PR DESCRIPTION
## Summary

`publish-testpypi` and `publish-pypi` each have a 15-minute timeout, depend on all platform builds completing before they can start, and use the `release` environment when `sign=true`.

`build-and-sign-mac`, `build-and-sign-mac-intel`, and `build-and-sign-windows` already use this environment, so they wait 15 minutes before starting execution.

`build-linux-x86` and `build-linux-arm-wheels` were missing this configuration, causing them to start immediately after `prepare` — running ahead of the other platform builds.

## Changes

- Added `environment: ${{ inputs.sign == true && 'release' || '' }}` to `build-linux-x86` and `build-linux-arm-wheels`, so all five build jobs respect the same 15-minute wait before starting.