### PR TITLE
Release infrastructure improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   workflow_dispatch:
   push:
-    branches: [main]
+    branches: [main, 'release/**']
   pull_request:
     branches: [main]
     types: [opened, synchronize, reopened, labeled]

--- a/cargo/licenses.json
+++ b/cargo/licenses.json
@@ -2597,7 +2597,7 @@
     "license": "Apache-2.0",
     "license_file": null,
     "name": "openssl",
-    "repository": "https://github.com/sfackler/rust-openssl"
+    "repository": "https://github.com/rust-openssl/rust-openssl"
   },
   {
     "authors": null,
@@ -2621,7 +2621,7 @@
     "license": "MIT",
     "license_file": null,
     "name": "openssl-sys",
-    "repository": "https://github.com/sfackler/rust-openssl"
+    "repository": "https://github.com/rust-openssl/rust-openssl"
   },
   {
     "authors": "Simon Ochsenreither <simon@ochsenreither.de>",

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -11,6 +11,7 @@ extensions = [
     "sphinx.ext.intersphinx",
     "autoapi.extension",
     "click_extra.sphinx",
+    "sphinxcontrib.mermaid",
 ]
 
 source_suffix = {

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -3,10 +3,9 @@
 Releases are managed by two GitHub Actions workflows under `.github/workflows/`:
 
 1. **`prepare-release.yml`** — Run first. Validates the version, checks that CI
-   passed, syncs translations, updates `.version`, and pushes everything
-   to the dispatching branch in a single commit. Normal CI then runs on the
-   resulting commit. Can be dispatched from any branch (not just main) for
-   hotfix/security releases. The CI check can be skipped with `skip-ci-check`.
+   passed, updates `.version`, and pushes everything to the dispatching branch
+   in a single commit. CI then runs automatically on the resulting commit (for
+   `release/**` branches). The CI check can be skipped with `skip-ci-check`.
 
 2. **`release.yml`** — Run after CI passes on the prepared commit. Builds
    installers and wheels for all platforms (Linux x86/ARM, macOS Intel/ARM,
@@ -16,11 +15,102 @@ Releases are managed by two GitHub Actions workflows under `.github/workflows/`:
 Both workflows are `workflow_dispatch` and share a `release` concurrency group so
 they cannot run simultaneously.
 
+## Version format
+
+Versions follow calendar versioning with PEP 440: `YY.MM` for stable releases
+(e.g. `26.04`), with optional `.patch` (e.g. `26.04.1`) and pre-release
+suffixes (`b1`, `rc1`, `a1`). Months must be zero-padded.
+
+Examples: `26.05b1` (beta), `26.05rc1` (release candidate), `26.05` (stable),
+`26.05.1` (patch).
+
+## Release branch workflow
+
+All releases are cut from a `release/YY.MM` branch. The branch name uses only
+the major version (`YY.MM`), not the full pre-release suffix — betas, release
+candidates, and the stable release all come from the same branch.
+
+### Standard release
+
+1. Create a release branch from `main`:
+   ```
+   git checkout -b release/26.05 main
+   git push origin release/26.05
+   ```
+
+2. CI runs automatically on push to `release/**` branches.
+
+3. Prepare the release (updates `.version` on the branch):
+   ```
+   just release::prepare --version 26.05b1 --ref release/26.05
+   ```
+
+4. Pull the version bump commit:
+   ```
+   git pull origin release/26.05
+   ```
+
+5. Verify on TestPyPI:
+   ```
+   just release::testpypi --ref release/26.05
+   ```
+
+6. Publish the full release:
+   ```
+   just release::public --ref release/26.05
+   ```
+
+7. For subsequent pre-releases or the stable release from the same cycle,
+   repeat steps 3-6 with the new version (e.g. `26.05b2`, `26.05rc1`, `26.05`).
+
+8. After the stable release, merge the release branch back to `main` to pick up
+   the `.version` bump and any cherry-picked fixes:
+   ```
+   git checkout main
+   git merge release/26.05
+   git push origin main
+   ```
+
+9. Delete the release branch after the stable release is published.
+
+### Security and hotfix releases
+
+For security fixes, an admin should first create a
+[security advisory](https://github.com/ankitects/anki/security/advisories)
+with a temporary private fork. Work on the fix in the private fork via the
+normal PR workflow. Do not open a public PR or publish the advisory until
+the fix is ready for release.
+
+Once the fix is ready:
+
+1. Create a release branch from the latest release tag:
+   ```
+   git checkout -b release/26.05 26.05
+   ```
+
+2. Cherry-pick the fix onto the release branch.
+
+3. Push the branch and wait for CI:
+   ```
+   git push origin release/26.05
+   ```
+
+4. Prepare and publish:
+   ```
+   just release::prepare --version 26.05.1 --ref release/26.05
+   just release::public --ref release/26.05
+   ```
+
+5. Merge the release branch back to `main`.
+
+6. For security patches, publish the advisory and credit the reporter if
+   applicable.
+
 ## Release process overview
 
-```mermaid
+```{mermaid}
 flowchart LR
-    A["<b>prepare-release.yml</b><br/>validate version<br/>check CI ✓<br/>check duplicate tag<br/>sync translations<br/>update .version<br/>push to branch"] --> B["<b>CI (ci.yml)</b><br/>runs automatically<br/>on the new commit"]
+    A["<b>prepare-release.yml</b><br/>validate version<br/>check CI<br/>check duplicate tag<br/>update .version<br/>push to branch"] --> B["<b>CI (ci.yml)</b><br/>runs automatically<br/>on release/** branches"]
     B --> C["<b>release.yml</b><br/>build all platforms<br/>optionally sign macOS/Windows<br/>optionally create draft GitHub release<br/>optionally publish to TestPyPI/PyPI"]
 
     style A fill:#2d333b,stroke:#539bf5,color:#adbac7
@@ -30,16 +120,16 @@ flowchart LR
 
 ## Release workflow jobs
 
-```mermaid
+```{mermaid}
 flowchart TD
     prepare[prepare<br/><i>validate version,<br/>check CI, check duplicates</i>]
 
-    prepare --> mac["build-and-sign-mac<br/>🍎 ARM"]
-    prepare --> macint["build-and-sign-mac-intel<br/>🍎 Intel"]
-    prepare --> win["build-and-sign-windows<br/>🪟🔏 Azure"]
-    prepare --> lin[build-linux-x86<br/>🐧 x86<br/><i>installer + wheels</i>]
-    prepare --> linarmw[build-linux-arm-wheels<br/>🐧 ARM wheels]
-    prepare --> linarmi[build-linux-arm-installer<br/>🐧 ARM installer]
+    prepare --> mac["build-and-sign-mac<br/>ARM"]
+    prepare --> macint["build-and-sign-mac-intel<br/>Intel"]
+    prepare --> win["build-and-sign-windows"]
+    prepare --> lin[build-linux-x86<br/><i>installer + wheels</i>]
+    prepare --> linarmw[build-linux-arm-wheels]
+    prepare --> linarmi[build-linux-arm-installer]
 
     mac --> release
     macint --> release
@@ -48,7 +138,7 @@ flowchart TD
     linarmw --> release
     linarmi --> release
 
-    release["release<br/>📦 draft GitHub release<br/><i>if draft-release</i>"]
+    release["release<br/>draft GitHub release<br/><i>if draft-release</i>"]
 
     mac --> testpypi
     macint --> testpypi
@@ -57,12 +147,12 @@ flowchart TD
     linarmw --> testpypi
     linarmi --> testpypi
 
-    testpypi["publish-testpypi<br/>🧪 TestPyPI<br/><i>if publish-testpypi or publish-pypi</i>"]
+    testpypi["publish-testpypi<br/>TestPyPI<br/><i>if publish-testpypi or publish-pypi</i>"]
 
     release --> pypi
     testpypi --> pypi
 
-    pypi["publish-pypi<br/>🚀 PyPI<br/><i>if publish-pypi</i>"]
+    pypi["publish-pypi<br/>PyPI<br/><i>if publish-pypi</i>"]
 
     style prepare fill:#2d333b,stroke:#539bf5,color:#adbac7
     style mac fill:#2d333b,stroke:#e5c07b,color:#adbac7
@@ -76,18 +166,10 @@ flowchart TD
     style pypi fill:#2d333b,stroke:#7ee787,color:#adbac7
 ```
 
-## Version format
-
-Versions follow calendar versioning with PEP 440: `YY.MM` for stable releases
-(e.g. `26.04`), with optional `.patch` (e.g. `26.04.1`) and pre-release
-suffixes (`b1`, `rc1`, `a1`). Months must be zero-padded.
-
 ## Workflow inputs
 
 **prepare-release:** takes a `version` string and an optional `skip-ci-check`
-boolean (default `false`). Set `skip-ci-check=true` for hotfix releases from
-non-main branches where CI was triggered via `workflow_dispatch` or hasn't run
-on the branch yet.
+boolean (default `false`).
 
 **release:** takes a `version` (must match `.version` for public release
 operations) and five boolean inputs:
@@ -96,7 +178,7 @@ operations) and five boolean inputs:
 - `draft-release` creates the draft GitHub release.
 - `publish-testpypi` publishes wheels to TestPyPI.
 - `publish-pypi` publishes wheels to PyPI.
-- `skip-ci-check` skips the CI status check (for hotfix releases).
+- `skip-ci-check` skips the CI status check.
 
 All booleans default to `false`. Non-release runs use the `.version`
 already in the repo, so builds work without a prepare step.
@@ -130,64 +212,31 @@ signed and published:
 | `draft-release`    | Creates a draft GitHub release with generated release notes and installer artifacts. Requires `sign=true`, the `release` environment, passing CI (unless skipped), no duplicate tag/release, and `version` matching `.version`.                   |
 | `publish-testpypi` | Publishes wheels to TestPyPI. Requires the `release` environment.                                                                                                                                                                                 |
 | `publish-pypi`     | Publishes wheels to PyPI. Requires the `release` environment, passing CI (unless skipped), and `version` matching `.version`. It also runs and waits for the TestPyPI publish job first. It does not require signing unless `draft-release=true`. |
-| `skip-ci-check`    | Skips the CI status check. Useful for hotfix releases from non-main branches where CI was run via `workflow_dispatch`.                                                                                                                            |
+| `skip-ci-check`    | Skips the CI status check. Useful for hotfix releases.                                                                                                                                                   |
 | `version`          | For `draft-release` or `publish-pypi`: must match `.version`. For build-only, signed-only, or TestPyPI-only runs: ignored (`.version` from the branch is used automatically).                                                                     |
-
-```mermaid
-flowchart TD
-    start["workflow_dispatch"]
-
-    start --> valid{"draft-release\nwithout sign?"}
-    valid -- Yes --> rejected["❌ Rejected"]
-    valid -- No --> build["Build all platforms"]
-
-    build --> sign{"sign?"}
-    sign -- Yes --> signed["Sign macOS/Windows\n<i>requires release env</i>"]
-    sign -- No --> unsigned["Unsigned artifacts\n<i>no release env</i>"]
-
-    signed --> artifacts["Upload artifacts"]
-    unsigned --> artifacts
-
-    artifacts --> draft{"draft-release?"}
-    draft -- Yes --> guards1["Release guards\n<i>CI (unless skipped), duplicate check,\nversion matches .version</i>"]
-    guards1 --> ghrel["Create draft GitHub release\n<i>requires release env</i>"]
-
-    artifacts --> testpypi{"publish-testpypi\nor publish-pypi?"}
-    testpypi -- Yes --> tpypi["Publish to TestPyPI\n<i>requires release env</i>"]
-
-    tpypi --> pypi{"publish-pypi?"}
-    pypi -- Yes --> guards2["Release guards\n<i>CI (unless skipped),\nversion matches .version</i>"]
-    ghrel --> pypi
-    guards2 --> realpypi["Publish to PyPI\n<i>requires release env</i>"]
-
-    style rejected fill:#3d2020,stroke:#f85149,color:#f85149
-    style guards1 fill:#2d333b,stroke:#539bf5,color:#adbac7
-    style guards2 fill:#2d333b,stroke:#539bf5,color:#adbac7
-```
 
 ## Dispatching with just
 
 Release workflows can be dispatched via `just` using the `release` module
-defined in `release.just`. All recipes read the version from `.version`
-automatically.
+defined in `release.just`. All recipes require an explicit `--ref` argument
+pointing to the release branch.
 
 Run `just --list --list-submodules` to see all available recipes and their
 arguments.
 
 ## Testing the release workflow from a feature branch
 
-`release.yml` can be dispatched from any branch for testing. The `main` branch
-requirement only applies when `draft-release` or `publish-pypi` is enabled. To
-run a test build:
+`release.yml` can be dispatched from any branch for testing. The release guards
+only apply when `draft-release` or `publish-pypi` is enabled. To run a test
+build:
 
 1. Dispatch `release.yml` from your branch with all boolean inputs left false:
    ```
-   just release::build <your-branch>
+   just release::build --ref <your-branch>
    ```
 2. The workflow reads `.version` from the branch as-is (the version input is
    ignored for non-release runs), so no prepare step is needed.
-3. All release guards (main-branch check, CI check, duplicate tag check) are
-   skipped.
+3. All release guards (CI check, duplicate tag check) are skipped.
 4. Artifacts are uploaded to the workflow run but nothing is published or tagged.
 
 ### Testing with code signing
@@ -198,7 +247,7 @@ To test the signing flow from a feature branch:
    branch to the allowed deployment branches.
 2. Dispatch the workflow:
    ```
-   just release::sign <your-branch>
+   just release::sign --ref <your-branch>
    ```
 3. Approve the environment deployment when prompted.
 4. After testing, remove your branch from the environment's allowed branches.
@@ -207,28 +256,6 @@ To test the signing flow from a feature branch:
 > if the workflow file exists on the default branch. If `release.yml` is new or
 > modified on your branch, use `gh workflow run` to trigger it — the UI
 > dropdown won't show it until it's merged to main.
-
-### Hotfix / security releases from non-main branches
-
-Both `prepare-release.yml` and `release.yml` can be dispatched from any branch.
-For a hotfix release (e.g. from a `25.09.3` branch):
-
-1. Trigger CI on the branch:
-   ```
-   just ci 25.09.3
-   ```
-2. Prepare the release (skip CI check if CI was triggered via `workflow_dispatch`):
-   ```
-   just release::prepare 25.09.3 skip-ci-check=true
-   ```
-3. Run the release workflow:
-   ```
-   just release::public 25.09.3
-   ```
-   Or with `skip-ci-check`:
-   ```
-   just release::custom 25.09.3 sign=true draft-release=true publish-testpypi=true publish-pypi=true skip-ci-check=true
-   ```
 
 ## Important notes
 
@@ -241,6 +268,8 @@ For a hotfix release (e.g. from a `25.09.3` branch):
 - When `publish-pypi=true`, wheels are published to TestPyPI first, then to
   PyPI after the TestPyPI job succeeds. If `draft-release=true` is also set,
   PyPI publishing waits for the draft GitHub release to succeed too.
+- Pre-release versions (e.g. `26.05b1`) are automatically marked as
+  pre-releases on the GitHub draft release.
 
 ## Announcements
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -212,7 +212,7 @@ signed and published:
 | `draft-release`    | Creates a draft GitHub release with generated release notes and installer artifacts. Requires `sign=true`, the `release` environment, passing CI (unless skipped), no duplicate tag/release, and `version` matching `.version`.                   |
 | `publish-testpypi` | Publishes wheels to TestPyPI. Requires the `release` environment.                                                                                                                                                                                 |
 | `publish-pypi`     | Publishes wheels to PyPI. Requires the `release` environment, passing CI (unless skipped), and `version` matching `.version`. It also runs and waits for the TestPyPI publish job first. It does not require signing unless `draft-release=true`. |
-| `skip-ci-check`    | Skips the CI status check. Useful for hotfix releases.                                                                                                                                                   |
+| `skip-ci-check`    | Skips the CI status check. Useful for hotfix releases.                                                                                                                                                                                            |
 | `version`          | For `draft-release` or `publish-pypi`: must match `.version`. For build-only, signed-only, or TestPyPI-only runs: ignored (`.version` from the branch is used automatically).                                                                     |
 
 ## Dispatching with just

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ docs = [
   "sphinx-autoapi",
   "sphinx-autobuild>=2024.10.3",
   "click-extra[sphinx]", # for GitHub alerts
+  "sphinxcontrib-mermaid>=2.0.1",
 ]
 
 # Local resolution guard; keep in sync with Dependabot cooldown.

--- a/release.just
+++ b/release.just
@@ -2,14 +2,18 @@ set windows-shell := ["cmd.exe", "/c"]
 
 version := `cat .version`
 
-# Prepare a release: validate version, check CI, sync translations, update .version
-prepare ref="HEAD" skip-ci-check="false":
+# Prepare a release: validate version, check CI, update .version
+[arg("version", long)]
+[arg("ref", long)]
+[arg("skip-ci-check", long)]
+prepare version ref skip-ci-check="false":
     gh workflow run prepare-release.yml --ref {{ ref }} \
         -f version="{{ version }}" \
         -f skip-ci-check={{ skip-ci-check }}
 
 # Build all platforms, no signing or publishing
-build ref="HEAD":
+[arg("ref", long)]
+build ref:
     gh workflow run release.yml --ref {{ ref }} \
         -f version="{{ version }}" \
         -f sign=false \
@@ -18,7 +22,8 @@ build ref="HEAD":
         -f publish-pypi=false
 
 # Build and sign artifacts
-sign ref="HEAD":
+[arg("ref", long)]
+sign ref:
     gh workflow run release.yml --ref {{ ref }} \
         -f version="{{ version }}" \
         -f sign=true \
@@ -27,7 +32,8 @@ sign ref="HEAD":
         -f publish-pypi=false
 
 # Full public release: sign, draft, testpypi, pypi
-public ref="main":
+[arg("ref", long)]
+public ref:
     gh workflow run release.yml --ref {{ ref }} \
         -f version="{{ version }}" \
         -f sign=true \
@@ -35,8 +41,34 @@ public ref="main":
         -f publish-testpypi=true \
         -f publish-pypi=true
 
-# Custom release with explicit flags
-custom ref="HEAD" sign="false" draft-release="false" publish-testpypi="false" publish-pypi="false" skip-ci-check="false":
+# Publish Python packages to TestPyPI only
+[arg("ref", long)]
+testpypi ref:
+    gh workflow run release.yml --ref {{ ref }} \
+        -f version="{{ version }}" \
+        -f sign=false \
+        -f draft-release=false \
+        -f publish-testpypi=true \
+        -f publish-pypi=false
+
+# Publish Python packages to TestPyPI and PyPI
+[arg("ref", long)]
+pypi ref:
+    gh workflow run release.yml --ref {{ ref }} \
+        -f version="{{ version }}" \
+        -f sign=false \
+        -f draft-release=false \
+        -f publish-testpypi=true \
+        -f publish-pypi=true
+
+# Manual release with explicit flags
+[arg("ref", long)]
+[arg("sign", long)]
+[arg("draft-release", long)]
+[arg("publish-testpypi", long)]
+[arg("publish-pypi", long)]
+[arg("skip-ci-check", long)]
+custom ref sign="false" draft-release="false" publish-testpypi="false" publish-pypi="false" skip-ci-check="false":
     gh workflow run release.yml --ref {{ ref }} \
         -f version="{{ version }}" \
         -f sign={{ sign }} \

--- a/uv.lock
+++ b/uv.lock
@@ -114,6 +114,7 @@ docs = [
     { name = "sphinx-autoapi" },
     { name = "sphinx-autobuild" },
     { name = "sphinx-book-theme" },
+    { name = "sphinxcontrib-mermaid" },
 ]
 
 [package.metadata]
@@ -147,6 +148,7 @@ docs = [
     { name = "sphinx-autoapi" },
     { name = "sphinx-autobuild", specifier = ">=2024.10.3" },
     { name = "sphinx-book-theme" },
+    { name = "sphinxcontrib-mermaid", specifier = ">=2.0.1" },
 ]
 
 [[package]]
@@ -1908,6 +1910,20 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b2/e8/9ed3830aeed71f17c026a07a5097edcf44b692850ef215b161b8ad875729/sphinxcontrib-jsmath-1.0.1.tar.gz", hash = "sha256:a9925e4a4587247ed2191a22df5f6970656cb8ca2bd6284309578f2153e0c4b8", size = 5787, upload-time = "2019-01-21T16:10:16.347Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c2/42/4c8646762ee83602e3fb3fbe774c2fac12f317deb0b5dbeeedd2d3ba4b77/sphinxcontrib_jsmath-1.0.1-py2.py3-none-any.whl", hash = "sha256:2ec2eaebfb78f3f2078e73666b1415417a116cc848b72e5172e596c871103178", size = 5071, upload-time = "2019-01-21T16:10:14.333Z" },
+]
+
+[[package]]
+name = "sphinxcontrib-mermaid"
+version = "2.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jinja2" },
+    { name = "pyyaml" },
+    { name = "sphinx" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2b/ae/999891de292919b66ea34f2c22fc22c9be90ab3536fbc0fca95716277351/sphinxcontrib_mermaid-2.0.1.tar.gz", hash = "sha256:a21a385a059a6cafd192aa3a586b14bf5c42721e229db67b459dc825d7f0a497", size = 19839, upload-time = "2026-03-05T14:10:41.901Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/46/25d64bcd7821c8d6f1080e1c43d5fcdfc442a18f759a230b5ccdc891093e/sphinxcontrib_mermaid-2.0.1-py3-none-any.whl", hash = "sha256:9dca7fbe827bad5e7e2b97c4047682cfd26e3e07398cfdc96c7a8842ae7f06e7", size = 14064, upload-time = "2026-03-05T14:10:40.533Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- Run CI automatically on `release/**` branches
- Update just recipes: require `--ref`, add `--version` to prepare, add `testpypi`/`pypi` recipes
- Document release branch workflow and update releasing docs
- Add `sphinxcontrib-mermaid` for Sphinx doc rendering