### PR TITLE
feat: expose setParameterUnlockClickTimeoutMs

### DIFF
--- a/ts/routes/deck-options/ParamsInput.svelte
+++ b/ts/routes/deck-options/ParamsInput.svelte
@@ -48,7 +48,15 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     }
 
     const UNLOCK_EDIT_COUNT = 3;
-    const UNLOCK_CLICK_TIMEOUT_MS = 500;
+    let unlock_click_timeout_ms = 500;
+
+    function setParameterUnlockClickTimeoutMs(ms: number) {
+        unlock_click_timeout_ms = ms;
+    }
+
+    globalThis.anki ||= {};
+    globalThis.anki.setParameterUnlockClickTimeoutMs = setParameterUnlockClickTimeoutMs;
+    globalThis.anki.defaultParameterUnlockClickTimeoutMs = unlock_click_timeout_ms;
     let clickCount = 0;
 
     let clickTimeout: ReturnType<typeof setTimeout>;
@@ -59,7 +67,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         if (clickCount < UNLOCK_EDIT_COUNT) {
             clickTimeout = setTimeout(() => {
                 clickCount = 0;
-            }, UNLOCK_CLICK_TIMEOUT_MS);
+            }, unlock_click_timeout_ms);
         } else {
             taRef.focus();
         }


### PR DESCRIPTION
<!--
Title (for the Pull Request title field at the top):
Use a short prefix so the change type is obvious. You do not need to repeat it in the body below.

Examples:
- fix: — bugfix
- feat: — feature
- refactor: — internal change without user-facing feature
- docs: — documentation only
- chore: — tooling, CI, deps, build housekeeping
- test: — tests only
-->

## Linked issue (required)

closes https://github.com/ankitects/anki/issues/4809
<!-- Fixes #123 / Closes #123 / Refs #123 -->

## Summary / motivation (required)

<!-- What this PR does and why. For larger changes, add enough context for reviewers. -->
This exposes a JS api to set the speed at which you click to unlock the FSRS parameters (See #4372)

## Steps to reproduce (required, use N/A if not applicable)

<!-- Steps to reproduce: how to trigger the bug in the broken state (the "before").
 - Mainly for bugfixes;
    - For bugs: numbered steps before the fix. For non-bugs: write N/A.
 - use N/A for features, refactors, docs, chore, etc.
-->

N/A

## How to test (required)

<!--- How to test: how you verified the change (checks, unit tests, manual steps, edge cases — the "after" or general validation). --->
Open the console in the deck options and run `anki.setParameterUnlockClickTimeoutMs(0)`. If you set it to 0 then it will be impossible to unlock. if you set it to something very high it will be very easy. 

### Checklist (minimum)

- [X] I ran `./ninja check` or an equivalent relevant check locally.
- [ ] I added or updated tests when the change is non-trivial or behavior changed.

### Details

<!-- Commands, manual steps, edge cases, and what you observed -->

## Before / after behavior (optional)

<!-- For bugfixes: behavior before vs after. For other types: N/A or a short note. -->

## Risk / compatibility / migration (optional)

<!-- Breaking changes, rollout notes, or N/A for small / low-risk PRs -->

## UI evidence (required for visual changes; otherwise N/A)

<!-- Screenshot or short video -->

## Scope

- [X] This PR is focused on one change (no unrelated edits).
