### PR TITLE
fix: Generate release notes from correct tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -652,12 +652,15 @@ jobs:
             prerelease_flag="--prerelease"
           fi
 
+          notes_start_tag=$(gh release list --exclude-drafts --limit 1 --json tagName --jq '.[0].tagName // empty')
+
           gh release create "$TAG_NAME" \
             dist/* \
             --draft \
             --target "$RELEASE_SHA" \
             --title "$RELEASE_NAME" \
             --generate-notes \
+            ${notes_start_tag:+--notes-start-tag "$notes_start_tag"} \
             ${prerelease_flag:+"$prerelease_flag"}
         env:
           GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}


### PR DESCRIPTION
Pass the `--notes-start-tag` argument to `gh release` with the latest release tag. Without this, the 26.05b1 release was including notes for the 25.09.2 release for some reason.