### PR TITLE
Add missing PyPI metadata to anki package

### DIFF
--- a/pylib/README.md
+++ b/pylib/README.md
@@ -1,3 +1,0 @@
-Anki's Python library code is in anki/.
-
-The Rust/Python extension module is in rsbridge/; it references the library defined in ../rslib.

--- a/pylib/README.md
+++ b/pylib/README.md
@@ -1,0 +1,40 @@
+# Anki
+
+[![Build Status](https://github.com/ankitects/anki/actions/workflows/ci.yml/badge.svg)](https://github.com/ankitects/anki/actions/workflows/ci.yml)
+
+Core Python library for [Anki](https://apps.ankiweb.net), the spaced repetition flashcard program.
+
+## About
+
+[Anki](https://apps.ankiweb.net) is a spaced repetition program that helps you remember things efficiently. This package contains the Python layer of Anki's core: it wraps the Rust backend (`rslib`) and exposes the primary API used by the desktop app and add-ons alike.
+
+It provides access to:
+
+- **Collection** — open, read, and write an Anki `.anki2` database
+- **Notes & Cards** — create, update, and query notes and cards
+- **Decks & Models** — manage deck configurations and note types
+- **Scheduler** — the FSRS/SM-2 scheduling algorithms
+- **Media** — media file management and sync
+- **Import / Export** — support for `.apkg`, `.colpkg`, and other formats
+- **Sync** — synchronisation with AnkiWeb
+- **Hooks** — event system for extending behaviour
+
+## Installation
+
+```bash
+pip install anki
+```
+
+> **Note:** `anki` is the headless library. If you want the full desktop application, install [`aqt`](https://pypi.org/project/aqt/) instead, which depends on this package.
+
+## Add-on development
+
+If you are building an Anki add-on, this is the package that gives you access to the collection and scheduling internals. See the [Add-on Guide](https://addon-docs.ankiweb.net/) for full documentation.
+
+## Contributing
+
+Want to contribute? Check out the [Contribution Guidelines](https://github.com/ankitects/anki/blob/main/docs/contributing.md) and the [Development Guide](https://github.com/ankitects/anki/blob/main/docs/development.md).
+
+## License
+
+[AGPL-3.0-or-later](https://github.com/ankitects/anki/blob/main/LICENSE)

--- a/pylib/pyproject.toml
+++ b/pylib/pyproject.toml
@@ -8,7 +8,13 @@ license = "AGPL-3.0-or-later"
 authors = [
   { name = "Anki Team" },
 ]
-urls = { Homepage = "https://github.com/ankitects/anki" }
+urls."Bug Tracker" = "https://github.com/ankitects/anki/issues"
+urls."Source Code" = "https://github.com/ankitects/anki"
+urls."Anki Forum" = "https://forums.ankiweb.net/"
+urls."Docs: Contributor Guide" = "https://dev-docs.ankiweb.net/en/latest/contributing.html"
+urls."Docs: User Guide" = "https://docs.ankiweb.net/"
+urls."Docs: Add-on Guide" = "https://addon-docs.ankiweb.net/"
+urls.homepage = "https://apps.ankiweb.net/"
 
 dependencies = [
   "decorator",

--- a/pylib/pyproject.toml
+++ b/pylib/pyproject.toml
@@ -2,7 +2,7 @@
 name = "anki"
 dynamic = ["version"]
 description = "Python library for Anki, the spaced repetition flashcard program"
-readme = "../README.md"
+readme = "README.md"
 requires-python = ">=3.10"
 license = "AGPL-3.0-or-later"
 authors = [

--- a/pylib/pyproject.toml
+++ b/pylib/pyproject.toml
@@ -1,8 +1,15 @@
 [project]
 name = "anki"
 dynamic = ["version"]
+description = "Python library for Anki, the spaced repetition flashcard program"
+readme = "README.md"
 requires-python = ">=3.10"
 license = "AGPL-3.0-or-later"
+authors = [
+  { name = "Anki Team" },
+]
+urls = { Homepage = "https://github.com/ankitects/anki" }
+
 dependencies = [
   "decorator",
   "markdown",

--- a/pylib/pyproject.toml
+++ b/pylib/pyproject.toml
@@ -2,7 +2,7 @@
 name = "anki"
 dynamic = ["version"]
 description = "Python library for Anki, the spaced repetition flashcard program"
-readme = "README.md"
+readme = "../README.md"
 requires-python = ">=3.10"
 license = "AGPL-3.0-or-later"
 authors = [

--- a/qt/README.md
+++ b/qt/README.md
@@ -1,1 +1,21 @@
-Python's Qt GUI is in aqt/
+# aqt — Anki Qt GUI
+
+`aqt` is the Qt-based desktop interface for [Anki](https://apps.ankiweb.net), the spaced repetition flashcard program.
+
+It provides all the visual components of the Anki desktop app: the deck browser, card editor, reviewer, browser, add-on manager, and more. Under the hood it uses PyQt6 and communicates with Anki's core logic via the [`anki`](https://pypi.org/project/anki/) package.
+
+## Running
+
+Once installed, Anki can be launched from the command line:
+
+```bash
+anki
+```
+
+## Add-on development
+
+If you are building an Anki add-on, this is the package that exposes the GUI hooks and Qt widgets you need. See the [Add-on Guide](https://addon-docs.ankiweb.net/) for full documentation.
+
+## Source code
+
+<https://github.com/ankitects/anki>

--- a/qt/pyproject.toml
+++ b/qt/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "aqt"
 dynamic = ["version"]
-description = "Anki's Qt-based desktop GUI for the spaced repetition flashcard program"
+description = "Qt-based desktop GUI for Anki, the spaced repetition flashcard program"
 readme = "README.md"
 requires-python = ">=3.10"
 license = "AGPL-3.0-or-later"

--- a/qt/pyproject.toml
+++ b/qt/pyproject.toml
@@ -1,8 +1,17 @@
 [project]
 name = "aqt"
 dynamic = ["version"]
+description = "Anki's Qt-based desktop GUI for the spaced repetition flashcard program"
+readme = "README.md"
 requires-python = ">=3.10"
 license = "AGPL-3.0-or-later"
+authors = [
+  { name = "Anki Team" },
+]
+urls."Bug Tracker" = "https://github.com/ankitects/anki/issues"
+urls."Source Code" = "https://github.com/ankitects/anki"
+urls.homepage = "https://github.com/ankitects/anki"
+
 dependencies = [
   "beautifulsoup4",
   "flask",


### PR DESCRIPTION
## Issue
#4821

## Summary/motivation 

The `anki` package on PyPI was missing key metadata fields.


## Changes
- `description`: short summary shown on the PyPI package page
- `readme`: points to `pylib/README.md` so PyPI renders the long description
- `authors`: identifies the Anki Team as the package author
- `urls`: links back to the GitHub repository
