### PR TITLE
fix: optimize Briefcase bundle size

### DIFF
--- a/qt/installer/app/pyproject.toml
+++ b/qt/installer/app/pyproject.toml
@@ -23,6 +23,7 @@ cleanup_paths = [
   "**/anki-*.icns",
   "**/*.debug.pak",
   "**/*.debug.bin",
+  "**/*.pyi",
 ]
 console_app = false
 use_full_install_path = false

--- a/qt/installer/app/pyproject.toml
+++ b/qt/installer/app/pyproject.toml
@@ -18,7 +18,12 @@ sources = [
   "src/anki",
 ]
 icon = "resources/anki"
-cleanup_paths = ["anki-*.ico", "**/anki-*.icns"]
+cleanup_paths = [
+  "anki-*.ico",
+  "**/anki-*.icns",
+  "**/*.debug.pak",
+  "**/*.debug.bin",
+]
 console_app = false
 use_full_install_path = false
 

--- a/qt/installer/app/pyproject.toml
+++ b/qt/installer/app/pyproject.toml
@@ -19,11 +19,39 @@ sources = [
 ]
 icon = "resources/anki"
 cleanup_paths = [
+  # document_type icons
   "anki-*.ico",
   "**/anki-*.icns",
+  # Qt WebEngine debug-symbol resources
   "**/*.debug.pak",
   "**/*.debug.bin",
+  # Type-checker stubs / markers
   "**/*.pyi",
+  "**/py.typed",
+  # PyQt6 binding sources / API completion files
+  "**/*.sip",
+  "**/PyQt6/bindings/**/*.toml",
+  "**/PyQt6/Qt6/qsci",
+  # pywin32 dev/help bundles
+  "**/PyWin32.chm",
+  "**/pythonwin",
+  "**/adodbapi",
+  "**/isapi",
+  "**/win32com/HTML",
+  "**/win32com/demos",
+  "**/win32com/makegw",
+  "**/win32com/include",
+  "**/win32com/libs",
+  "**/win32com/readme.html",
+  # Vendored test suites
+  "**/test",
+  "**/tests",
+  # Packaging metadata
+  "**/*.dist-info/INSTALLER",
+  "**/*.dist-info/RECORD",
+  "**/*.dist-info/WHEEL",
+  # Console scripts
+  "**/app_packages/bin/*",
 ]
 console_app = false
 use_full_install_path = false

--- a/qt/tools/build_installer.py
+++ b/qt/tools/build_installer.py
@@ -11,14 +11,38 @@ import subprocess
 import sys
 from pathlib import Path
 
+sys.path.extend(["pylib", "out/pylib"])
+
+from anki.lang import lang_to_disk_lang, langs
+
 installer_dir = Path("qt/installer")
 app_dir = installer_dir / "app"
 out_dir = Path("out/installer").resolve()
+
+# Anki disk-lang codes whose Chromium .pak filename differs from the disk lang.
+_CHROMIUM_PAK_LANG_REMAP = {"tl": "fil"}
 
 
 def normalize_wheel_path(out_dir: Path, path: str) -> str:
     path = Path(path).absolute().relative_to(out_dir.parent).as_posix()
     return f"../{path}"
+
+
+def chromium_paks_to_keep() -> set[str]:
+    keep = {"en-US"}
+    for _name, code in langs:
+        disk = lang_to_disk_lang(code)
+        keep.add(_CHROMIUM_PAK_LANG_REMAP.get(disk, disk))
+        if "-" in disk:
+            keep.add(disk.split("-", 1)[0])
+    return keep
+
+
+def prune_webengine_locales(bundle_root: Path) -> None:
+    keep = chromium_paks_to_keep()
+    for pak in bundle_root.rglob("qtwebengine_locales/*.pak"):
+        if pak.stem not in keep:
+            pak.unlink()
 
 
 def get_briefcase_template_path() -> Path | None:
@@ -82,6 +106,7 @@ def build(args: argparse.Namespace) -> None:
         ],
         cwd=out_dir,
     )
+    prune_webengine_locales(out_dir)
 
 
 def package(args: argparse.Namespace) -> None:


### PR DESCRIPTION

## Linked issue

Closes #4820

## Summary

Optimize size of the Briefcase bundle by removing unused dependency files:
- Remove large *.debug.pak/*.debug.bin files included in Qt.
- Remove packaging/typing/testing metadata.
- Remove app_packages/bin binaries.
- Remove miscellaneous unused files in PyQt6/pywin32.
- Trim large qtwebengine_locales files by only keeping files for languages we support.
- Set MSI compression level in the Wix template to "high".

This reduces the size of the Windows MSI by ~30 MB. I was tempted to go further and prune unused Qt modules since the bulk of the app size comes from Qt, but that proved to be error-prone: We can't simply remove modules not imported by Anki as they can be possibly used by add-ons and other modules might have hidden dependencies on them.

## How to test

Build the installer and confirm installation works.
