### PR TITLE
fix: beta/rc suffix handling in int_version()

### DIFF
--- a/pylib/anki/utils.py
+++ b/pylib/anki/utils.py
@@ -313,7 +313,7 @@ def int_version() -> int:
 
     from anki.buildinfo import version
 
-    match = re.match(r"^(\d+)\.(\d+)(?:\.(\d+))?", version)
+    match = re.match(r"(\d+)\.(\d+)(?:\.(\d+))?", version)
     if not match:
         raise ValueError(f"unrecognised version: {version!r}")
 

--- a/pylib/anki/utils.py
+++ b/pylib/anki/utils.py
@@ -306,23 +306,20 @@ def version_with_build() -> str:
 def int_version() -> int:
     """Anki's version as an integer in the form YYMMPP, e.g. 230900.
     (year, month, patch).
-    In 2.1.x releases, this was just the last number."""
+    In 2.1.x releases, this was just the last number.
+    Beta/rc suffixes (e.g. '26.05b1', '25.09rc1') decode to the same
+    value as the base release."""
     import re
 
     from anki.buildinfo import version
 
-    # Strip non-numeric characters (handles beta/rc suffixes like '25.02b1' or 'rc3')
-    numeric_version = re.sub(r"[^0-9.]", "", version)
+    match = re.match(r"^(\d+)\.(\d+)(?:\.(\d+))?", version)
+    if not match:
+        raise ValueError(f"unrecognised version: {version!r}")
 
-    try:
-        [year, month, patch] = numeric_version.split(".")
-    except ValueError:
-        [year, month] = numeric_version.split(".")
-        patch = "0"
-
-    year_num = int(year)
-    month_num = int(month)
-    patch_num = int(patch)
+    year_num = int(match.group(1))
+    month_num = int(match.group(2))
+    patch_num = int(match.group(3)) if match.group(3) else 0
 
     return year_num * 10_000 + month_num * 100 + patch_num
 

--- a/pylib/tests/test_utils.py
+++ b/pylib/tests/test_utils.py
@@ -1,10 +1,55 @@
 # Copyright: Ankitects Pty Ltd and contributors
 # License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
-from anki.utils import int_version_to_str
+from unittest.mock import patch
+
+import pytest
+
+from anki.utils import int_version, int_version_to_str
 
 
-def test_int_version_to_str():
-    assert int_version_to_str(23) == "2.1.23"
-    assert int_version_to_str(230900) == "23.09"
-    assert int_version_to_str(230901) == "23.09.1"
+@pytest.mark.parametrize(
+    "ver,expected",
+    [
+        # 2.1.x releases: ver is just the patch number
+        (0, "2.1.0"),
+        (23, "2.1.23"),
+        (99, "2.1.99"),
+        # YY.MM releases with no patch
+        (230900, "23.09"),
+        (250200, "25.02"),
+        (260500, "26.05"),
+        # YY.MM.PP releases with a patch
+        (230901, "23.09.1"),
+        (231012, "23.10.12"),
+        (260501, "26.05.1"),
+    ],
+)
+def test_int_version_to_str(ver, expected):
+    assert int_version_to_str(ver) == expected
+
+
+@pytest.mark.parametrize(
+    "version,expected",
+    [
+        ("23.09", 230900),
+        ("23.09.1", 230901),
+        ("25.02", 250200),
+        ("26.05", 260500),
+        # beta/rc suffixes decode to the same int as the base release
+        ("25.02b1", 250200),
+        ("25.02rc3", 250200),
+        ("23.09.1b2", 230901),
+        ("23.09.1rc3", 230901),
+        ("26.05b1", 260500),
+    ],
+)
+def test_int_version(version, expected):
+    with patch("anki.buildinfo.version", version):
+        assert int_version() == expected
+
+
+def test_int_version_rejects_garbage():
+    with patch("anki.buildinfo.version", "not-a-version"):
+        with pytest.raises(ValueError):
+            int_version()


### PR DESCRIPTION
## Linked issue

#4827

## Summary

Strip beta/rc numbers from the version before conversion so they map to the same number as the stable version.

## Steps to reproduce

See the linked issue

## How to test

Run Python tests: `./ninja check:pytest`

