### PR TITLE
fix: regex error fix

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -276,6 +276,7 @@ barisayyildiz <99ayyldzbaris99@gmail.com>
 Christos Longros <chris.longros@gmail.com> 
 Maskady <florent.tout@gmail.com>
 Jeremy Fleischman <jeremyfleischman@gmail.com>
+Chirag Jagga <chiragjagga26@gmail.com>
 
 ********************
 

--- a/qt/aqt/browser/find_and_replace.py
+++ b/qt/aqt/browser/find_and_replace.py
@@ -10,6 +10,7 @@ from markdown import markdown
 import aqt
 import aqt.forms
 import aqt.operations
+from anki.collection import OpChangesWithCount
 from anki.notes import NoteId
 from aqt import AnkiQt
 from aqt.operations import QueryOp
@@ -167,17 +168,19 @@ class FindAndReplaceDialog(QDialog):
                 match_case=match_case,
             )
 
-        if not self.note_ids:
-            op.success(
-                lambda out: tooltip(
-                    tr.browsing_notes_updated(count=out.count),
-                    parent=self.parentWidget(),
+        def on_success(changes: OpChangesWithCount) -> None:
+            if self.note_ids:
+                message = tr.findreplace_notes_updated(
+                    changed=changes.count, total=len(self.note_ids)
                 )
-            )
+            else:
+                message = tr.browsing_notes_updated(count=changes.count)
+            tooltip(message, parent=self.parentWidget())
+            super(FindAndReplaceDialog, self).accept()
+
+        op.success(on_success)
         op.failure(lambda err: showWarning(markdown(str(err))))
         op.run_in_background()
-
-        super().accept()
 
     def show_help(self) -> None:
         openHelp(HelpPage.BROWSING_FIND_AND_REPLACE)

--- a/qt/aqt/browser/find_and_replace.py
+++ b/qt/aqt/browser/find_and_replace.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 
+from markdown import markdown
+
 import aqt
 import aqt.forms
 import aqt.operations
@@ -27,6 +29,7 @@ from aqt.utils import (
     save_combo_index_for_session,
     save_is_checked,
     saveGeom,
+    showWarning,
     tooltip,
     tr,
 )
@@ -171,6 +174,7 @@ class FindAndReplaceDialog(QDialog):
                     parent=self.parentWidget(),
                 )
             )
+        op.failure(lambda err: showWarning(markdown(str(err))))
         op.run_in_background()
 
         super().accept()

--- a/rslib/src/error/mod.rs
+++ b/rslib/src/error/mod.rs
@@ -158,7 +158,7 @@ impl AnkiError {
             AnkiError::SearchError { source } => source.message(tr),
             AnkiError::ParseNumError => tr.errors_parse_number_fail().into(),
             AnkiError::FilteredDeckError { source } => source.message(tr),
-            AnkiError::InvalidRegex { info: source } => format!("<pre>{source}</pre>"),
+            AnkiError::InvalidRegex { info: source } => source.into(),
             AnkiError::MultipleNotetypesSelected => tr.errors_multiple_notetypes_selected().into(),
             AnkiError::DatabaseCheckRequired => tr.errors_please_check_database().into(),
             AnkiError::MediaCheckRequired => tr.errors_please_check_media().into(),

--- a/rslib/src/error/mod.rs
+++ b/rslib/src/error/mod.rs
@@ -158,7 +158,7 @@ impl AnkiError {
             AnkiError::SearchError { source } => source.message(tr),
             AnkiError::ParseNumError => tr.errors_parse_number_fail().into(),
             AnkiError::FilteredDeckError { source } => source.message(tr),
-            AnkiError::InvalidRegex { info: source } => source.into(),
+            AnkiError::InvalidRegex { info: source } => format!("<pre>{source}</pre>"),
             AnkiError::MultipleNotetypesSelected => tr.errors_multiple_notetypes_selected().into(),
             AnkiError::DatabaseCheckRequired => tr.errors_please_check_database().into(),
             AnkiError::MediaCheckRequired => tr.errors_please_check_media().into(),


### PR DESCRIPTION
<!--
Title (for the Pull Request title field at the top):
Use a short prefix so the change type is obvious. You do not need to repeat it in the body below.

Examples:
- fix: — bugfix
- feat: — feature
- refactor: — internal change without user-facing feature
- docs: — documentation only
- chore: — tooling, CI, deps, build housekeeping
- test: — tests only
-->

## Linked issue (required)

Fixes #4835 

## Summary / motivation (required)

<!-- What this PR does and why. For larger changes, add enough context for reviewers. -->

Fixes the issue #4835 with a minor change in InvalidRegex error.

## Steps to reproduce (required, use N/A if not applicable)

<!-- Steps to reproduce: how to trigger the bug in the broken state (the "before").
 - Mainly for bugfixes;
    - For bugs: numbered steps before the fix. For non-bugs: write N/A.
 - use N/A for features, refactors, docs, chore, etc.
-->

1. Open the browser and do a find & replace.
2. Put b[ in “Find”.
3. Enable the regex option.
4. Confirm.

## How to test (required)

<!--- How to test: how you verified the change (checks, unit tests, manual steps, edge cases — the "after" or general validation). --->
Reproduce the fix and verify the regex error is not within the `<pre>` tag.

### Checklist (minimum)

- [x] I ran `./ninja check` or an equivalent relevant check locally.
- [x] I added or updated tests when the change is non-trivial or behavior changed.

### Details

Regex error was return with `<pre>` tags which are removed now so that the text in the error box is displayed correctly.

## Before / after behavior (optional)
<img width="372" height="211" alt="image" src="https://github.com/user-attachments/assets/91f53745-301b-4679-b1a5-53fafd628de7" />

<!-- For bugfixes: behavior before vs after. For other types: N/A or a short note. -->

## Risk / compatibility / migration (optional)

<!-- Breaking changes, rollout notes, or N/A for small / low-risk PRs -->

## UI evidence (required for visual changes; otherwise N/A)

<img width="360" height="226" alt="image" src="https://github.com/user-attachments/assets/3b7b3f23-9f35-423e-9b10-62834e0a0dd6" />

<!-- Screenshot or short video -->

## Scope

- [x] This PR is focused on one change (no unrelated edits).
