### PR TITLE
fix: Prevent Windows elevation errors when running ninja_gen's update binaries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4186,6 +4186,7 @@ dependencies = [
  "anyhow",
  "camino",
  "dunce",
+ "embed-resource",
  "globset",
  "hex",
  "itertools 0.14.0",

--- a/build/ninja_gen/Cargo.toml
+++ b/build/ninja_gen/Cargo.toml
@@ -23,6 +23,9 @@ sha2.workspace = true
 walkdir.workspace = true
 which.workspace = true
 
+[build-dependencies]
+embed-resource.workspace = true
+
 [target.'cfg(windows)'.dependencies]
 reqwest = { workspace = true, features = ["blocking", "json", "native-tls"] }
 

--- a/build/ninja_gen/build.rs
+++ b/build/ninja_gen/build.rs
@@ -1,0 +1,14 @@
+// Copyright: Ankitects Pty Ltd and contributors
+// License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
+
+fn main() {
+    #[cfg(windows)]
+    {
+        // Prevent Windows UAC "Installer Detection" from requiring elevation.
+        // Windows auto-elevates executables whose names match installer heuristics
+        // (install/update/setup/patch). An asInvoker manifest overrides this.
+        embed_resource::compile("win/update-tools.rc", embed_resource::NONE)
+            .manifest_required()
+            .unwrap();
+    }
+}

--- a/build/ninja_gen/win/update-tools.manifest
+++ b/build/ninja_gen/win/update-tools.manifest
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+    <assemblyIdentity type="win32" name="Anki.Build.UpdateTool" version="1.0.0.0" />
+    <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
+        <security>
+            <requestedPrivileges xmlns="urn:schemas-microsoft-com:asm.v3">
+                <requestedExecutionLevel level="asInvoker" uiAccess="false" />
+            </requestedPrivileges>
+        </security>
+    </trustInfo>
+    <application xmlns="urn:schemas-microsoft-com:asm.v3">
+        <windowsSettings>
+            <longPathAware xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">true</longPathAware>
+            <activeCodePage xmlns="http://schemas.microsoft.com/SMI/2019/WindowsSettings">UTF-8</activeCodePage>
+        </windowsSettings>
+    </application>
+</assembly>

--- a/build/ninja_gen/win/update-tools.rc
+++ b/build/ninja_gen/win/update-tools.rc
@@ -1,0 +1,2 @@
+#define RT_MANIFEST 24
+1 RT_MANIFEST "update-tools.manifest"


### PR DESCRIPTION
## Linked issue

Closes #4847

## Summary

Prevent Windows elevation errors when running ninja_gen's update binaries by embedding a manifest with `asInvoker`.


## How to test

Run `./tools/ninja check` or `cargo run --bin update_node` and confirm no elevation errors.
