### PR TITLE
fix(import): avoid case-folding already existing media filenames

### DIFF
--- a/rslib/src/media/files.rs
+++ b/rslib/src/media/files.rs
@@ -173,17 +173,25 @@ pub fn add_data_to_folder_uniquely<'a, P>(
 where
     P: AsRef<Path>,
 {
-    // force lowercase to account for case-insensitive filesystems
-    // but not within normalize_filename, for existing media refs
-    let normalized_name: Cow<_> = normalize_filename(desired_name).to_lowercase().into();
+    let normalized_name = normalize_filename(desired_name);
 
     let mut target_path = folder.as_ref().join(normalized_name.as_ref());
 
     let existing_file_hash = existing_file_sha1(&target_path)?;
     if existing_file_hash.is_none() {
-        // no file with that name exists yet
-        write_file(&target_path, data)?;
-        return Ok(normalized_name);
+        let lowercased_name = normalized_name.to_lowercase();
+        if lowercased_name == normalized_name {
+            // no file with that name that's also in lowercase exists yet
+            write_file(&target_path, data)?;
+            return Ok(normalized_name);
+        } else {
+            // try again with the lowercased name
+            return Ok(
+                add_data_to_folder_uniquely(folder, &lowercased_name, data, sha1)?
+                    .to_string()
+                    .into(),
+            );
+        }
     }
 
     if existing_file_hash.unwrap() == sha1 {


### PR DESCRIPTION
<!--
Title (for the Pull Request title field at the top):
Use a short prefix so the change type is obvious. You do not need to repeat it in the body below.

Examples:
- fix: — bugfix
- feat: — feature
- refactor: — internal change without user-facing feature
- docs: — documentation only
- chore: — tooling, CI, deps, build housekeeping
- test: — tests only
-->

## Linked issue (required)

Fixes #4716 

## Summary / motivation (required)

#4435 made it so that all new added media would have lowercased names, but this was bugged and led to media refs pointing to inexistent files on case-insensitive filesystems

The fix proposed is to try adding new files with lowercased names only if they don't already exist, using the existing file otherwise

## Steps to reproduce (required, use N/A if not applicable)

See linked issue

## How to test (required)

Try copy-pasting a media file from the Edit window of an existing note to the Add window and see that the filename in the resulting media ref isn't forced to be lowercased

When pasting a new file, see that the filename is now lowercased

### Checklist (minimum)

- [x] I ran `./ninja check` or an equivalent relevant check locally.
- [ ] I added or updated tests when the change is non-trivial or behavior changed.

## Scope

- [x] This PR is focused on one change (no unrelated edits).
