### PR TITLE
fix(import): force lowercasing before adding hash suffix as well

### DIFF
--- a/rslib/src/media/files.rs
+++ b/rslib/src/media/files.rs
@@ -178,24 +178,25 @@ where
     let mut target_path = folder.as_ref().join(normalized_name.as_ref());
 
     let existing_file_hash = existing_file_sha1(&target_path)?;
-    if existing_file_hash.is_none() {
-        let lowercased_name = normalized_name.to_lowercase();
-        if lowercased_name == normalized_name {
-            // no file with that name that's also in lowercase exists yet
-            write_file(&target_path, data)?;
-            return Ok(normalized_name);
-        } else {
-            // try again with the lowercased name
-            return Ok(
-                add_data_to_folder_uniquely(folder, &lowercased_name, data, sha1)?
-                    .to_string()
-                    .into(),
-            );
-        }
+
+    if matches!(existing_file_hash, Some(hash) if hash == sha1) {
+        // existing file has same checksum, nothing to do
+        return Ok(normalized_name);
     }
 
-    if existing_file_hash.unwrap() == sha1 {
-        // existing file has same checksum, nothing to do
+    let lowercased_name = normalized_name.to_lowercase();
+    if lowercased_name != normalized_name {
+        // try again with the lowercased name (to_lowercase is idempotent)
+        return Ok(
+            add_data_to_folder_uniquely(folder, &lowercased_name, data, sha1)?
+                .to_string()
+                .into(),
+        );
+    }
+
+    if existing_file_hash.is_none() {
+        // no file with that name that's also in lowercase exists yet
+        write_file(&target_path, data)?;
         return Ok(normalized_name);
     }
 


### PR DESCRIPTION
<!--
Title (for the Pull Request title field at the top):
Use a short prefix so the change type is obvious. You do not need to repeat it in the body below.

Examples:
- fix: — bugfix
- feat: — feature
- refactor: — internal change without user-facing feature
- docs: — documentation only
- chore: — tooling, CI, deps, build housekeeping
- test: — tests only
-->

## Linked issue (required)

- #4851
- #4716

## Summary / motivation (required)

I made a mistake in #4851 by not lowercasing in the case where a file with the same name but different contents already exists, leading to inconsistent behaviour across platforms

## Steps to reproduce (required, use N/A if not applicable)

See linked pr

## How to test (required)

Run ./check on linux and windows and see that the same lowercasing behaviour occurs on both

### Checklist (minimum)

- [x] I ran `./ninja check` or an equivalent relevant check locally.
- [ ] I added or updated tests when the change is non-trivial or behavior changed.

## Scope

- [x] This PR is focused on one change (no unrelated edits).
