### PR TITLE
fix(check-media): case-sensitivity in unused/missing check

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -196,6 +196,7 @@ name = "anki_io"
 version = "0.0.0"
 dependencies = [
  "camino",
+ "rand 0.9.4",
  "snafu",
  "tempfile",
 ]

--- a/rslib/io/Cargo.toml
+++ b/rslib/io/Cargo.toml
@@ -10,5 +10,6 @@ description = "Utils for better I/O error reporting"
 
 [dependencies]
 camino.workspace = true
+rand.workspace = true
 snafu.workspace = true
 tempfile.workspace = true

--- a/rslib/io/src/lib.rs
+++ b/rslib/io/src/lib.rs
@@ -365,6 +365,11 @@ pub fn write_file_if_changed(path: impl AsRef<Path>, contents: impl AsRef<[u8]>)
     }
 }
 
+pub fn is_case_sensitive(_dir: &Path) -> bool {
+    // TODO: make robust?
+    cfg!(unix) && !cfg!(target_os = "macos")
+}
+
 pub trait ToUtf8PathBuf {
     fn utf8(self) -> Result<Utf8PathBuf>;
 }

--- a/rslib/io/src/lib.rs
+++ b/rslib/io/src/lib.rs
@@ -365,8 +365,20 @@ pub fn write_file_if_changed(path: impl AsRef<Path>, contents: impl AsRef<[u8]>)
     }
 }
 
-pub fn is_case_sensitive(_dir: &Path) -> bool {
-    // TODO: make robust?
+pub fn is_case_sensitive(dir: &Path) -> bool {
+    let opt = OpenOptions::new().write(true).create_new(true).to_owned();
+    for _ in 0..100 {
+        let fname = format!("__case-test-{}", rand::random::<u128>());
+        let fname_upper = fname.to_uppercase();
+        if open_file_ext(dir.join(&fname), opt.to_owned()).is_ok() {
+            let sensitive = open_file_ext(dir.join(&fname_upper), opt.to_owned()).is_ok();
+            let _ = std::fs::remove_file(dir.join(fname));
+            if sensitive {
+                let _ = std::fs::remove_file(dir.join(fname_upper));
+            }
+            return sensitive;
+        }
+    }
     cfg!(unix) && !cfg!(target_os = "macos")
 }
 

--- a/rslib/src/media/check.rs
+++ b/rslib/src/media/check.rs
@@ -14,6 +14,7 @@ use data_encoding::BASE64;
 use regex::Regex;
 use tracing::debug;
 use tracing::info;
+use unicase::UniCase;
 
 use crate::error::DbErrorKind;
 use crate::latex::extract_latex_expanding_clozes;
@@ -57,6 +58,58 @@ struct MediaFolderCheck {
 impl Collection {
     pub fn media_checker(&mut self) -> Result<MediaChecker<'_>> {
         MediaChecker::new(self)
+    }
+}
+
+/// If the media folder is case-insensitive, `[sound:blah.mp3]` and
+/// `[sound:BLAH.Mp3]` are identical
+enum References {
+    Sensitive(HashMap<String, Vec<NoteId>>),
+    Insensitive(HashMap<UniCase<String>, Vec<NoteId>>),
+}
+
+impl References {
+    fn new(is_case_sensitive: bool) -> Self {
+        if is_case_sensitive {
+            Self::Sensitive(HashMap::new())
+        } else {
+            Self::Insensitive(HashMap::new())
+        }
+    }
+
+    fn add(&mut self, fname: String, nid: NoteId) {
+        match self {
+            References::Sensitive(refs) => refs.entry(fname).or_insert_with(Vec::new).push(nid),
+            References::Insensitive(refs) => refs
+                .entry(UniCase::new(fname))
+                .or_insert_with(Vec::new)
+                .push(nid),
+        }
+    }
+
+    fn contains_key(&self, fname: &str) -> bool {
+        match self {
+            References::Sensitive(refs) => refs.contains_key(fname),
+            References::Insensitive(refs) => refs.contains_key(&UniCase::new(fname.to_string())),
+        }
+    }
+
+    fn remove(&mut self, fname: String) {
+        match self {
+            References::Sensitive(refs) => refs.remove(&fname),
+            References::Insensitive(refs) => refs.remove(&UniCase::new(fname)),
+        };
+    }
+
+    fn for_each(&self, mut f: impl FnMut((&String, &Vec<NoteId>))) {
+        match self {
+            References::Sensitive(refs) => {
+                refs.iter().for_each(f);
+            }
+            References::Insensitive(refs) => {
+                refs.iter().for_each(|(fname, notes)| f((fname, notes)));
+            }
+        }
     }
 }
 

--- a/rslib/src/media/check.rs
+++ b/rslib/src/media/check.rs
@@ -943,4 +943,31 @@ Unused: unused.jpg
 
         Ok(())
     }
+
+    #[test]
+    fn unused_check_accounts_for_case_insensitivity() -> Result<()> {
+        let (_dir, mgr, mut col) = common_setup()?;
+
+        let ref_fname = "ABC.mp3".to_owned();
+        let disk_fname = ref_fname.to_lowercase();
+
+        NoteAdder::basic(&mut col)
+            .fields(&["abc", &format!("[sound:{}]", ref_fname)])
+            .add(&mut col);
+
+        write_file(mgr.media_folder.join(&disk_fname), "blah")?;
+
+        let output = {
+            let mut checker = col.media_checker()?;
+            checker.check()?
+        };
+
+        // only considered missing if the media folder is case sensitive
+        assert_eq!(
+            output.missing.contains(&ref_fname),
+            anki_io::is_case_sensitive(&mgr.media_folder)
+        );
+
+        Ok(())
+    }
 }

--- a/rslib/src/media/check.rs
+++ b/rslib/src/media/check.rs
@@ -394,11 +394,9 @@ impl MediaChecker<'_> {
     }
 
     /// Find all media references in notes, fixing as necessary.
-    fn check_media_references(
-        &mut self,
-        renamed: &HashMap<String, String>,
-    ) -> Result<HashMap<String, Vec<NoteId>>> {
-        let mut referenced_files = HashMap::new();
+    fn check_media_references(&mut self, renamed: &HashMap<String, String>) -> Result<References> {
+        let is_case_sensitive = anki_io::is_case_sensitive(&self.media.media_folder);
+        let mut referenced_files = References::new(is_case_sensitive);
         let notetypes = self.col.get_all_notetypes()?;
         let mut collection_modified = false;
 
@@ -413,12 +411,7 @@ impl MediaChecker<'_> {
                 .ok_or_else(|| {
                     AnkiError::db_error("missing note type", DbErrorKind::MissingEntity)
                 })?;
-            let mut tracker = |fname| {
-                referenced_files
-                    .entry(fname)
-                    .or_insert_with(Vec::new)
-                    .push(nid)
-            };
+            let mut tracker = |fname| referenced_files.add(fname, nid);
             if self.fix_and_extract_media_refs(&mut note, &mut tracker, renamed)? {
                 // note was modified, needs saving
                 note.prepare_for_update(nt, false)?;
@@ -554,22 +547,22 @@ struct UnusedAndMissingFiles {
 }
 
 impl UnusedAndMissingFiles {
-    fn new(files: Vec<String>, mut references: HashMap<String, Vec<NoteId>>) -> Self {
+    fn new(files: Vec<String>, mut references: References) -> Self {
         let mut unused = vec![];
         for file in files {
             if !file.starts_with('_') && !references.contains_key(&file) {
                 unused.push(file);
             } else {
-                references.remove(&file);
+                references.remove(file);
             }
         }
 
         let mut missing = Vec::new();
         let mut notes = HashSet::new();
-        for (fname, nids) in references {
-            missing.push(fname);
+        references.for_each(|(fname, nids)| {
+            missing.push(fname.to_string());
             notes.extend(nids);
-        }
+        });
 
         Self {
             unused,


### PR DESCRIPTION
<!--
Title (for the Pull Request title field at the top):
Use a short prefix so the change type is obvious. You do not need to repeat it in the body below.

Examples:
- fix: — bugfix
- feat: — feature
- refactor: — internal change without user-facing feature
- docs: — documentation only
- chore: — tooling, CI, deps, build housekeeping
- test: — tests only
-->

## Linked issue (required)

- #4716

## Summary / motivation (required)

Currently, on filesystems where the media folder is treated as case-insensitive, `[sound:BLAH.mp3]` and `[sound:blah.mp3]` point to the same file on disk (if any), but one of the two would be considered as a ref pointing to a missing file by the media checker which assumes case-sensitivity

## Steps to reproduce (required, use N/A if not applicable)

See linked pr

## How to test (required)

On windows/macos, add `blah.mp3`, rename `blah.mp3` to `Blah.mp3` in the ref, run `Check Media` and see that `Blah.mp3` isn't considered missing

### Checklist (minimum)

- [x] I ran `./ninja check` or an equivalent relevant check locally.
- [ ] I added or updated tests when the change is non-trivial or behavior changed.

## Scope

- [x] This PR is focused on one change (no unrelated edits).
