### PR TITLE
fix: border color of browser cells in macOS

### DIFF
--- a/qt/aqt/theme.py
+++ b/qt/aqt/theme.py
@@ -268,6 +268,8 @@ class ThemeManager:
 
         else:
             app.setStyle(QStyleFactory.create(self._default_style))  # type: ignore
+            # Qt 6.10+ reads this from the system's theme
+            buf += f"QTableView {{ gridline-color: {self.var(colors.BORDER_SUBTLE)}; }}"
 
         # allow addons to modify the styling
         buf = gui_hooks.style_did_init(buf)


### PR DESCRIPTION

## Linked issue

Closes #4870

## Summary

This fixes the border color of browser cells in macOS not following Anki's theme after Qt 6.10+

## Steps to reproduce (before)

1. Set Anki's theme from _Anki (`python` in dev environment) > Preferences > Theme_ to be the opposite of your system theme. 
2. Open the Browse screen and notice the cell borders have the opposite color of your Anki theme, matching the system theme.

## How to test (after)

Notice cell borders are more subtle now.

### Details

## UI evidence

Before:
<img width="628" height="346" alt="image" src="https://github.com/user-attachments/assets/3b46c9fe-5eb8-4e03-ac93-5429d1768344" />

After:
<img width="628" height="346" alt="image" src="https://github.com/user-attachments/assets/aeea6867-ebfe-46cc-8b4a-6f7440da16f4" />
