### PR TITLE
Feat: Expose card's decay and DR to custom scheduler

### DIFF
--- a/proto/anki/scheduler.proto
+++ b/proto/anki/scheduler.proto
@@ -324,6 +324,8 @@ message CustomStudyRequest {
 message SchedulingContext {
   string deck_name = 1;
   uint64 seed = 2;
+  optional float decay = 3;
+  optional float desired_retention = 4;
 }
 
 message CustomStudyDefaultsRequest {

--- a/rslib/src/scheduler/queue/mod.rs
+++ b/rslib/src/scheduler/queue/mod.rs
@@ -143,6 +143,8 @@ fn new_scheduling_context(col: &mut Collection, card: &Card) -> Result<Schedulin
             .or_not_found(card.deck_id)?
             .human_name(),
         seed: card.review_seed(),
+        decay: card.decay,
+        desired_retention: card.desired_retention,
     })
 }
 


### PR DESCRIPTION
## Linked issue (required)

No existing issue

## Summary / motivation (required)

I wanted to use the card's decay in my custom scheduling script. But, Anki doesn't expose it to JS. This small change exposes the values to JS.

## Steps to reproduce (required, use N/A if not applicable)

NA

## How to test (required)

Used `ctx.decay` in the custom scheduling script to fetch the card's decay and it worked.

### Checklist (minimum)

- [ ] I ran `./ninja check` or an equivalent relevant check locally.
- [ ] I added or updated tests when the change is non-trivial or behavior changed.

### Details

<!-- Commands, manual steps, edge cases, and what you observed -->

## Before / after behavior (optional)

<!-- For bugfixes: behavior before vs after. For other types: N/A or a short note. -->

## Risk / compatibility / migration (optional)

<!-- Breaking changes, rollout notes, or N/A for small / low-risk PRs -->

## UI evidence (required for visual changes; otherwise N/A)

<!-- Screenshot or short video -->

## Scope

- [x] This PR is focused on one change (no unrelated edits).