### PR TITLE
feat: Install required system dependencies in install.sh

### DIFF
--- a/qt/installer/app/pyproject.toml
+++ b/qt/installer/app/pyproject.toml
@@ -67,32 +67,6 @@ entitlement."com.apple.security.cs.disable-executable-page-protection" = true
 entitlement."com.apple.security.cs.allow-dyld-environment-variables" = true
 entitlement."com.apple.security.device.audio-input" = true
 
-[tool.briefcase.app.anki.linux]
-system_runtime_requires = [
-  "libdbus-1-3",
-  "libfontconfig1",
-  "libfreetype6",
-  "libgl1",
-  "libglib2.0-0",
-  "libnss3",
-  "libxcb-icccm4",
-  "libxcb-image0",
-  "libxcb-keysyms1",
-  "libxcb-randr0",
-  "libxcb-render-util0",
-  "libxcb-shape0",
-  "libxcb-xinerama0",
-  "libxcb-xkb1",
-  "libxcomposite1",
-  "libxcursor1",
-  "libxi6",
-  "libxkbcommon0",
-  "libxkbcommon-x11-0",
-  "libxrandr2",
-  "libxrender1",
-  "libxtst6",
-]
-
 [tool.briefcase.app.anki.linux.flatpak]
 supported = false
 

--- a/qt/installer/linux-template/{{ cookiecutter.format }}/{{ cookiecutter.app_name }}/install.sh
+++ b/qt/installer/linux-template/{{ cookiecutter.format }}/{{ cookiecutter.app_name }}/install.sh
@@ -7,6 +7,46 @@ if [ "$(dirname "$(realpath "$0")")" != "$(realpath "$PWD")" ]; then
   exit 1
 fi
 
+_install_deps() {
+  if [ ! -f /etc/os-release ]; then
+    echo "Warning: /etc/os-release not found; skipping dependency installation."
+    return
+  fi
+
+  # shellcheck disable=SC1091
+  . /etc/os-release
+
+  DEBIAN_DEPS=(
+    libdbus-1-3 libfontconfig1 libfreetype6 libgl1 libnss3
+    libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0
+    libxcb-render-util0 libxcb-shape0 libxcb-xinerama0 libxcb-xkb1
+    libxcomposite1 libxcursor1 libxi6 libxkbcommon0 libxkbcommon-x11-0
+    libxrandr2 libxrender1 libxtst6
+  )
+
+  _apt() {
+    # libglib2.0-0 was renamed to libglib2.0-0t64 in Ubuntu 24.04+
+    local glib_pkg=libglib2.0-0
+    apt-cache show libglib2.0-0t64 >/dev/null 2>&1 && glib_pkg=libglib2.0-0t64
+    apt-get install -y "${DEBIAN_DEPS[@]}" "$glib_pkg"
+  }
+
+  case "${ID:-}" in
+    debian|ubuntu|linuxmint|pop)      _apt    ;;
+    *)
+      case "${ID_LIKE:-}" in
+        *debian*|*ubuntu*) _apt    ;;
+        *)
+          echo "Warning: unknown distribution '${ID:-}'; skipping dependency installation."
+          echo "Please run Anki with QT_DEBUG_PLUGINS=1 to show missing Qt dependencies."
+          ;;
+      esac
+      ;;
+  esac
+}
+
+_install_deps || echo "Warning: dependency installation failed; continuing anyway."
+
 if [ "$PREFIX" = "" ]; then
 	PREFIX=/usr/local
 fi


### PR DESCRIPTION
## Linked issue

Closes #4834

## Summary

This installs required Linux system dependencies in the install.sh script for Debian-based distributions.

## Steps to reproduce (before)

No system dependencies are installed automatically. Users have to refer to the [manual](https://docs.ankiweb.net/platform/linux/installing.html#requirements) to find a (partial) list of required packages.

## How to test (after)

Build the installer and run install.sh in any supported distro and confirm dependencies are installed.
