### PR TITLE
fix: app unresponsive after clicking on Help button in modal dialogs

### DIFF
--- a/qt/aqt/errors.py
+++ b/qt/aqt/errors.py
@@ -59,7 +59,9 @@ def show_exception(*, parent: QWidget, exception: Exception) -> None:
         )
     error_text = "\n".join(error_lines)
     print(error_lines)
-    _mbox = _init_message_box(str(exception), error_text, help_page, text_format)
+    _mbox = _init_message_box(
+        str(exception), error_text, help_page, text_format, parent
+    )
     _mbox.show()
 
 
@@ -183,10 +185,11 @@ def _init_message_box(
     debug_text: str,
     help_page=HelpPage.TROUBLESHOOTING,
     text_format=Qt.TextFormat.PlainText,
+    parent: QWidget | None = None,
 ):
     global _mbox
 
-    _mbox = QMessageBox()
+    _mbox = QMessageBox(parent=parent)
     _mbox.setWindowTitle("Anki")
     _mbox.setText(user_text)
     _mbox.setIcon(QMessageBox.Icon.Warning)

--- a/qt/aqt/errors.py
+++ b/qt/aqt/errors.py
@@ -207,12 +207,12 @@ def _init_message_box(
         debug_info = _mbox.addButton(
             tr.errors_copy_debug_info_button(), QMessageBox.ButtonRole.ActionRole
         )
-        debug_info.disconnect()
+        debug_info.clicked.disconnect()
         debug_info.clicked.connect(copy_debug_info)
     cancel = _mbox.addButton(QMessageBox.StandardButton.Cancel)
     cancel.setText(tr.actions_close())
 
-    help.disconnect()
+    help.clicked.disconnect()
     help.clicked.connect(show_help)
 
     return _mbox


### PR DESCRIPTION

## Linked issue

Closes #4896

## Summary

On macOS, clicking the Help button in error dialogs shown on top of modal dialogs such as the Filtered deck screen was causing the app to become unresponsive after the recent Qt upgrade. This was fixed by:

1. Setting a parent widget for `QMessageBox`.
2. Limiting the `.disconnect()` calls to the `clicked` signal.

## Steps to reproduce (before)

I was not able to reproduce the issue in a dev environment. I had to build and run the Briefcase package. Follow the steps in the [forums](https://forums.ankiweb.net/t/anki-26-05-beta-1/69707/43?u=abdo) and confirm you can reproduce the issue.

## How to test (after)

Run the Briefcase package with the changes and follow reproduction steps and confirm the issue is fixed.