### PR TITLE
fix: Validate add-on's zip entries

### DIFF
--- a/qt/aqt/addons.py
+++ b/qt/aqt/addons.py
@@ -492,7 +492,7 @@ class AddonManager:
 
     def _install(self, module: str, zfile: ZipFile) -> None:
         # previously installed?
-        base = self.addonsFolder(module)
+        base = os.path.realpath(self.addonsFolder(module))
         if os.path.exists(base):
             self.backupUserFiles(module)
             try:
@@ -509,7 +509,11 @@ class AddonManager:
                 # folder; ignore
                 continue
 
-            path = os.path.join(base, n)
+            # skip unsafe paths
+            path = os.path.realpath(os.path.join(base, n))
+            if not path.startswith(base + os.sep):
+                continue
+
             # skip existing user files
             if os.path.exists(path) and n.startswith("user_files/"):
                 continue

--- a/qt/tests/test_addons.py
+++ b/qt/tests/test_addons.py
@@ -5,6 +5,7 @@ import os.path
 from tempfile import TemporaryDirectory
 from zipfile import ZipFile
 
+import pytest
 from mock import MagicMock
 
 from aqt.addons import AddonManager, package_name_valid
@@ -77,21 +78,21 @@ def test_package_name_validation():
     assert package_name_valid("ab")
 
 
-def _make_addon_manager(addon_folder: str) -> AddonManager:
+@pytest.fixture
+def addon_manager(tmp_path) -> AddonManager:
     adm = AddonManager(MagicMock())
-    adm.mw.pm.addonFolder.return_value = addon_folder
+    adm.mw.pm.addonFolder.return_value = tmp_path
     return adm
 
 
-def test_install_extracts_safe_files(tmp_path):
-    adm = _make_addon_manager(tmp_path)
+def test_install_extracts_safe_files(tmp_path, addon_manager):
     zfn = os.path.join(tmp_path, "addon.zip")
     with ZipFile(zfn, "w") as zfile:
         zfile.writestr("main.py", "content")
         zfile.writestr("../unsafe.txt", "content")
         zfile.writestr("subdir/helper.py", "content")
     with ZipFile(zfn) as zfile:
-        adm._install("12345", zfile)
+        addon_manager._install("12345", zfile)
     addon_dir = os.path.join(tmp_path, "12345")
     assert os.path.exists(os.path.join(addon_dir, "main.py"))
     assert os.path.exists(os.path.join(addon_dir, "subdir", "helper.py"))

--- a/qt/tests/test_addons.py
+++ b/qt/tests/test_addons.py
@@ -75,3 +75,24 @@ def test_package_name_validation():
     assert not package_name_valid("a/b")
     assert not package_name_valid("..")
     assert package_name_valid("ab")
+
+
+def _make_addon_manager(addon_folder: str) -> AddonManager:
+    adm = AddonManager(MagicMock())
+    adm.mw.pm.addonFolder.return_value = addon_folder
+    return adm
+
+
+def test_install_extracts_safe_files(tmp_path):
+    adm = _make_addon_manager(tmp_path)
+    zfn = os.path.join(tmp_path, "addon.zip")
+    with ZipFile(zfn, "w") as zfile:
+        zfile.writestr("main.py", "content")
+        zfile.writestr("../unsafe.txt", "content")
+        zfile.writestr("subdir/helper.py", "content")
+    with ZipFile(zfn) as zfile:
+        adm._install("12345", zfile)
+    addon_dir = os.path.join(tmp_path, "12345")
+    assert os.path.exists(os.path.join(addon_dir, "main.py"))
+    assert os.path.exists(os.path.join(addon_dir, "subdir", "helper.py"))
+    assert not os.path.exists(os.path.join(tmp_path, "unsafe.txt"))


### PR DESCRIPTION
This validates add-on's zip paths to skip things such as UNC paths