### PR TITLE
test: add cross-platform tests for _fix_win_taskbar_pinning

### DIFF
--- a/qt/tests/test_package.py
+++ b/qt/tests/test_package.py
@@ -3,24 +3,94 @@
 
 import os
 import sys
+from unittest.mock import MagicMock
 
 import pytest
 
 
 @pytest.mark.skipif(sys.platform != "win32", reason="windows taskbar test")
-@pytest.mark.parametrize("is_launcher", [False, True])
-def test_app_user_model_id_set(is_launcher: bool) -> None:
-    from pywintypes import com_error
-    from win32com.shell import shell
+class TestFixWinTaskbarPinningIntegration:
+    """Tests using real Win32 APIs. Only runs on Windows."""
 
-    if is_launcher:
-        os.environ["ANKI_LAUNCHER"] = "testpath"
+    def test_skips_without_launcher(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Function does nothing on Windows when ANKI_LAUNCHER env var is not set."""
+        from pywintypes import com_error
+        from win32com.shell import shell
+
+        monkeypatch.delenv("ANKI_LAUNCHER", raising=False)
+
+        from aqt.package import _fix_win_taskbar_pinning
+
+        _fix_win_taskbar_pinning()
+
+        with pytest.raises(com_error):
+            shell.GetCurrentProcessExplicitAppUserModelID()
+
+    def test_sets_app_user_model_id(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Function sets AppUserModelID when on Windows with ANKI_LAUNCHER set."""
+        from win32com.shell import shell
+
+        monkeypatch.setenv("ANKI_LAUNCHER", "testpath")
 
         from aqt.package import _fix_win_taskbar_pinning
 
         _fix_win_taskbar_pinning()
 
         assert shell.GetCurrentProcessExplicitAppUserModelID() == "Ankitects.Anki"
-    else:
-        with pytest.raises(com_error):
-            shell.GetCurrentProcessExplicitAppUserModelID()
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="mocked platform tests, covered by TestFixWinTaskbarPinningIntegration on Windows",
+)
+class TestFixWinTaskbarPinning:
+    """Tests using mocked Win32 APIs. Runs on macOS and Linux."""
+
+    def test_skips_on_non_windows(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Function does nothing when not running on Windows."""
+        monkeypatch.setattr(sys, "platform", "darwin")
+        monkeypatch.delenv("ANKI_LAUNCHER", raising=False)
+
+        mock_win32com_shell = MagicMock()
+        monkeypatch.setitem(sys.modules, "win32com", MagicMock())
+        monkeypatch.setitem(sys.modules, "win32com.shell", mock_win32com_shell)
+
+        from aqt.package import _fix_win_taskbar_pinning
+
+        _fix_win_taskbar_pinning()
+
+        mock_win32com_shell.shell.SetCurrentProcessExplicitAppUserModelID.assert_not_called()
+
+    def test_skips_without_launcher(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Function does nothing on Windows when ANKI_LAUNCHER env var is not set."""
+        monkeypatch.setattr(sys, "platform", "win32")
+        monkeypatch.delenv("ANKI_LAUNCHER", raising=False)
+
+        mock_win32com_shell = MagicMock()
+        monkeypatch.setitem(sys.modules, "win32com", MagicMock())
+        monkeypatch.setitem(sys.modules, "win32com.shell", mock_win32com_shell)
+
+        from aqt.package import _fix_win_taskbar_pinning
+
+        _fix_win_taskbar_pinning()
+
+        mock_win32com_shell.shell.SetCurrentProcessExplicitAppUserModelID.assert_not_called()
+
+    def test_sets_app_user_model_id(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Function sets AppUserModelID when on Windows with ANKI_LAUNCHER set."""
+        monkeypatch.setattr(sys, "platform", "win32")
+        monkeypatch.setenv("ANKI_LAUNCHER", "testpath")
+
+        mock_shell = MagicMock()
+        mock_win32com_shell = MagicMock()
+        mock_win32com_shell.shell = mock_shell
+        monkeypatch.setitem(sys.modules, "win32com", MagicMock())
+        monkeypatch.setitem(sys.modules, "win32com.shell", mock_win32com_shell)
+
+        from aqt.package import _fix_win_taskbar_pinning
+
+        _fix_win_taskbar_pinning()
+
+        mock_shell.SetCurrentProcessExplicitAppUserModelID.assert_called_once_with(
+            "Ankitects.Anki"
+        )


### PR DESCRIPTION
## Changes

The original `test_app_user_model_id_set` test had two issues:

- The `is_launcher=False` branch never called `_fix_win_taskbar_pinning()` — it only
  checked a pre-condition, not the function's behavior.
- `os.environ["ANKI_LAUNCHER"]` was set without cleanup, potentially leaking state
  into subsequent tests.

The test is now refactored into `TestFixWinTaskbarPinningIntegration`, which fixes
both issues: the negative case now actually calls the function before asserting, and
`monkeypatch` handles env cleanup automatically.

## New tests

`TestFixWinTaskbarPinning` adds mocked cross-platform tests that run on macOS and
Linux, where the Windows-only tests are always skipped. This ensures all branches of
`_fix_win_taskbar_pinning` are covered in CI regardless of the platform — without
this, coverage reports would differ between Windows and macOS/Linux, since the
integration tests are skipped outside of Windows.

- `test_skips_on_non_windows` — verifies the function is a no-op when
  `sys.platform != "win32"`
- `test_skips_without_launcher` — verifies the function is a no-op on Windows when
  `ANKI_LAUNCHER` is not set
- `test_sets_app_user_model_id` — verifies `SetCurrentProcessExplicitAppUserModelID`
  is called with the correct value when both conditions are met