### PR TITLE
fix: Use Powershell to run just commands on Windows

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,4 +1,4 @@
-set windows-shell := ["cmd.exe", "/c"]
+set windows-shell := ["pwsh", "-NoLogo", "-NoProfileLoadTime", "-Command"]
 
 mod release
 

--- a/release.just
+++ b/release.just
@@ -1,4 +1,4 @@
-set windows-shell := ["cmd.exe", "/c"]
+set windows-shell := ["pwsh", "-NoLogo", "-NoProfileLoadTime", "-Command"]
 
 version := `cat .version`
 


### PR DESCRIPTION
## Linked issue

Closes #4920

## Summary

Default to PowerShell 7+ to run just commands on Windows for more consistent argument quoting rules.

## Steps to reproduce (before)

- Trigger the release workflow: `just release::build --ref main`.
- Inspect the logs of the `prepare` step on GitHub and notice that the version has literal double quotes.

## How to test (after)

Repeat the same steps and confirm quotes are not passed literally.
