### PR TITLE
chore: Updates just recipes and add AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,8 +1,9 @@
 # Claude Code Configuration
 
-> **Note:** Commands for building, testing, linting, and formatting are
-> defined as recipes in the project `justfile`. Run `just --list` to see
-> them. Do not invoke `./ninja` directly — use the `just` recipes instead.
+> **Note:** Every command you need — building, running, testing, linting,
+> formatting — is defined as a recipe in the project `justfile`. Run
+> `just --list` to see them. Do not invoke `./ninja`, `./run`, or scripts
+> under `./tools` directly — use the `just` recipes instead.
 
 ## Project Overview
 
@@ -20,14 +21,15 @@ Anki is a spaced repetition flashcard program with a multi-layered architecture.
 To build and run Anki in development mode:
 
 ```
-./run
+just run
 ```
 
 This builds pylib and qt, then launches Anki with debugging enabled. Web
 views are served at http://localhost:40000/_anki/pages/ (e.g.,
-deckconfig.html). For live-reloading during web development, run
-`./tools/web-watch` in a separate terminal — it monitors ts/, sass/, and
-qt/aqt/data/web/ and auto-rebuilds on changes.
+deckconfig.html). Use `just run-optimized` for a release-optimized build.
+For live-reloading during web development, run `just web-watch` in a
+separate terminal — it monitors ts/, sass/, and qt/aqt/data/web/ and
+auto-rebuilds on changes (`just rebuild-web` triggers a one-off rebuild).
 
 ## Building/checking
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,9 +1,8 @@
 # Claude Code Configuration
 
-> **Note:** All commands you need for building, testing, linting, and
-> formatting are defined as recipes in the project `justfile`. Run
-> `just --list` to see them. Do not invoke `./ninja` or scripts under
-> `./tools` directly — use the `just` recipes instead.
+> **Note:** Commands for building, testing, linting, and formatting are
+> defined as recipes in the project `justfile`. Run `just --list` to see
+> them. Do not invoke `./ninja` directly — use the `just` recipes instead.
 
 ## Project Overview
 
@@ -15,6 +14,20 @@ Anki is a spaced repetition flashcard program with a multi-layered architecture.
 - Core Rust layer in rslib/
 - Protobuf definitions in proto/ that are used by the different layers to
   talk to each other.
+
+## Running Anki
+
+To build and run Anki in development mode:
+
+```
+./run
+```
+
+This builds pylib and qt, then launches Anki with debugging enabled. Web
+views are served at http://localhost:40000/_anki/pages/ (e.g.,
+deckconfig.html). For live-reloading during web development, run
+`./tools/web-watch` in a separate terminal — it monitors ts/, sass/, and
+qt/aqt/data/web/ and auto-rebuilds on changes.
 
 ## Building/checking
 
@@ -80,7 +93,8 @@ though you may sometimes find it useful to view out/{pylib/anki,qt/\_aqt,ts/lib/
 ## Launcher/installer
 
 The code for our launcher is in qt/launcher, with separate code for each
-platform.
+platform. Release recipes are in the `release` just module — run
+`just --list release` to see them.
 
 ## Rust dependencies
 

--- a/justfile
+++ b/justfile
@@ -10,6 +10,22 @@ default:
 build:
     {{ ninja }} pylib qt
 
+# Build and run Anki in development mode
+run *args:
+    {{ run_script }} {{ args }}
+
+# Build and run Anki in optimized (release) mode
+run-optimized *args:
+    {{ if os() == "windows" { "$env:RELEASE='1'; .\\run.bat" } else { "RELEASE=1 ./run" } }} {{ args }}
+
+# Watch web sources and rebuild/reload Anki's web stack on change (macOS/Linux)
+web-watch:
+    ./tools/web-watch
+
+# Rebuild and reload Anki's web stack without restarting (macOS/Linux)
+rebuild-web:
+    ./tools/rebuild-web
+
 # Build wheels (needed for some platforms)
 wheels:
     {{ ninja }} wheels
@@ -154,8 +170,13 @@ docs-rust:
 ci branch:
     gh workflow run ci.yml --ref {{ branch }}
 
+# Remove build outputs from out/ (pass keep-env to keep node_modules/pyenv); macOS/Linux
+clean *args:
+    ./tools/clean {{ args }}
+
 # Helpers to get the right commands for the platform
 
 ninja := if os() == "windows" { "tools\\ninja" } else { "./ninja" }
+run_script := if os() == "windows" { ".\\run.bat" } else { "./run" }
 playwright_env := if os() == "windows" { "set PLAYWRIGHT_BROWSERS_PATH=out\\playwright-browsers&&" } else { "PLAYWRIGHT_BROWSERS_PATH=out/playwright-browsers" }
 yarn := if os() == "windows" { "out\\extracted\\node\\yarn.cmd" } else { "out/extracted/node/bin/yarn" }

--- a/tools/minilints/src/main.rs
+++ b/tools/minilints/src/main.rs
@@ -154,6 +154,7 @@ impl LintContext {
             "49699333+dependabot[bot]@users.noreply.github.com",
             "41898282+github-actions[bot]@users.noreply.github.com",
             "github-actions[bot]@users.noreply.github.com",
+            "Claude <noreply@anthropic.com>",
         ];
 
         if BOT_EMAILS.contains(&last_author.as_str())


### PR DESCRIPTION
## Linked issue

Closes #4836

## Summary/motivation

Three related housekeeping changes to improve AI-agent and developer ergonomics:

1. **justfile**: Expose `./run`, `./run.bat` (Windows), `./tools/web-watch`,
   `./tools/rebuild-web`, and `./tools/clean` as `just` recipes (`run`,
   `run-optimized`, `web-watch`, `rebuild-web`, `clean`), consistent with the
   Project convention that all commands go through `just`.

2. **CLAUDE.md**: Add a "Running Anki" section documenting `just run` and
   `just web-watch`; tighten the opening note to explicitly mention `./run`.

3. **AGENTS.md**: Add a symlink to `CLAUDE.md` so that OpenAI Codex and other
   Agents that look for `AGENTS.md` pick up the same project instructions.

## How to test

- `just run` launches Anki in dev mode (same as `./run`)
- `just run-optimized` launches with `RELEASE=1`
- `just web-watch` starts the file-watcher (macOS/Linux)
- `just clean` removes build outputs
- `AGENTS.md` resolves to the same content as `CLAUDE.md`

