### PR TITLE
fix: Preserve .tar.zst suffix of Linux release zip

### DIFF
--- a/qt/tests/test_installer.py
+++ b/qt/tests/test_installer.py
@@ -154,8 +154,8 @@ def test_signing_args(monkeypatch) -> None:
         ("win32", "ARM64", "-win-arm64"),
         ("darwin", "arm64", "-mac-apple"),
         ("darwin", "x86_64", "-mac-intel"),
-        ("linux", "x86_64", "-linux-x86_64"),
-        ("linux", "aarch64", "-linux-aarch64"),
+        ("linux", "x86_64", "-linux-x86_64.tar"),
+        ("linux", "aarch64", "-linux-aarch64.tar"),
         ("unknown", "unknown", ""),
     ],
 )

--- a/qt/tools/build_installer.py
+++ b/qt/tools/build_installer.py
@@ -219,7 +219,8 @@ def get_platform_suffix() -> str:
         platform_suffix = f"-mac-{arch}"
     elif sys.platform == "linux":
         arch = platform.machine()
-        platform_suffix = f"-linux-{arch}"
+        # Preserve .tar.zst suffix after file is renamed
+        platform_suffix = f"-linux-{arch}.tar"
     return platform_suffix
 
 


### PR DESCRIPTION
## Linked issue

Closes #4960


## Steps to reproduce (before)

The latest beta zips have only ".zst" as the suffix: https://github.com/ankitects/anki/releases/tag/26.05b2

## How to test (after)

Check the artifacts of this GHA run and confirm the suffix is preserved: https://github.com/ankitects/anki/actions/runs/27027272624