### PR TITLE
test: cover attribute and tag stripping in HTML filter

### DIFF
--- a/ts/html-filter/index.test.ts
+++ b/ts/html-filter/index.test.ts
@@ -47,4 +47,48 @@ describe("filterHTML", () => {
             ),
         ).toBe("<span style=\"background-color: transparent;\"></span>");
     });
+
+    test("event handler attributes are stripped", () => {
+        expect(filterHTML("<p onclick=\"alert(1)\">hi</p>", false, false)).toBe(
+            "<p>hi</p>",
+        );
+        expect(filterHTML("<div onclick=\"alert(1)\">hi</div>", false, false)).toBe(
+            "<div>hi</div>",
+        );
+        expect(
+            filterHTML("<img src=\"a.png\" onerror=\"alert(1)\">", false, false),
+        ).toBe("<img src=\"a.png\">");
+    });
+
+    test("script tags are removed, including in nested contexts", () => {
+        expect(filterHTML("<script></script>", false, false)).toBe("");
+        expect(
+            filterHTML("<div><script></script>hello</div>", false, false),
+        ).toBe("<div>hello</div>");
+        expect(
+            filterHTML("<div><script>alert(1)</script>hello</div>", false, false),
+        ).toBe("<div>alert(1)hello</div>");
+    });
+
+    test("unknown or disallowed tags are removed", () => {
+        expect(filterHTML("<foo></foo>", false, false)).toBe("");
+        expect(filterHTML("<foo>bar</foo>", false, false)).toBe("bar");
+        expect(filterHTML("<marquee>x</marquee>", false, false)).toBe("x");
+    });
+
+    test("span styling honours night mode", () => {
+        document.body.classList.add("nightMode");
+
+        try {
+            expect(
+                filterHTML(
+                    "<span style=\"font-weight: bold; background-color: blue;\"></span>",
+                    false,
+                    true,
+                ),
+            ).toBe("<span style=\"font-weight: bold;\"></span>");
+        } finally {
+            document.body.classList.remove("nightMode");
+        }
+    });
 });

--- a/ts/html-filter/index.test.ts
+++ b/ts/html-filter/index.test.ts
@@ -70,10 +70,28 @@ describe("filterHTML", () => {
         ).toBe("<div>alert(1)hello</div>");
     });
 
+    test("title tag is removed entirely, including its content", () => {
+        // TITLE is an explicitly allowed tag mapped to removeElement, so unlike
+        // unknown tags (which unwrap their content), the title content is discarded.
+        expect(filterHTML("<title>page title</title>", false, false)).toBe("");
+        expect(filterHTML("<title>page title</title>", false, true)).toBe("");
+    });
+
     test("unknown or disallowed tags are removed", () => {
         expect(filterHTML("<foo></foo>", false, false)).toBe("");
         expect(filterHTML("<foo>bar</foo>", false, false)).toBe("bar");
         expect(filterHTML("<marquee>x</marquee>", false, false)).toBe("x");
+    });
+
+    test("extended-only tags are unwrapped in basic mode but kept in extended mode", () => {
+        // <b> exists only in tagsAllowedExtended; in basic mode it is treated as
+        // an unknown tag and its content is unwrapped.
+        expect(filterHTML("<b>bold</b>", false, false)).toBe("bold");
+        expect(filterHTML("<b>bold</b>", false, true)).toBe("<b>bold</b>");
+
+        // <a> keeps href in extended mode; in basic mode the tag is unwrapped.
+        expect(filterHTML("<a href=\"x\">link</a>", false, false)).toBe("link");
+        expect(filterHTML("<a href=\"x\">link</a>", false, true)).toBe("<a href=\"x\">link</a>");
     });
 
     test("span styling honours night mode", () => {


### PR DESCRIPTION
## Linked issue

Closes #4929

## Summary / motivation

`ts/html-filter/element.ts` is responsible for sanitizing HTML on paste in the note editor, so it's security-sensitive code. About 8% of it wasn't covered by tests, including the branches that strip attributes and tags. This PR adds tests to get it to full coverage (statements, branches, functions, and lines) so we don't accidentally break the filtering later. There are no changes to the actual code, just tests.

## Steps to reproduce

N/A - tests only.

## How to test

### Checklist (minimum)

- [x] I ran `./ninja check` or an equivalent relevant check locally.
- [x] I added or updated tests when the change is non-trivial or behaviour changed.

### Details

Ran `just check` (the full lint and test build) and everything passed.

For coverage specifically, I scoped vitest to the target file:

`npx vitest run html-filter/index.test.ts --coverage --coverage.include='html-filter/element.ts'`

That reports element.ts at 100% for statements, branches, functions, and lines.

New tests cover:
- event handler attributes (`onclick`/`onerror`) stripped from allowed elements
- `<script>` removal, including empty and nested cases
- unknown/disallowed tags dropped (empty) or unwrapped (with content)
- `<span>` styling honouring night mode (the previously uncovered branch)

## Before / after behavior

N/A - no behaviour change, tests document existing behaviour.

## UI evidence

N/A

## Scope

- [x] This PR is focused on one change (no unrelated edits).

**Note for reviewers:** the originating issue listed "verify `<p>` → `<div>` conversion" as a criterion, but `element.ts` treats `<p>` as an allowed tag (`P: allowNone`) and preserves it, so there is no `p`→`div` conversion in this component. The tests document the actual behaviour (`<p>` kept, attributes stripped). Happy to adjust if a conversion was intended elsewhere.