### PR TITLE
fix: Repaint UI after answer reveal

### DIFF
--- a/qt/aqt/reviewer.py
+++ b/qt/aqt/reviewer.py
@@ -686,6 +686,9 @@ class Reviewer:
             play_clicked_audio(url, self.card)
         elif url.startswith("updateToolbar"):
             self.mw.toolbarWeb.update_background_image()
+        elif url == "repaintNeeded":
+            # Ensure stale frames showing previous or corrupt content are not displayed (#3668)
+            self.web.update()
         elif url == "statesMutated":
             self._states_mutated = True
         else:

--- a/ts/reviewer/index.ts
+++ b/ts/reviewer/index.ts
@@ -188,6 +188,7 @@ export function _showQuestion(q: string, a: string, bodyclass: string): void {
 
 function scrollToAnswer(): void {
     document.getElementById("answer")?.scrollIntoView();
+    bridgeCommand("repaintNeeded");
 }
 
 export function _showAnswer(a: string, bodyclass: string): void {


### PR DESCRIPTION
## Linked issue

Closes #4969

## Summary

Add a [QWidget.update()](https://doc.qt.io/qt-6/qwidget.html#update) call for the main webview after the answer is revealed and images are loaded. This should reduce UI glitches, especially on cards with images.

## How to test

It's hard to test and reproduce this, because its frequency varies between operating systems and graphics drivers.
I've seen improvements on my collection on Windows with the default video driver (Direct3D) while doing my daily reviews today with this change and I'll continue testing over the week.