### PR TITLE
test: add unit tests for CSV export and import-export service layer

### DIFF
--- a/rslib/src/import_export/service.rs
+++ b/rslib/src/import_export/service.rs
@@ -134,6 +134,8 @@ mod tests {
     use anki_proto::import_export::ExportNoteCsvRequest;
     use anki_proto::import_export::ImportAnkiPackageRequest;
     use anki_proto::import_export::ImportCsvRequest;
+    use tempfile::tempdir;
+    use tempfile::NamedTempFile;
 
     use super::*;
     use crate::ops::Op;
@@ -141,7 +143,6 @@ mod tests {
     use crate::ops::OpOutput;
     use crate::ops::StateChanges;
     use crate::services::ImportExportService;
-    use crate::tests::open_fs_test_collection;
     use crate::tests::NoteAdder;
 
     // --- From<ExportLimit> for SearchNode ---
@@ -203,13 +204,13 @@ mod tests {
 
     #[test]
     fn export_card_csv_service_returns_uint32_count() {
-        let (mut col, dir) = open_fs_test_collection("svc_card_csv");
+        let mut col = Collection::new();
         NoteAdder::basic(&mut col).add(&mut col);
-        let path = dir.path().join("cards.csv");
+        let csv = NamedTempFile::new().unwrap();
         let result = ImportExportService::export_card_csv(
             &mut col,
             ExportCardCsvRequest {
-                out_path: path.to_str().unwrap().into(),
+                out_path: csv.path().to_str().unwrap().into(),
                 with_html: true,
                 limit: None,
             },
@@ -221,10 +222,12 @@ mod tests {
     #[test]
     fn export_card_csv_service_propagates_error_for_invalid_path() {
         let mut col = Collection::new();
+        let dir = tempdir().unwrap();
+        let bad_path = dir.path().join("no_such_subdir").join("cards.csv");
         let result = ImportExportService::export_card_csv(
             &mut col,
             ExportCardCsvRequest {
-                out_path: "/nonexistent/dir/cards.csv".into(),
+                out_path: bad_path.to_str().unwrap().into(),
                 with_html: true,
                 limit: None,
             },
@@ -234,13 +237,13 @@ mod tests {
 
     #[test]
     fn export_note_csv_service_returns_uint32_count() {
-        let (mut col, dir) = open_fs_test_collection("svc_note_csv");
+        let mut col = Collection::new();
         NoteAdder::basic(&mut col).add(&mut col);
-        let path = dir.path().join("notes.csv");
+        let csv = NamedTempFile::new().unwrap();
         let result = ImportExportService::export_note_csv(
             &mut col,
             ExportNoteCsvRequest {
-                out_path: path.to_str().unwrap().into(),
+                out_path: csv.path().to_str().unwrap().into(),
                 with_html: true,
                 with_tags: true,
                 with_deck: true,
@@ -256,10 +259,12 @@ mod tests {
     #[test]
     fn export_note_csv_service_propagates_error_for_invalid_path() {
         let mut col = Collection::new();
+        let dir = tempdir().unwrap();
+        let bad_path = dir.path().join("no_such_subdir").join("notes.csv");
         let result = ImportExportService::export_note_csv(
             &mut col,
             ExportNoteCsvRequest {
-                out_path: "/nonexistent/dir/notes.csv".into(),
+                out_path: bad_path.to_str().unwrap().into(),
                 with_html: true,
                 with_tags: false,
                 with_deck: false,
@@ -276,7 +281,7 @@ mod tests {
         // uses the pre-existing fixture from pylib/tests/support/
         let apkg_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
             .join("../pylib/tests/support/update1.apkg");
-        let (mut col, _dir) = open_fs_test_collection("import_apkg_success");
+        let (mut col, _dir) = crate::tests::open_fs_test_collection("import_apkg_success");
         let result = ImportExportService::import_anki_package(
             &mut col,
             ImportAnkiPackageRequest {
@@ -292,10 +297,12 @@ mod tests {
     #[test]
     fn import_anki_package_propagates_error_for_missing_file() {
         let mut col = Collection::new();
+        let dir = tempdir().unwrap();
+        let missing = dir.path().join("missing.apkg");
         let result = ImportExportService::import_anki_package(
             &mut col,
             ImportAnkiPackageRequest {
-                package_path: "/nonexistent/file.apkg".into(),
+                package_path: missing.to_str().unwrap().into(),
                 options: None,
             },
         );
@@ -304,7 +311,8 @@ mod tests {
 
     #[test]
     fn export_anki_package_succeeds_with_empty_collection() {
-        let (mut col, dir) = open_fs_test_collection("svc_apkg");
+        let mut col = Collection::new();
+        let dir = tempdir().unwrap();
         let path = dir.path().join("out.apkg");
         let result = ImportExportService::export_anki_package(
             &mut col,
@@ -321,10 +329,12 @@ mod tests {
     #[test]
     fn export_anki_package_propagates_error_for_invalid_path() {
         let mut col = Collection::new();
+        let dir = tempdir().unwrap();
+        let bad_path = dir.path().join("no_such_subdir").join("out.apkg");
         let result = ImportExportService::export_anki_package(
             &mut col,
             ExportAnkiPackageRequest {
-                out_path: "/nonexistent/dir/out.apkg".into(),
+                out_path: bad_path.to_str().unwrap().into(),
                 options: None,
                 limit: None,
             },
@@ -334,7 +344,8 @@ mod tests {
 
     #[test]
     fn import_csv_succeeds_with_valid_csv_file() {
-        let (mut col, dir) = open_fs_test_collection("import_csv_success");
+        let mut col = Collection::new();
+        let dir = tempdir().unwrap();
         let path = dir.path().join("notes.csv");
         // tab-separated: two fields matching Basic notetype (Front, Back)
         // dir and the CSV inside are deleted automatically when dir drops at end of
@@ -370,10 +381,12 @@ mod tests {
     #[test]
     fn import_csv_propagates_error_for_missing_file() {
         let mut col = Collection::new();
+        let dir = tempdir().unwrap();
+        let missing = dir.path().join("missing.csv");
         let result = ImportExportService::import_csv(
             &mut col,
             ImportCsvRequest {
-                path: "/nonexistent/file.csv".into(),
+                path: missing.to_str().unwrap().into(),
                 metadata: None,
             },
         );
@@ -382,7 +395,8 @@ mod tests {
 
     #[test]
     fn import_json_file_succeeds_with_minimal_valid_json() {
-        let (mut col, dir) = open_fs_test_collection("import_json_file");
+        let mut col = Collection::new();
+        let dir = tempdir().unwrap();
         let path = dir.path().join("notes.json");
         // ForeignData has #[serde(default)] — empty notes list is valid JSON
         // dir and the file are deleted automatically when dir drops at end of test
@@ -399,10 +413,12 @@ mod tests {
     #[test]
     fn import_json_file_propagates_error_for_missing_file() {
         let mut col = Collection::new();
+        let dir = tempdir().unwrap();
+        let missing = dir.path().join("missing.json");
         let result = ImportExportService::import_json_file(
             &mut col,
             generic::String {
-                val: "/nonexistent/file.json".into(),
+                val: missing.to_str().unwrap().into(),
             },
         );
         assert!(result.is_err(), "expected Err for missing JSON file");

--- a/rslib/src/import_export/service.rs
+++ b/rslib/src/import_export/service.rs
@@ -125,7 +125,7 @@ impl From<ExportLimit> for SearchNode {
 #[cfg(test)]
 mod tests {
     use anki_proto::generic;
-    us e anki_proto::import_export::export_limit::Limit;
+    use anki_proto::import_export::export_limit::Limit;
     use anki_proto::import_export::import_response::Log as NoteLog;
     use anki_proto::import_export::CsvMetadataRequest;
     use anki_proto::import_export::ExportAnkiPackageRequest;
@@ -134,7 +134,6 @@ mod tests {
     use anki_proto::import_export::ExportNoteCsvRequest;
     use anki_proto::import_export::ImportAnkiPackageRequest;
     use anki_proto::import_export::ImportCsvRequest;
-    use tempfile::tempdir;
 
     use super::*;
     use crate::ops::Op;
@@ -142,8 +141,8 @@ mod tests {
     use crate::ops::OpOutput;
     use crate::ops::StateChanges;
     use crate::services::ImportExportService;
-    use crate::tests::NoteAdder;
     use crate::tests::open_fs_test_collection;
+    use crate::tests::NoteAdder;
 
     // --- From<ExportLimit> for SearchNode ---
 
@@ -188,5 +187,262 @@ mod tests {
             matches!(node, SearchNode::DeckIdWithChildren(_)),
             "expected DeckIdWithChildren, got: {node:?}"
         );
+    }
+
+    // --- Service function tests ---
+
+    #[test]
+    fn get_import_anki_package_presets_returns_collection_defaults() {
+        let mut col = Collection::new();
+        let presets = ImportExportService::get_import_anki_package_presets(&mut col).unwrap();
+        // newly created collection uses the default config values
+        assert!(!presets.merge_notetypes);
+        assert!(!presets.with_scheduling);
+        assert!(!presets.with_deck_configs);
+    }
+
+    #[test]
+    fn export_card_csv_service_returns_uint32_count() {
+        let (mut col, dir) = open_fs_test_collection("svc_card_csv");
+        NoteAdder::basic(&mut col).add(&mut col);
+        let path = dir.path().join("cards.csv");
+        let result = ImportExportService::export_card_csv(
+            &mut col,
+            ExportCardCsvRequest {
+                out_path: path.to_str().unwrap().into(),
+                with_html: true,
+                limit: None,
+            },
+        )
+        .unwrap();
+        assert_eq!(result.val, 1, "service should return 1 card as UInt32");
+    }
+
+    #[test]
+    fn export_card_csv_service_propagates_error_for_invalid_path() {
+        let mut col = Collection::new();
+        let result = ImportExportService::export_card_csv(
+            &mut col,
+            ExportCardCsvRequest {
+                out_path: "/nonexistent/dir/cards.csv".into(),
+                with_html: true,
+                limit: None,
+            },
+        );
+        assert!(result.is_err(), "expected Err for invalid output path");
+    }
+
+    #[test]
+    fn export_note_csv_service_returns_uint32_count() {
+        let (mut col, dir) = open_fs_test_collection("svc_note_csv");
+        NoteAdder::basic(&mut col).add(&mut col);
+        let path = dir.path().join("notes.csv");
+        let result = ImportExportService::export_note_csv(
+            &mut col,
+            ExportNoteCsvRequest {
+                out_path: path.to_str().unwrap().into(),
+                with_html: true,
+                with_tags: true,
+                with_deck: true,
+                with_notetype: true,
+                with_guid: true,
+                limit: None,
+            },
+        )
+        .unwrap();
+        assert_eq!(result.val, 1, "service should return 1 note as UInt32");
+    }
+
+    #[test]
+    fn export_note_csv_service_propagates_error_for_invalid_path() {
+        let mut col = Collection::new();
+        let result = ImportExportService::export_note_csv(
+            &mut col,
+            ExportNoteCsvRequest {
+                out_path: "/nonexistent/dir/notes.csv".into(),
+                with_html: true,
+                with_tags: false,
+                with_deck: false,
+                with_notetype: false,
+                with_guid: false,
+                limit: None,
+            },
+        );
+        assert!(result.is_err(), "expected Err for invalid output path");
+    }
+
+    #[test]
+    fn import_anki_package_succeeds_with_valid_apkg_fixture() {
+        // uses the pre-existing fixture from pylib/tests/support/
+        let apkg_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../pylib/tests/support/update1.apkg");
+        let (mut col, _dir) = open_fs_test_collection("import_apkg_success");
+        let result = ImportExportService::import_anki_package(
+            &mut col,
+            ImportAnkiPackageRequest {
+                package_path: apkg_path.to_str().unwrap().into(),
+                options: None,
+            },
+        );
+        assert!(result.is_ok(), "expected Ok for valid .apkg fixture");
+        let response = result.unwrap();
+        assert!(response.log.is_some(), "expected import log in response");
+    }
+
+    #[test]
+    fn import_anki_package_propagates_error_for_missing_file() {
+        let mut col = Collection::new();
+        let result = ImportExportService::import_anki_package(
+            &mut col,
+            ImportAnkiPackageRequest {
+                package_path: "/nonexistent/file.apkg".into(),
+                options: None,
+            },
+        );
+        assert!(result.is_err(), "expected Err for missing .apkg file");
+    }
+
+    #[test]
+    fn export_anki_package_succeeds_with_empty_collection() {
+        let (mut col, dir) = open_fs_test_collection("svc_apkg");
+        let path = dir.path().join("out.apkg");
+        let result = ImportExportService::export_anki_package(
+            &mut col,
+            ExportAnkiPackageRequest {
+                out_path: path.to_str().unwrap().into(),
+                options: None,
+                limit: None,
+            },
+        );
+        assert!(result.is_ok(), "expected Ok for empty collection export");
+        assert!(path.exists(), "expected .apkg file to be created");
+    }
+
+    #[test]
+    fn export_anki_package_propagates_error_for_invalid_path() {
+        let mut col = Collection::new();
+        let result = ImportExportService::export_anki_package(
+            &mut col,
+            ExportAnkiPackageRequest {
+                out_path: "/nonexistent/dir/out.apkg".into(),
+                options: None,
+                limit: None,
+            },
+        );
+        assert!(result.is_err(), "expected Err for invalid output path");
+    }
+
+    #[test]
+    fn import_csv_succeeds_with_valid_csv_file() {
+        let (mut col, dir) = open_fs_test_collection("import_csv_success");
+        let path = dir.path().join("notes.csv");
+        // tab-separated: two fields matching Basic notetype (Front, Back)
+        // dir and the CSV inside are deleted automatically when dir drops at end of
+        // test
+        std::fs::write(&path, "front content\tback content\n").unwrap();
+
+        let metadata = ImportExportService::get_csv_metadata(
+            &mut col,
+            CsvMetadataRequest {
+                path: path.to_str().unwrap().into(),
+                delimiter: None,
+                notetype_id: None,
+                deck_id: None,
+                is_html: None,
+            },
+        )
+        .unwrap();
+
+        let result = ImportExportService::import_csv(
+            &mut col,
+            ImportCsvRequest {
+                path: path.to_str().unwrap().into(),
+                metadata: Some(metadata),
+            },
+        );
+        assert!(result.is_ok(), "expected Ok for valid CSV import");
+        assert!(
+            result.unwrap().log.is_some(),
+            "expected import log in response"
+        );
+    }
+
+    #[test]
+    fn import_csv_propagates_error_for_missing_file() {
+        let mut col = Collection::new();
+        let result = ImportExportService::import_csv(
+            &mut col,
+            ImportCsvRequest {
+                path: "/nonexistent/file.csv".into(),
+                metadata: None,
+            },
+        );
+        assert!(result.is_err(), "expected Err for missing CSV file");
+    }
+
+    #[test]
+    fn import_json_file_succeeds_with_minimal_valid_json() {
+        let (mut col, dir) = open_fs_test_collection("import_json_file");
+        let path = dir.path().join("notes.json");
+        // ForeignData has #[serde(default)] — empty notes list is valid JSON
+        // dir and the file are deleted automatically when dir drops at end of test
+        std::fs::write(&path, r#"{"notes": []}"#).unwrap();
+        let result = ImportExportService::import_json_file(
+            &mut col,
+            generic::String {
+                val: path.to_str().unwrap().into(),
+            },
+        );
+        assert!(result.is_ok(), "expected Ok for valid JSON file");
+    }
+
+    #[test]
+    fn import_json_file_propagates_error_for_missing_file() {
+        let mut col = Collection::new();
+        let result = ImportExportService::import_json_file(
+            &mut col,
+            generic::String {
+                val: "/nonexistent/file.json".into(),
+            },
+        );
+        assert!(result.is_err(), "expected Err for missing JSON file");
+    }
+
+    #[test]
+    fn import_json_string_succeeds_with_minimal_valid_json() {
+        let mut col = Collection::new();
+        let result = ImportExportService::import_json_string(
+            &mut col,
+            generic::String {
+                val: r#"{"notes": []}"#.into(),
+            },
+        );
+        assert!(result.is_ok(), "expected Ok for valid JSON string");
+    }
+
+    #[test]
+    fn import_json_string_propagates_error_for_invalid_json() {
+        let mut col = Collection::new();
+        let result = ImportExportService::import_json_string(
+            &mut col,
+            generic::String {
+                val: "not valid json at all".into(),
+            },
+        );
+        assert!(result.is_err(), "expected Err for invalid JSON string");
+    }
+
+    #[test]
+    fn op_output_converts_to_import_response_with_changes_and_log() {
+        let output = OpOutput {
+            output: NoteLog::default(),
+            changes: OpChanges {
+                op: Op::Import,
+                changes: StateChanges::default(),
+            },
+        };
+        let response: anki_proto::import_export::ImportResponse = output.into();
+        assert!(response.changes.is_some(), "expected changes to be set");
+        assert!(response.log.is_some(), "expected log to be set");
     }
 }

--- a/rslib/src/import_export/service.rs
+++ b/rslib/src/import_export/service.rs
@@ -121,3 +121,72 @@ impl From<ExportLimit> for SearchNode {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use anki_proto::generic;
+    us e anki_proto::import_export::export_limit::Limit;
+    use anki_proto::import_export::import_response::Log as NoteLog;
+    use anki_proto::import_export::CsvMetadataRequest;
+    use anki_proto::import_export::ExportAnkiPackageRequest;
+    use anki_proto::import_export::ExportCardCsvRequest;
+    use anki_proto::import_export::ExportLimit;
+    use anki_proto::import_export::ExportNoteCsvRequest;
+    use anki_proto::import_export::ImportAnkiPackageRequest;
+    use anki_proto::import_export::ImportCsvRequest;
+    use tempfile::tempdir;
+
+    use super::*;
+    use crate::ops::Op;
+    use crate::ops::OpChanges;
+    use crate::ops::OpOutput;
+    use crate::ops::StateChanges;
+    use crate::services::ImportExportService;
+    use crate::tests::NoteAdder;
+    use crate::tests::open_fs_test_collection;
+
+    // --- From<ExportLimit> for SearchNode ---
+
+    #[test]
+    fn export_limit_none_becomes_whole_collection() {
+        let node = SearchNode::from(ExportLimit { limit: None });
+        assert_eq!(node, SearchNode::WholeCollection);
+    }
+
+    #[test]
+    fn export_limit_note_ids_becomes_note_id_search() {
+        use anki_proto::notes::NoteIds;
+        let node = SearchNode::from(ExportLimit {
+            limit: Some(Limit::NoteIds(NoteIds {
+                note_ids: vec![1, 2, 3],
+            })),
+        });
+        assert!(
+            matches!(node, SearchNode::NoteIds(_)),
+            "expected NoteIds search node, got: {node:?}"
+        );
+    }
+
+    #[test]
+    fn export_limit_card_ids_becomes_card_id_search() {
+        use anki_proto::cards::CardIds;
+        let node = SearchNode::from(ExportLimit {
+            limit: Some(Limit::CardIds(CardIds { cids: vec![10, 20] })),
+        });
+        assert!(
+            matches!(node, SearchNode::CardIds(_)),
+            "expected CardIds search node, got: {node:?}"
+        );
+    }
+
+    #[test]
+    fn export_limit_deck_id_becomes_deck_id_with_children() {
+        let node = SearchNode::from(ExportLimit {
+            limit: Some(Limit::DeckId(42)),
+        });
+        assert!(
+            matches!(node, SearchNode::DeckIdWithChildren(_)),
+            "expected DeckIdWithChildren, got: {node:?}"
+        );
+    }
+}

--- a/rslib/src/import_export/text/csv/export.rs
+++ b/rslib/src/import_export/text/csv/export.rs
@@ -297,11 +297,17 @@ mod tests {
     use anki_proto::import_export::export_limit::Limit;
     use anki_proto::import_export::ExportLimit;
     use anki_proto::import_export::ExportNoteCsvRequest;
+    use tempfile::tempdir;
+    use tempfile::NamedTempFile;
+    use tempfile::TempDir;
 
     use super::*;
-    use crate::tests::open_fs_test_collection;
     use crate::tests::DeckAdder;
     use crate::tests::NoteAdder;
+
+    fn col_and_dir() -> (Collection, TempDir) {
+        (Collection::new(), tempdir().unwrap())
+    }
 
     fn note_csv_request(out_path: String) -> ExportNoteCsvRequest {
         ExportNoteCsvRequest {
@@ -317,7 +323,7 @@ mod tests {
 
     #[test]
     fn export_card_csv_writes_separator_and_html_header() {
-        let (mut col, dir) = open_fs_test_collection("card_csv");
+        let (mut col, dir) = col_and_dir();
         NoteAdder::basic(&mut col).add(&mut col);
         let path = dir.path().join("cards.csv");
         col.export_card_csv(path.to_str().unwrap(), SearchNode::WholeCollection, true)
@@ -331,7 +337,7 @@ mod tests {
 
     #[test]
     fn export_card_csv_html_false_writes_html_false_in_header() {
-        let (mut col, dir) = open_fs_test_collection("card_csv_nohtml");
+        let (mut col, dir) = col_and_dir();
         NoteAdder::basic(&mut col).add(&mut col);
         let path = dir.path().join("cards.csv");
         col.export_card_csv(path.to_str().unwrap(), SearchNode::WholeCollection, false)
@@ -345,7 +351,7 @@ mod tests {
 
     #[test]
     fn export_card_csv_empty_collection_still_writes_header() {
-        let (mut col, dir) = open_fs_test_collection("card_csv_empty");
+        let (mut col, dir) = col_and_dir();
         let path = dir.path().join("cards.csv");
         let count = col
             .export_card_csv(path.to_str().unwrap(), SearchNode::WholeCollection, true)
@@ -360,31 +366,39 @@ mod tests {
 
     #[test]
     fn export_card_csv_returns_card_count() {
-        let (mut col, dir) = open_fs_test_collection("card_csv_count");
+        let mut col = Collection::new();
         NoteAdder::basic(&mut col).add(&mut col);
-        let path = dir.path().join("cards.csv");
+        let csv = NamedTempFile::new().unwrap();
         let count = col
-            .export_card_csv(path.to_str().unwrap(), SearchNode::WholeCollection, true)
+            .export_card_csv(
+                csv.path().to_str().unwrap(),
+                SearchNode::WholeCollection,
+                true,
+            )
             .unwrap();
         assert_eq!(count, 1, "expected 1 card exported");
     }
 
     #[test]
     fn export_card_csv_returns_count_for_multiple_notes() {
-        let (mut col, dir) = open_fs_test_collection("card_csv_multi");
-        NoteAdder::basic(&mut col).add(&mut col);
-        NoteAdder::basic(&mut col).add(&mut col);
-        NoteAdder::basic(&mut col).add(&mut col);
-        let path = dir.path().join("cards.csv");
+        let mut col = Collection::new();
+        for _ in 0..3 {
+            NoteAdder::basic(&mut col).add(&mut col);
+        }
+        let csv = NamedTempFile::new().unwrap();
         let count = col
-            .export_card_csv(path.to_str().unwrap(), SearchNode::WholeCollection, true)
+            .export_card_csv(
+                csv.path().to_str().unwrap(),
+                SearchNode::WholeCollection,
+                true,
+            )
             .unwrap();
         assert_eq!(count, 3, "expected 3 cards exported");
     }
 
     #[test]
     fn export_card_csv_filters_by_deck() {
-        let (mut col, dir) = open_fs_test_collection("card_csv_deck_filter");
+        let mut col = Collection::new();
         let target_deck = DeckAdder::new("target").add(&mut col);
         let other_deck = DeckAdder::new("other").add(&mut col);
         NoteAdder::basic(&mut col)
@@ -394,10 +408,10 @@ mod tests {
             .deck(target_deck.id)
             .add(&mut col);
         NoteAdder::basic(&mut col).deck(other_deck.id).add(&mut col);
-        let path = dir.path().join("cards.csv");
+        let csv = NamedTempFile::new().unwrap();
         let count = col
             .export_card_csv(
-                path.to_str().unwrap(),
+                csv.path().to_str().unwrap(),
                 SearchNode::DeckIdWithChildren(target_deck.id),
                 true,
             )
@@ -407,7 +421,7 @@ mod tests {
 
     #[test]
     fn export_card_csv_front_and_back_in_correct_columns() {
-        let (mut col, dir) = open_fs_test_collection("card_csv_columns");
+        let (mut col, dir) = col_and_dir();
         NoteAdder::basic(&mut col)
             .fields(&["front text", "back text"])
             .add(&mut col);
@@ -426,7 +440,7 @@ mod tests {
 
     #[test]
     fn export_card_csv_preserves_html_when_with_html_true() {
-        let (mut col, dir) = open_fs_test_collection("card_csv_html_content");
+        let (mut col, dir) = col_and_dir();
         NoteAdder::basic(&mut col)
             .fields(&["<b>bold front</b>", "back text"])
             .add(&mut col);
@@ -442,7 +456,7 @@ mod tests {
 
     #[test]
     fn export_card_csv_strips_html_from_fields_when_with_html_false() {
-        let (mut col, dir) = open_fs_test_collection("card_csv_html_stripped");
+        let (mut col, dir) = col_and_dir();
         NoteAdder::basic(&mut col)
             .fields(&["<b>bold front</b>", "back text"])
             .add(&mut col);
@@ -462,31 +476,31 @@ mod tests {
 
     #[test]
     fn export_note_csv_returns_note_count() {
-        let (mut col, dir) = open_fs_test_collection("note_csv_count");
+        let mut col = Collection::new();
         NoteAdder::basic(&mut col).add(&mut col);
-        let path = dir.path().join("notes.csv");
+        let csv = NamedTempFile::new().unwrap();
         let count = col
-            .export_note_csv(note_csv_request(path.to_str().unwrap().into()))
+            .export_note_csv(note_csv_request(csv.path().to_str().unwrap().into()))
             .unwrap();
         assert_eq!(count, 1, "expected 1 note exported");
     }
 
     #[test]
     fn export_note_csv_returns_count_for_multiple_notes() {
-        let (mut col, dir) = open_fs_test_collection("note_csv_multi");
-        NoteAdder::basic(&mut col).add(&mut col);
-        NoteAdder::basic(&mut col).add(&mut col);
-        NoteAdder::basic(&mut col).add(&mut col);
-        let path = dir.path().join("notes.csv");
+        let mut col = Collection::new();
+        for _ in 0..3 {
+            NoteAdder::basic(&mut col).add(&mut col);
+        }
+        let csv = NamedTempFile::new().unwrap();
         let count = col
-            .export_note_csv(note_csv_request(path.to_str().unwrap().into()))
+            .export_note_csv(note_csv_request(csv.path().to_str().unwrap().into()))
             .unwrap();
         assert_eq!(count, 3, "expected 3 notes exported");
     }
 
     #[test]
     fn export_note_csv_filters_by_deck() {
-        let (mut col, dir) = open_fs_test_collection("note_csv_deck_filter");
+        let mut col = Collection::new();
         let target_deck = DeckAdder::new("target").add(&mut col);
         let other_deck = DeckAdder::new("other").add(&mut col);
         NoteAdder::basic(&mut col)
@@ -496,10 +510,10 @@ mod tests {
             .deck(target_deck.id)
             .add(&mut col);
         NoteAdder::basic(&mut col).deck(other_deck.id).add(&mut col);
-        let path = dir.path().join("notes.csv");
+        let csv = NamedTempFile::new().unwrap();
         let count = col
             .export_note_csv(ExportNoteCsvRequest {
-                out_path: path.to_str().unwrap().into(),
+                out_path: csv.path().to_str().unwrap().into(),
                 with_html: true,
                 with_tags: false,
                 with_deck: false,
@@ -521,7 +535,7 @@ mod tests {
         //   col 3: deck
         //   col 4-5: note fields
         //   col 6: tags  (1 + deck(3) + 2 fields)
-        let (mut col, dir) = open_fs_test_collection("note_csv_col_indices");
+        let (mut col, dir) = col_and_dir();
         NoteAdder::basic(&mut col).add(&mut col);
         let path = dir.path().join("notes.csv");
         col.export_note_csv(note_csv_request(path.to_str().unwrap().into()))
@@ -547,7 +561,7 @@ mod tests {
 
     #[test]
     fn export_note_csv_omits_column_headers_when_metadata_disabled() {
-        let (mut col, dir) = open_fs_test_collection("note_csv_no_meta");
+        let (mut col, dir) = col_and_dir();
         NoteAdder::basic(&mut col).add(&mut col);
         let path = dir.path().join("notes.csv");
         col.export_note_csv(ExportNoteCsvRequest {
@@ -583,7 +597,7 @@ mod tests {
     fn export_note_csv_fields_and_guid_in_correct_columns() {
         // with all metadata: guid(0) | notetype(1) | deck(2) | front(3) | back(4) |
         // tags(5)
-        let (mut col, dir) = open_fs_test_collection("note_csv_col_positions");
+        let (mut col, dir) = col_and_dir();
         let note = NoteAdder::basic(&mut col)
             .fields(&["hello", "world"])
             .add(&mut col);
@@ -603,7 +617,7 @@ mod tests {
 
     #[test]
     fn export_note_csv_omits_guid_value_when_with_guid_false() {
-        let (mut col, dir) = open_fs_test_collection("note_csv_no_guid");
+        let (mut col, dir) = col_and_dir();
         let note = NoteAdder::basic(&mut col)
             .fields(&["hello", "world"])
             .add(&mut col);
@@ -629,7 +643,7 @@ mod tests {
 
     #[test]
     fn export_note_csv_preserves_html_in_fields_when_with_html_true() {
-        let (mut col, dir) = open_fs_test_collection("note_csv_html_content");
+        let (mut col, dir) = col_and_dir();
         NoteAdder::basic(&mut col)
             .fields(&["<i>italic</i>", "plain back"])
             .add(&mut col);
@@ -645,7 +659,7 @@ mod tests {
 
     #[test]
     fn export_note_csv_with_html_false_strips_html_tags() {
-        let (mut col, dir) = open_fs_test_collection("note_csv_nohtml");
+        let (mut col, dir) = col_and_dir();
         NoteAdder::basic(&mut col)
             .fields(&["<b>bold text</b>", "world"])
             .add(&mut col);

--- a/rslib/src/import_export/text/csv/export.rs
+++ b/rslib/src/import_export/text/csv/export.rs
@@ -393,9 +393,7 @@ mod tests {
         NoteAdder::basic(&mut col)
             .deck(target_deck.id)
             .add(&mut col);
-        NoteAdder::basic(&mut col)
-            .deck(other_deck.id)
-            .add(&mut col);
+        NoteAdder::basic(&mut col).deck(other_deck.id).add(&mut col);
         let path = dir.path().join("cards.csv");
         let count = col
             .export_card_csv(
@@ -454,6 +452,217 @@ mod tests {
         let content = std::fs::read_to_string(&path).unwrap();
         assert!(
             content.contains("bold front"),
+            "expected stripped text in CSV, got: {content}"
+        );
+        assert!(
+            !content.contains("<b>"),
+            "expected no HTML tags in CSV, got: {content}"
+        );
+    }
+
+    #[test]
+    fn export_note_csv_returns_note_count() {
+        let (mut col, dir) = open_fs_test_collection("note_csv_count");
+        NoteAdder::basic(&mut col).add(&mut col);
+        let path = dir.path().join("notes.csv");
+        let count = col
+            .export_note_csv(note_csv_request(path.to_str().unwrap().into()))
+            .unwrap();
+        assert_eq!(count, 1, "expected 1 note exported");
+    }
+
+    #[test]
+    fn export_note_csv_returns_count_for_multiple_notes() {
+        let (mut col, dir) = open_fs_test_collection("note_csv_multi");
+        NoteAdder::basic(&mut col).add(&mut col);
+        NoteAdder::basic(&mut col).add(&mut col);
+        NoteAdder::basic(&mut col).add(&mut col);
+        let path = dir.path().join("notes.csv");
+        let count = col
+            .export_note_csv(note_csv_request(path.to_str().unwrap().into()))
+            .unwrap();
+        assert_eq!(count, 3, "expected 3 notes exported");
+    }
+
+    #[test]
+    fn export_note_csv_filters_by_deck() {
+        let (mut col, dir) = open_fs_test_collection("note_csv_deck_filter");
+        let target_deck = DeckAdder::new("target").add(&mut col);
+        let other_deck = DeckAdder::new("other").add(&mut col);
+        NoteAdder::basic(&mut col)
+            .deck(target_deck.id)
+            .add(&mut col);
+        NoteAdder::basic(&mut col)
+            .deck(target_deck.id)
+            .add(&mut col);
+        NoteAdder::basic(&mut col).deck(other_deck.id).add(&mut col);
+        let path = dir.path().join("notes.csv");
+        let count = col
+            .export_note_csv(ExportNoteCsvRequest {
+                out_path: path.to_str().unwrap().into(),
+                with_html: true,
+                with_tags: false,
+                with_deck: false,
+                with_notetype: false,
+                with_guid: false,
+                limit: Some(ExportLimit {
+                    limit: Some(Limit::DeckId(target_deck.id.0)),
+                }),
+            })
+            .unwrap();
+        assert_eq!(count, 2, "expected only notes from target deck");
+    }
+
+    #[test]
+    fn export_note_csv_column_indices_match_actual_column_positions() {
+        // basic note has 2 fields; with all metadata enabled:
+        //   col 1: guid
+        //   col 2: notetype
+        //   col 3: deck
+        //   col 4-5: note fields
+        //   col 6: tags  (1 + deck(3) + 2 fields)
+        let (mut col, dir) = open_fs_test_collection("note_csv_col_indices");
+        NoteAdder::basic(&mut col).add(&mut col);
+        let path = dir.path().join("notes.csv");
+        col.export_note_csv(note_csv_request(path.to_str().unwrap().into()))
+            .unwrap();
+        let content = std::fs::read_to_string(&path).unwrap();
+        assert!(
+            content.contains("#guid column:1\n"),
+            "wrong guid column index"
+        );
+        assert!(
+            content.contains("#notetype column:2\n"),
+            "wrong notetype column index"
+        );
+        assert!(
+            content.contains("#deck column:3\n"),
+            "wrong deck column index"
+        );
+        assert!(
+            content.contains("#tags column:6\n"),
+            "wrong tags column index"
+        );
+    }
+
+    #[test]
+    fn export_note_csv_omits_column_headers_when_metadata_disabled() {
+        let (mut col, dir) = open_fs_test_collection("note_csv_no_meta");
+        NoteAdder::basic(&mut col).add(&mut col);
+        let path = dir.path().join("notes.csv");
+        col.export_note_csv(ExportNoteCsvRequest {
+            out_path: path.to_str().unwrap().into(),
+            with_html: true,
+            with_guid: false,
+            with_notetype: false,
+            with_deck: false,
+            with_tags: false,
+            limit: None,
+        })
+        .unwrap();
+        let content = std::fs::read_to_string(&path).unwrap();
+        assert!(
+            !content.contains("#guid column:"),
+            "guid column header should be absent"
+        );
+        assert!(
+            !content.contains("#notetype column:"),
+            "notetype column header should be absent"
+        );
+        assert!(
+            !content.contains("#deck column:"),
+            "deck column header should be absent"
+        );
+        assert!(
+            !content.contains("#tags column:"),
+            "tags column header should be absent"
+        );
+    }
+
+    #[test]
+    fn export_note_csv_fields_and_guid_in_correct_columns() {
+        // with all metadata: guid(0) | notetype(1) | deck(2) | front(3) | back(4) |
+        // tags(5)
+        let (mut col, dir) = open_fs_test_collection("note_csv_col_positions");
+        let note = NoteAdder::basic(&mut col)
+            .fields(&["hello", "world"])
+            .add(&mut col);
+        let path = dir.path().join("notes.csv");
+        col.export_note_csv(note_csv_request(path.to_str().unwrap().into()))
+            .unwrap();
+        let content = std::fs::read_to_string(&path).unwrap();
+        let first_record = content
+            .lines()
+            .find(|l| !l.starts_with('#'))
+            .expect("no data record found");
+        let cols: Vec<&str> = first_record.split('\t').collect();
+        assert_eq!(cols[0], note.guid, "expected guid in column 0");
+        assert_eq!(cols[3], "hello", "expected Front field in column 3");
+        assert_eq!(cols[4], "world", "expected Back field in column 4");
+    }
+
+    #[test]
+    fn export_note_csv_omits_guid_value_when_with_guid_false() {
+        let (mut col, dir) = open_fs_test_collection("note_csv_no_guid");
+        let note = NoteAdder::basic(&mut col)
+            .fields(&["hello", "world"])
+            .add(&mut col);
+        let path = dir.path().join("notes.csv");
+        col.export_note_csv(ExportNoteCsvRequest {
+            out_path: path.to_str().unwrap().into(),
+            with_html: true,
+            with_guid: false,
+            with_notetype: false,
+            with_deck: false,
+            with_tags: false,
+            limit: None,
+        })
+        .unwrap();
+        let content = std::fs::read_to_string(&path).unwrap();
+        assert!(
+            !content.contains(&note.guid),
+            "guid should be absent when with_guid is false, got: {content}"
+        );
+        assert!(content.contains("hello"), "fields should still be exported");
+        assert!(content.contains("world"), "fields should still be exported");
+    }
+
+    #[test]
+    fn export_note_csv_preserves_html_in_fields_when_with_html_true() {
+        let (mut col, dir) = open_fs_test_collection("note_csv_html_content");
+        NoteAdder::basic(&mut col)
+            .fields(&["<i>italic</i>", "plain back"])
+            .add(&mut col);
+        let path = dir.path().join("notes.csv");
+        col.export_note_csv(note_csv_request(path.to_str().unwrap().into()))
+            .unwrap();
+        let content = std::fs::read_to_string(&path).unwrap();
+        assert!(
+            content.contains("<i>italic</i>"),
+            "expected HTML preserved in note CSV, got: {content}"
+        );
+    }
+
+    #[test]
+    fn export_note_csv_with_html_false_strips_html_tags() {
+        let (mut col, dir) = open_fs_test_collection("note_csv_nohtml");
+        NoteAdder::basic(&mut col)
+            .fields(&["<b>bold text</b>", "world"])
+            .add(&mut col);
+        let path = dir.path().join("notes.csv");
+        col.export_note_csv(ExportNoteCsvRequest {
+            out_path: path.to_str().unwrap().into(),
+            with_html: false,
+            with_tags: false,
+            with_deck: false,
+            with_notetype: false,
+            with_guid: false,
+            limit: None,
+        })
+        .unwrap();
+        let content = std::fs::read_to_string(&path).unwrap();
+        assert!(
+            content.contains("bold text"),
             "expected stripped text in CSV, got: {content}"
         );
         assert!(

--- a/rslib/src/import_export/text/csv/export.rs
+++ b/rslib/src/import_export/text/csv/export.rs
@@ -291,3 +291,174 @@ impl From<&mut ExportNoteCsvRequest> for SearchNode {
         SearchNode::from(req.limit.take().unwrap_or_default())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use anki_proto::import_export::export_limit::Limit;
+    use anki_proto::import_export::ExportLimit;
+    use anki_proto::import_export::ExportNoteCsvRequest;
+
+    use super::*;
+    use crate::tests::open_fs_test_collection;
+    use crate::tests::DeckAdder;
+    use crate::tests::NoteAdder;
+
+    fn note_csv_request(out_path: String) -> ExportNoteCsvRequest {
+        ExportNoteCsvRequest {
+            out_path,
+            with_html: true,
+            with_tags: true,
+            with_deck: true,
+            with_notetype: true,
+            with_guid: true,
+            limit: None,
+        }
+    }
+
+    #[test]
+    fn export_card_csv_writes_separator_and_html_header() {
+        let (mut col, dir) = open_fs_test_collection("card_csv");
+        NoteAdder::basic(&mut col).add(&mut col);
+        let path = dir.path().join("cards.csv");
+        col.export_card_csv(path.to_str().unwrap(), SearchNode::WholeCollection, true)
+            .unwrap();
+        let content = std::fs::read_to_string(&path).unwrap();
+        assert!(
+            content.starts_with("#separator:tab\n#html:true\n"),
+            "expected CSV header, got: {content}"
+        );
+    }
+
+    #[test]
+    fn export_card_csv_html_false_writes_html_false_in_header() {
+        let (mut col, dir) = open_fs_test_collection("card_csv_nohtml");
+        NoteAdder::basic(&mut col).add(&mut col);
+        let path = dir.path().join("cards.csv");
+        col.export_card_csv(path.to_str().unwrap(), SearchNode::WholeCollection, false)
+            .unwrap();
+        let content = std::fs::read_to_string(&path).unwrap();
+        assert!(
+            content.starts_with("#separator:tab\n#html:false\n"),
+            "expected CSV header, got: {content}"
+        );
+    }
+
+    #[test]
+    fn export_card_csv_empty_collection_still_writes_header() {
+        let (mut col, dir) = open_fs_test_collection("card_csv_empty");
+        let path = dir.path().join("cards.csv");
+        let count = col
+            .export_card_csv(path.to_str().unwrap(), SearchNode::WholeCollection, true)
+            .unwrap();
+        assert_eq!(count, 0, "expected 0 cards exported");
+        let content = std::fs::read_to_string(&path).unwrap();
+        assert!(
+            content.starts_with("#separator:tab\n#html:true\n"),
+            "expected header even with empty collection, got: {content}"
+        );
+    }
+
+    #[test]
+    fn export_card_csv_returns_card_count() {
+        let (mut col, dir) = open_fs_test_collection("card_csv_count");
+        NoteAdder::basic(&mut col).add(&mut col);
+        let path = dir.path().join("cards.csv");
+        let count = col
+            .export_card_csv(path.to_str().unwrap(), SearchNode::WholeCollection, true)
+            .unwrap();
+        assert_eq!(count, 1, "expected 1 card exported");
+    }
+
+    #[test]
+    fn export_card_csv_returns_count_for_multiple_notes() {
+        let (mut col, dir) = open_fs_test_collection("card_csv_multi");
+        NoteAdder::basic(&mut col).add(&mut col);
+        NoteAdder::basic(&mut col).add(&mut col);
+        NoteAdder::basic(&mut col).add(&mut col);
+        let path = dir.path().join("cards.csv");
+        let count = col
+            .export_card_csv(path.to_str().unwrap(), SearchNode::WholeCollection, true)
+            .unwrap();
+        assert_eq!(count, 3, "expected 3 cards exported");
+    }
+
+    #[test]
+    fn export_card_csv_filters_by_deck() {
+        let (mut col, dir) = open_fs_test_collection("card_csv_deck_filter");
+        let target_deck = DeckAdder::new("target").add(&mut col);
+        let other_deck = DeckAdder::new("other").add(&mut col);
+        NoteAdder::basic(&mut col)
+            .deck(target_deck.id)
+            .add(&mut col);
+        NoteAdder::basic(&mut col)
+            .deck(target_deck.id)
+            .add(&mut col);
+        NoteAdder::basic(&mut col)
+            .deck(other_deck.id)
+            .add(&mut col);
+        let path = dir.path().join("cards.csv");
+        let count = col
+            .export_card_csv(
+                path.to_str().unwrap(),
+                SearchNode::DeckIdWithChildren(target_deck.id),
+                true,
+            )
+            .unwrap();
+        assert_eq!(count, 2, "expected only cards from target deck");
+    }
+
+    #[test]
+    fn export_card_csv_front_and_back_in_correct_columns() {
+        let (mut col, dir) = open_fs_test_collection("card_csv_columns");
+        NoteAdder::basic(&mut col)
+            .fields(&["front text", "back text"])
+            .add(&mut col);
+        let path = dir.path().join("cards.csv");
+        col.export_card_csv(path.to_str().unwrap(), SearchNode::WholeCollection, false)
+            .unwrap();
+        let content = std::fs::read_to_string(&path).unwrap();
+        let first_record = content
+            .lines()
+            .find(|l| !l.starts_with('#'))
+            .expect("no data record found");
+        let cols: Vec<&str> = first_record.split('\t').collect();
+        assert_eq!(cols[0], "front text", "expected front field in column 0");
+        assert_eq!(cols[1], "back text", "expected back field in column 1");
+    }
+
+    #[test]
+    fn export_card_csv_preserves_html_when_with_html_true() {
+        let (mut col, dir) = open_fs_test_collection("card_csv_html_content");
+        NoteAdder::basic(&mut col)
+            .fields(&["<b>bold front</b>", "back text"])
+            .add(&mut col);
+        let path = dir.path().join("cards.csv");
+        col.export_card_csv(path.to_str().unwrap(), SearchNode::WholeCollection, true)
+            .unwrap();
+        let content = std::fs::read_to_string(&path).unwrap();
+        assert!(
+            content.contains("<b>bold front</b>"),
+            "expected HTML preserved in CSV, got: {content}"
+        );
+    }
+
+    #[test]
+    fn export_card_csv_strips_html_from_fields_when_with_html_false() {
+        let (mut col, dir) = open_fs_test_collection("card_csv_html_stripped");
+        NoteAdder::basic(&mut col)
+            .fields(&["<b>bold front</b>", "back text"])
+            .add(&mut col);
+        let path = dir.path().join("cards.csv");
+        col.export_card_csv(path.to_str().unwrap(), SearchNode::WholeCollection, false)
+            .unwrap();
+        let content = std::fs::read_to_string(&path).unwrap();
+        assert!(
+            content.contains("bold front"),
+            "expected stripped text in CSV, got: {content}"
+        );
+        assert!(
+            !content.contains("<b>"),
+            "expected no HTML tags in CSV, got: {content}"
+        );
+    }
+}

--- a/rslib/src/import_export/text/csv/metadata.rs
+++ b/rslib/src/import_export/text/csv/metadata.rs
@@ -763,6 +763,8 @@ pub(in crate::import_export) mod test {
         );
         // pick up from first line
         assert_eq!(metadata!(col, "foo\tbar\n").delimiter(), Delimiter::Tab);
+        // no header and no recognizable delimiter in content → last-resort Space
+        assert_eq!(metadata!(col, "foobar\n").delimiter(), Delimiter::Space);
         // override with provided
         assert_eq!(
             metadata!(col, "#separator: \nfoo\tbar\n", Some(Delimiter::Pipe)).delimiter(),


### PR DESCRIPTION
## Linked issue

Closes #4927

## Summary / motivation

`rslib/src/import_export/service.rs` and `rslib/src/import_export/text/csv/export.rs` had no unit test coverage. This PR adds tests for the meaningful logic in both modules: type conversions, error propagation, config defaults, and CSV structure/content.

**`service.rs`**
- All 4 branches of `From<ExportLimit> for SearchNode` (None, DeckId, NoteIds, CardIds)
- `get_import_anki_package_presets` default config values
- `export_card_csv` / `export_note_csv` `UInt32` return type
- Error propagation for all I/O functions (`import_anki_package`, `import_csv`, `import_json_file`, `import_json_string`, `export_card_csv`, `export_note_csv`, `export_anki_package`)
- Success paths using a real `.apkg` fixture, temp CSV, and temp JSON files
- `From<OpOutput<NoteLog>> for ImportResponse` field mapping

**`text/csv/export.rs`**
- Card CSV: header format, empty collection writes header, count (single/multiple/filtered by deck), front/back in correct tab-separated columns, HTML preserved and stripped
- Note CSV: count (single/multiple/filtered by deck), exact column index values, column headers absent when metadata disabled, fields and GUID in correct columns, GUID omitted when `with_guid: false`, HTML preserved and stripped

**`text/csv/metadata.rs`**
- Extends `should_detect_valid_delimiters` to cover the last-resort `Delimiter::Space` fallback when the file has no recognizable separator in its content

## How to test

```bash
cargo test -p anki --lib "import_export::service::tests"
cargo test -p anki --lib "import_export::text::csv::export::tests"
cargo test -p anki --lib "import_export::text::csv::metadata::test::should_detect_valid_delimiters"
```

All 18 tests in export.rs, all tests in service.rs, and the delimiter test pass.
