### PR TITLE
chore(ci): use pull_request_target to fix write perms on fork PRs

### DIFF
--- a/.github/workflows/check-linked-issue.yml
+++ b/.github/workflows/check-linked-issue.yml
@@ -1,7 +1,7 @@
 name: Check Linked Issue
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, edited]
 
 jobs:


### PR DESCRIPTION
## Summary / motivation

The `check-linked-issue` workflow was triggering with the `pull_request` event. This caused the step "Apply missing-issue label and comment" to fail with:

> HttpError: Resource not accessible by integration

Switching to `pull_request_target` makes the workflow run in the context of the base repository instead of the fork, so the declared write permissions are honoured.

The change is safe because this workflow never checks out PR code. It only reads PR metadata (body, labels) through the API. There is no risk of running untrusted code with elevated permissions.

## Steps to reproduce

1. Open a PR from an external fork that has no linked issue.
2. Observe the "Check Linked Issue" CI job failing with
   `HttpError: Resource not accessible by integration`.

## Before / after behavior

**Before:** workflow crashes on every fork PR that lacks a linked issue.  
**After:** workflow applies the label and posts the comment as intended.
