### PR TITLE
Rerun check-linked-issue.yml on `labeled` event

### DIFF
--- a/.github/workflows/check-linked-issue.yml
+++ b/.github/workflows/check-linked-issue.yml
@@ -2,7 +2,7 @@ name: Check Linked Issue
 
 on:
   pull_request_target:
-    types: [opened, edited]
+    types: [opened, edited, labeled]
 
 jobs:
   check-linked-issue:


### PR DESCRIPTION
This triggers the check-linked-issue.yml workflow on the `labeled` event, so that if the `hotfix` label is added later after the PR is opened, the workflow is rerun.