### PR TITLE
chore: Run complexipy-diff as part of ninja check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,7 +126,7 @@ jobs:
         continue-on-error: true
         run: |
           git fetch origin main:main 2>/dev/null || true
-          just complexipy-diff main
+          just complexipy-diff
 
       - name: Upload SARIF results for complexipy
         if: steps.complexipy.outcome == 'failure'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,8 +120,24 @@ jobs:
           just build
           just lint
           just test --coverage
+
+      - name: Run complexipy diff
+        id: complexipy
+        continue-on-error: true
+        run: |
           git fetch origin main:main 2>/dev/null || true
           just complexipy-diff main
+
+      - name: Upload SARIF results for complexipy
+        if: steps.complexipy.outcome == 'failure'
+        uses: github/codeql-action/upload-sarif@a6fd1787519fd23e68309fad43738e41a6ff2a9d #v4
+        with:
+            sarif_file: out/complexipy/complexipy-results.sarif
+            category: complexipy
+
+      - name: Fail if complexipy check failed
+        if: steps.complexipy.outcome == 'failure'
+        run: exit 1
 
       - name: Cache coverage baseline
         if: github.ref_name == 'main'
@@ -133,12 +149,6 @@ jobs:
       - name: Check coverage regression
         if: github.event_name == 'pull_request'
         run: python3 tools/coverage/check-coverage-regression.py out/coverage-baseline out/coverage
-
-      - name: Upload SARIF results for complexipy
-        uses: github/codeql-action/upload-sarif@a6fd1787519fd23e68309fad43738e41a6ff2a9d #v4
-        with:
-            sarif_file: out/complexipy/complexipy-results.sarif
-            category: complexipy
 
       - name: Run e2e tests
         run: just test-e2e

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,10 +10,3 @@ repos:
             pass_filenames: false
             always_run: true
             stages: [pre-push]
-          - id: complexipy
-            name: complexipy
-            entry: just complexipy-diff main
-            language: system
-            pass_filenames: false
-            always_run: true
-            stages: [pre-push]

--- a/build/configure/src/aqt.rs
+++ b/build/configure/src/aqt.rs
@@ -12,8 +12,8 @@ use ninja_gen::inputs;
 use ninja_gen::node::CompileSass;
 use ninja_gen::node::EsbuildScript;
 use ninja_gen::node::TypescriptCheck;
+use ninja_gen::python::check_complexity;
 use ninja_gen::python::python_format;
-use ninja_gen::python::Complexipy;
 use ninja_gen::python::PythonTest;
 use ninja_gen::rsync::RsyncFiles;
 use ninja_gen::Build;
@@ -355,11 +355,9 @@ fn build_wheel(build: &mut Build) -> Result<()> {
 }
 
 fn check_python(build: &mut Build) -> Result<()> {
-    python_format(
-        build,
-        "qt",
-        inputs![glob!("qt/**/*.py", "qt/installer/*-template/**")],
-    )?;
+    let py_inputs = inputs![glob!("qt/**/*.py", "qt/installer/*-template/**")];
+
+    python_format(build, "qt", py_inputs.clone())?;
 
     build.add_action(
         "check:pytest:aqt",
@@ -375,11 +373,7 @@ fn check_python(build: &mut Build) -> Result<()> {
         },
     )?;
 
-    build.add_action(
-        "check:complexity:aqt",
-        Complexipy {
-            folders: &["qt"],
-            deps: inputs![":qt"],
-        },
-    )
+    check_complexity(build, "qt", "qt", py_inputs)?;
+
+    Ok(())
 }

--- a/build/configure/src/pylib.rs
+++ b/build/configure/src/pylib.rs
@@ -9,8 +9,8 @@ use ninja_gen::copy::LinkFile;
 use ninja_gen::glob;
 use ninja_gen::hashmap;
 use ninja_gen::inputs;
+use ninja_gen::python::check_complexity;
 use ninja_gen::python::python_format;
-use ninja_gen::python::Complexipy;
 use ninja_gen::python::PythonTest;
 use ninja_gen::Build;
 
@@ -79,7 +79,9 @@ pub fn build_pylib(build: &mut Build) -> Result<()> {
 }
 
 pub fn check_pylib(build: &mut Build) -> Result<()> {
-    python_format(build, "pylib", inputs![glob!("pylib/**/*.py")])?;
+    let py_inputs = inputs![glob!("pylib/**/*.py")];
+
+    python_format(build, "pylib", py_inputs.clone())?;
 
     build.add_action(
         "check:pytest:pylib",
@@ -90,13 +92,9 @@ pub fn check_pylib(build: &mut Build) -> Result<()> {
         },
     )?;
 
-    build.add_action(
-        "check:complexity:pylib",
-        Complexipy {
-            folders: &["pylib"],
-            deps: inputs![":pylib"],
-        },
-    )
+    check_complexity(build, "pylib", "pylib", py_inputs)?;
+
+    Ok(())
 }
 
 pub struct GenBuildInfo {}

--- a/build/ninja_gen/src/python.rs
+++ b/build/ninja_gen/src/python.rs
@@ -308,21 +308,53 @@ impl BuildAction for PythonTest {
 }
 
 pub struct Complexipy {
-    pub folders: &'static [&'static str],
     pub deps: BuildInput,
+    pub folder: &'static str,
+    pub diff_mode: bool,
 }
 
 impl BuildAction for Complexipy {
     fn command(&self) -> &str {
-        "$complexipy $folders --suggest-refactors"
+        "$complexipy $folder --suggest-refactors $diff_args"
     }
 
     fn files(&mut self, build: &mut impl crate::build::FilesHandle) {
         build.add_inputs("", &self.deps);
         build.add_inputs("", inputs![".complexipy.toml"]);
         build.add_inputs("complexipy", inputs![":pyenv:complexipy"]);
-        build.add_variable("folders", self.folders.join(" "));
-        let hash = simple_hash(&self.deps);
-        build.add_output_stamp(format!("tests/complexipy.{hash}"));
+        build.add_variable("folder", self.folder);
+        let diff_args = if self.diff_mode {
+            "--diff main -R -mx 15"
+        } else {
+            ""
+        };
+        build.add_variable("diff_args", diff_args);
+        let hash = simple_hash(self.folder);
+        let kind = if self.diff_mode { "diff" } else { "check" };
+        build.add_output_stamp(format!("tests/complexipy.{kind}.{hash}"));
     }
+}
+
+pub fn check_complexity(
+    build: &mut Build,
+    group: &str,
+    folder: &'static str,
+    deps: BuildInput,
+) -> Result<()> {
+    build.add_action(
+        format!("check:complexipy:{group}"),
+        Complexipy {
+            deps: deps.clone(),
+            folder,
+            diff_mode: false,
+        },
+    )?;
+    build.add_action(
+        format!("check:complexipy-diff:{group}"),
+        Complexipy {
+            deps,
+            folder,
+            diff_mode: true,
+        },
+    )
 }

--- a/justfile
+++ b/justfile
@@ -170,9 +170,9 @@ docs-rust:
 ci branch:
     gh workflow run ci.yml --ref {{ branch }}
 
-# Run Complexipy in regression-only mode for CI
-complexipy-diff branch:
-    {{ uv }} run complexipy --diff {{ branch }} -R -mx 15
+# Run Complexipy in regression-only mode
+complexipy-diff:
+    {{ ninja }} check:complexipy-diff
 
 # Remove build outputs from out/ (pass keep-env to keep node_modules/pyenv); macOS/Linux
 clean *args:


### PR DESCRIPTION
## Linked issue

Closes #4986
Closes #4985

## Summary

- Move the complexipy-diff check to Ninja so it can be run locally as part of `./ninja check`.
- Fix [SARIF](https://docs.github.com/en/code-security/reference/code-scanning/sarif-files/sarif-support) results not being uploaded if the Complexipy check fails.

## Steps to reproduce (before)

complexipy-diff was only run on CI and pre-push automatically. It was not covered by ninja check, which is not consistent with most tests and tools.

## How to test (after)

- Run `./ninja check:complexipy-diff` and confirm it passes.
- Introduce some complex Python change (e.g. add some nested if statements) so that the check fails now.
- Update your pre-commit config: `./out/extracted/uv/uv run pre-commit install`.
