### PR TITLE
fix: move add_dynamic_styling_and_props_then_show to _on_load_finished

### DIFF
--- a/qt/aqt/webview.py
+++ b/qt/aqt/webview.py
@@ -377,6 +377,7 @@ class AnkiWebView(QWebEngineView):
         self._pendingActions: list[tuple[str, Sequence[Any]]] = []
         self.requiresCol = True
         self._disable_zoom = False
+        self._uses_dynamic_styling = False
 
         self.resetHandlers()
         self._filterSet = False
@@ -395,7 +396,8 @@ class AnkiWebView(QWebEngineView):
         });
         """
         )
-        self.add_dynamic_styling_and_props_then_show()
+        if self._uses_dynamic_styling:
+            self.add_dynamic_styling_and_props_then_show()
 
     def page(self) -> AnkiWebPage:
         return cast(AnkiWebPage, super().page())
@@ -877,6 +879,7 @@ html {{ {font} }}
         else:
             extra = ""
         self.load_url(QUrl(f"{mw.serverURL()}_anki/pages/{name}.html{extra}"))
+        self._uses_dynamic_styling = True
 
     def load_sveltekit_page(self, path: str) -> None:
         from aqt import mw
@@ -893,6 +896,7 @@ html {{ {font} }}
             server = mw.serverURL()
 
         self.load_url(QUrl(f"{server}{path}{extra}"))
+        self._uses_dynamic_styling = True
 
     def force_load_hack(self) -> None:
         """Force process to initialize.

--- a/qt/aqt/webview.py
+++ b/qt/aqt/webview.py
@@ -395,6 +395,7 @@ class AnkiWebView(QWebEngineView):
         });
         """
         )
+        self.add_dynamic_styling_and_props_then_show()
 
     def page(self) -> AnkiWebPage:
         return cast(AnkiWebPage, super().page())
@@ -876,7 +877,6 @@ html {{ {font} }}
         else:
             extra = ""
         self.load_url(QUrl(f"{mw.serverURL()}_anki/pages/{name}.html{extra}"))
-        self.add_dynamic_styling_and_props_then_show()
 
     def load_sveltekit_page(self, path: str) -> None:
         from aqt import mw
@@ -893,7 +893,6 @@ html {{ {font} }}
             server = mw.serverURL()
 
         self.load_url(QUrl(f"{server}{path}{extra}"))
-        self.add_dynamic_styling_and_props_then_show()
 
     def force_load_hack(self) -> None:
         """Force process to initialize.


### PR DESCRIPTION
<!--
Title (for the Pull Request title field at the top):
Use a short prefix so the change type is obvious. You do not need to repeat it in the body below.

Examples:
- fix: — bugfix
- feat: — feature
- refactor: — internal change without user-facing feature
- docs: — documentation only
- chore: — tooling, CI, deps, build housekeeping
- test: — tests only
-->

## Linked issue (required)

<!-- Fixes #123 / Closes #123 / Refs #123 -->
Fixes #4992

## Summary / motivation (required)

<!-- What this PR does and why. For larger changes, add enough context for reviewers. -->
This prevents the webview refreshing from affecting the styling of the page.

## Steps to reproduce (required, use N/A if not applicable)

<!-- Steps to reproduce: how to trigger the bug in the broken state (the "before").
 - Mainly for bugfixes;
    - For bugs: numbered steps before the fix. For non-bugs: write N/A.
 - use N/A for features, refactors, docs, chore, etc.
-->

1. Load an anki webview
2. Refresh it (Using the ankiview web inspector addon or otherwise)
3. The body will have none of the classes on it and none of the other styling will be applied

## How to test (required)

<!--- How to test: how you verified the change (checks, unit tests, manual steps, edge cases — the "after" or general validation). --->
Follow the reproduction steps and the classes should be the same as before

### Checklist (minimum)

- [X] I ran `./ninja check` or an equivalent relevant check locally.
- [ ] I added or updated tests when the change is non-trivial or behavior changed.

### Details

<!-- Commands, manual steps, edge cases, and what you observed -->

## Before / after behavior (optional)

<!-- For bugfixes: behavior before vs after. For other types: N/A or a short note. -->

Before (After a refresh):
<img width="644" height="103" alt="image" src="https://github.com/user-attachments/assets/888c1794-ed1a-447f-8b14-6cc631a1a1d3" />
After (After a refresh):
<img width="644" height="103" alt="image" src="https://github.com/user-attachments/assets/49a7d6af-0292-4907-8faa-258d94190663" />

## Risk / compatibility / migration (optional)

<!-- Breaking changes, rollout notes, or N/A for small / low-risk PRs -->

## UI evidence (required for visual changes; otherwise N/A)

<!-- Screenshot or short video -->

## Scope

- [X] This PR is focused on one change (no unrelated edits).
