### PR TITLE
Fix: text input refocues when list item shortcuts are pressed

### DIFF
--- a/ts/editor/editor-toolbar/CommandIconButton.svelte
+++ b/ts/editor/editor-toolbar/CommandIconButton.svelte
@@ -25,9 +25,9 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
     const { focusedInput } = noteEditorContext.get();
 
-    function action() {
+    async function action() {
+        await $focusedInput?.focus();
         execCommand(key);
-        $focusedInput?.focus();
     }
 
     $: disabled = !$focusedInput || !editingInputIsRichText($focusedInput);

--- a/ts/editor/rich-text-input/RichTextInput.svelte
+++ b/ts/editor/rich-text-input/RichTextInput.svelte
@@ -119,7 +119,6 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
     async function focus(): Promise<void> {
         const richText = await richTextPromise;
-        richText.blur();
         richText.focus();
     }
 


### PR DESCRIPTION
<!--
Title (for the Pull Request title field at the top):
Use a short prefix so the change type is obvious. You do not need to repeat it in the body below.

Examples:
- fix: — bugfix
- feat: — feature
- refactor: — internal change without user-facing feature
- docs: — documentation only
- chore: — tooling, CI, deps, build housekeeping
- test: — tests only
-->

## Linked issue (required)

<!-- Fixes #123 / Closes #123 / Refs #123 -->
fixes #5006

## Steps to reproduce (required, use N/A if not applicable)

<!-- Steps to reproduce: how to trigger the bug in the broken state (the "before").
 - Mainly for bugfixes;
    - For bugs: numbered steps before the fix. For non-bugs: write N/A.
 - use N/A for features, refactors, docs, chore, etc.
-->

> I. Undo duplication
> 
> (1) Write into the editor “line”.
> 
> (2) In the non html editor, select this line, then press the unordered/ordered list button in the tool bar (or use keyword shortcut); the html field of the editor becomes
> 
> ```
> <ol><li>line</li></ol>
> 
> ```
> 
> (3) Press the undo shortcut (command + Z on Mac)
> 
> Result: the list is still there, but its content is duplicated after the list; the html field reads:
> 
> ```
> <ol><li>line</li></ol>line
> 
> ```
> 
> Remark: the same bug occurs when we begin with multiple lines instead of just one.

## How to test (required)

<!--- How to test: how you verified the change (checks, unit tests, manual steps, edge cases — the "after" or general validation). --->
Follow the reproduction steps. Undo should remove the text in the order that it appeared.

### Checklist (minimum)

- [X] I ran `./ninja check` or an equivalent relevant check locally.
- [ ] I added or updated tests when the change is non-trivial or behavior changed.

## Risk / compatibility / migration (optional)

<!-- Breaking changes, rollout notes, or N/A for small / low-risk PRs -->

Undoes some of the behaviour from #3483. I couldn't reproduce the bug he mentioned with this patch but I'm not entirely sure this doesn't re introduce https://github.com/ankitects/anki/issues/3338 as a bug. 

## Scope

- [X] This PR is focused on one change (no unrelated edits).
