### PR TITLE
fix: Bump minimum required macOS version

### DIFF
--- a/qt/installer/app/pyproject.toml
+++ b/qt/installer/app/pyproject.toml
@@ -61,7 +61,7 @@ permission.camera = "Add-ons may access your camera."
 
 [tool.briefcase.app.anki.macOS]
 universal_build = false
-min_os_version = "12.0"
+min_os_version = "13.0"
 entitlement."com.apple.security.cs.allow-jit" = true
 entitlement."com.apple.security.cs.disable-executable-page-protection" = true
 entitlement."com.apple.security.cs.allow-dyld-environment-variables" = true


### PR DESCRIPTION
## Linked issue

Closes #5009

## Summary

Bump the minimum macOS version for the Briefcase build to 13.0 to match Qt requirements.
