### PR TITLE
docs: Update docs for 26.05

### DIFF
--- a/docs-site/manual/files.mdx
+++ b/docs-site/manual/files.mdx
@@ -201,12 +201,16 @@ remaining open, you can instead use:
 The full path including drive letter is required - if you try using
 `\anki\anki.exe` instead you will find syncing stops working.
 
-WARNING: The drive letter must be the same on all devices. If you set this up for drive E,
+<Warning>
+The drive letter must be the same on all devices. If you set this up for drive E,
 it won't work for a flash drive mapped to drive D for example.
+</Warning>
 
-WARNING: Media syncing with AnkiWeb may not work if your flash drive is formatted
+<Warning>
+Media syncing with AnkiWeb may not work if your flash drive is formatted
 as FAT32. Please format the drive as NTFS to ensure media syncs
 correctly.
+</Warning>
 
 ### Anki Launcher
 

--- a/docs-site/manual/files.mdx
+++ b/docs-site/manual/files.mdx
@@ -64,13 +64,13 @@ modify the other files in the folder either.
 
 ## Program Files
 
-Anki's launcher is installed in the following locations by default:
+Anki is installed in the following locations by default:
 
 - Windows: `%LOCALAPPDATA%\Programs\Anki`
 - macOS: `/Applications/Anki.app`
 - Linux: `/usr/local/share/anki`
 
-When you install/update Anki with the launcher, it downloads support
+When you install/update Anki in versions 25.07 to 25.09.4, it downloads support
 files and places them in the following locations:
 
 - Windows: `%LOCALAPPDATA%\AnkiProgramFiles`
@@ -183,12 +183,34 @@ On Windows, Anki can be installed on a USB / flash drive and run as a
 portable application. The following example assumes your USB drive is
 drive E; adjust as necessary.
 
+- Copy the %LOCALAPPDATA%\Programs\Anki folder to the flash drive, so you
+  have a folder like E:\\Anki.
+
+- Create a text file called E:\\anki.bat with the following text:
+
+  E:\anki\anki.exe -b E:\ankidata
+
+If you would like to prevent the black command prompt window from
+remaining open, you can instead use:
+
+    start /b E:\anki\anki.exe -b E:\ankidata
+
+- Double-clicking on anki.bat should start Anki with the user data
+  stored in E:\\ankidata.
+
+The full path including drive letter is required - if you try using
+`\anki\anki.exe` instead you will find syncing stops working.
+
 WARNING: The drive letter must be the same on all devices. If you set this up for drive E,
 it won't work for a flash drive mapped to drive D for example.
 
 WARNING: Media syncing with AnkiWeb may not work if your flash drive is formatted
 as FAT32. Please format the drive as NTFS to ensure media syncs
 correctly.
+
+### Anki Launcher
+
+These instructions apply to Anki versions 25.07 to 25.09.4:
 
 1. Download the latest Anki launcher, and install it in a custom location:
    `E:\Anki\Launcher`. Not `E:\Anki\Launcher\Anki`.

--- a/docs-site/manual/files.mdx
+++ b/docs-site/manual/files.mdx
@@ -183,20 +183,19 @@ On Windows, Anki can be installed on a USB / flash drive and run as a
 portable application. The following example assumes your USB drive is
 drive E; adjust as necessary.
 
-- Copy the %LOCALAPPDATA%\Programs\Anki folder to the flash drive, so you
-  have a folder like E:\\Anki.
-
-- Create a text file called E:\\anki.bat with the following text:
-
+- Copy the `%LOCALAPPDATA%\Programs\Anki` folder to the flash drive, so you
+  have a folder like `E:\\Anki`.
+- Create a text file called `E:\\anki.bat` with the following text:
+  ```bat
   E:\anki\anki.exe -b E:\ankidata
-
-If you would like to prevent the black command prompt window from
+  ```
+- If you would like to prevent the black command prompt window from
 remaining open, you can instead use:
-
-    start /b E:\anki\anki.exe -b E:\ankidata
-
-- Double-clicking on anki.bat should start Anki with the user data
-  stored in E:\\ankidata.
+  ```bat
+  start /b E:\anki\anki.exe -b E:\ankidata
+  ```
+- Double-clicking on `anki.bat` should start Anki with the user data
+  stored in `E:\\ankidata`.
 
 The full path including drive letter is required - if you try using
 `\anki\anki.exe` instead you will find syncing stops working.

--- a/docs-site/manual/platform/linux/installing.mdx
+++ b/docs-site/manual/platform/linux/installing.mdx
@@ -6,9 +6,9 @@ title: "Installing & Upgrading Anki on Linux"
 
 ## Requirements
 
-The packaged version requires a recent 64 bit Intel/AMD Linux with glibc 2.36+, and common
+The packaged version requires a recent 64 bit Intel/AMD Linux with glibc 2.35+ or ARM/AArch64 with glibc 2.39+, and common
 libraries like libwayland-client and systemd. If you are on a different
-architecture (e.g ARM/AArch64), or a barebones Linux distro, you will not be able to use the
+architecture, or a barebones Linux distro, you will not be able to use the
 packaged version, but you may be able to use the [Python wheels](https://betas.ankiweb.net/#via-pypipip)
 instead.
 
@@ -40,8 +40,8 @@ To install Anki:
 3. Open a terminal and run the following commands, replacing the filename as appropriate.
 
 ```shell
-tar xaf Downloads/anki-launcher-2XXX-linux.tar.zst
-cd anki-launcher-2XXX-linux
+tar xaf Downloads/anki-2XXX-linux-x86_64.tar.zst
+cd anki-linux
 sudo ./install.sh
 ```
 
@@ -71,32 +71,12 @@ you can download older Anki versions from the [releases page](https://github.com
 
 ## System Qt versions
 
-Anki's launcher uses the official PyQt builds by default. This makes it easier to
+Anki uses the official PyQt builds by default. This makes it easier to
 install Anki on distros that don't have the relevant Python/Qt versions, but means that
 you may not have access certain Qt features provided by your Linux distro, such as certain
 Qt themes, support for the FCITX input method, etc.
 
 If your Linux distro provides up-to-date Anki packages, you may find using them easiest.
-
-If it doesn't, advanced users may wish to combine Anki's launcher with their system's Qt version.
-To do this, your system needs to have a Python version Anki supports (soon to be 3.11+),
-and suitable PyQt libraries (6.2+).
-
-WARNING: This is an experimental feature, and your system's Qt may fix some bugs while
-introducing others.
-
-1. Install Python and the relevant PyQt packages. On Ubuntu:
-
-   > sudo apt install python3-pyqt6.qtwebengine
-
-1. If you previously used the launcher, `rm -rf ~/.local/share/AnkiProgramFiles`.
-
-1. Untar the launcher, and cd to its folder.
-
-1. Run `touch system_qt` to create a system_qt file in that folder.
-
-1. Install Anki via ./anki or ./install.sh. In the list of installed packages,
-   you should not see any mention of PyQt6.
 
 ## Problems
 

--- a/docs-site/manual/platform/windows/startup-issues.mdx
+++ b/docs-site/manual/platform/windows/startup-issues.mdx
@@ -80,7 +80,7 @@ updates are installed, instead of running Anki directly, press the <kbd>Windows<
 %LocalAppData%\Programs\Anki\anki-console.bat
 ```
 
-For Anki versions 25.07 to 25.09.x, paste
+For Anki versions 25.07 to 25.09.4, paste
 
 ```
 %LocalAppData%\Programs\Anki\anki-console.exe

--- a/docs-site/manual/sync-server.mdx
+++ b/docs-site/manual/sync-server.mdx
@@ -40,10 +40,10 @@ set SYNC_USER1=user:pass
 Or MacOS, in Terminal.app:
 
 ```
-SYNC_USER1=user:pass /Applications/Anki.app/Contents/MacOS/launcher --syncserver
+SYNC_USER1=user:pass /Applications/Anki.app/Contents/MacOS/anki --syncserver
 ```
 
-Replace 'launcher' with 'anki' for old packaged builds prior to 25.07.
+Replace 'anki' with 'launcher' for versions 25.07 to 25.09.4.
 
 Or Linux:
 

--- a/docs-site/manual/sync-server.mdx
+++ b/docs-site/manual/sync-server.mdx
@@ -43,7 +43,9 @@ Or MacOS, in Terminal.app:
 SYNC_USER1=user:pass /Applications/Anki.app/Contents/MacOS/anki --syncserver
 ```
 
-Replace 'anki' with 'launcher' for versions 25.07 to 25.09.4.
+<Note>
+Replace 'anki' with 'launcher' in the above command for anki versions 25.07 to 25.09.4.
+</Note>
 
 Or Linux:
 


### PR DESCRIPTION

## Linked issue

This syncs changes in https://github.com/ankitects/anki-manual/pull/497 to the new website.
Closes https://github.com/ankitects/anki-manual/issues/490
Closes #4696

## How to test

Run `mint dev` under the docs-site directory to view the website or go to https://anki-release-docs.mintlify.app/

