### PR TITLE
fix: Do not pass "--no-ytdl" to mpv on Intel Mac

### DIFF
--- a/qt/aqt/mpv.py
+++ b/qt/aqt/mpv.py
@@ -94,8 +94,8 @@ class MPVBase:
 
     if is_win:
         default_argv += ["--af-add=lavfi=[apad=pad_dur=0.150]"]
-    if not is_mac or platform.machine() != "arm64":
-        # our arm64 mpv build doesn't support this option (compiled out)
+    if not is_mac:
+        # our mpv build for macOS doesn't support this option (compiled out)
         default_argv += ["--no-ytdl"]
 
     def __init__(self, window_id=None, debug=False):

--- a/qt/aqt/mpv.py
+++ b/qt/aqt/mpv.py
@@ -30,7 +30,6 @@ from __future__ import annotations
 import inspect
 import json
 import os
-import platform
 import select
 import socket
 import subprocess


### PR DESCRIPTION
Fix audio broken on Intel Macs because our new mpv build doesn't recognize the `--no-ytdl` option.