### PR TITLE
fix: failing syncserver Docker build

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -280,6 +280,7 @@ Jeremy Fleischman <me@jfly.fyi>
 Tim Gatzke <post@tim-gatzke.de>
 Chirag Jagga <chiragjagga26@gmail.com>
 David Sauerwein <david@sauerwein.xyz>
+Konstantin Tutsch <mail@konstantintutsch.com>
 
 ********************
 

--- a/docs/syncserver/Dockerfile
+++ b/docs/syncserver/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.85.0-alpine3.20 AS builder
+FROM rust:1.96.0-alpine3.21 AS builder
 
 ARG ANKI_VERSION
 

--- a/docs/syncserver/Dockerfile.distroless
+++ b/docs/syncserver/Dockerfile.distroless
@@ -1,4 +1,4 @@
-FROM rust:1.85.0 AS builder
+FROM rust:1.96.0 AS builder
 
 ARG ANKI_VERSION
 


### PR DESCRIPTION
## Summary / motivation (required)

This PR fixes Docker Image builds for syncserver failing due to a Rust version being used in both available Dockerfiles that is no longer supported by the two dependencies `time@0.3.47` and `time-core@0.1.8`.

## Issue

Fixes #5022 

## Steps to reproduce (required, use N/A if not applicable)

1. `cd docs/syncserver`
2. `docker build -f Dockerfile --no-cache --build-arg ANKI_VERSION=26.05 -t anki-sync-server .`
3. Error (see issue)

## How to test (required)

1. `cd docs/syncserver`
2. `docker build -f Dockerfile --no-cache --build-arg ANKI_VERSION=26.05 -t anki-sync-server .`
3. run Docker image

## Scope

- [x] This PR is focused on one change (no unrelated edits).
