### PR TITLE
fix(syncserver): use built-in --healthcheck instead of wget

### DIFF
--- a/docs/syncserver/Dockerfile
+++ b/docs/syncserver/Dockerfile
@@ -30,10 +30,12 @@ RUN chmod +x /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["anki-sync-server"]
 
-# This health check will work for Anki versions 24.08.x and newer.
-# For older versions, it may incorrectly report an unhealthy status, which should not be the case.
+# Use the built-in healthcheck to avoid noisy HTTP log entries on every probe.
+# The --healthcheck flag exits 0 if the server is healthy, 1 otherwise, and
+# produces no stdout output — allowing Docker/k3s to surface health status
+# without polluting container logs.
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
-    CMD wget -qO- http://127.0.0.1:8080/health || exit 1
+    CMD anki-sync-server --healthcheck
 
 VOLUME /anki_data
 


### PR DESCRIPTION
The wget probe logs a line on every interval, polluting container stdout in Docker and k3s. The --healthcheck flag exits 0/1 silently, letting the platform report health without log noise.
