### PR TITLE
fix: Additional support for newlines in search

### DIFF
--- a/qt/aqt/browser/browser.py
+++ b/qt/aqt/browser/browser.py
@@ -520,7 +520,13 @@ class Browser(QMainWindow):
         self.search()
 
     def current_search(self) -> str:
-        return self._line_edit().text().replace("\r\n", " ").replace("\r", " ").replace("\n", " ")
+        return (
+            self._line_edit()
+            .text()
+            .replace("\r\n", " ")
+            .replace("\r", " ")
+            .replace("\n", " ")
+        )
 
     def search(self) -> None:
         """Search triggered programmatically. Caller must have saved note first."""

--- a/qt/aqt/browser/browser.py
+++ b/qt/aqt/browser/browser.py
@@ -520,13 +520,7 @@ class Browser(QMainWindow):
         self.search()
 
     def current_search(self) -> str:
-        return (
-            self._line_edit()
-            .text()
-            .replace("\r\n", " ")
-            .replace("\r", " ")
-            .replace("\n", " ")
-        )
+        return re.sub(r"\s", " ", self._line_edit().text())
 
     def search(self) -> None:
         """Search triggered programmatically. Caller must have saved note first."""

--- a/qt/aqt/browser/browser.py
+++ b/qt/aqt/browser/browser.py
@@ -520,7 +520,7 @@ class Browser(QMainWindow):
         self.search()
 
     def current_search(self) -> str:
-        return self._line_edit().text().replace("\n", " ")
+        return self._line_edit().text().replace("\r\n", " ").replace("\r", " ").replace("\n", " ")
 
     def search(self) -> None:
         """Search triggered programmatically. Caller must have saved note first."""


### PR DESCRIPTION
## Linked issue (required)

Fixes #5046.

This is an expansion upon this PR: https://github.com/ankitects/anki/pull/4336 (original issue: https://github.com/ankitects/anki/issues/4215)

## Summary / motivation (required)

The previous PR only replaced `\n`. This did not work correctly on some OS/environments (for example, on Windows 11). This PR expands the replacement behavior to `\r\n` and `\r`.

## Steps to reproduce

On Windows 11:
Add this to an existing card's field: `THIS<BR>IS<BR>AN<BR>EXAMPLE`, then copy paste the rendered HTML to the browser search bar and press enter.

Before: no search results.

After: the search should behave as expected.

## How to test (required)

### Checklist (minimum)

- [ ] I ran `./ninja check` or an equivalent relevant check locally.
- [ ] I added or updated tests when the change is non-trivial or behavior changed.

### Details

## UI evidence (required for visual changes; otherwise N/A)

N/A

## Scope

- [x] This PR is focused on one change (no unrelated edits).