### PR TITLE
feat: Add missing Zoom related keyboard shortcuts

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -283,6 +283,7 @@ David Sauerwein <david@sauerwein.xyz>
 roostwp07 <https://github.com/roostwp07>
 Konstantin Tutsch <mail@konstantintutsch.com>
 RedPine404 <https://github.com/RedPine404>
+Vince Au <https://github.com/vinceau>
 
 ********************
 

--- a/qt/aqt/forms/browser.ui
+++ b/qt/aqt/forms/browser.ui
@@ -713,10 +713,17 @@
    <property name="text">
     <string>qt_accel_zoom_editor_in</string>
    </property>
+   <property name="shortcut">
+    <string notr="true">Ctrl++</string>
+    <string notr="true">Ctrl+=</string>
+   </property>
   </action>
   <action name="actionZoomOut">
    <property name="text">
     <string>qt_accel_zoom_editor_out</string>
+   </property>
+   <property name="shortcut">
+    <string notr="true">Ctrl+-</string>
    </property>
   </action>
   <action name="actionResetZoom">

--- a/qt/aqt/forms/main.ui
+++ b/qt/aqt/forms/main.ui
@@ -260,10 +260,17 @@
    <property name="text">
     <string>qt_accel_zoom_in</string>
    </property>
+   <property name="shortcut">
+    <string notr="true">Ctrl++</string>
+    <string notr="true">Ctrl+=</string>
+   </property>
   </action>
   <action name="actionZoomOut">
    <property name="text">
     <string>qt_accel_zoom_out</string>
+   </property>
+   <property name="shortcut">
+    <string notr="true">Ctrl+-</string>
    </property>
   </action>
   <action name="actionResetZoom">


### PR DESCRIPTION
### Add keyboard shortcuts for Zooming in and out

<!--
Title (for the Pull Request title field at the top):
Use a short prefix so the change type is obvious. You do not need to repeat it in the body below.

Examples:
- fix: — bugfix
- feat: — feature
- refactor: — internal change without user-facing feature
- docs: — documentation only
- chore: — tooling, CI, deps, build housekeeping
- test: — tests only
-->

## Linked issue (required)

Fixes #5056

## Summary / motivation (required)

<!-- What this PR does and why. For larger changes, add enough context for reviewers. -->
I tried to zoom in and out with keyboard shortcuts but it didn't work. I had to keep manually clicking from the view toolbar.

## Steps to reproduce (required, use N/A if not applicable)

N/A

## How to test (required)

<!--- How to test: how you verified the change (checks, unit tests, manual steps, edge cases — the "after" or general validation). --->
Press the keyboard shortcuts.

### Checklist (minimum)

- [x] I ran `./ninja check` or an equivalent relevant check locally.
- [x] I added or updated tests when the change is non-trivial or behavior changed.

### Details

It binds both the Plus and Equals key so uses don't have to press shift when zooming in.

## UI evidence (required for visual changes; otherwise N/A)

<!-- Screenshot or short video -->
N/A

## Scope

- [x] This PR is focused on one change (no unrelated edits).
