### PR TITLE
chore: Do not fail CI if Complexipy fails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,10 +135,6 @@ jobs:
             sarif_file: out/complexipy/complexipy-results.sarif
             category: complexipy
 
-      - name: Fail if complexipy check failed
-        if: steps.complexipy.outcome == 'failure'
-        run: exit 1
-
       - name: Cache coverage baseline
         if: github.ref_name == 'main'
         uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 #v4


### PR DESCRIPTION
Avoid failing CI if Complexipy fails, as we're still evaluating if the tool is useful for us and do not want it to unnecessarily hinder work. Results are still visible as inline comments thanks to GitHub's [code scanning](https://docs.github.com/en/code-security/reference/code-scanning/sarif-files/sarif-support) feature. (Example: https://github.com/ankitects/anki/pull/5041#discussion_r3438418621)