### PR TITLE
fix: set minimum height for deck options

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -284,6 +284,7 @@ roostwp07 <https://github.com/roostwp07>
 Konstantin Tutsch <mail@konstantintutsch.com>
 RedPine404 <https://github.com/RedPine404>
 krMaynard <55507135+krMaynard@users.noreply.github.com>
+Niko Savola <nikomsavola@gmail.com>
 
 ********************
 

--- a/qt/aqt/deckoptions.py
+++ b/qt/aqt/deckoptions.py
@@ -39,6 +39,7 @@ class DeckOptionsDialog(QDialog):
         self.setWindowModality(Qt.WindowModality.ApplicationModal)
         self.mw.garbage_collect_on_dialog_finish(self)
         self.setMinimumWidth(400)
+        self.setMinimumHeight(500)
         disable_help_button(self)
         restoreGeom(self, self.TITLE, default_size=(800, 800))
 


### PR DESCRIPTION
## Linked issue (required)

Fixes #5061

## Summary / motivation (required)

This PR resolves a sizing issue with the options view on Hyprland and possibly other Wayland-based tiling window managers.

### Changes:
**Minimum Height Constraint:** Adds `self.setMinimumHeight(500)` to `DeckOptionsDialog._setup_ui()`. This ensures that even when the webview is temporarily hidden on load (`self.web.hide_while_preserving_layout()`), tiling window managers do not collapse the dialog to an unusable height.

## Steps to reproduce (required, use N/A if not applicable)

See #5061

## How to test (required)

### Checklist (minimum)

- [x] I ran `./ninja check` or an equivalent relevant check locally.
- [x] I added or updated tests when the change is non-trivial or behavior changed. (The existing dialog geometry helpers cover this, and all Pytest/Aqt checks pass).

### Details

Tested manually on a Linux setup running Hyprland:
1. **Minimum Size:** When opening the deck options, the window respects the minimum size constraints and opens at a readable size.
   <img width="1395" height="1375" alt="image" src="https://github.com/user-attachments/assets/963e9c46-ef7b-42f1-8b54-3a7f9a1473ce" />


## Before / after behavior (optional)

* **Before:** Window opened collapsed into a tiny horizontal box on tiling compositors under Wayland, and user-resized geometries were lost on Save/Cancel close events.
  
  <img width="1403" height="626" alt="image" src="https://github.com/user-attachments/assets/5cd02070-4563-4d73-9526-b86c8345649e" />

* **After:** Window is reliably opened at least 500px high, and user size adjustments are correctly saved on all close operations.
  <img width="1395" height="1375" alt="image" src="https://github.com/user-attachments/assets/963e9c46-ef7b-42f1-8b54-3a7f9a1473ce" />


## Risk / compatibility / migration (optional)

Low risk. A minimum height of 500px easily fits on all standard modern screens (including small laptops). The number may also be changed if this seems too large.

## UI evidence (required for visual changes; otherwise N/A)

See screenshots above

## Scope

- [x] This PR is focused on one change (no unrelated edits).
