### PR TITLE
test: add basic tests for sound module and mpv binary (closes #5016)

### DIFF
--- a/pylib/tests/test_sound.py
+++ b/pylib/tests/test_sound.py
@@ -1,0 +1,47 @@
+# Copyright: Ankitects Pty Ltd and contributors
+# License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
+
+import os
+
+from anki.sound import AV_REF_RE, SoundOrVideoTag, strip_av_refs
+
+
+def test_sound_tag_path_relative_joins_media_folder():
+    tag = SoundOrVideoTag(filename="audio.mp3")
+    assert tag.path("/media") == "/media/audio.mp3"
+
+
+def test_sound_tag_path_absolute_ignores_media_folder():
+    abs_path = os.path.abspath("/some/absolute/audio.mp3")
+    tag = SoundOrVideoTag(filename=abs_path)
+    assert tag.path("/media") == abs_path
+
+
+def test_strip_av_refs_removes_play_tag():
+    assert strip_av_refs("Hello [anki:play:q:0] world") == "Hello  world"
+
+
+def test_strip_av_refs_leaves_unrelated_text_unchanged():
+    assert strip_av_refs("No audio here") == "No audio here"
+
+
+def test_strip_av_refs_removes_multiple_tags():
+    assert strip_av_refs("[anki:play:q:0]front[anki:play:a:1]back") == "frontback"
+
+
+def test_av_ref_re_matches_question_side():
+    m = AV_REF_RE.search("[anki:play:q:0]")
+    assert m is not None
+    assert m.group(2) == "q"
+    assert m.group(3) == "0"
+
+
+def test_av_ref_re_matches_answer_side():
+    m = AV_REF_RE.search("[anki:play:a:2]")
+    assert m is not None
+    assert m.group(2) == "a"
+    assert m.group(3) == "2"
+
+
+def test_av_ref_re_does_not_match_legacy_sound_tag():
+    assert AV_REF_RE.search("[sound:foo.mp3]") is None

--- a/qt/tests/test_sound.py
+++ b/qt/tests/test_sound.py
@@ -1,0 +1,32 @@
+# Copyright: Ankitects Pty Ltd and contributors
+# License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from aqt.sound import _packagedCmd, is_audio_file
+
+
+def test_is_audio_file_recognizes_common_formats():
+    for ext in ("mp3", "wav", "ogg", "flac", "m4a", "opus", "spx", "oga"):
+        assert is_audio_file(f"test.{ext}")
+
+
+def test_is_audio_file_rejects_non_audio():
+    for ext in ("mp4", "avi", "jpg", "png", "pdf"):
+        assert not is_audio_file(f"test.{ext}")
+
+
+def test_mpv_binary_runs():
+    cmd, env = _packagedCmd(["mpv"])
+    mpv = cmd[0]
+    if not Path(mpv).is_absolute():
+        mpv = shutil.which(mpv)
+        if mpv is None:
+            pytest.skip("mpv not found")
+
+    result = subprocess.run([mpv, "--version"], env=env, capture_output=True)
+    assert result.returncode == 0, result.stderr.decode()


### PR DESCRIPTION
Closes #5016

## Summary
- Adds `pylib/tests/test_sound.py` covering `anki/sound.py`: `SoundOrVideoTag.path()`, `strip_av_refs()`, and `AV_REF_RE` matching
- Adds `qt/tests/test_sound.py` covering `aqt/sound.py`: audio file extension detection and mpv binary smoke test (skipped on platforms without a bundled binary)

## How to test
```
just test-py --coverage
```

Feel free to suggest additional tests if this isn't comprehensive enough.
