### PR TITLE
fix: Update allowed origins for recent Chromium

### DIFF
--- a/.vscode.dist/launch.json
+++ b/.vscode.dist/launch.json
@@ -24,7 +24,7 @@
                 "PYTHONPYCACHEPREFIX": "out/pycache",
                 "ANKIDEV": "1",
                 "QTWEBENGINE_REMOTE_DEBUGGING": "8080",
-                "QTWEBENGINE_CHROMIUM_FLAGS": "--remote-allow-origins=http://localhost:8080",
+                "QTWEBENGINE_CHROMIUM_FLAGS": "--remote-allow-origins=https://chrome-devtools-frontend.appspot.com,http://localhost:8080",
                 "RUST_BACKTRACE": "1",
                 // "TRACESQL": "1",
                 // "HMR": "1",

--- a/run
+++ b/run
@@ -7,7 +7,7 @@ export PYTHONPYCACHEPREFIX=out/pycache
 # define these as blank before calling the script if you want to disable them
 export ANKIDEV=${ANKIDEV-1}
 export QTWEBENGINE_REMOTE_DEBUGGING=${QTWEBENGINE_REMOTE_DEBUGGING-8080}
-export QTWEBENGINE_CHROMIUM_FLAGS=${QTWEBENGINE_CHROMIUM_FLAGS---remote-allow-origins=http://localhost:$QTWEBENGINE_REMOTE_DEBUGGING}
+export QTWEBENGINE_CHROMIUM_FLAGS=${QTWEBENGINE_CHROMIUM_FLAGS---remote-allow-origins=https://chrome-devtools-frontend.appspot.com,http://localhost:$QTWEBENGINE_REMOTE_DEBUGGING}
 export PYENV=${PYENV-out/pyenv}
 
 # The pages can be accessed by, e.g. surfing to

--- a/run.bat
+++ b/run.bat
@@ -5,7 +5,7 @@ set PYTHONWARNINGS=default
 set PYTHONPYCACHEPREFIX=out\pycache
 set ANKIDEV=1
 set QTWEBENGINE_REMOTE_DEBUGGING=8080
-set QTWEBENGINE_CHROMIUM_FLAGS=--remote-allow-origins=http://localhost:8080
+set QTWEBENGINE_CHROMIUM_FLAGS=--remote-allow-origins=https://chrome-devtools-frontend.appspot.com,http://localhost:8080
 set ANKI_API_PORT=40000
 set ANKI_API_HOST=127.0.0.1
 


### PR DESCRIPTION
## Linked issue

Closes #5079

## Summary / motivation

Anki's webviews can be debugged by accessing http://127.0.0.1:8080/ in Chromium-based browsers. In recent Chromium builds, the DevTools inspector page is served from https://chrome-devtools-frontend.appspot.com, which needs to be passed to `--remote-allow-origins` to allow the connection.

## Steps to reproduce (before)

- Navigate http://127.0.0.1:8080/ after launching Anki (using one of the run scripts)
- Open any listed page there and confirm you see an error: "Debugging connection was closed".

## How to test (after)

Repeat the same steps and confirm you can access DevTools with no errors.

## UI evidence

<img width="304" height="144" alt="image" src="https://github.com/user-attachments/assets/159cfd9a-6112-4144-b88b-f2bee80b76a3" />
