### PR TITLE
chore: Move complexipy out of Ninja checks

### DIFF
--- a/build/ninja_gen/src/python.rs
+++ b/build/ninja_gen/src/python.rs
@@ -319,7 +319,7 @@ pub fn check_complexity(
     deps: BuildInput,
 ) -> Result<()> {
     build.add_action(
-        format!("check:complexipy:{group}"),
+        format!("complexipy:{group}"),
         Complexipy {
             deps: deps.clone(),
             folder,
@@ -327,7 +327,7 @@ pub fn check_complexity(
         },
     )?;
     build.add_action(
-        format!("check:complexipy-diff:{group}"),
+        format!("complexipy-diff:{group}"),
         Complexipy {
             deps,
             folder,

--- a/justfile
+++ b/justfile
@@ -172,7 +172,7 @@ ci branch:
 
 # Run Complexipy in regression-only mode
 complexipy-diff:
-    {{ ninja }} check:complexipy-diff
+    {{ ninja }} complexipy-diff
 
 # Remove build outputs from out/ (pass keep-env to keep node_modules/pyenv); macOS/Linux
 clean *args:


### PR DESCRIPTION
A follow-up to #5060

This moves the `complexipy` and `complexipy-diff` Ninja actions out of the base `check` actions so that they are not run on `./ninja check`.

