### PR TITLE
test: strengthen audio playback coverage

### DIFF
--- a/pylib/tests/test_sound.py
+++ b/pylib/tests/test_sound.py
@@ -17,6 +17,27 @@ def test_sound_tag_path_absolute_ignores_media_folder():
     assert tag.path("/media") == abs_path
 
 
+def test_sound_tag_path_with_directory_separator_uses_abspath():
+    # filename with a separator but not absolute - goes through os.path.abspath,
+    # so the media folder is ignored and the file's directory is used instead.
+    tag = SoundOrVideoTag(filename="subdir/audio.mp3")
+    result = tag.path("/media")
+    expected = os.path.join(os.path.abspath("subdir"), "audio.mp3")
+    assert result == expected
+
+
+def test_sound_tag_path_applies_media_file_filter(monkeypatch):
+    # hooks.media_file_filter is applied to the tail component of the path.
+    import anki.sound as sound_module
+
+    def fake_filter(fname: str) -> str:
+        return fname.replace("audio", "renamed")
+
+    monkeypatch.setattr(sound_module.hooks, "media_file_filter", fake_filter)
+    tag = SoundOrVideoTag(filename="audio.mp3")
+    assert tag.path("/media") == "/media/renamed.mp3"
+
+
 def test_strip_av_refs_removes_play_tag():
     assert strip_av_refs("Hello [anki:play:q:0] world") == "Hello  world"
 

--- a/pylib/tests/test_sound.py
+++ b/pylib/tests/test_sound.py
@@ -8,7 +8,7 @@ from anki.sound import AV_REF_RE, SoundOrVideoTag, strip_av_refs
 
 def test_sound_tag_path_relative_joins_media_folder():
     tag = SoundOrVideoTag(filename="audio.mp3")
-    assert tag.path("/media") == "/media/audio.mp3"
+    assert tag.path("/media") == os.path.join("/media", "audio.mp3")
 
 
 def test_sound_tag_path_absolute_ignores_media_folder():
@@ -35,7 +35,7 @@ def test_sound_tag_path_applies_media_file_filter(monkeypatch):
 
     monkeypatch.setattr(sound_module.hooks, "media_file_filter", fake_filter)
     tag = SoundOrVideoTag(filename="audio.mp3")
-    assert tag.path("/media") == "/media/renamed.mp3"
+    assert tag.path("/media") == os.path.join("/media", "renamed.mp3")
 
 
 def test_strip_av_refs_removes_play_tag():

--- a/pylib/tests/test_sound.py
+++ b/pylib/tests/test_sound.py
@@ -6,9 +6,9 @@ import os
 from anki.sound import AV_REF_RE, SoundOrVideoTag, strip_av_refs
 
 
-def test_sound_tag_path_relative_joins_media_folder():
+def test_sound_tag_path_relative_joins_media_folder(tmp_path):
     tag = SoundOrVideoTag(filename="audio.mp3")
-    assert tag.path("/media") == os.path.join("/media", "audio.mp3")
+    assert tag.path(str(tmp_path)) == os.path.join(str(tmp_path), "audio.mp3")
 
 
 def test_sound_tag_path_absolute_ignores_media_folder():
@@ -26,7 +26,7 @@ def test_sound_tag_path_with_directory_separator_uses_abspath():
     assert result == expected
 
 
-def test_sound_tag_path_applies_media_file_filter(monkeypatch):
+def test_sound_tag_path_applies_media_file_filter(monkeypatch, tmp_path):
     # hooks.media_file_filter is applied to the tail component of the path.
     import anki.sound as sound_module
 
@@ -35,7 +35,7 @@ def test_sound_tag_path_applies_media_file_filter(monkeypatch):
 
     monkeypatch.setattr(sound_module.hooks, "media_file_filter", fake_filter)
     tag = SoundOrVideoTag(filename="audio.mp3")
-    assert tag.path("/media") == os.path.join("/media", "renamed.mp3")
+    assert tag.path(str(tmp_path)) == os.path.join(str(tmp_path), "renamed.mp3")
 
 
 def test_strip_av_refs_removes_play_tag():

--- a/qt/tests/test_sound.py
+++ b/qt/tests/test_sound.py
@@ -5,11 +5,14 @@ import shutil
 import subprocess
 import wave
 from pathlib import Path
+from unittest.mock import MagicMock
 
 import pytest
 
+import aqt
+from anki.sound import SoundOrVideoTag
 from anki.utils import is_mac, is_win
-from aqt.sound import _packagedCmd, is_audio_file
+from aqt.sound import MpvManager, _packagedCmd, is_audio_file
 
 
 def test_is_audio_file_recognizes_common_formats():
@@ -75,14 +78,18 @@ def test_mpv_binary_runs():
     assert result.returncode == 0, result.stderr.decode()
 
 
-def test_mpv_can_play_generated_wav(tmp_path: Path):
+@pytest.fixture
+def generated_wav(tmp_path: Path) -> Path:
     wav_path = tmp_path / "silence.wav"
     with wave.open(str(wav_path), "wb") as wav:
         wav.setnchannels(1)
         wav.setsampwidth(2)
         wav.setframerate(44_100)
         wav.writeframes(b"\0\0" * 4_410)
+    return wav_path
 
+
+def test_mpv_can_play_generated_wav(generated_wav: Path):
     cmd, env = _resolved_mpv_command(
         [
             "mpv",
@@ -94,9 +101,24 @@ def test_mpv_can_play_generated_wav(tmp_path: Path):
             "--ao=null",
             "--vo=null",
             "--",
-            str(wav_path),
+            str(generated_wav),
         ]
     )
 
     result = subprocess.run(cmd, env=env, capture_output=True, timeout=10)
     assert result.returncode == 0, result.stderr.decode()
+
+
+def test_mpvmanager_can_play_generated_wav(
+    monkeypatch, tmp_path: Path, generated_wav: Path
+):
+    monkeypatch.setattr(
+        MpvManager, "default_argv", MpvManager.default_argv + ["--ao=null", "--vo=null"]
+    )
+    mock_mw = MagicMock()
+    mock_mw.taskman.run_in_background.side_effect = (
+        lambda task, on_done=None, **kwargs: task()
+    )
+    monkeypatch.setattr(aqt, "mw", mock_mw)
+    manager = MpvManager(tmp_path, tmp_path)
+    manager.play(SoundOrVideoTag(filename=str(generated_wav.name)), lambda _: None)

--- a/qt/tests/test_sound.py
+++ b/qt/tests/test_sound.py
@@ -3,10 +3,12 @@
 
 import shutil
 import subprocess
+import wave
 from pathlib import Path
 
 import pytest
 
+from anki.utils import is_mac, is_win
 from aqt.sound import _packagedCmd, is_audio_file
 
 
@@ -15,18 +17,86 @@ def test_is_audio_file_recognizes_common_formats():
         assert is_audio_file(f"test.{ext}")
 
 
+def test_is_audio_file_is_case_insensitive():
+    for ext in ("MP3", "WAV", "OGG", "FLAC"):
+        assert is_audio_file(f"test.{ext}")
+
+
 def test_is_audio_file_rejects_non_audio():
+    # mp4/avi are video-only; jpg/png/pdf are not media Anki plays via mpv.
     for ext in ("mp4", "avi", "jpg", "png", "pdf"):
         assert not is_audio_file(f"test.{ext}")
 
 
-def test_mpv_binary_runs():
-    cmd, env = _packagedCmd(["mpv"])
+def test_is_audio_file_rejects_no_extension():
+    assert not is_audio_file("audiofile")
+
+
+def test_packagedcmd_returns_absolute_path_when_anki_audio_available():
+    # _packagedCmd should prefer the binary bundled in anki_audio over a
+    # system-wide one on macOS and Windows. This is the regression caught by
+    # issue #5015: an updated anki_audio build was not being picked up.
+    if not (is_mac or is_win):
+        pytest.skip("anki_audio binary preference is only used on macOS/Windows")
+
+    try:
+        from pathlib import Path as _Path
+
+        import anki_audio
+
+        audio_pkg_path = _Path(anki_audio.__file__).parent
+    except ImportError:
+        pytest.skip("anki_audio package not installed")
+
+    cmd, _env = _packagedCmd(["mpv"])
+    mpv_path = Path(cmd[0])
+
+    assert mpv_path.is_absolute(), "expected an absolute path to the packaged binary"
+    assert str(audio_pkg_path) in str(mpv_path), (
+        f"expected binary inside anki_audio package at {audio_pkg_path}, got {mpv_path}"
+    )
+
+
+def _resolved_mpv_command(args: list[str]) -> tuple[list[str], dict[str, str]]:
+    cmd, env = _packagedCmd(args)
     mpv = cmd[0]
     if not Path(mpv).is_absolute():
         mpv = shutil.which(mpv)
         if mpv is None:
             pytest.skip("mpv not found")
+        cmd[0] = mpv
 
-    result = subprocess.run([mpv, "--version"], env=env, capture_output=True)
+    return cmd, env
+
+
+def test_mpv_binary_runs():
+    cmd, env = _resolved_mpv_command(["mpv"])
+    result = subprocess.run(cmd + ["--version"], env=env, capture_output=True)
+    assert result.returncode == 0, result.stderr.decode()
+
+
+def test_mpv_can_play_generated_wav(tmp_path: Path):
+    wav_path = tmp_path / "silence.wav"
+    with wave.open(str(wav_path), "wb") as wav:
+        wav.setnchannels(1)
+        wav.setsampwidth(2)
+        wav.setframerate(44_100)
+        wav.writeframes(b"\0\0" * 4_410)
+
+    cmd, env = _resolved_mpv_command(
+        [
+            "mpv",
+            "--no-terminal",
+            "--force-window=no",
+            "--audio-display=no",
+            "--keep-open=no",
+            "--autoload-files=no",
+            "--ao=null",
+            "--vo=null",
+            "--",
+            str(wav_path),
+        ]
+    )
+
+    result = subprocess.run(cmd, env=env, capture_output=True, timeout=10)
     assert result.returncode == 0, result.stderr.decode()


### PR DESCRIPTION
## Linked issue

Refs #5016

## Summary / motivation 

Adds follow-up test coverage for audio playback after #5066.

This strengthens the previous basic sound tests by covering additional edge cases in `anki.sound` and by adding a real mpv playback smoke test. The goal is to catch regressions where the mpv binary exists and responds to `--version`, but fails to actually load/decode/play an audio file in Anki's automated environment.

Coverage added:

- `SoundOrVideoTag.path()` with filenames containing directory separators
- `hooks.media_file_filter` application in sound tag path resolution
- case-insensitive audio extension detection
- rejection of filenames without extensions
- `_packagedCmd()` preference for `anki_audio` only on macOS/Windows
- generated WAV playback through mpv in headless mode

## Steps to reproduce

1. Have a broken or incompatible mpv/`anki_audio` binary available.
2. Run the sound-related Python tests.
3. Without a playback smoke test, `mpv --version` may pass even if mpv cannot load/play an audio file.

## How to test

Run:

```sh
just test-py
```

Both passed locally.

The mpv smoke test generates a minimal WAV file and runs mpv with headless/null audio-video output, so it validates decoding/playback without requiring audio hardware.

## Before / after behavior
Before: coverage verified that mpv existed and responded to `--version`, but did not prove it could play/decode an audio file.

After: tests verify that mpv can load and play a generated WAV file in an automated headless mode.