### PR TITLE
fix(ci): clean up bot noise when linked issue is added

### DIFF
--- a/.github/workflows/check-linked-issue.yml
+++ b/.github/workflows/check-linked-issue.yml
@@ -34,7 +34,7 @@ jobs:
             }
             core.setOutput('exempt', 'false');
 
-            const linkedIssuePattern = /\b(closes|fixes|resolves|close|fix|resolve)\s+#\d+/i;
+            const linkedIssuePattern = /\b(closes|close|fixes|fix|resolves|resolve|refs|ref|references)\s+#\d+/i;
             const hasLinkedIssue = linkedIssuePattern.test(body);
             core.setOutput('has_linked_issue', hasLinkedIssue);
 

--- a/.github/workflows/check-linked-issue.yml
+++ b/.github/workflows/check-linked-issue.yml
@@ -73,7 +73,7 @@ jobs:
               });
             }
 
-      - name: Remove missing-issue label if issue is now linked
+      - name: Remove missing-issue label and bot comment if issue is now linked
         if: steps.check.outputs.has_linked_issue == 'true'
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b #v7
         with:
@@ -87,13 +87,28 @@ jobs:
               issue_number
             });
 
-            const hasMissingLabel = labels.data.some(l => l.name === 'missing-issue');
-
-            if (hasMissingLabel) {
+            if (labels.data.some(l => l.name === 'missing-issue')) {
               await github.rest.issues.removeLabel({
                 owner,
                 repo,
                 issue_number,
                 name: 'missing-issue'
               });
+            }
+
+            const comments = await github.rest.issues.listComments({
+              owner,
+              repo,
+              issue_number,
+              per_page: 100
+            });
+
+            for (const comment of comments.data) {
+              if (comment.user.type === 'Bot' && comment.body.includes('To link an issue, edit the PR description')) {
+                await github.rest.issues.deleteComment({
+                  owner,
+                  repo,
+                  comment_id: comment.id
+                });
+              }
             }


### PR DESCRIPTION
## Summary / motivation

Two related bugs in the `check-linked-issue` workflow caused unnecessary noise on PRs:

1. **Wrong keywords**: the regex only accepted `closes`, `fixes`, and `resolves` variants, but the PR template explicitly shows `Refs #123` as a valid option. Any PR using `Refs #NNN`, `Ref #NNN`, or `References #NNN` was incorrectly flagged. Observed in #5087.

2. **Stale bot comment**: once the contributor added an issue link and the `missing-issue` label was removed, the bot's warning comment remained visible on the PR, creating unnecessary noise.

## Steps to reproduce (required, use N/A if not applicable)

1. Open a PR with `Refs #<open issue>` in the linked issue section (following the template hint).
2. Bot applies `missing-issue` label and posts a comment despite the issue being referenced.
3. Edit the PR description to use `Closes #NNN` instead, label is removed but the bot comment stays.

## How to test (required)

1. Open a draft PR with no issue link → verify label and comment are applied.
2. Edit the description to add `Refs #NNN` → verify label and comment are both removed.
3. Repeat with `Closes #NNN`, `Fixes #NNN`, `References #NNN`.

## Risk / compatibility / migration

No Risk, CI workflow only.

