### PR TITLE
fix: calendar graph year navigation buttons position in RTL layouts

### DIFF
--- a/ts/routes/graphs/CalendarGraph.svelte
+++ b/ts/routes/graphs/CalendarGraph.svelte
@@ -66,7 +66,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 </script>
 
 <Graph {title}>
-    <InputBox>
+    <InputBox dir="ltr">
         <span>
             <button on:click={() => targetYear--} disabled={minYear >= targetYear}>
                 ◄

--- a/ts/routes/graphs/InputBox.svelte
+++ b/ts/routes/graphs/InputBox.svelte
@@ -9,7 +9,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 </script>
 
 <div {dir}>
-    <slot/>
+    <slot />
 </div>
 
 <style lang="scss">

--- a/ts/routes/graphs/InputBox.svelte
+++ b/ts/routes/graphs/InputBox.svelte
@@ -3,10 +3,13 @@ Copyright: Ankitects Pty Ltd and contributors
 License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 -->
 <script lang="ts">
+    import { direction } from "@tslib/i18n";
+
+    export let dir = direction();
 </script>
 
-<div>
-    <slot />
+<div {dir}>
+    <slot/>
 </div>
 
 <style lang="scss">


### PR DESCRIPTION
## Linked issue (required)

Refs #4749

## Summary / motivation (required)

In the statistics Calendar graph, the previous/next year navigation buttons are in the wrong position for RTL interface languages (Arabic, Hebrew, Persian). they sat on the wrong sides. 

The graph itself is drawn **LTR**  (oldest weeks on the left, most recent on the right). The navigation row, however, inherited the interface's RTL direction: `InputBox` is a centered flex row, so under RTL its children lay out right-to-left, flipping "previous" to the right and "next" to the left, against the grid they control) 

This pins the calendar's navigation row to LTR so the arrows stay aligned with the LTR-rendered heatmap. To allow that, the shared `InputBox` now takes an optional `dir` prop that defaults to the interface direction, and the calendar passes `dir="ltr"`.

## Steps to reproduce

<!-- Steps to reproduce: how to trigger the bug in the broken state (the "before").
 - Mainly for bugfixes;
    - For bugs: numbered steps before the fix. For non-bugs: write N/A.
 - use N/A for features, refactors, docs, chore, etc.
-->

1. Set the interface language to any RTL language.
2. Open the Statistics screen and view the Calendar graph.
3. Observe the previous/next year buttons: they sit on the wrong sides

## How to test (required)

**Check that the fix is working:**
Run anki with a RTL language `./run -l ar`. Follow steps to reproduce the issue. Click in the buttons to assert that right arrow advance year and left arrow go to previous year.

**Check that there were no regressions:** 
Change language to any LTR one `./run -l en`. Go to the same calendar graph. Click in the buttons to assert that right arrow advance year and left arrow go to previous year.


### Checklist 

- [x] I ran `./ninja check` or an equivalent relevant check locally.
- [x] I added or updated tests when the change is non-trivial or behavior changed.

I believe this is a trivial change, and I don't think the codebase has tooling to automatically test this kind of UI fix now.

# Before / after

before
<img width="778" height="290" alt="image" src="https://github.com/user-attachments/assets/676799ed-4530-4a34-99bd-11f007166d9d" />


after
<img width="790" height="274" alt="image" src="https://github.com/user-attachments/assets/95cbccc7-0e3b-4978-8693-9362f5eac19c" />


## UI evidence (no regressions in english anki)

<img width="784" height="292" alt="image" src="https://github.com/user-attachments/assets/069465d7-f71c-4df5-a455-45fc7e69a915" />


## Scope

- [x] This PR is focused on one change (no unrelated edits).
