### PR TITLE
fix: mirror help icon for arabic script rtl langs

### DIFF
--- a/ts/lib/components/HelpModal.svelte
+++ b/ts/lib/components/HelpModal.svelte
@@ -4,6 +4,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 -->
 <script lang="ts">
     import * as tr from "@generated/ftl";
+    import { usesArabicScript } from "@tslib/i18n";
     import { renderMarkdown } from "@tslib/helpers";
     import Carousel from "bootstrap/js/dist/carousel";
     import { createEventDispatcher, onMount } from "svelte";
@@ -45,7 +46,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     let activeIndex = startIndex;
 </script>
 
-<Badge on:click={() => modal.show()} iconSize={125}>
+<Badge on:click={() => modal.show()} iconSize={125} flipX={usesArabicScript()}>
     <Icon icon={infoCircle} />
 </Badge>
 

--- a/ts/lib/tslib/i18n/utils.test.ts
+++ b/ts/lib/tslib/i18n/utils.test.ts
@@ -1,0 +1,25 @@
+// Copyright: Ankitects Pty Ltd and contributors
+// License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
+
+import { FluentBundle, setBundles } from "@generated/ftl";
+import { expect, test } from "vitest";
+
+import { usesArabicScript } from "./utils";
+
+function setLanguage(lang: string): void {
+    setBundles([new FluentBundle([lang, "en-US"])]);
+}
+
+test("Arabic-script languages mirror the question mark", () => {
+    for (const lang of ["ar", "ar-SA", "fa", "fa-IR"]) {
+        setLanguage(lang);
+        expect(usesArabicScript()).toBe(true);
+    }
+});
+
+test("Hebrew is RTL but keeps the Latin question mark", () => {
+    for (const lang of ["he", "en", "en-US"]) {
+        setLanguage(lang);
+        expect(usesArabicScript()).toBe(false);
+    }
+});

--- a/ts/lib/tslib/i18n/utils.ts
+++ b/ts/lib/tslib/i18n/utils.ts
@@ -8,6 +8,14 @@ import type { ModuleName } from "@generated/ftl";
 import { FluentBundle, FluentResource } from "@generated/ftl";
 import { firstLanguage, setBundles } from "@generated/ftl";
 
+export function usesArabicScript(): boolean {
+    const firstLang = firstLanguage();
+    return (
+        firstLang.startsWith("ar")
+        || firstLang.startsWith("fa")
+    );
+}
+
 export function supportsVerticalText(): boolean {
     const firstLang = firstLanguage();
     return (


### PR DESCRIPTION
fix: mirror help icon for Arabic-script languages

## Linked issue (required)

Refs #4749

## Summary / motivation (required)

The help icon (info circle) in HelpModal was not mirrored for Arabic-script languages (Arabic, Persian). This PR adds a `flipX` prop to the Badge component wrapping the icon when the user's language uses Arabic script, matching the existing RTL mirroring behavior applied elsewhere in the UI.

https://en.wikipedia.org/wiki/Question_mark
<img width="951" height="400" alt="image" src="https://github.com/user-attachments/assets/516d1bcd-b9ce-4891-96ef-adcae450a08c" />


## Steps to reproduce (required)

1. Switch Anki's language to Arabic or Persian.
2. Open any dialog that shows the help badge (e.g., deck options).
3. Observe the info circle icon is not horizontally flipped.
4. Compare with other icons in RTL layouts which are properly mirrored.

## How to test (required)

1. Switch Anki's language to Arabic (ar) or Persian (fa).
2. Open deck options or any screen containing the help modal badge.
3. Confirm the info circle icon is mirrored (flipped horizontally).
4. Switch back to a non-Arabic-script language (e.g., English) and confirm the icon is unflipped.

### Checklist (minimum)

- [x] I ran `./ninja check` or an equivalent relevant check locally.
- [x] I added or updated tests when the change is non-trivial or behavior changed.
I added tests because this change don't fit any of the cases where tests arent required in CONTRIBUTING.md

## Before / after behavior (optional)
**Before:**
<img width="790" height="329" alt="image" src="https://github.com/user-attachments/assets/ee643152-34b1-4918-9bd6-e93bf12820dc" />

**After:** Help icon is horizontally flipped for Arabic and Persian language users, consistent with other RTL mirroring.

<img width="767" height="320" alt="image" src="https://github.com/user-attachments/assets/6f15b557-6096-4d09-8a0a-29b0de70d311" />

## Scope

- [x] This PR is focused on one change (no unrelated edits).