### PR TITLE
Fix mathjax wrap newline handling and add regression test

### DIFF
--- a/ts/lib/tslib/wrap.test.ts
+++ b/ts/lib/tslib/wrap.test.ts
@@ -1,0 +1,34 @@
+// @vitest-environment jsdom
+// Copyright: Ankitects Pty Ltd and contributors
+// License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
+
+import { expect, test, vi } from "vitest";
+
+import { wrapInternal } from "./wrap";
+
+test("wrapInternal preserves HTML and converts <br> to newline inside mathjax", () => {
+    const execCommandMock = vi.fn();
+    (document as any).execCommand = execCommandMock;
+
+    document.body.innerHTML = "<div id=\"base\"><b>Line1</b><br /><i>Line2</i></div>";
+    const base = document.getElementById("base")!;
+
+    const textNode1 = base.querySelector("b")!.firstChild!;
+    const textNode2 = base.querySelector("i")!.firstChild!;
+
+    const range = document.createRange();
+    range.setStart(textNode1, 0);
+    range.setEnd(textNode2, textNode2.textContent!.length);
+
+    const selection = document.getSelection()!;
+    selection.removeAllRanges();
+    selection.addRange(range);
+
+    wrapInternal(base, "<anki-mathjax focusonmount>", "</anki-mathjax>", false);
+
+    expect(execCommandMock).toHaveBeenCalledWith(
+        "inserthtml",
+        false,
+        "<anki-mathjax focusonmount><b>Line1</b>\n<i>Line2</i></anki-mathjax>",
+    );
+});

--- a/ts/lib/tslib/wrap.ts
+++ b/ts/lib/tslib/wrap.ts
@@ -23,6 +23,14 @@ function moveCursorInside(selection: Selection, postfix: string): void {
     selection.addRange(range);
 }
 
+function isMathjaxWrapper(front: string): boolean {
+    return front.trimStart().startsWith("<anki-mathjax");
+}
+
+function convertBrToNewline(html: string): string {
+    return html.replace(/<br\s*\/?>/gi, "\n");
+}
+
 export function wrapInternal(
     base: Element,
     front: string,
@@ -45,7 +53,9 @@ export function wrapInternal(
         const new_ = wrappedExceptForWhitespace(span.innerText, front, back);
         document.execCommand("inserttext", false, new_);
     } else {
-        const new_ = wrappedExceptForWhitespace(span.innerHTML, front, back);
+        const html = span.innerHTML;
+        const value = isMathjaxWrapper(front) ? convertBrToNewline(html) : html;
+        const new_ = wrappedExceptForWhitespace(value, front, back);
         document.execCommand("inserthtml", false, new_);
     }
 


### PR DESCRIPTION
If you start by writing the mathjax and then wrapping it with the mathjax tools, the new lines are incorrectly rendered as `<br>`. This problem exists generally with any formatting, but in my experience, the new line case is the most common one. In particular because there is currently zero way to add the new line properly before wrapping the math in mathjax.

Further correction will wait until someone with decision power give feedback on the issue request.

This change is done with a simple search and replace and not parsing HTML, for the sake of the simplicity, and to ensure this still works if HTML is somehow badly formatted.

Refs #5106