### PR TITLE
i18n: add core FTL strings for browse card-row status chips

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -290,6 +290,7 @@ RedPine404 <https://github.com/RedPine404>
 krMaynard <55507135+krMaynard@users.noreply.github.com>
 Niko Savola <nikomsavola@gmail.com>
 iDavi <odavi20527@gmail.com>
+Ian E <ian@ankihub.net>
 
 ********************
 

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -290,7 +290,7 @@ RedPine404 <https://github.com/RedPine404>
 krMaynard <55507135+krMaynard@users.noreply.github.com>
 Niko Savola <nikomsavola@gmail.com>
 iDavi <odavi20527@gmail.com>
-Ian E <ian@ankihub.net>
+Ian E <ian@ankihub.net> 
 
 ********************
 

--- a/ftl/core/browsing.ftl
+++ b/ftl/core/browsing.ftl
@@ -156,6 +156,20 @@ browsing-sidebar-due-today = Due
 browsing-sidebar-untagged = Untagged
 browsing-sidebar-overdue = Overdue
 browsing-row-deleted = (deleted)
+# Compact due text in browse card rows when a card is overdue or due today
+browsing-due-now = Now
+# Status chip label in browse card rows
+browsing-leech = Leech
+browsing-more-tags =
+    { $count ->
+        [one] 1 more tag
+       *[other] { $count } more tags
+    }
+browsing-leech-lapses =
+    { $count ->
+        [one] Leech, { $count } lapse
+       *[other] Leech, { $count } lapses
+    }
 browsing-removed-unused-tags-count =
     { $count ->
         [one] Removed { $count } unused tag.


### PR DESCRIPTION
## Linked issue (required)

Refs ankitects/ankimobile#10 (pt 1)

## Summary / motivation (required)

Adds four new core FTL strings in `ftl/core/browsing.ftl` for AnkiMobile's redesigned browse card rows. AnkiMobile pt 1 still hardcodes a few user-visible and VoiceOver labels (leech chip, compact "now" due text, tag overflow, leech+lapse a11y). Compact due spans already reuse `scheduling-answer-button-time-*`; these are the remaining gaps called out in AnkiMobile PR #24.

All keys are **new additions only** — no existing strings are changed, and nothing in desktop/core consumes them yet. Intended for AnkiMobile wiring first, with desktop and AnkiDroid able to reuse later.

| Key | English | Use |
|-----|---------|-----|
| `browsing-leech` | Leech | Status chip label |
| `browsing-due-now` | Now | Compact due text for overdue / due-today |
| `browsing-more-tags` | 1 more tag / {count} more tags | VoiceOver for tag overflow chip |
| `browsing-leech-lapses` | Leech, {count} lapse(s) | VoiceOver for leech badge with lapse count |

Out of scope: `browsing-card-suspended-undo` (AnkiMobile pt 2, mobile-only for now).

## Steps to reproduce (required, use N/A if not applicable)

N/A — new i18n keys only; no behavior change in this repo.

## How to test (required)

### Checklist (minimum)

- [x] I ran `./ninja check` or an equivalent relevant check locally.
- [ ] I added or updated tests when the change is non-trivial or behavior changed.

### Details

- Ran `./ninja rslib:i18n` to regenerate bindings.
- Verified new keys appear in generated TypeScript/Python/Rust output (`browsingDueNow`, `browsingLeech`, `browsingMoreTags`, `browsingLeechLapses`).
- No runtime callers added in this PR; AnkiMobile will wire these up after core lands.

## Before / after behavior (optional)

N/A — strings are added to the template but unused until consumers adopt them.

## Risk / compatibility / migration (optional)

Low risk. Additive-only FTL change; no breaking changes or migration needed.

## UI evidence (required for visual changes; otherwise N/A)

N/A — no UI changes in this repo.

## Scope

- [x] This PR is focused on one change (no unrelated edits).


Made with [Cursor](https://cursor.com)