### PR TITLE
fix: sync_status() reporting FULL_SYNC for new empty collections

### DIFF
--- a/rslib/src/collection/timestamps.rs
+++ b/rslib/src/collection/timestamps.rs
@@ -17,6 +17,10 @@ impl CollectionTimestamps {
     pub fn schema_changed_since_sync(&self) -> bool {
         self.schema_change > self.last_sync
     }
+
+    pub fn never_synced(&self) -> bool {
+        self.last_sync.0 == 0
+    }
 }
 
 impl Collection {

--- a/rslib/src/sync/collection/status.rs
+++ b/rslib/src/sync/collection/status.rs
@@ -15,7 +15,12 @@ impl Collection {
     /// are pending on AnkiWeb, NoChanges will be returned.
     pub fn sync_status_offline(&mut self) -> Result<sync_status_response::Required> {
         let stamps = self.storage.get_collection_timestamps()?;
-        let required = if stamps.schema_changed_since_sync() {
+        let required = if stamps.never_synced() {
+            // A collection that has never synced can't know its true state without
+            // consulting the server; reporting FullSync here would otherwise stick
+            // permanently when both sides are empty (mod=0 on both ends).
+            sync_status_response::Required::NoChanges
+        } else if stamps.schema_changed_since_sync() {
             sync_status_response::Required::FullSync
         } else if stamps.collection_changed_since_sync() {
             sync_status_response::Required::NormalSync

--- a/rslib/src/sync/collection/tests.rs
+++ b/rslib/src/sync/collection/tests.rs
@@ -6,6 +6,7 @@
 use std::future::Future;
 use std::sync::LazyLock;
 
+use anki_proto::sync::sync_status_response;
 use axum::http::StatusCode;
 use reqwest::Client;
 use reqwest::Url;
@@ -41,6 +42,7 @@ use crate::sync::collection::normal::SyncOutput;
 use crate::sync::collection::protocol::EmptyInput;
 use crate::sync::collection::protocol::SyncProtocol;
 use crate::sync::collection::start::StartRequest;
+use crate::sync::collection::status::online_sync_status_check;
 use crate::sync::collection::upload::UploadResponse;
 use crate::sync::collection::upload::CORRUPT_MESSAGE;
 use crate::sync::http_client::HttpSyncClient;
@@ -281,6 +283,50 @@ async fn sync_roundtrip() -> Result<()> {
         let ctx = SyncTestContext::new(client);
         upload_download(&ctx).await?;
         regular_sync(&ctx).await?;
+        Ok(())
+    })
+    .await
+}
+
+/// See issue #5109
+#[tokio::test]
+async fn new_empty_collection_should_not_require_full_sync() -> Result<()> {
+    with_active_server(|client: HttpSyncClient| async move {
+        let ctx = SyncTestContext::new(client);
+        let mut col1 = ctx.col1();
+
+        // a new collection reports NoChanges, deferring to the online check
+        assert_eq!(
+            col1.sync_status_offline()?,
+            sync_status_response::Required::NoChanges
+        );
+
+        // the online check agrees when the remote account is also new
+        let state = online_sync_status_check(col1.sync_meta()?, &mut ctx.cloned_client()).await?;
+        assert_eq!(state.required, SyncActionRequired::NoChanges);
+
+        // syncing is a no-op that doesn't stamp last_sync, and the status
+        // must remain NoChanges afterwards
+        let out = ctx.normal_sync(&mut col1).await;
+        assert_eq!(out.required, SyncActionRequired::NoChanges);
+        assert_eq!(
+            col1.sync_status_offline()?,
+            sync_status_response::Required::NoChanges
+        );
+
+        // once local changes exist, the online check picks them up, even
+        // though the offline check still defers
+        col1_setup(&mut col1);
+        assert_eq!(
+            col1.sync_status_offline()?,
+            sync_status_response::Required::NoChanges
+        );
+        let state = online_sync_status_check(col1.sync_meta()?, &mut ctx.cloned_client()).await?;
+        assert!(matches!(
+            state.required,
+            SyncActionRequired::FullSyncRequired { .. }
+        ));
+
         Ok(())
     })
     .await


### PR DESCRIPTION
## Linked issue

Fixes #5109

## Summary / motivation

This changes the `sync_status()` method so that it reports `NoChanges` for new empty collections. Currently it reports `FullSync` on a fresh collection and this status persists even after syncs because the process works as follows:
1. Anki checks the local collection's modification and schema change timestamps against the time of the last sync (See `sync_status_offline()`).
2. If the collection was never synced (`last_sync=0`) `sync_status_offline()` returns `FullSync` as there's no special handling for this case.
3. `sync_status_inner()` returns the value returned by `sync_status_offline()` if it's not `NoChanges`, skipping the AnkiWeb network request, so the remote collection's modification time is never compared to the local modification time (they are both 0 on a fresh collection & account, so `online_sync_status_check()` would have returned `NoChanges` if not for the early return).
4. When the user clicks the sync button, the action required is determined solely by `online_sync_status_check()`, which returns `NoChanges` as noted earlier, so no sync is done and `last_sync` never gets updated, causing the offline sync status to get stuck on `FullSync`.

## Steps to reproduce (before)

1. Create a new AnkiWeb account and log in to it in a fresh Anki profile. Notice the sync button is now red.
2. Click the sync button (without creating notes or making any DB modifications to the collection) and confirm no prompt to accept the "fake" full sync.
3. Notice the button is still red, indicating the full sync status persists and won't be cleared until you make changes to the either the local or remote collection.

## How to test (after)

Repeat the same process and confirm the sync button is never red for a fresh collection.
