### PR TITLE
fix: omit empty "Error details:" line from network errors

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -291,6 +291,7 @@ krMaynard <55507135+krMaynard@users.noreply.github.com>
 Niko Savola <nikomsavola@gmail.com>
 iDavi <odavi20527@gmail.com>
 Ian E <ian@ankihub.net> 
+Ashish Yadav <48384865+criticalAY@users.noreply.github.com>
 
 ********************
 

--- a/rslib/src/error/network.rs
+++ b/rslib/src/error/network.rs
@@ -204,8 +204,12 @@ impl NetworkError {
             NetworkErrorKind::ProxyAuth => tr.network_proxy_auth(),
             NetworkErrorKind::Other => tr.network_other(),
         };
-        let details = tr.network_details(self.info.as_str());
-        format!("{summary}\n\n{details}")
+        if self.info.trim().is_empty() {
+            summary.into_owned()
+        } else {
+            let details = tr.network_details(self.info.as_str());
+            format!("{summary}\n\n{details}")
+        }
     }
 }
 
@@ -228,5 +232,52 @@ impl From<HttpError> for AnkiError {
         } else {
             AnkiError::sync_error(format!("{err:?}"), SyncErrorKind::Other)
         }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    fn other_error(info: &str) -> NetworkError {
+        NetworkError {
+            info: info.to_string(),
+            kind: NetworkErrorKind::Other,
+        }
+    }
+
+    #[test]
+    fn empty_info_omits_the_details_line() {
+        let tr = I18n::template_only();
+        assert_eq!(
+            other_error("").message(&tr),
+            tr.network_other().into_owned()
+        );
+    }
+
+    #[test]
+    fn whitespace_info_omits_the_details_line() {
+        let tr = I18n::template_only();
+        assert_eq!(
+            other_error("  ").message(&tr),
+            tr.network_other().into_owned()
+        );
+    }
+
+    #[test]
+    fn nonempty_info_keeps_the_details_line() {
+        let tr = I18n::template_only();
+        let expected = format!("{}\n\n{}", tr.network_other(), tr.network_details("boom"));
+        assert_eq!(other_error("boom").message(&tr), expected);
+    }
+
+    #[test]
+    fn empty_timeout_shows_only_the_timeout_summary() {
+        let tr = I18n::template_only();
+        let err = NetworkError {
+            info: String::new(),
+            kind: NetworkErrorKind::Timeout,
+        };
+        assert_eq!(err.message(&tr), tr.network_timeout().into_owned());
     }
 }


### PR DESCRIPTION
<!--
Title (for the Pull Request title field at the top):
Use a short prefix so the change type is obvious. You do not need to repeat it in the body below.

Examples:
- fix: — bugfix
- feat: — feature
- refactor: — internal change without user-facing feature
- docs: — documentation only
- chore: — tooling, CI, deps, build housekeeping
- test: — tests only
-->

## Linked issue (required)
- Fixes #5117

## Summary / motivation (required)
`NetworkError::message` always appended the `network-details` line, so an error with an empty `info` string rendered a dangling "Error details:" label with nothing after it. Only append the details when there is something to show.

The message is built in the shared backend, so the empty label showed up on every client (it was reported on AnkiDroid) is still used unchanged when details are present.

## Steps to reproduce (required, use N/A if not applicable)
Any network error

## How to test (required)
Added tests

### Checklist (minimum)

- [ ] I ran `./ninja check` or an equivalent relevant check locally.
- [x] I added or updated tests when the change is non-trivial or behavior changed.

### Details

<!-- Commands, manual steps, edge cases, and what you observed -->

## Before / after behavior (optional)

<!-- For bugfixes: behavior before vs after. For other types: N/A or a short note. -->

## Risk / compatibility / migration (optional)

<!-- Breaking changes, rollout notes, or N/A for small / low-risk PRs -->

## UI evidence (required for visual changes; otherwise N/A)

<!-- Screenshot or short video -->

## Scope

- [x] This PR is focused on one change (no unrelated edits).
