### PR TITLE
fix: Add new string for "No Updates available"

### DIFF
--- a/ftl/core/errors.ftl
+++ b/ftl/core/errors.ftl
@@ -11,6 +11,7 @@ errors-please-check-media = Please use the Check Media action, then try again.
 errors-collection-too-new = This collection requires a newer version of Anki to open.
 errors-invalid-ids = This deck contains timestamps in the future. Please contact the deck author and ask them to fix the issue.
 errors-inconsistent-db-state = Your database appears to be in an inconsistent state. Please use the Check Database action.
+errors-no-updates-available = No updates available.
 
 ## Card Rendering
 

--- a/rslib/src/backend/github.rs
+++ b/rslib/src/backend/github.rs
@@ -62,7 +62,7 @@ fn release_is_downloaded(filename: &str, checksum: &str) -> Result<bool> {
 
 impl BackendGithubService for Backend {
     fn get_latest_release(&self, input: LatestReleaseRequest) -> Result<GithubRelease> {
-        let no_updates_msg = self.tr.addons_no_updates_available();
+        let no_updates_msg = self.tr.errors_no_updates_available();
         let platform_suffix = get_platform_suffix().or_invalid(no_updates_msg.clone())?;
         let url = if input.include_prerelease {
             ALL_RELEASES_URL


### PR DESCRIPTION
We were using a Qt Fluent string in the core, which is not pulled by AnkiMobile. See https://github.com/ankitects/ankimobile-ftl/pull/4

