### PR TITLE
chore: Fix advisory RUSTSEC-2026-0204

### DIFF
--- a/.deny.toml
+++ b/.deny.toml
@@ -5,10 +5,6 @@
 db-path = "~/.cargo/advisory-db"
 db-urls = ["https://github.com/rustsec/advisory-db"]
 ignore = [
-  # burn depends on an unmaintained package 'paste'
-  "RUSTSEC-2024-0436",
-  # bincode is unmaintained (via burn). Alternatives: postcard, bitcode, rkyv, wincode
-  "RUSTSEC-2025-0141",
   # rustls-pemfile is unmaintained. Alternative: use rustls-pki-types directly (PemObject trait)
   "RUSTSEC-2025-0134",
   # unic-* crates are unmaintained (used for Unicode category detection).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -908,9 +908,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
This bumps the `crossbeam-epoch` crate to address [RUSTSEC-2026-0204](https://rustsec.org/advisories/RUSTSEC-2026-0204).

CI failure: https://github.com/ankitects/anki/actions/runs/28952247163/job/85901791834
