### PR TITLE
feat(i18n): add browsing-card-count for browse result counts

### DIFF
--- a/ftl/core/browsing.ftl
+++ b/ftl/core/browsing.ftl
@@ -116,6 +116,11 @@ browsing-note-count =
         [one] { $count } note
        *[other] { $count } notes
     }
+browsing-card-count =
+    { $count ->
+        [one] { $count } card
+       *[other] { $count } cards
+    }
 browsing-notes-updated =
     { $count ->
         [one] { $count } note updated.


### PR DESCRIPTION
Symmetric partner to browsing-note-count for displaying a search result total in cards mode (e.g. the browse redesign count pill). Thought it might be useful in core.