### PR TITLE
fix: Work around race issue with activeWindow() in request handlers

### DIFF
--- a/qt/aqt/mediasrv.py
+++ b/qt/aqt/mediasrv.py
@@ -814,6 +814,10 @@ class AsyncRequestHandler(Generic[AsyncRequestReturnType]):
         return await self.future
 
 
+def active_window_or_main() -> QWidget:
+    return aqt.mw.app.activeWindow() or aqt.mw
+
+
 async def open_file_picker() -> bytes:
     req = frontend_pb2.openFilePickerRequest()
     req.ParseFromString(request.data)
@@ -824,8 +828,7 @@ async def open_file_picker() -> bytes:
         def cb(filename: str | None) -> None:
             request_handler.set_result(filename)
 
-        window = aqt.mw.app.activeWindow()
-        assert window is not None
+        window = active_window_or_main()
         getFile(
             parent=window,
             title=req.title,
@@ -870,8 +873,7 @@ async def record_audio() -> bytes:
         def cb(path: str | None) -> None:
             request_handler.set_result(path)
 
-        window = aqt.mw.app.activeWindow()
-        assert window is not None
+        window = active_window_or_main()
         record_audio(window, aqt.mw, True, cb)
 
     request_handler: AsyncRequestHandler[str | None] = AsyncRequestHandler(callback)

--- a/qt/aqt/mediasrv.py
+++ b/qt/aqt/mediasrv.py
@@ -596,12 +596,6 @@ def _extract_request(
     return LocalFileRequest(root=aqt.mw.col.media.dir(), path=path)
 
 
-def run_on_main_with_delay(callback: Callable) -> None:
-    # on certain systems, modal dialogs such as askUser's QMessageBox.question unset the active window
-    # so we wait for the next event loop before querying the next current active window
-    aqt.mw.taskman.run_on_main(lambda: QTimer.singleShot(0, callback))
-
-
 def congrats_info() -> bytes:
     if not aqt.mw.col.sched._is_finished():
         aqt.mw.taskman.run_on_main(lambda: aqt.mw.moveToState("overview"))
@@ -725,7 +719,9 @@ def deck_options_require_close() -> bytes:
         if isinstance(window, DeckOptionsDialog):
             window.require_close()
 
-    run_on_main_with_delay(handle_on_main)
+    # on certain linux systems, askUser's QMessageBox.question unsets the active window
+    # so we wait for the next event loop before querying the next current active window
+    aqt.mw.taskman.run_on_main(lambda: QTimer.singleShot(0, handle_on_main))
     return b""
 
 
@@ -809,7 +805,7 @@ class AsyncRequestHandler(Generic[AsyncRequestReturnType]):
         self.future = self.loop.create_future()
 
     def run(self) -> None:
-        run_on_main_with_delay(lambda: self.callback(self))
+        aqt.mw.taskman.run_on_main(lambda: self.callback(self))
 
     def set_result(self, result: AsyncRequestReturnType) -> None:
         self.loop.call_soon_threadsafe(self.future.set_result, result)
@@ -922,7 +918,7 @@ def close_add_cards() -> bytes:
         if isinstance(window, NewAddCards):
             window._close_if_user_wants_to_discard_changes(req.val)
 
-    run_on_main_with_delay(handle_on_main)
+    aqt.mw.taskman.run_on_main(lambda: QTimer.singleShot(0, handle_on_main))
     return b""
 
 
@@ -934,7 +930,7 @@ def close_edit_current() -> bytes:
         if isinstance(window, NewEditCurrent):
             window.close()
 
-    run_on_main_with_delay(handle_on_main)
+    aqt.mw.taskman.run_on_main(lambda: QTimer.singleShot(0, handle_on_main))
     return b""
 
 
@@ -1016,7 +1012,7 @@ def open_fields_dialog() -> bytes:
         if hasattr(window, "editor") and isinstance(window.editor, NewEditor):
             window.editor.onFields()
 
-    run_on_main_with_delay(handle_on_main)
+    aqt.mw.taskman.run_on_main(handle_on_main)
     return b""
 
 
@@ -1029,7 +1025,7 @@ def open_cards_dialog() -> bytes:
         if hasattr(window, "editor") and isinstance(window.editor, NewEditor):
             window.editor.onCardLayout()
 
-    run_on_main_with_delay(handle_on_main)
+    aqt.mw.taskman.run_on_main(handle_on_main)
     return b""
 
 
@@ -1174,7 +1170,7 @@ def raw_backend_request(endpoint: str) -> Callable[[], bytes]:
                 handler = aqt.mw.app.activeWindow()
                 on_op_finished(aqt.mw, changes, handler)
 
-            run_on_main_with_delay(handle_on_main)
+            aqt.mw.taskman.run_on_main(handle_on_main)
 
         return output
 

--- a/qt/aqt/mediasrv.py
+++ b/qt/aqt/mediasrv.py
@@ -805,7 +805,9 @@ class AsyncRequestHandler(Generic[AsyncRequestReturnType]):
         self.future = self.loop.create_future()
 
     def run(self) -> None:
-        aqt.mw.taskman.run_on_main(lambda: self.callback(self))
+        aqt.mw.taskman.run_on_main(
+            lambda: QTimer.singleShot(0, lambda: self.callback(self))
+        )
 
     def set_result(self, result: AsyncRequestReturnType) -> None:
         self.loop.call_soon_threadsafe(self.future.set_result, result)
@@ -1012,7 +1014,7 @@ def open_fields_dialog() -> bytes:
         if hasattr(window, "editor") and isinstance(window.editor, NewEditor):
             window.editor.onFields()
 
-    aqt.mw.taskman.run_on_main(handle_on_main)
+    aqt.mw.taskman.run_on_main(lambda: QTimer.singleShot(0, handle_on_main))
     return b""
 
 
@@ -1025,7 +1027,7 @@ def open_cards_dialog() -> bytes:
         if hasattr(window, "editor") and isinstance(window.editor, NewEditor):
             window.editor.onCardLayout()
 
-    aqt.mw.taskman.run_on_main(handle_on_main)
+    aqt.mw.taskman.run_on_main(lambda: QTimer.singleShot(0, handle_on_main))
     return b""
 
 
@@ -1170,7 +1172,7 @@ def raw_backend_request(endpoint: str) -> Callable[[], bytes]:
                 handler = aqt.mw.app.activeWindow()
                 on_op_finished(aqt.mw, changes, handler)
 
-            aqt.mw.taskman.run_on_main(handle_on_main)
+            aqt.mw.taskman.run_on_main(lambda: QTimer.singleShot(0, handle_on_main))
 
         return output
 

--- a/qt/aqt/mediasrv.py
+++ b/qt/aqt/mediasrv.py
@@ -596,6 +596,12 @@ def _extract_request(
     return LocalFileRequest(root=aqt.mw.col.media.dir(), path=path)
 
 
+def run_on_main_with_delay(callback: Callable) -> None:
+    # on certain systems, modal dialogs such as askUser's QMessageBox.question unset the active window
+    # so we wait for the next event loop before querying the next current active window
+    aqt.mw.taskman.run_on_main(lambda: QTimer.singleShot(0, callback))
+
+
 def congrats_info() -> bytes:
     if not aqt.mw.col.sched._is_finished():
         aqt.mw.taskman.run_on_main(lambda: aqt.mw.moveToState("overview"))
@@ -719,9 +725,7 @@ def deck_options_require_close() -> bytes:
         if isinstance(window, DeckOptionsDialog):
             window.require_close()
 
-    # on certain linux systems, askUser's QMessageBox.question unsets the active window
-    # so we wait for the next event loop before querying the next current active window
-    aqt.mw.taskman.run_on_main(lambda: QTimer.singleShot(0, handle_on_main))
+    run_on_main_with_delay(handle_on_main)
     return b""
 
 
@@ -805,9 +809,7 @@ class AsyncRequestHandler(Generic[AsyncRequestReturnType]):
         self.future = self.loop.create_future()
 
     def run(self) -> None:
-        aqt.mw.taskman.run_on_main(
-            lambda: QTimer.singleShot(0, lambda: self.callback(self))
-        )
+        run_on_main_with_delay(lambda: self.callback(self))
 
     def set_result(self, result: AsyncRequestReturnType) -> None:
         self.loop.call_soon_threadsafe(self.future.set_result, result)
@@ -920,7 +922,7 @@ def close_add_cards() -> bytes:
         if isinstance(window, NewAddCards):
             window._close_if_user_wants_to_discard_changes(req.val)
 
-    aqt.mw.taskman.run_on_main(lambda: QTimer.singleShot(0, handle_on_main))
+    run_on_main_with_delay(handle_on_main)
     return b""
 
 
@@ -932,7 +934,7 @@ def close_edit_current() -> bytes:
         if isinstance(window, NewEditCurrent):
             window.close()
 
-    aqt.mw.taskman.run_on_main(lambda: QTimer.singleShot(0, handle_on_main))
+    run_on_main_with_delay(handle_on_main)
     return b""
 
 
@@ -1014,7 +1016,7 @@ def open_fields_dialog() -> bytes:
         if hasattr(window, "editor") and isinstance(window.editor, NewEditor):
             window.editor.onFields()
 
-    aqt.mw.taskman.run_on_main(lambda: QTimer.singleShot(0, handle_on_main))
+    run_on_main_with_delay(handle_on_main)
     return b""
 
 
@@ -1027,7 +1029,7 @@ def open_cards_dialog() -> bytes:
         if hasattr(window, "editor") and isinstance(window.editor, NewEditor):
             window.editor.onCardLayout()
 
-    aqt.mw.taskman.run_on_main(lambda: QTimer.singleShot(0, handle_on_main))
+    run_on_main_with_delay(handle_on_main)
     return b""
 
 
@@ -1172,7 +1174,7 @@ def raw_backend_request(endpoint: str) -> Callable[[], bytes]:
                 handler = aqt.mw.app.activeWindow()
                 on_op_finished(aqt.mw, changes, handler)
 
-            aqt.mw.taskman.run_on_main(lambda: QTimer.singleShot(0, handle_on_main))
+            run_on_main_with_delay(handle_on_main)
 
         return output
 


### PR DESCRIPTION

## Linked issue

Reported on [Discord](https://discord.com/channels/368267295601983490/373169624797282304/1524169568862601287).

## Summary / motivation

We call `QApplication.activeWindow()` in several mediasrv request handlers to get a parent for Qt dialogs or do asynchronous operations, but it returns None on some systems, apparently due to race issues.

```
Anki 26.05 (5d51ca02) (ao)
Python 3.13.13 Qt 6.11.0 PyQt 6.11.0
Platform: macOS-26.5.1-arm64-arm-64bit-Mach-O

Traceback (most recent call last):
  File "/Users/criticalay/Documents/GitHub/anki/qt/aqt/taskman.py", line 152, in raise_exception
    raise exception
  File "/Users/criticalay/Documents/GitHub/anki/qt/aqt/taskman.py", line 148, in _on_closures_pending
    closure()
    ~~~~~~~^^
  File "/Users/criticalay/Documents/GitHub/anki/qt/aqt/mediasrv.py", line 808, in <lambda>
    aqt.mw.taskman.run_on_main(lambda: self.callback(self))
                                       ~~~~~~~~~~~~~^^^^^^
  File "/Users/criticalay/Documents/GitHub/anki/qt/aqt/mediasrv.py", line 828, in callback
    assert window is not None
           ^^^^^^^^^^^^^^^^^^
AssertionError

===Add-ons (active)===
(add-on provided name [Add-on folder, installed at, version, is config changed])
AnkiWebView Inspector ['31746032', 2023-06-28T00:56, 'None', '']

===IDs of active AnkiWeb add-ons===
31746032

===Add-ons (inactive)===
(add-on provided name [Add-on folder, installed at, version, is config changed])
```

## Steps to reproduce

I failed to reproduce it so far on macOS/Windows.


