### PR TITLE
chore(ci): use prebuilt binaries for cargo-llvm-cov and cargo-nextest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,13 @@ jobs:
       - name: Install just
         uses: extractions/setup-just@f8a3cce218d9f83db3a2ecd90e41ac3de6cdfd9b #v3
 
+      - name: Install cargo-llvm-cov and cargo-nextest
+        uses: taiki-e/install-action@c7eb1735f09259a5035e8e5d44b1406b1cddc0fb #v2.83.0
+        with:
+          tool: |
+            cargo-llvm-cov@0.8.4
+            cargo-nextest@0.9.99
+
       - name: Symlink node_modules
         run: ln -sf out/node_modules .
 
@@ -234,6 +241,13 @@ jobs:
       - name: Install just
         uses: extractions/setup-just@f8a3cce218d9f83db3a2ecd90e41ac3de6cdfd9b #v3
 
+      - name: Install cargo-llvm-cov and cargo-nextest
+        uses: taiki-e/install-action@c7eb1735f09259a5035e8e5d44b1406b1cddc0fb #v2.83.0
+        with:
+          tool: |
+            cargo-llvm-cov@0.8.4
+            cargo-nextest@0.9.99
+
       - name: Symlink node_modules
         run: ln -sf out/node_modules .
 
@@ -309,6 +323,13 @@ jobs:
 
       - name: Install just
         uses: extractions/setup-just@f8a3cce218d9f83db3a2ecd90e41ac3de6cdfd9b #v3
+
+      - name: Install cargo-llvm-cov and cargo-nextest
+        uses: taiki-e/install-action@c7eb1735f09259a5035e8e5d44b1406b1cddc0fb #v2.83.0
+        with:
+          tool: |
+            cargo-llvm-cov@0.8.4
+            cargo-nextest@0.9.99
 
       - name: Build, lint, and test
         run: |

--- a/build/ninja_gen/src/cargo.rs
+++ b/build/ninja_gen/src/cargo.rs
@@ -141,6 +141,10 @@ fn setup_flags(build: &mut Build) -> Result<()> {
     })
 }
 
+fn running_on_ci() -> bool {
+    std::option_env!("CI") == Some("true")
+}
+
 pub struct CargoTest {
     pub inputs: BuildInput,
 }
@@ -152,20 +156,27 @@ impl BuildAction for CargoTest {
 
     fn files(&mut self, build: &mut impl FilesHandle) {
         build.add_inputs("", &self.inputs);
-        build.add_inputs("", inputs![":cargo-nextest"]);
+        if !running_on_ci() {
+            build.add_inputs("", inputs![":cargo-nextest"]);
+        }
         build.add_env_var("ANKI_TEST_MODE", "1");
         build.add_output_stamp("tests/cargo_test");
     }
 
     fn on_first_instance(&self, build: &mut Build) -> Result<()> {
-        build.add_action(
+        // on ci, expect prebuilt binary to be available
+        // but `format` doesn't need it, so don't check existence rn
+        if !running_on_ci() {
+            build.add_action(
             "cargo-nextest",
             CargoInstall {
                 binary_name: "cargo-nextest",
                 args: "cargo-nextest --version 0.9.99 --locked --no-default-features --features default-no-update",
             },
         )?;
-        setup_flags(build)
+            setup_flags(build)?;
+        }
+        Ok(())
     }
 }
 

--- a/tools/coverage/coverage-rust
+++ b/tools/coverage/coverage-rust
@@ -8,11 +8,19 @@ outdir="out/coverage/rust"
 LLVMCOVPATH="out/bin"
 
 mkdir -p $outdir $LLVMCOVPATH
-test -x $LLVMCOVPATH/cargo-llvm-cov || cargo install cargo-llvm-cov --version 0.8.4 --locked --root out
-ANKI_TEST_MODE=1 $LLVMCOVPATH/cargo-llvm-cov llvm-cov --workspace --locked --json --summary-only \
+
+if [[ "${CI:-}" == "true" ]]; then
+    # prebuilt binary shouldve been installed
+    cargo_cmd="cargo"
+else
+    cargo_cmd="$LLVMCOVPATH/cargo-llvm-cov"
+    test -x "$cargo_cmd" || cargo install cargo-llvm-cov --version 0.8.4 --locked --root out
+fi
+
+ANKI_TEST_MODE=1 "$cargo_cmd" llvm-cov --workspace --locked --json --summary-only \
     --output-path $outdir/coverage-summary.json --fail-under-lines 64
 
 if [ "$html" = "--html" ]; then
-    ANKI_TEST_MODE=1 $LLVMCOVPATH/cargo-llvm-cov llvm-cov report --html --output-dir $outdir
+    ANKI_TEST_MODE=1 "$cargo_cmd" llvm-cov report --html --output-dir $outdir
     echo "Rust coverage report: $outdir/html/index.html"
 fi

--- a/tools/coverage/coverage-rust.bat
+++ b/tools/coverage/coverage-rust.bat
@@ -13,16 +13,23 @@ set "outdir=out\coverage\rust"
 set "LLVMCOVPATH=out\bin"
 
 if not exist %outdir% mkdir %outdir%
-if not exist %LLVMCOVPATH% mkdir %LLVMCOVPATH%
-if not exist %LLVMCOVPATH%\cargo-llvm-cov.exe (
-    cargo install cargo-llvm-cov --version 0.8.4 --locked --root out || exit /b 1
+
+if "%CI%"=="true" (
+  rem prebuilt binary shouldve been installed earlier
+  set "CARGO_CMD=cargo"
+) else (
+  if not exist %LLVMCOVPATH% mkdir %LLVMCOVPATH%
+  if not exist %LLVMCOVPATH%\cargo-llvm-cov.exe (
+      cargo install cargo-llvm-cov --version 0.8.4 --locked --root out || exit /b 1
+  )
+  set "CARGO_CMD=%LLVMCOVPATH%\cargo-llvm-cov.exe"
 )
 
 set "ANKI_TEST_MODE=1"
-%LLVMCOVPATH%\cargo-llvm-cov llvm-cov --workspace --locked --json --summary-only ^
+"%CARGO_CMD%" llvm-cov --workspace --locked --json --summary-only ^
     --output-path %outdir%\coverage-summary.json --fail-under-lines 64 || exit /b 1
 
 if "%1"=="--html" (
-    %LLVMCOVPATH%\cargo-llvm-cov llvm-cov report --html --output-dir %outdir% || exit /b 1
+    "%CARGO_CMD%" llvm-cov report --html --output-dir %outdir% || exit /b 1
     echo Rust coverage report: %outdir%\html\index.html
 )


### PR DESCRIPTION

## Linked issue (required)

Refs #5134

## Summary / motivation (required)

When running ci, instead of manually compiling cargo-llvm-cov and cargo-nextest when not cached, this pr pulls them in as prebuilt binaries instead

## Steps to reproduce (required, use N/A if not applicable)

N/A

## How to test (required)

CI should pass, and running `./check` and `just test --coverage` should work locally too

### Checklist (minimum)

- [x] I ran `./ninja check` or an equivalent relevant check locally.
- [ ] I added or updated tests when the change is non-trivial or behavior changed.

### Details

Continuing from https://github.com/ankitects/anki/issues/5134#issuecomment-4936603431, we can avoid installing the crates globally when run locally, but in ci it doesn't really matter so we can use install-action as per normal. W.r.t nextest's features, all `default-no-update` does is remove its ability to self-update. Since we're puling in prebuilt binaries during ci there's no difference

I've left out n2 for now, as without a release workflow on its repo or on anki's fork, we'd still have to compile it ourselves (caching it can be unsafe, but it sort of is already cached by setup-rust-toolchain?)

## Scope

- [x] This PR is focused on one change (no unrelated edits).
