### PR TITLE
fix: clean up FindDuplicatesDialog's webview on close to prevent theme-change crash

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -292,6 +292,7 @@ Niko Savola <nikomsavola@gmail.com>
 iDavi <odavi20527@gmail.com>
 Ian E <ian@ankihub.net> 
 Ashish Yadav <48384865+criticalAY@users.noreply.github.com>
+Timothy Lee <timothyl@berkeley.edu>
 
 ********************
 

--- a/qt/aqt/browser/find_duplicates.py
+++ b/qt/aqt/browser/find_duplicates.py
@@ -55,6 +55,7 @@ class FindDuplicatesDialog(QDialog):
         form.webView.stdHtml("", context=self)
 
         def on_finished(code: Any) -> None:
+            form.webView.cleanup()
             saveGeom(self, "findDupes")
 
         qconnect(self.finished, on_finished)


### PR DESCRIPTION
## Linked issue (required)
Fixes #5140

## Summary / motivation (required)
`FindDuplicatesDialog` never called `AnkiWebView.cleanup()` on close, unlike
the other dialogs that embed a webview (`EmptyCardsDialog`, `CardInfoDialog`,
`NewDeckStats`), which all do. Without it, the webview's `on_theme_did_change`
stays registered in `gui_hooks.theme_did_change` after Qt destroys the
underlying C++ widget, so a theme change shortly after close crashes with
`RuntimeError: wrapped C/C++ object of type FindDupesWebView has been deleted`.

## Steps to reproduce
1. Open Find Duplicates (Notes menu → Find Duplicates).
2. Close the dialog.
3. Trigger a theme change (toggle system light/dark mode).
4. Anki crashes with the RuntimeError above.

## How to test
Reproduced the crash via the steps above. No automated test included - this
change just applies the same `.cleanup()` call the three sibling dialogs
already make in their `finished`/`reject` handler. `./ninja check` passes.

### Checklist (minimum)
- [x] I ran `./ninja check` or an equivalent relevant check locally.
- [ ] I added or updated tests when the change is non-trivial or behavior changed. (same pattern as EmptyCardsDialog/CardInfoDialog/NewDeckStats - see above)

## Before / after behavior
Before: closing Find Duplicates then triggering a theme change could crash
Anki. After: the dialog cleans up its webview like its sibling dialogs, so
the same theme change no longer touches a deleted object.

## Risk / compatibility / migration
None - additive cleanup call, same pattern already used elsewhere in the
codebase.

## UI evidence
N/A - no visual change.

## Scope
- [x] This PR is focused on one change (no unrelated edits).
