### PR TITLE
fix: broken tags editor in legacy editor

### DIFF
--- a/ts/routes/editor/NoteEditor.svelte
+++ b/ts/routes/editor/NoteEditor.svelte
@@ -369,9 +369,12 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     function saveTags({ detail }: CustomEvent): void {
         tagAmount = detail.tags.filter((tag: string) => tag != "").length;
         lastSavedTags = detail.tags;
-        note!.tags = detail.tags;
-        bridgeCommand("saveTags");
-        updateCurrentNote();
+        if (isLegacy) {
+            bridgeCommand(`saveTags:${JSON.stringify(detail.tags)}`);
+        } else {
+            note!.tags = detail.tags;
+            updateCurrentNote();
+        }
     }
 
     const fieldSave = new ChangeTimer();


### PR DESCRIPTION
Closes #5152

> it seems that tags are not saved?
> https://forums.ankiweb.net/t/anki-26-08-beta-1/70398/2?u=llama

This pr restores the codepath for saving tags that was mistakenly removed in the new editor pr