### PR TITLE
fix: image occlusion masks lost when adding notes

### DIFF
--- a/qt/aqt/addcards_legacy.py
+++ b/qt/aqt/addcards_legacy.py
@@ -279,10 +279,7 @@ class AddCards(QMainWindow):
     def add_current_note(self) -> None:
         if self.editor.current_notetype_is_image_occlusion():
             self.editor.update_occlusions_field()
-            self.editor.call_after_note_saved(self._add_current_note)
-            self.editor.reset_image_occlusion()
-        else:
-            self.editor.call_after_note_saved(self._add_current_note)
+        self.editor.call_after_note_saved(self._add_current_note)
 
     def _add_current_note(self) -> None:
         note = self.editor.note
@@ -304,6 +301,10 @@ class AddCards(QMainWindow):
 
             tooltip(tr.importing_cards_added(count=changes.count), period=500)
             av_player.stop_and_clear_queue()
+            # resetting any earlier races the background add and can blank
+            # the occlusions field (#4754)
+            if self.editor.current_notetype_is_image_occlusion():
+                self.editor.reset_image_occlusion()
             self._load_new_note(sticky_fields_from=note)
             gui_hooks.add_cards_did_add_note(note)
 

--- a/ts/lib/editable/change-timer.test.ts
+++ b/ts/lib/editable/change-timer.test.ts
@@ -21,9 +21,13 @@ test("an action scheduled during a flush is not discarded", async () => {
     timer.schedule(async () => {
         ran.push("second");
     }, 10_000);
+    // replaces the second; only the latest pending action may run
+    timer.schedule(async () => {
+        ran.push("third");
+    }, 10_000);
     release();
     await flush;
     await timer.fireImmediately();
 
-    expect(ran).toEqual(["first", "second"]);
+    expect(ran).toEqual(["first", "third"]);
 });

--- a/ts/lib/editable/change-timer.test.ts
+++ b/ts/lib/editable/change-timer.test.ts
@@ -1,0 +1,29 @@
+// Copyright: Ankitects Pty Ltd and contributors
+// License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
+
+import { expect, test } from "vitest";
+
+import { ChangeTimer } from "./change-timer";
+
+test("an action scheduled during a flush is not discarded", async () => {
+    const timer = new ChangeTimer();
+    const ran: string[] = [];
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => (release = resolve));
+
+    timer.schedule(async () => {
+        ran.push("first");
+        await gate;
+    }, 10_000);
+    const flush = timer.fireImmediately();
+
+    // arrives while the first action is still running
+    timer.schedule(async () => {
+        ran.push("second");
+    }, 10_000);
+    release();
+    await flush;
+    await timer.fireImmediately();
+
+    expect(ran).toEqual(["first", "second"]);
+});

--- a/ts/lib/editable/change-timer.ts
+++ b/ts/lib/editable/change-timer.ts
@@ -4,6 +4,7 @@
 export class ChangeTimer {
     private value: number | null = null;
     private action: (() => Promise<void>) | null = null;
+    private running: Promise<void> | null = null;
 
     constructor() {
         this.fireImmediately = this.fireImmediately.bind(this);
@@ -23,11 +24,20 @@ export class ChangeTimer {
     }
 
     async fireImmediately(): Promise<void> {
-        if (this.action) {
-            await this.action();
-            this.action = null;
+        if (this.running) {
+            // wait for the run in flight, then flush anything scheduled since
+            await this.running;
         }
-
         this.clear();
+        // take the action before running it; one scheduled during the await
+        // below would otherwise be discarded when the run finished
+        const action = this.action;
+        this.action = null;
+        if (action) {
+            this.running = action().finally(() => {
+                this.running = null;
+            });
+            await this.running;
+        }
     }
 }

--- a/ts/routes/editor/NoteEditor.svelte
+++ b/ts/routes/editor/NoteEditor.svelte
@@ -374,7 +374,8 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         updateCurrentNote();
     }
 
-    const fieldSave = new ChangeTimer();
+    // one timer per field, so a save cannot cancel another field's pending save (#4754)
+    const fieldSaves = new Map<number, ChangeTimer>();
 
     async function transformContentBeforeSave(content: string): Promise<string> {
         content = content.replace(/ data-editor-shrink="(true|false)"/g, "");
@@ -409,7 +410,12 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     }
 
     async function updateField(index: number, content: string): Promise<void> {
-        fieldSave.schedule(async () => {
+        let timer = fieldSaves.get(index);
+        if (!timer) {
+            timer = new ChangeTimer();
+            fieldSaves.set(index, timer);
+        }
+        timer.schedule(async () => {
             if (isLegacy) {
                 bridgeCommand(
                     `key:${index}:${getNoteId()}:${await transformContentBeforeSave(
@@ -427,7 +433,9 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
     async function saveFieldNow() {
         /* this will always be a key save */
-        await fieldSave.fireImmediately();
+        for (const timer of fieldSaves.values()) {
+            await timer.fireImmediately();
+        }
     }
 
     async function saveNow() {

--- a/ts/tests/e2e/io-mask-save-race.spec.ts
+++ b/ts/tests/e2e/io-mask-save-race.spec.ts
@@ -1,0 +1,148 @@
+// Copyright: Ankitects Pty Ltd and contributors
+// License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
+
+/**
+ * Regression test for #4754: a keystroke in another field within 600 ms of
+ * the last mask edit cancelled the pending debounced save of the Occlusions
+ * field, and it was never re-scheduled, so masks drawn since the last
+ * commit were missing from the added note.
+ *
+ * Mutates the collection: adds the Image Occlusion notetype and notes.
+ */
+
+import { AddImageOcclusionNoteRequest } from "@generated/anki/image_occlusion_pb";
+import { AddNoteRequest } from "@generated/anki/notes_pb";
+import type { Page } from "@playwright/test";
+import path from "path";
+
+import { expect, test } from "./fixtures";
+import { callRpc, chooserButton, decodeRequestBody, editableField, isRpc, openChooserAndSelect } from "./helpers";
+
+// stock image occlusion notetype field order (rslib/src/image_occlusion/notetype.rs)
+const OCCLUSIONS_FIELD = 0;
+const HEADER_FIELD = 2;
+
+const TEST_IMAGE = path.resolve("qt/aqt/data/web/imgs/anki-logo-thin.png");
+
+function clozeCount(field: string): number {
+    return (field.match(/image-occlusion:/g) ?? []).length;
+}
+
+function shapeCount(page: Page): Promise<number> {
+    return page.evaluate(() => {
+        const canvas = (globalThis as any).canvas;
+        return canvas.getObjects().filter((o: any) => o.id !== "boundingBox").length;
+    });
+}
+
+async function drawRect(
+    page: Page,
+    box: { x: number; y: number },
+    from: [number, number],
+    to: [number, number],
+    expectedShapes: number,
+): Promise<void> {
+    // a drag occasionally fails to register while the canvas layout is
+    // still settling, so verify the shape landed and retry if not
+    for (let attempt = 0; attempt < 3; attempt++) {
+        await page.mouse.move(box.x + from[0], box.y + from[1]);
+        await page.mouse.down();
+        await page.mouse.move(box.x + to[0], box.y + to[1], { steps: 3 });
+        await page.mouse.up();
+        if (await shapeCount(page) === expectedShapes) {
+            return;
+        }
+        await page.waitForTimeout(300);
+    }
+    throw new Error("failed to draw a rectangle on the mask canvas");
+}
+
+// Leaving Image Occlusion as the current notetype would strand later tests
+// in the mask picker view. The switch only persists once a note is added.
+test.afterEach(async ({ editorPage: page }) => {
+    try {
+        await chooserButton(page, "notetype").click();
+        const modal = page.locator(".modal.show");
+        await modal.waitFor({ state: "visible", timeout: 5_000 });
+        await modal.getByRole("button", { name: "Select Basic", exact: true }).click();
+        await modal.waitFor({ state: "hidden", timeout: 5_000 });
+        const field = editableField(page, 0);
+        await field.click();
+        await field.pressSequentially("io-race cleanup");
+        const added = page.waitForRequest(isRpc("addNote"), { timeout: 5_000 });
+        await page.getByRole("button", { name: "Add", exact: true }).click();
+        await added;
+    } catch {
+        // best effort
+    }
+});
+
+test("masks drawn shortly before typing in another field are saved", async ({ editor: page }) => {
+    // addImageOcclusionNote with notetypeId 0 creates the notetype on demand
+    await callRpc(
+        page,
+        "addImageOcclusionNote",
+        new AddImageOcclusionNoteRequest({
+            notetypeId: 0n,
+            imagePath: TEST_IMAGE,
+            occlusions: "{{c1::image-occlusion:rect:left=.1:top=.1:width=.2:height=.2}}",
+            header: "seed",
+            backExtra: "",
+            tags: [],
+        }),
+        1,
+    );
+    await openChooserAndSelect(page, "notetype", "Image Occlusion");
+    // the modal's fade-out backdrop intercepts pointer events
+    await page.waitForFunction(
+        () => !document.querySelector(".modal.show") && !document.querySelector(".modal-backdrop"),
+        { timeout: 5_000 },
+    );
+
+    await page.evaluate(
+        (imagePath) => (globalThis as any).setupMaskEditorForNewNote(imagePath),
+        TEST_IMAGE,
+    );
+    // canvas is ready once the bounding box has been added
+    await page.waitForFunction(() => {
+        const canvas = (globalThis as any).canvas;
+        return canvas && canvas.getObjects().length >= 1;
+    }, { timeout: 15_000 });
+
+    // shapes must be drawn inside the image's bounding box
+    const imageBox = await page.locator("#image").boundingBox();
+    expect(imageBox).not.toBeNull();
+    const rectA: [[number, number], [number, number]] = [
+        [imageBox!.width * 0.1, imageBox!.height * 0.2],
+        [imageBox!.width * 0.3, imageBox!.height * 0.7],
+    ];
+    const rectB: [[number, number], [number, number]] = [
+        [imageBox!.width * 0.5, imageBox!.height * 0.2],
+        [imageBox!.width * 0.7, imageBox!.height * 0.7],
+    ];
+
+    // rectangle A, allowed to commit normally
+    await drawRect(page, imageBox!, ...rectA, 1);
+    await page.waitForTimeout(900);
+
+    const toggleButton = page.locator("#io-mask-btn");
+    await expect(toggleButton).toBeVisible();
+
+    // rectangle B, then switch to the fields view and get a Header keystroke
+    // in before the debounced occlusions save fires (600 ms after mouse-up)
+    await drawRect(page, imageBox!, ...rectB, 2);
+    const drawnAt = Date.now();
+    await toggleButton.click();
+    await editableField(page, HEADER_FIELD).click();
+    await page.keyboard.type("s");
+    // past the debounce window the test passes without exercising the race
+    expect(Date.now() - drawnAt).toBeLessThan(600);
+
+    await page.waitForTimeout(900);
+
+    const addNoteReqPromise = page.waitForRequest(isRpc("addNote"), { timeout: 10_000 });
+    await page.getByRole("button", { name: "Add", exact: true }).click();
+    const decoded = decodeRequestBody(await addNoteReqPromise, AddNoteRequest);
+
+    expect(clozeCount(decoded.note!.fields[OCCLUSIONS_FIELD])).toBe(2);
+});

--- a/ts/tests/e2e/io-mask-save-race.spec.ts
+++ b/ts/tests/e2e/io-mask-save-race.spec.ts
@@ -106,7 +106,7 @@ test("masks drawn shortly before typing in another field are saved", async ({ ed
     // canvas is ready once the bounding box has been added
     await page.waitForFunction(() => {
         const canvas = (globalThis as any).canvas;
-        return canvas && canvas.getObjects().length >= 1;
+        return canvas && canvas.getObjects && canvas.getObjects().length >= 1;
     }, { timeout: 15_000 });
 
     // shapes must be drawn inside the image's bounding box


### PR DESCRIPTION
## Linked issue (required)

Closes #4754

## Summary / motivation (required)

Image occlusion masks could silently go missing from a note at add time. Two separate problems caused this, both timing dependent, which is why the bug was rare and hard to reproduce.

**Problem 1: the editor reset races the add (desktop).** Clicking Add on an image occlusion note saved the note, queued the actual add, and reset the mask editor all at once. The reset clears the canvas, and clearing the canvas writes an empty value into the Occlusions field of the same note object the add was about to read. Depending on which message arrived first: the add worked normally (the common case), the note was added with no masks and no warning, or the add was wrongly rejected with "no occlusion created" while the masks were plainly visible. Fix: reset the mask editor only after the add succeeds, matching the ordering the non-legacy TS editor page already uses. This also means a rejected add no longer wipes the masks you drew.

**Problem 2: one field's save cancels another's.** All fields committed through a single shared save timer, and scheduling a save cancelled the timer's previous pending action. Mask edits commit the Occlusions field through that timer with a 600 ms debounce, so typing into Header or Back Extra within 600 ms of the last mask edit threw away the pending occlusions write. It was never retried, because later saves saw the store already held the same value and skipped notifying. Every mask drawn since the last committed write was then missing from the added note. Fix: give each field its own timer. This also surfaced a second bug in `ChangeTimer` itself: an action scheduled while `fireImmediately()` was awaiting a previous action was silently discarded when that await finished; fixed by taking the action before running it and letting a concurrent flush wait for the run in flight.

## Steps to reproduce (required, use N/A if not applicable)

Problem 2 (reliably reproducible):
1. Add an Image Occlusion note, draw a mask, wait for it to auto-commit (~1s).
2. Draw a second mask.
3. Immediately (within ~600 ms) switch to the fields view and type a character into Header.
4. Wait a second, click Add.
5. Before this fix: the added note is missing the second mask. No warning is shown.

Problem 1 (event-loop timing dependent, not reliably reproducible by hand):
1. Add an Image Occlusion note, paste an image, draw one or more masks.
2. Click Add.
3. Before this fix: rarely, the note is added with an empty Occlusions field and no warning, or Add is rejected with "no occlusion created" while masks are visible on screen.

## How to test (required)

### Checklist (minimum)

- [x] I ran `./ninja check` or an equivalent relevant check locally.
- [x] I added or updated tests when the change is non-trivial or behavior changed.

### Details

- `ts/tests/e2e/io-mask-save-race.spec.ts` reproduces problem 2 with real mouse drawing and real keystrokes at the real 600 ms timing. Fails on current `main` (payload contains 1 cloze instead of 2, consistently across repeated runs) and passes with this change.
- `ts/lib/editable/change-timer.test.ts` covers the discarded-action case in `ChangeTimer` and fails without the fix.
- Full Playwright e2e suite (`just test-e2e`) passes repeatedly across fresh profiles.
- `just fmt`, `just lint`, and the vitest suite are clean.
- Problem 1 has no reliable automated test: the outcome depends on how the Qt event loop interleaves two webChannel messages and a background task. I verified the mechanism with a scripted headless Anki that drives the real `AddCards` flow and delivers the racing write inside the vulnerable window, and confirmed by inspection that after this change the empty write can no longer be issued while an add is in flight.

## Before / after behavior (optional)

Before: masks could be silently dropped from a newly added note (problem 2, common), or the note could be added completely empty of masks / spuriously rejected (problem 1, rare). After: neither race is possible; a rejected add also no longer clears the masks you've drawn, so you can fix the note and retry instead of redrawing.

## Risk / compatibility / migration (optional)

Low risk. Both fixes are ordering/scoping changes with no behavior change outside the affected race windows. No schema, API, or migration changes.

## UI evidence (required for visual changes; otherwise N/A)

N/A (no visual/UI changes).

## Scope

- [x] This PR is focused on one change (no unrelated edits).

This PR contains two fixes rather than one. I considered splitting them, but both are root causes of the same reported bug (#4754) discovered during the same investigation, they are already isolated into two separate commits for review, and neither is a complete fix for the issue on its own. Happy to split into two PRs if you'd prefer.
