### PR TITLE
ci: Normalize GitHub noreply emails for all contributors

### DIFF
--- a/tools/minilints/src/main.rs
+++ b/tools/minilints/src/main.rs
@@ -149,6 +149,10 @@ impl LintContext {
                 .stdout,
         )?;
         let all_contributors = all_contributors.lines().collect::<HashSet<&str>>();
+        let normalized_contributors: HashSet<&str> = all_contributors
+            .iter()
+            .map(|e| normalize_email(e))
+            .collect();
 
         const BOT_EMAILS: &[&str] = &[
             "49699333+dependabot[bot]@users.noreply.github.com",
@@ -157,7 +161,7 @@ impl LintContext {
         ];
 
         if BOT_EMAILS.contains(&last_author.as_str())
-            || all_contributors.contains(last_author.as_str())
+            || normalized_contributors.contains(normalize_email(&last_author))
         {
             return Ok(());
         }


### PR DESCRIPTION
This normalizes GitHub noreply emails (e.g. `user@users.noreply.github.com`, `12345+user@users.noreply.github.com`) for the CONTRIBUTORS file check. Previously it was only done for emails coming from the `CONTRIBUTORS_BYPASS_EMAILS` env var.