### PR TITLE
Prevent Deck Options window from staying minimized on macOS

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -295,6 +295,7 @@ Ashish Yadav <48384865+criticalAY@users.noreply.github.com>
 Timothy Lee <timothyl@berkeley.edu>
 DespicableGoose <68354378+DespicableGoose@users.noreply.github.com>
 Han Lua <72375847+xiaohan484@users.noreply.github.com>
+Jiaming Pei <jiamingpei16@gmail.com>
 
 ********************
 

--- a/qt/aqt/deckoptions.py
+++ b/qt/aqt/deckoptions.py
@@ -9,6 +9,7 @@ import aqt.main
 from anki.cards import Card
 from anki.decks import DeckDict, DeckId
 from anki.lang import without_unicode_isolation
+from anki.utils import is_mac
 from aqt import gui_hooks
 from aqt.qt import *
 from aqt.utils import (
@@ -58,6 +59,19 @@ class DeckOptionsDialog(QDialog):
     def set_ready(self):
         self._ready = True
         gui_hooks.deck_options_did_load(self)
+
+    def changeEvent(self, evt: QEvent | None) -> None:
+        # A minimized application-modal window can't be restored on macOS (not
+        # from the Dock or the Window menu), leaving the app unusable until it's
+        # force-quit. Refuse to stay minimized.
+        if (
+            is_mac
+            and evt is not None
+            and evt.type() == QEvent.Type.WindowStateChange
+            and self.isMinimized()
+        ):
+            self.showNormal()
+        super().changeEvent(evt)
 
     def closeEvent(self, evt: QCloseEvent | None) -> None:
         if self._close_event_has_cleaned_up or not self._ready:


### PR DESCRIPTION
## Linked issue

Closes #5164

## Summary / motivation

On macOS an application-modal window can't be restored once minimized: the OS greys out its Dock/Window-menu entry and delivers no de-miniaturize event on re-activation. Because Deck Options is application-modal, the main window stays blocked and Anki can't be closed except by force-quit (⌘Q).

Modality can't simply be dropped — the Deck Options load/close flow finds the window via `activeModalWidget()` in `mediasrv.py`, so a non-modal window would never load or close. Instead, this refuses to let the dialog stay minimized on macOS by restoring it in `changeEvent`.

## Steps to reproduce

1. Main window → a deck's gear icon → **Options**
2. Click the yellow **minimize** button on the Deck Options window
3. Before the fix: the window can't be restored (its Dock/Window-menu entry is greyed out) and the app can't be closed. After the fix: it bounces straight back and stays usable.

## How to test

On macOS, open Deck Options and click the yellow minimize button → the window returns instead of vanishing into the Dock, and the app never locks up. Behaviour on other platforms is unchanged (`is_mac`-guarded).

## UI evidence

**Before** — same app, only the modality differs.

Anki's own (non-modal) main window minimized — its Dock/Window-menu entry is blue and restorable:

<img width="210" alt="main window (non-modal) can be restored" src="https://github.com/user-attachments/assets/4040fa5f-8dee-4e54-b375-740aad53ab57" />

The Deck Options (application-modal) window minimized — its entry is greyed out and can't be clicked, so it's unrecoverable:

<img width="229" alt="deck options (modal) cannot be restored" src="https://github.com/user-attachments/assets/b56f3149-ff78-4138-8ed3-4e419c7ffaf9" />

**After the fix** — clicking minimize bounces the window straight back and the app stays usable:

https://github.com/user-attachments/assets/b23e5ffa-c32f-44cf-a4f7-288eeefb6849
