### PR TITLE
fix: detect CSV delimiter by consistency, not first-occurrence

### DIFF
--- a/rslib/src/import_export/text/csv/metadata.rs
+++ b/rslib/src/import_export/text/csv/metadata.rs
@@ -528,16 +528,67 @@ fn delimiter_from_value(value: &str) -> Option<Delimiter> {
     })
 }
 
-fn delimiter_from_reader(mut reader: impl Read) -> Result<Delimiter> {
-    let mut buf = [0; 8 * 1024];
-    let _ = reader.read(&mut buf)?;
-    // TODO: use smarter heuristic
-    for delimiter in Delimiter::iter() {
-        if buf.contains(&delimiter.byte()) {
-            return Ok(delimiter);
+fn delimiter_from_reader(reader: impl Read) -> Result<Delimiter> {
+    // read_to_end avoids a short read (a fixed-size `read` can return fewer
+    // bytes than available for a pipe/socket); cap it at 8KB via take.
+    let mut buf = Vec::with_capacity(8 * 1024);
+    reader.take(8 * 1024).read_to_end(&mut buf)?;
+    let text = String::from_utf8_lossy(&buf);
+    // Examine the first several non-empty lines and pick the delimiter that
+    // splits them most consistently (the same positive count on the most
+    // lines). This avoids choosing a delimiter that merely appears inside field
+    // content - e.g. a ':' in a time, or a ',' decimal separator in a
+    // semicolon-delimited file.
+    let lines: Vec<&str> = text
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .take(10)
+        .collect();
+
+    // Tie-break order: genuine delimiters first, content-prone ones (colon and
+    // space) last, so an otherwise-ambiguous file is read the way it was most
+    // likely written.
+    const TIE_BREAK_ORDER: [Delimiter; 6] = [
+        Delimiter::Tab,
+        Delimiter::Pipe,
+        Delimiter::Semicolon,
+        Delimiter::Comma,
+        Delimiter::Colon,
+        Delimiter::Space,
+    ];
+
+    let mut best: Option<(usize, Delimiter)> = None;
+    for delimiter in TIE_BREAK_ORDER {
+        let score = delimiter_consistency(&lines, delimiter.byte());
+        if score == 0 {
+            continue;
+        }
+        // earlier (higher-priority) delimiters win ties
+        match best {
+            Some((best_score, _)) if best_score >= score => {}
+            _ => best = Some((score, delimiter)),
         }
     }
-    Ok(Delimiter::Space)
+
+    Ok(best
+        .map(|(_, delimiter)| delimiter)
+        .unwrap_or(Delimiter::Space))
+}
+
+/// The largest number of lines that share a single positive per-line count of
+/// `byte`. A higher value means the delimiter splits the sample into a
+/// consistent number of columns; 0 means the byte never appears.
+fn delimiter_consistency(lines: &[&str], byte: u8) -> usize {
+    let counts: Vec<usize> = lines
+        .iter()
+        .map(|line| line.bytes().filter(|&b| b == byte).count())
+        .filter(|&count| count > 0)
+        .collect();
+    counts
+        .iter()
+        .map(|&target| counts.iter().filter(|&&count| count == target).count())
+        .max()
+        .unwrap_or(0)
 }
 
 fn map_single_record<T>(
@@ -770,6 +821,29 @@ pub(in crate::import_export) mod test {
             metadata!(col, "#separator: \nfoo\tbar\n", Some(Delimiter::Pipe)).delimiter(),
             Delimiter::Pipe
         );
+    }
+
+    #[test]
+    fn should_prefer_consistent_delimiter_over_content_characters() {
+        let mut col = Collection::new();
+        // a comma file whose fields contain colons (e.g. times) must be
+        // detected as comma, not colon
+        assert_eq!(
+            metadata!(col, "time,note\n9:00,wake up\n10:30,run\n").delimiter(),
+            Delimiter::Comma
+        );
+        // even on a single line, prefer comma over the content colon
+        assert_eq!(
+            metadata!(col, "9:00,wake up\n").delimiter(),
+            Delimiter::Comma
+        );
+        // a semicolon file with decimal commas must stay semicolon, not comma
+        assert_eq!(
+            metadata!(col, "1,5;2,7\n3,1;4,2\n").delimiter(),
+            Delimiter::Semicolon
+        );
+        // a genuinely colon-delimited file is still detected as colon
+        assert_eq!(metadata!(col, "a:b\nc:d\n").delimiter(), Delimiter::Colon);
     }
 
     #[test]

--- a/rslib/src/import_export/text/csv/metadata.rs
+++ b/rslib/src/import_export/text/csv/metadata.rs
@@ -533,18 +533,6 @@ fn delimiter_from_reader(reader: impl Read) -> Result<Delimiter> {
     // bytes than available for a pipe/socket); cap it at 8KB via take.
     let mut buf = Vec::with_capacity(8 * 1024);
     reader.take(8 * 1024).read_to_end(&mut buf)?;
-    let text = String::from_utf8_lossy(&buf);
-    // Examine the first several non-empty lines and pick the delimiter that
-    // splits them most consistently (the same positive count on the most
-    // lines). This avoids choosing a delimiter that merely appears inside field
-    // content - e.g. a ':' in a time, or a ',' decimal separator in a
-    // semicolon-delimited file.
-    let lines: Vec<&str> = text
-        .lines()
-        .filter(|line| !line.trim().is_empty())
-        .take(10)
-        .collect();
-
     // Tie-break order: genuine delimiters first, content-prone ones (colon and
     // space) last, so an otherwise-ambiguous file is read the way it was most
     // likely written.
@@ -559,7 +547,7 @@ fn delimiter_from_reader(reader: impl Read) -> Result<Delimiter> {
 
     let mut best: Option<(usize, Delimiter)> = None;
     for delimiter in TIE_BREAK_ORDER {
-        let score = delimiter_consistency(&lines, delimiter.byte());
+        let score = delimiter_consistency(&buf, delimiter.byte());
         if score == 0 {
             continue;
         }
@@ -575,14 +563,21 @@ fn delimiter_from_reader(reader: impl Read) -> Result<Delimiter> {
         .unwrap_or(Delimiter::Space))
 }
 
-/// The largest number of lines that share a single positive per-line count of
-/// `byte`. A higher value means the delimiter splits the sample into a
-/// consistent number of columns; 0 means the byte never appears.
-fn delimiter_consistency(lines: &[&str], byte: u8) -> usize {
-    let counts: Vec<usize> = lines
-        .iter()
-        .map(|line| line.bytes().filter(|&b| b == byte).count())
-        .filter(|&count| count > 0)
+/// The largest number of records that share a field count greater than one
+/// when parsed with `byte` as the delimiter. Parsing each candidate as CSV
+/// prevents delimiter-like characters inside quoted fields from affecting the
+/// score.
+fn delimiter_consistency(sample: &[u8], byte: u8) -> usize {
+    let counts: Vec<usize> = csv::ReaderBuilder::new()
+        .delimiter(byte)
+        .has_headers(false)
+        .flexible(true)
+        .from_reader(sample)
+        .byte_records()
+        .take(10)
+        .filter_map(|record| record.ok())
+        .map(|record| record.len())
+        .filter(|&field_count| field_count > 1)
         .collect();
     counts
         .iter()
@@ -841,6 +836,12 @@ pub(in crate::import_export) mod test {
         assert_eq!(
             metadata!(col, "1,5;2,7\n3,1;4,2\n").delimiter(),
             Delimiter::Semicolon
+        );
+        // delimiter-like characters inside quoted fields must not participate
+        // in detection
+        assert_eq!(
+            metadata!(col, "\"a;b\",c\n\"d;e\",f\n").delimiter(),
+            Delimiter::Comma
         );
         // a genuinely colon-delimited file is still detected as colon
         assert_eq!(metadata!(col, "a:b\nc:d\n").delimiter(), Delimiter::Colon);


### PR DESCRIPTION
## Linked issue (required)

Fixes #5253.

Also refs #3853, which reported the same symptom and is closed. That report had two causes: the mangled `#separator:Comma,,` header line, fixed at the time by trimming trailing delimiters from comment lines, and the underlying auto-detection favouring `:` over `,` whenever both appear, per @dae's analysis there. This PR fixes the second, which is still reachable today on any file without a valid `#separator:` header.

## Summary / motivation (required)

`delimiter_from_reader` returned the **first** delimiter byte found anywhere in the 8KB sample, in a fixed enum order that tries `:` before `,`. So a normal comma CSV containing a colon in any field (a time like `9:00`, a URL, a `parent::child` tag, `"Note:"`) was detected as colon-delimited and split into the wrong columns, corrupting the import. This is the content-driven half of the misdetection discussed in #3853; the header-line half was already fixed by trimming trailing delimiters from `#`-comment lines.

The fix keeps detection dependency-free: parse the sample with each candidate delimiter and pick the one that produces the most consistent positive field count. Because each candidate is parsed as CSV, delimiter-like characters inside quoted fields do not affect the score. Ties use a priority order that keeps genuine delimiters ahead of content-prone ones such as colon and space. For example, a semicolon file with decimal commas (`1,5;2,7`) stays semicolon.

## Steps to reproduce (required, use N/A if not applicable)

1. Save as `test.csv` (no `#separator:` header):
   ```
   time,note
   9:00,wake up
   10:30,run
   ```
2. Import via File → Import.
3. The preview splits rows on `:` instead of `,`.

## How to test (required)

### Checklist (minimum)

- [x] I ran `./ninja check` or an equivalent relevant check locally.
- [x] I added or updated tests when the change is non-trivial or behavior changed.

### Details

- New unit tests in `metadata.rs` cover comma files with colons in fields, quoted fields containing another candidate delimiter, semicolon files with decimal commas, and genuinely colon-delimited files. The existing detection cases still pass.
- Upstream CI for the latest commit: https://github.com/ankitects/anki/actions/runs/31341127603
- The new regression test and all 539 Rust tests passed. Format and minilints also passed. The workflow is red because the current Python suite reports 63% coverage against the repository's 65% floor; this PR does not touch Python.

## Before / after behavior (optional)

Before: first-occurrence detection mis-splits comma CSVs containing colons (or any delimiter byte appearing earlier in the enum order than the real one). After: consistency-based detection reads them correctly; explicitly-specified delimiters are unaffected.

## Risk / compatibility / migration (optional)

Only the auto-detection fallback changes; `#separator:` headers and delimiters passed explicitly through the import dialog are untouched. Detection remains a heuristic and can still guess wrong on genuinely ambiguous files. The tie-break deliberately prefers comma and semicolon over colon and space, so a colon-delimited file whose every line also contains exactly one comma now resolves to comma where the old code resolved to colon. That trade-off favors the far more common case (comma/semicolon files with colons in content) at the expense of a rare one, and any file with a consistent delimiter and no equally-consistent impostor is detected correctly.

## UI evidence (required for visual changes; otherwise N/A)

N/A

## Scope

- [x] This PR is focused on one change (no unrelated edits).

