### PR TITLE
fix: reparent deck onto string-prefix sibling instead of no-op

### DIFF
--- a/rslib/src/decks/name.rs
+++ b/rslib/src/decks/name.rs
@@ -64,10 +64,17 @@ impl NativeDeckName {
     /// list. The returned name should be used to replace `self`.
     pub(crate) fn reparented_name(&self, target: Option<&NativeDeckName>) -> Option<Self> {
         let dragged_base = self.0.rsplit('\x1f').next().unwrap();
-        let dragged_root = self.components().next().unwrap();
         if let Some(target) = target {
-            let target_root = target.components().next().unwrap();
-            if target.0.starts_with(&self.0) && target_root == dragged_root {
+            // A deck can't be dropped onto itself or onto one of its own
+            // descendants. Compare on component boundaries, so a sibling whose
+            // name merely shares a string prefix (e.g. `foo::bar` and
+            // `foo::barbaz`) is not mistaken for a descendant.
+            let onto_self_or_descendant = target.0 == self.0
+                || target
+                    .0
+                    .strip_prefix(self.0.as_str())
+                    .is_some_and(|rest| rest.starts_with('\x1f'));
+            if onto_self_or_descendant {
                 // foo onto foo::bar, or foo onto itself -> no-op
                 None
             } else {
@@ -292,5 +299,11 @@ mod test {
         assert_eq!(reparented_name("foo:bar", Some("foo:bar")), None);
         // names that are prefixes of the target are handled correctly
         assert_eq!(reparented_name("a", Some("ab")), n_opt("ab:a"));
+        // a sibling whose name has the dragged deck's name as a string prefix
+        // is not a descendant, so the drop must still reparent (not no-op)
+        assert_eq!(
+            reparented_name("foo:bar", Some("foo:barbaz")),
+            n_opt("foo:barbaz:bar")
+        );
     }
 }


### PR DESCRIPTION
## Linked issue (required)

Closes #5183

## Summary / motivation (required)

`reparented_name()` used `target.0.starts_with(&self.0)` to detect a drop onto the dragged deck or one of its descendants. Because this compared the raw `\x1f`-joined names rather than component boundaries, a sibling whose name merely shares a string prefix (e.g. dragging `foo::bar` onto `foo::barbaz`) was misclassified as a descendant and the drop became a silent no-op.

The fix compares on `\x1f` component boundaries so only the deck itself or a genuine descendant is treated as a no-op.

## Steps to reproduce (required, use N/A if not applicable)

1. Create decks `foo::bar` and `foo::barbaz`.
2. In the deck list, drag `foo::bar` onto `foo::barbaz`.
3. Observe nothing happens (silent no-op) instead of `bar` becoming `foo::barbaz::bar`.

## How to test (required)

### Checklist (minimum)

- [ ] I ran `./ninja check` or an equivalent relevant check locally.
- [x] I added or updated tests when the change is non-trivial or behavior changed.

### Details

Adds a regression assertion to the `drag_drop` test. Developed and passed full CI (`check` on Linux/macOS/Windows, `format`, `minilints`) on a combined branch; per-branch CI runs on push. Draft until CI is green.

## Before / after behavior (optional)

Before: reparenting onto a string-prefix sibling is a silent no-op. After: it reparents correctly.

## Risk / compatibility / migration (optional)

Low risk.

## UI evidence (required for visual changes; otherwise N/A)

N/A

## Scope

- [x] This PR is focused on one change (no unrelated edits).
