### PR TITLE
feat: lazy-load MathJax on Reviewer

### DIFF
--- a/qt/aqt/reviewer.py
+++ b/qt/aqt/reviewer.py
@@ -346,8 +346,6 @@ class Reviewer:
             self.revHtml(),
             css=["css/reviewer.css"],
             js=[
-                "js/mathjax.js",
-                "js/vendor/mathjax/tex-chtml-full.js",
                 "js/reviewer.js",
             ],
             context=self,

--- a/ts/reviewer/index.ts
+++ b/ts/reviewer/index.ts
@@ -24,6 +24,37 @@ import { preloadResources } from "./preload";
 
 declare const MathJax: any;
 
+let mathjaxLoading: Promise<void> | null = null;
+
+function _ensureMathJaxLoaded(): Promise<void> {
+    if (mathjaxLoading) {
+        return mathjaxLoading;
+    }
+    if (typeof MathJax !== "undefined" && MathJax.startup) {
+        return Promise.resolve();
+    }
+    mathjaxLoading = new Promise((resolve, reject) => {
+        const configScript = document.createElement("script");
+        configScript.src = "/_anki/js/mathjax.js";
+        configScript.onload = () => {
+            const mathjaxScript = document.createElement("script");
+            mathjaxScript.src = "/_anki/js/vendor/mathjax/tex-chtml-full.js";
+            mathjaxScript.onload = () => resolve();
+            mathjaxScript.onerror = () => reject(new Error("Failed to load MathJax"));
+            document.head.appendChild(mathjaxScript);
+        };
+        configScript.onerror = () => reject(new Error("Failed to load MathJax config"));
+        document.head.appendChild(configScript);
+    });
+    return mathjaxLoading;
+}
+
+const mathjaxRegex = /\\\[|\\\(|\\ce\{/;
+
+function _containsMathjax(html: string): boolean {
+    return mathjaxRegex.test(html);
+}
+
 type Callback = () => void | Promise<void>;
 
 export const onUpdateHook: Array<Callback> = [];
@@ -147,15 +178,25 @@ export async function _updateQA(
     // dynamic toolbar background
     bridgeCommand("updateToolbar");
 
-    // wait for mathjax to ready
-    await MathJax.startup.promise
-        .then(() => {
-            // clear MathJax buffers from previous typesets
-            MathJax.typesetClear();
+    if (_containsMathjax(html)) {
+        try {
+            await _ensureMathJaxLoaded();
+        } catch (error) {
+            console.error(error);
+        }
+    }
 
-            return MathJax.typesetPromise([qa]);
-        })
-        .catch(renderError("MathJax"));
+    if (typeof MathJax !== "undefined" && MathJax.startup) {
+        // wait for mathjax to ready
+        await MathJax.startup.promise
+            .then(() => {
+                // clear MathJax buffers from previous typesets
+                MathJax.typesetClear();
+
+                return MathJax.typesetPromise([qa]);
+            })
+            .catch(renderError("MathJax"));
+    }
 
     qa.style.opacity = "1";
 


### PR DESCRIPTION


## Linked issue (required)

* Closes #5172

## Summary / motivation (required)

Loading MathJax makes the reviewer initialization slower, which is relevant for people who don't use MathJax and slower devices (such as phones)

## Steps to reproduce (required, use N/A if not applicable)

N/A

## How to test (required)

1. Opened a deck with a card with no MathJax
2. In developer tools' console,, check whether `MathJax` is not defined
3. Answer some cards until a card with MathJax appears -> Check if it is correctly loaded

### Checklist (minimum)

- [X] I ran `./ninja check` or an equivalent relevant check locally.
- [ ] I added or updated tests when the change is non-trivial or behavior changed.

### Details

<!-- Commands, manual steps, edge cases, and what you observed -->

## Before / after behavior (optional)

<!-- For bugfixes: behavior before vs after. For other types: N/A or a short note. -->

## Risk / compatibility / migration (optional)

<!-- Breaking changes, rollout notes, or N/A for small / low-risk PRs -->

## UI evidence (required for visual changes; otherwise N/A)

N/A

## Scope

- [X] This PR is focused on one change (no unrelated edits).
