### PR TITLE
feat: only show "this will save your config" when config is modified when optimizing all presets

### DIFF
--- a/ts/routes/deck-options/FsrsOptions.svelte
+++ b/ts/routes/deck-options/FsrsOptions.svelte
@@ -348,7 +348,8 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     async function computeAllParams(): Promise<void> {
         await commitEditing();
 
-        if (confirm(tr.deckConfigFsrsConfirmSaveAndOptimize())) {
+        const modified = await state.isModified();
+        if (!modified || confirm(tr.deckConfigFsrsConfirmSaveAndOptimize())) {
             state.save(UpdateDeckConfigsMode.COMPUTE_ALL_PARAMS);
             window.location.reload();
         }


### PR DESCRIPTION
closes #5175 

To test run "optimise all presets" before making changes and no confirm should appear.
Run it after making a change to the config and the prompt should appear.