### PR TITLE
fix(io): text label escaping

### DIFF
--- a/rslib/src/cloze.rs
+++ b/rslib/src/cloze.rs
@@ -519,6 +519,8 @@ pub(crate) fn cloze_only_filter<'a>(text: &'a str, context: &RenderContext) -> C
 mod test {
     use std::collections::HashSet;
 
+    use anki_proto::image_occlusion::get_image_occlusion_note_response::ImageOcclusionProperty;
+
     use super::*;
     use crate::text::strip_html;
 
@@ -840,5 +842,24 @@ mod test {
 
         let card2_html = reveal_cloze_text(text, 2, true);
         assert!(card2_html.contains(r#"data-ordinal="1,2""#));
+    }
+
+    #[test]
+    fn image_occlusion_with_funny_text() {
+        let text =
+            r#"{{c1::image-occlusion:text:left=10:top=20:text=\:l\\ol\::width=30:height=40}}"#;
+        let occlusions = parse_image_occlusions(text);
+        assert_eq!(occlusions.len(), 1);
+        let text = occlusions.first().unwrap().shapes.first().unwrap();
+        assert_eq!(text.shape, "text");
+        assert_eq!(text.properties.len(), 5);
+        assert!(text.properties.contains(&ImageOcclusionProperty {
+            name: "text".into(),
+            value: r#":l\ol:"#.into()
+        }));
+        assert!(text.properties.contains(&ImageOcclusionProperty {
+            name: "width".into(),
+            value: "30".into()
+        }));
     }
 }

--- a/rslib/src/cloze.rs
+++ b/rslib/src/cloze.rs
@@ -194,10 +194,12 @@ fn parse_text_with_clozes(text: &str) -> Vec<TextOrCloze<'_>> {
             }
             Token::Text(mut text) => {
                 if let Some(cloze) = open_clozes.last_mut() {
-                    // extract hint if found
-                    if let Some((head, tail)) = text.split_once("::") {
-                        text = head;
-                        cloze.hint = Some(tail);
+                    if !text.starts_with("image-occlusion:") {
+                        // extract hint if found
+                        if let Some((head, tail)) = text.split_once("::") {
+                            text = head;
+                            cloze.hint = Some(tail);
+                        }
                     }
                     cloze.nodes.push(TextOrCloze::Text(text));
                 } else {

--- a/rslib/src/image_occlusion/imageocclusion.rs
+++ b/rslib/src/image_occlusion/imageocclusion.rs
@@ -158,7 +158,11 @@ fn test_get_image_cloze_data() {
         r#"data-shape="polygon" data-points="0,0 10,10 20,0" "#,
     );
     assert_eq!(
-        get_image_cloze_data("text:text=foo\\:bar:left=10"),
-        r#"data-shape="text" data-text="foo&#x3A;bar" data-left="10" "#,
+        get_image_cloze_data(r#"text:text=\\foo\:bar\::left=10"#),
+        r#"data-shape="text" data-text="&#x5C;foo&#x3A;bar&#x3A;" data-left="10" "#,
+    );
+    assert_eq!(
+        get_image_cloze_data(r#"text:text=\:lol\::left=10"#),
+        r#"data-shape="text" data-text="&#x3A;lol&#x3A;" data-left="10" "#,
     );
 }

--- a/rslib/src/image_occlusion/imageocclusion.rs
+++ b/rslib/src/image_occlusion/imageocclusion.rs
@@ -6,18 +6,14 @@ use std::fmt::Write;
 use anki_proto::image_occlusion::get_image_occlusion_note_response::ImageOcclusionProperty;
 use anki_proto::image_occlusion::get_image_occlusion_note_response::ImageOcclusionShape;
 use htmlescape::encode_attribute;
-use nom::bytes::complete::escaped;
+use nom::bytes::complete::escaped_transform;
 use nom::bytes::complete::is_not;
 use nom::bytes::complete::tag;
-use nom::character::complete::char;
+use nom::character::complete::one_of;
 use nom::error::ErrorKind;
 use nom::sequence::preceded;
 use nom::sequence::separated_pair;
 use nom::Parser;
-
-fn unescape(text: &str) -> String {
-    text.replace("\\:", ":")
-}
 
 pub fn parse_image_cloze(text: &str) -> Option<ImageOcclusionShape> {
     if let Some((shape, _)) = text.split_once(':') {
@@ -26,12 +22,11 @@ pub fn parse_image_cloze(text: &str) -> Option<ImageOcclusionShape> {
         while let Ok((rem, (name, value))) = separated_pair::<_, _, _, (_, ErrorKind), _, _, _>(
             preceded(tag(":"), is_not("=")),
             tag("="),
-            escaped(is_not("\\:"), '\\', char(':')),
+            escaped_transform(is_not("\\:"), '\\', one_of("\\:")),
         )
         .parse(remaining)
         {
             remaining = rem;
-            let value = unescape(value);
             properties.push(ImageOcclusionProperty {
                 name: name.to_string(),
                 value,

--- a/ts/routes/image-occlusion/shapes/to-cloze.ts
+++ b/ts/routes/image-occlusion/shapes/to-cloze.ts
@@ -183,7 +183,7 @@ function shapeOrShapesToCloze(
 ): string {
     let text = "";
     function addKeyValue(key: string, value: string) {
-        value = value.replace(":", "\\:");
+        value = value.replace(/\\/g, "\\\\").replace(/:/g, "\\:");
         text += `:${key}=${value}`;
     }
 


### PR DESCRIPTION
## Linked issue (required)

Fixes #5204

## Summary / motivation (required)

This pr fixes incorrect IO text label escaping logic

## Steps to reproduce (required, use N/A if not applicable)

1. In the IO editor, make a text label with `:abc:`
2. Reload the note and observe that its gone

## How to test (required)

`./check` and IO notes with text labels like `:abc:`, `\:a\b\:`, `::\::` etc.

### Checklist (minimum)

- [x] I ran `./ninja check` or an equivalent relevant check locally.
- [x] I added or updated tests when the change is non-trivial or behavior changed.

### Details

Please see commit messages

## Scope

- [x] This PR is focused on one change (no unrelated edits).
