### PR TITLE
fix: avoid integer overflow in browser average interval/ease columns

### DIFF
--- a/rslib/src/browser_table.rs
+++ b/rslib/src/browser_table.rs
@@ -576,7 +576,7 @@ impl RowContext {
         if eases.is_empty() {
             self.tr.browsing_new().into()
         } else {
-            format!("{}%", eases.iter().sum::<u16>() / eases.len() as u16 / 10)
+            format!("{}%", average_ease_percent(&eases))
         }
     }
 
@@ -599,11 +599,7 @@ impl RowContext {
         if intervals.is_empty() {
             "".into()
         } else {
-            time_span(
-                (intervals.iter().sum::<u32>() * 86400 / (intervals.len() as u32)) as f32,
-                &self.tr,
-                false,
-            )
+            time_span(average_interval_secs(&intervals), &self.tr, false)
         }
     }
 
@@ -681,5 +677,49 @@ impl RowContext {
                 }
             }
         }
+    }
+}
+
+/// Mean of the given day-intervals, in seconds. Caller must ensure the slice is
+/// non-empty. Summed and scaled in u64 so a large interval (or the sum across
+/// many cards in notes mode) can't overflow.
+fn average_interval_secs(intervals: &[u32]) -> f32 {
+    let total: u64 = intervals.iter().map(|&i| i as u64).sum();
+    (total * 86_400 / intervals.len() as u64) as f32
+}
+
+/// Mean ease factor of the given cards, as a percentage. Caller must ensure the
+/// slice is non-empty. Summed in u32 so averaging many cards in notes mode
+/// can't overflow u16 (the sum exceeds u16::MAX after ~27 cards).
+fn average_ease_percent(eases: &[u16]) -> u32 {
+    let total: u32 = eases.iter().map(|&e| e as u32).sum();
+    total / eases.len() as u32 / 10
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn average_interval_does_not_overflow() {
+        // a single interval (in days) beyond ~49,710 overflows u32 * 86_400
+        assert_eq!(
+            average_interval_secs(&[49_711]),
+            (49_711u64 * 86_400) as f32
+        );
+        // and so does the sum across multiple large intervals (notes mode)
+        assert_eq!(
+            average_interval_secs(&[30_000, 30_000]),
+            (30_000u64 * 86_400) as f32
+        );
+        // ordinary case still averages correctly
+        assert_eq!(average_interval_secs(&[10, 20]), (15u64 * 86_400) as f32);
+    }
+
+    #[test]
+    fn average_ease_does_not_overflow() {
+        // summing 30 ease factors of 2500 exceeds u16::MAX (65_535)
+        assert_eq!(average_ease_percent(&[2500u16; 30]), 250);
+        assert_eq!(average_ease_percent(&[2500]), 250);
     }
 }

--- a/rslib/src/browser_table.rs
+++ b/rslib/src/browser_table.rs
@@ -684,8 +684,11 @@ impl RowContext {
 /// non-empty. Calculate in f64 so neither summing many cards nor converting
 /// days to seconds can overflow an integer accumulator.
 fn average_interval_secs(intervals: &[u32]) -> f32 {
-    let average_days =
-        intervals.iter().map(|&interval| f64::from(interval)).sum::<f64>() / intervals.len() as f64;
+    let average_days = intervals
+        .iter()
+        .map(|&interval| f64::from(interval))
+        .sum::<f64>()
+        / intervals.len() as f64;
     (average_days * 86_400.0) as f32
 }
 

--- a/rslib/src/browser_table.rs
+++ b/rslib/src/browser_table.rs
@@ -681,19 +681,20 @@ impl RowContext {
 }
 
 /// Mean of the given day-intervals, in seconds. Caller must ensure the slice is
-/// non-empty. Summed and scaled in u64 so a large interval (or the sum across
-/// many cards in notes mode) can't overflow.
+/// non-empty. Calculate in f64 so neither summing many cards nor converting
+/// days to seconds can overflow an integer accumulator.
 fn average_interval_secs(intervals: &[u32]) -> f32 {
-    let total: u64 = intervals.iter().map(|&i| i as u64).sum();
-    (total * 86_400 / intervals.len() as u64) as f32
+    let average_days =
+        intervals.iter().map(|&interval| f64::from(interval)).sum::<f64>() / intervals.len() as f64;
+    (average_days * 86_400.0) as f32
 }
 
 /// Mean ease factor of the given cards, as a percentage. Caller must ensure the
-/// slice is non-empty. Summed in u32 so averaging many cards in notes mode
-/// can't overflow u16 (the sum exceeds u16::MAX after ~27 cards).
+/// slice is non-empty. Summed in u64 so even a very large set of cards cannot
+/// overflow the accumulator.
 fn average_ease_percent(eases: &[u16]) -> u32 {
-    let total: u32 = eases.iter().map(|&e| e as u32).sum();
-    total / eases.len() as u32 / 10
+    let total: u64 = eases.iter().map(|&ease| u64::from(ease)).sum();
+    (total / eases.len() as u64 / 10) as u32
 }
 
 #[cfg(test)]
@@ -714,6 +715,13 @@ mod test {
         );
         // ordinary case still averages correctly
         assert_eq!(average_interval_secs(&[10, 20]), (15u64 * 86_400) as f32);
+        // multiplying a u64 sum by seconds-per-day would still overflow at
+        // this scale; the floating-point calculation remains finite.
+        let intervals = vec![u32::MAX; 50_000];
+        assert_eq!(
+            average_interval_secs(&intervals),
+            (f64::from(u32::MAX) * 86_400.0) as f32
+        );
     }
 
     #[test]
@@ -721,5 +729,7 @@ mod test {
         // summing 30 ease factors of 2500 exceeds u16::MAX (65_535)
         assert_eq!(average_ease_percent(&[2500u16; 30]), 250);
         assert_eq!(average_ease_percent(&[2500]), 250);
+        // and a sufficiently large set can exceed u32::MAX as well
+        assert_eq!(average_ease_percent(&vec![u16::MAX; 65_538]), 6553);
     }
 }


### PR DESCRIPTION
## Linked issue (required)

Fixes #5207

## Summary / motivation (required)

The browser's **average-interval** column computed `intervals.iter().sum::<u32>() * 86400` in `u32`. Intervals are in days, so a single card with an interval beyond ~49,710 days (reachable via a large maximum-interval setting, "set due date", or add-ons) overflowed `u32` — panicking in debug builds and rendering a wildly wrong span in release.

The **average-ease** column had the same shape: `eases.iter().sum::<u16>()` overflows `u16` once ~27 cards are averaged in notes mode.

The fix extracts the two averages into small helpers that accumulate in a wider type (`u64` for intervals, `u32` for eases).

## Steps to reproduce (required, use N/A if not applicable)

1. Set a card's interval to a very large value (e.g. via "Set Due Date" with a large offset, or a high maximum interval).
2. Select it in the Browser with the Average Interval column shown.
3. In a debug build this panics; in release the displayed span is wildly wrong.
4. For ease: select ~30+ cards in notes mode with the Average Ease column shown.

## How to test (required)

### Checklist (minimum)

- [x] I ran `./ninja check` or an equivalent relevant check locally.
- [x] I added or updated tests when the change is non-trivial or behavior changed.

### Details

Adds unit tests covering the overflow-triggering inputs for both helpers. The full CI workflow ran against this exact commit: https://github.com/krMaynard/anki-fork/actions/runs/30141307409

`Build, lint, and test` passed on Linux, macOS, and Windows, and `format` and `minilints` passed. The workflow's only failure was the Linux SARIF upload step (`Resource not accessible by integration`), after the substantive Linux checks had passed.

## Before / after behavior (optional)

Before: overflow panic (debug) / garbage value (release) for large intervals or many-card ease averages. After: correct averages via wider accumulation.

## Risk / compatibility / migration (optional)

Low risk; display-only computation in the browser table.

## UI evidence (required for visual changes; otherwise N/A)

N/A (no visual layout change; corrects an incorrectly-computed cell value)

## Scope

- [x] This PR is focused on one change (no unrelated edits).
