### PR TITLE
fix: remap card template index using source note id on apkg import

### DIFF
--- a/rslib/src/import_export/package/apkg/import/cards.rs
+++ b/rslib/src/import_export/package/apkg/import/cards.rs
@@ -99,6 +99,22 @@ impl Context<'_> {
 impl CardContext<'_> {
     fn import_cards(&mut self, mut cards: Vec<Card>) -> Result<()> {
         for card in &mut cards {
+            // Remap the template index using the card's *source* note id, before
+            // map_to_imported_note rewrites note_id to the target's. notetype_map
+            // and remapped_templates are keyed by source ids, so doing this
+            // afterwards would miss the lookup and leave the card pointing at the
+            // wrong template whenever a note's id changes on import. Doing it here
+            // also means card_ordinal_already_exists dedupes on the final ordinal.
+            // The common import has no remapped templates, so skip the per-card
+            // lookup entirely in that case.
+            if !self.remapped_templates.is_empty() {
+                card.template_idx = remapped_template_index(
+                    self.notetype_map,
+                    self.remapped_templates,
+                    card.note_id,
+                    card.template_idx,
+                );
+            }
             if self.map_to_imported_note(card) && !self.card_ordinal_already_exists(card) {
                 self.add_card(card)?;
             }
@@ -135,7 +151,6 @@ impl CardContext<'_> {
     fn add_card(&mut self, card: &mut Card) -> Result<()> {
         card.usn = self.usn;
         self.remap_deck_ids(card);
-        self.remap_template_index(card);
         card.shift_collection_relative_dates(self.collection_delta);
         let old_id = self.uniquify_card_id(card);
 
@@ -162,16 +177,24 @@ impl CardContext<'_> {
             card.original_deck_id = *did;
         }
     }
+}
 
-    fn remap_template_index(&self, card: &mut Card) {
-        card.template_idx = self
-            .notetype_map
-            .get(&card.note_id)
-            .and_then(|ntid| self.remapped_templates.get(ntid))
-            .and_then(|map| map.get(&card.template_idx))
-            .copied()
-            .unwrap_or(card.template_idx);
-    }
+/// Map a card's `template_idx` through `remapped_templates`, looked up by the
+/// card's *source* note id (the key space of `notetype_map`). Returns the
+/// original index when the note's notetype wasn't remapped or the ordinal isn't
+/// in the map.
+fn remapped_template_index(
+    notetype_map: &HashMap<NoteId, NotetypeId>,
+    remapped_templates: &HashMap<NotetypeId, TemplateMap>,
+    source_note_id: NoteId,
+    template_idx: u16,
+) -> u16 {
+    notetype_map
+        .get(&source_note_id)
+        .and_then(|ntid| remapped_templates.get(ntid))
+        .and_then(|map| map.get(&template_idx))
+        .copied()
+        .unwrap_or(template_idx)
 }
 
 impl Card {
@@ -193,5 +216,31 @@ impl Card {
 
     fn original_due_in_days_since_collection_creation(&self) -> bool {
         self.ctype == CardType::Review
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn template_index_is_remapped_via_source_notetype() {
+        let notetype_map = HashMap::from([(NoteId(10), NotetypeId(100))]);
+        let remapped_templates = HashMap::from([(NotetypeId(100), TemplateMap::from([(0, 1)]))]);
+        // source note 10 -> notetype 100 -> template ordinal 0 remaps to 1
+        assert_eq!(
+            remapped_template_index(&notetype_map, &remapped_templates, NoteId(10), 0),
+            1
+        );
+        // an ordinal that isn't in the map is left unchanged
+        assert_eq!(
+            remapped_template_index(&notetype_map, &remapped_templates, NoteId(10), 5),
+            5
+        );
+        // a note whose notetype wasn't remapped is left unchanged
+        assert_eq!(
+            remapped_template_index(&notetype_map, &remapped_templates, NoteId(999), 0),
+            0
+        );
     }
 }


### PR DESCRIPTION
## Linked issue (required)

Fixes #5209

## Summary / motivation (required)

`import_cards` remapped a card's template index (`ord`) inside `add_card`, which runs **after** `map_to_imported_note` has already overwritten `card.note_id` with the target note id. But `notetype_map` — and therefore `remapped_templates` — is keyed by the **source** note id, so the lookup missed and the template index was left unchanged whenever a note's id changed on import (id-collision uniquify, or a guid match to a differently-id'd note).

Consequences: cards could point at the wrong template after import, and `card_ordinal_already_exists` deduplicated on the un-remapped ordinal.

The fix computes the remapped index in `import_cards` using the **source** note id, before `map_to_imported_note` runs, via a small pure helper.

## Steps to reproduce (required, use N/A if not applicable)

1. Have a collection whose notetype template ordinals were reordered relative to a source deck.
2. Export a deck to `.apkg` where an imported note's id collides with an existing note (forcing uniquify) or matches by guid to a differently-id'd note.
3. Import the `.apkg` into the target collection.
4. Observe that affected cards render with the wrong template (their ordinal was not remapped).

## How to test (required)

### Checklist (minimum)

- [x] I ran `./ninja check` or an equivalent relevant check locally (via the fork CI run linked below).
- [x] I added or updated tests when the change is non-trivial or behavior changed.

### Details

Adds a unit test for the remap lookup exercising the source-note-id keying. Full CI (`check` on Linux/macOS/Windows, `format`, `minilints`) was run against this exact commit on the fork: https://github.com/krMaynard/anki-fork/actions/runs/30167008557 — build, lint, and test pass on all three OSes. (The run shows red only for the `Upload SARIF results for complexipy` step, which always fails on forks due to a token-permission limitation, not a code failure.)

## Before / after behavior (optional)

Before: template ordinals silently left un-remapped when a note's id changed on import. After: ordinals remapped using the source note id.

## Risk / compatibility / migration (optional)

Low risk; import-path-only change, no schema or scheduling impact.

## UI evidence (required for visual changes; otherwise N/A)

N/A

## Scope

- [x] This PR is focused on one change (no unrelated edits).
