### PR TITLE
Don't append a trailing dot to extensionless hash-suffixed media filenames

### DIFF
--- a/rslib/src/media/files.rs
+++ b/rslib/src/media/files.rs
@@ -215,7 +215,15 @@ pub(crate) fn add_hash_suffix_to_file_stem(fname: &str, hash: &Sha1Hash) -> Stri
 
     let (stem, ext) = split_and_truncate_filename(fname, max_len);
 
-    format!("{}-{}.{}", stem, hex::encode(hash), ext)
+    let mut name = format!("{}-{}", stem, hex::encode(hash));
+    // Only append the extension when there is one; an extensionless filename
+    // must not gain a trailing dot, which is invalid on Windows (the other
+    // filename paths apply the same trailing-character fix-up).
+    if !ext.is_empty() {
+        name.push('.');
+        name.push_str(ext);
+    }
+    name
 }
 
 /// If filename is longer than max_bytes, truncate it.
@@ -486,6 +494,11 @@ mod test {
         assert_eq!(
             add_hash_suffix_to_file_stem("test.jpg", &hash).as_str(),
             "test-aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434d.jpg"
+        );
+        // an extensionless name must not gain a trailing dot (invalid on Windows)
+        assert_eq!(
+            add_hash_suffix_to_file_stem("test", &hash).as_str(),
+            "test-aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434d"
         );
     }
 


### PR DESCRIPTION
## Linked issue (required)

Fixes #5211

## Summary / motivation (required)

`add_hash_suffix_to_file_stem` unconditionally formatted `"{stem}-{hash}.{ext}"`. For an extensionless filename the extension is empty, producing a name that ends in `.` (e.g. `foo-<hash>.`), which is invalid on Windows. Every other filename path in this module applies a `WINDOWS_TRAILING_CHAR` fix-up. The hashed name is written straight to disk on a media collision and used as the apkg import target, so the invalid name reaches the filesystem.

The fix omits the `.` separator when there is no extension.

## Steps to reproduce (required, use N/A if not applicable)

1. On Windows, import media containing an extensionless filename that collides with an existing file (triggering the hash-suffix path).
2. Observe a filename ending in `.` is produced, which is invalid on Windows.

## How to test (required)

### Checklist (minimum)

- [x] I ran `./ninja check` or an equivalent relevant check locally.
- [x] I added or updated tests when the change is non-trivial or behavior changed.

### Details

Adds a unit test for the extensionless case. Full CI (`check` on Linux/macOS/Windows, `format`, `minilints`) passed on this branch: https://github.com/krMaynard/anki-fork/actions/runs/30211937815 (the only failing step is the SARIF upload, which cannot succeed on forks).

## Before / after behavior (optional)

Before: extensionless hashed media names end in `.` (invalid on Windows). After: no trailing dot.

## Risk / compatibility / migration (optional)

Low risk.

## UI evidence (required for visual changes; otherwise N/A)

N/A

## Scope

- [x] This PR is focused on one change (no unrelated edits).
