### PR TITLE
fix(ci): re-verify PR state before auto-closing to prevent race conditions

### DIFF
--- a/.github/workflows/auto-close-missing-issue.yml
+++ b/.github/workflows/auto-close-missing-issue.yml
@@ -65,7 +65,7 @@ jobs:
               const currentLabels = currentPr.data.labels.map(l => l.name);
               if (!currentLabels.includes('missing-issue')) continue;
 
-              const linkedIssuePattern = /\b(closes|close|fixes|fix|resolves|resolve|refs|ref|references)\s+(?:[a-zA-Z0-9_.-]+\/[a-zA-Z0-9_.-]+)?#\d+/i;
+              const linkedIssuePattern = /\b(closes|close|closed|fixes|fix|fixed|resolves|resolve|resolved|refs|ref|references):?\s+(?:[a-zA-Z0-9_.-]+\/[a-zA-Z0-9_.-]+)?#\d+/i;
               if (linkedIssuePattern.test(currentPr.data.body || '')) continue;
 
               await github.rest.pulls.update({

--- a/.github/workflows/auto-close-missing-issue.yml
+++ b/.github/workflows/auto-close-missing-issue.yml
@@ -51,6 +51,23 @@ jobs:
               if (!labelEvent) continue;
               if (new Date(labelEvent.created_at) > fourDaysAgo) continue;
 
+              // Re-fetch the PR's current state to guard against race conditions:
+              // the label may have been removed between the initial paginated query
+              // and this point in the loop.
+              const currentPr = await github.rest.pulls.get({
+                owner,
+                repo,
+                pull_number: pr.number,
+              });
+
+              if (currentPr.data.state !== 'open') continue;
+
+              const currentLabels = currentPr.data.labels.map(l => l.name);
+              if (!currentLabels.includes('missing-issue')) continue;
+
+              const linkedIssuePattern = /\b(closes|close|fixes|fix|resolves|resolve|refs|ref|references)\s+(?:[a-zA-Z0-9_.-]+\/[a-zA-Z0-9_.-]+)?#\d+/i;
+              if (linkedIssuePattern.test(currentPr.data.body || '')) continue;
+
               await github.rest.pulls.update({
                 owner,
                 repo,

--- a/.github/workflows/check-linked-issue.yml
+++ b/.github/workflows/check-linked-issue.yml
@@ -42,7 +42,7 @@ jobs:
             }
             core.setOutput('exempt', 'false');
 
-            const linkedIssuePattern = /\b(closes|close|fixes|fix|resolves|resolve|refs|ref|references)\s+(?:[a-zA-Z0-9_.-]+\/[a-zA-Z0-9_.-]+)?#\d+/i;
+            const linkedIssuePattern = /\b(closes|close|closed|fixes|fix|fixed|resolves|resolve|resolved|refs|ref|references):?\s+(?:[a-zA-Z0-9_.-]+\/[a-zA-Z0-9_.-]+)?#\d+/i;
             const hasLinkedIssue = linkedIssuePattern.test(body);
             core.setOutput('has_linked_issue', hasLinkedIssue);
 


### PR DESCRIPTION
## Linked issue

Refs #5189

## Summary / motivation

The `auto-close-missing-issue` cron was closing PRs that had already had their `missing-issue` label removed, including PRs with a valid linked issue.

## Before / after behavior

**Before**: PRs could be closed even after contributors linked an issue, due to a stale snapshot from the initial pagination.  
**After**: the cron re-verifies each PR's current state immediately before closing, eliminating the race condition.
