### PR TITLE
fix: mirror toggle switches in RTL layouts

### DIFF
--- a/ts/lib/components/Switch.svelte
+++ b/ts/lib/components/Switch.svelte
@@ -55,6 +55,10 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         .form-check-input {
             margin-left: 0;
             margin-right: 1.5em;
+            background-position: right center;
+            &:checked {
+                background-position: left center;
+            }
         }
     }
 </style>


### PR DESCRIPTION
## Linked issue (required)

Refs #4749

## Summary / motivation (required)

Toggle switches (`Switch.svelte`) look wrong in RTL interface languages (Arabic, Hebrew, Persian): the on/off knob keeps animating in the LTR direction even though the rest of the switch is already mirrored.

The component already flips its outer padding/margin under `.form-switch.rtl` so the track sits on the correct side of the row. However, the knob itself is drawn via the checkbox's `background`, which Bootstrap positions with `background-position: left center` (unchecked) transitioning to `right center` (checked). That rule isn't direction-aware, so under RTL the knob still starts on the left and moves right when toggled on, out of step with the now-mirrored track.

This adds a `.form-switch.rtl .form-check-input` override so the knob starts at `right center` and moves to `left center` when checked, matching the mirrored track.

## Steps to reproduce

1. Set the interface language to any RTL language.
2. Open a screen with toggle switches, e.g. Deck Options (any tab with switches, such as Timer or Audio).
3. Toggle a switch and observe the knob position/direction doesn't match the mirrored track.

## How to test (required)

**Check that the fix is working:**
Run anki with a RTL language `./run -l ar`. Click in setting icon of any deck and in deck options screen toggle a switch. Confirm the knob sits on the right when off and moves to the left when on, consistent with the mirrored track.

**Check that there were no regressions:**
Change language to any LTR one `./run -l en`. Open the same Deck Options screen. Confirm switches still animate left (off) to right (on) as before.

### Checklist

- [x] I ran `./ninja check` or an equivalent relevant check locally.
- [x] I added or updated tests when the change is non-trivial or behavior changed.

I believe this is a trivial CSS-only change, and I don't think the codebase has tooling to automatically test this kind of UI fix now.

## Before / after behavior

before: animates left→right regardless of interface direction, out of sync with the mirrored RTL track.
<img width="493" height="54" alt="image" src="https://github.com/user-attachments/assets/6abbfeaf-28e6-46c5-91c0-f678985e5cd8" />


after: animates right→left in RTL, matching the mirrored track; 
<img width="708" height="64" alt="image" src="https://github.com/user-attachments/assets/26d1c861-5617-4244-8309-da06bc02c166" />

no regressions in ltr:
<img width="715" height="65" alt="image" src="https://github.com/user-attachments/assets/c3100aad-9283-438a-99fd-6c18d3bee54b" />


## Scope

- [x] This PR is focused on one change (no unrelated edits).