### PR TITLE
Ensure editor field's focus events are handled in order

### DIFF
--- a/ts/lib/tslib/promise.ts
+++ b/ts/lib/tslib/promise.ts
@@ -7,3 +7,26 @@ export function promiseWithResolver<T>(): [Promise<T>, (value: T) => void] {
 
     return [promise, resolve!];
 }
+
+/**
+ * Runs callbacks one at a time, in the order `run()` was called, regardless
+ * of how long each one takes to settle. Useful when independent event
+ * handlers race to perform async work (e.g. an RPC call) that must reach
+ * some other observer (e.g. a message sent to the backend) in the same
+ * order the triggering events originally fired in.
+ */
+export class SerialQueue {
+    private tail: Promise<void> = Promise.resolve();
+
+    run<T>(fn: () => Promise<T> | T): Promise<T> {
+        const result = this.tail.then(fn);
+        this.tail = result.then(
+            () => undefined,
+            (error) => {
+                console.error("SerialQueue task failed", error);
+                return undefined;
+            },
+        );
+        return result;
+    }
+}

--- a/ts/routes/editor/NoteEditor.svelte
+++ b/ts/routes/editor/NoteEditor.svelte
@@ -69,6 +69,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     import { onDestroy, onMount, tick } from "svelte";
     import { get, writable } from "svelte/store";
     import { nodeIsCommonElement } from "@tslib/dom";
+    import { SerialQueue } from "@tslib/promise";
 
     import Absolute from "$lib/components/Absolute.svelte";
     import Badge from "$lib/components/Badge.svelte";
@@ -1380,6 +1381,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     const focusedField: NoteEditorAPI["focusedField"] = writable(null);
     const focusedInput: NoteEditorAPI["focusedInput"] = writable(null);
     let focusedFieldIndex = 0;
+    const focusEventQueue = new SerialQueue();
 
     const api: NoteEditorAPI = {
         ...apiPartial,
@@ -1494,31 +1496,33 @@ components and functionality for general note editing.
                     {index}
                     flipInputs={plainTextDefaults[index]}
                     api={fields[index]}
-                    on:focusin={() => {
-                        $focusedField = fields[index];
-                        focusedFieldIndex = index;
-                        setAddonButtonsDisabled(false);
-                        bridgeCommand(`focus:${index}`);
-                    }}
-                    on:focusout={async () => {
-                        $focusedField = null;
-                        focusedFieldIndex = 0;
-                        setAddonButtonsDisabled(true);
-                        if (isLegacy) {
-                            bridgeCommand(
-                                `blur:${index}:${getNoteId()}:${await transformContentBeforeSave(
+                    on:focusin={() =>
+                        focusEventQueue.run(async () => {
+                            $focusedField = fields[index];
+                            focusedFieldIndex = index;
+                            setAddonButtonsDisabled(false);
+                            bridgeCommand(`focus:${index}`);
+                        })}
+                    on:focusout={() =>
+                        focusEventQueue.run(async () => {
+                            $focusedField = null;
+                            focusedFieldIndex = 0;
+                            setAddonButtonsDisabled(true);
+                            if (isLegacy) {
+                                bridgeCommand(
+                                    `blur:${index}:${getNoteId()}:${await transformContentBeforeSave(
+                                        get(content),
+                                    )}`,
+                                );
+                            } else {
+                                bridgeCommand(`blur:${index}`);
+                                note!.fields[index] = await transformContentBeforeSave(
                                     get(content),
-                                )}`,
-                            );
-                        } else {
-                            bridgeCommand(`blur:${index}`);
-                            note!.fields[index] = await transformContentBeforeSave(
-                                get(content),
-                            );
-                            await updateCurrentNote();
-                            await updateDuplicateDisplay();
-                        }
-                    }}
+                                );
+                                await updateCurrentNote();
+                                await updateDuplicateDisplay();
+                            }
+                        })}
                     on:mouseenter={() => {
                         $hoveredField = fields[index];
                     }}


### PR DESCRIPTION
## Linked issue

Closes #5217

## Summary

The editor's `focusout`/`focusin` event handlers were received by the backend out-of-order. The focusout handler does more work (it calls `transformContentBeforeSave()`) so there was a high chance an earlier `focusout` event gets handled by the backend after a more recent focusin, resulting in `Editor.currentField` being set to `None` despite the field being focused.

## Steps to reproduce (before)

Follow the reproduction steps in https://forums.ankiweb.net/t/anki-26-08-beta-2/70535/3 or install this minimal add-on and observe that `currentField None` is printed after clicking the `test` button more than once:
```python
from aqt.editor import Editor, NewEditor
from aqt.gui_hooks import editor_did_init_buttons


def on_button(editor: Editor | NewEditor) -> None:
    print('currentField', editor.currentField)
    editor.loadNote()

def add_button(buttons: list[str], editor: Editor | NewEditor) -> None:
    button = editor.addButton(icon=None, cmd="test", func=on_button)
    buttons.append(button)

editor_did_init_buttons.append(add_button)
```


## How to test (after)

Confirm there's no difference in behavior between the first and subsequent button clicks.


