### PR TITLE
Unescape quotes in preset/custom-data search values so they round-trip

### DIFF
--- a/rslib/src/search/parser.rs
+++ b/rslib/src/search/parser.rs
@@ -387,7 +387,7 @@ fn search_node_for_text_with_argument<'a>(
         "w" => SearchNode::WordBoundary(unescape(val)?),
         "dupe" => parse_dupe(val)?,
         "has-cd" => SearchNode::CustomData(unescape(val)?),
-        "preset" => SearchNode::Preset(val.into()),
+        "preset" => SearchNode::Preset(unescape_quotes(val)),
         // anything else is a field search
         _ => parse_single_field(key, val)?,
     })
@@ -506,7 +506,9 @@ fn parse_prop(prop_clause: &str) -> ParseResult<'_, SearchNode> {
         },
         prop if prop.starts_with("cds:") => PropertyKind::CustomDataString {
             key: prop.strip_prefix("cds:").unwrap().into(),
-            value: num.into(),
+            // unescape \" like the writer expects (and like Regex/Preset do),
+            // so a value containing a quote round-trips through parse -> write
+            value: unescape_quotes(num),
         },
         _ => unreachable!(),
     };

--- a/rslib/src/search/writer.rs
+++ b/rslib/src/search/writer.rs
@@ -243,6 +243,22 @@ mod test {
     }
 
     #[test]
+    fn preset_and_cds_quotes_round_trip() {
+        // A literal " in a preset/custom-data value must survive
+        // parse -> write -> parse. These nodes previously stored the value
+        // without unescaping, so the writer's added escape compounded into
+        // `\\"` and the result no longer re-parsed.
+        for input in [r#"preset:a\"b"#, r#"prop:cds:k=a\"b"#] {
+            let normalized = normalize_search(input).unwrap();
+            assert_eq!(
+                normalize_search(&normalized).unwrap(),
+                normalized,
+                "re-normalizing {normalized:?} changed it"
+            );
+        }
+    }
+
+    #[test]
     fn replacing() -> Result<()> {
         assert_eq!(
             replace_search_node(parse("deck:baz bar")?, parse("deck:foo")?.pop().unwrap()),

--- a/rslib/src/search/writer.rs
+++ b/rslib/src/search/writer.rs
@@ -250,6 +250,7 @@ mod test {
         // `\\"` and the result no longer re-parsed.
         for input in [r#"preset:a\"b"#, r#"prop:cds:k=a\"b"#] {
             let normalized = normalize_search(input).unwrap();
+            assert_eq!(normalized, input, "normalizing changed the quoted value");
             assert_eq!(
                 normalize_search(&normalized).unwrap(),
                 normalized,


### PR DESCRIPTION
## Linked issue (required)

Fixes #5228

## Summary / motivation (required)

The `Preset` and `prop:cds` (custom-data string) parser arms stored their value verbatim, without unescaping `\"` the way the `Regex` node and the writer's `maybe_quote` already assume. So a value containing a double quote did not survive parse → write → parse: the writer re-escaped the already-present backslash-quote into `\\"`, which then failed to re-parse.

The fix unescapes `\"` when parsing these two nodes (matching the `Regex` arm), so the stored value is the literal text and the writer's escaping round-trips.

## Steps to reproduce (required, use N/A if not applicable)

1. Use a search containing a preset or `prop:cds` value with an escaped quote, e.g. `preset:a\"b` or `prop:cds:k=a\"b`.
2. Normalize/round-trip the search (parse → write → parse).
3. Observe the value no longer re-parses correctly (the escape compounds to `\\"`).

## How to test (required)

### Checklist (minimum)

- [x] I ran `./ninja check` or an equivalent relevant check locally.
- [x] I added or updated tests when the change is non-trivial or behavior changed.

### Details

Adds a normalization round-trip regression test in `writer.rs`. Full CI (`check` on Linux/macOS/Windows, `format`, `minilints`) passed on this branch: https://github.com/krMaynard/anki-fork/actions/runs/30381555262 (the only failing step is the SARIF upload, which cannot succeed on forks).

## Before / after behavior (optional)

Before: a quote in a preset/custom-data search value does not survive round-tripping. After: it round-trips correctly.

## Risk / compatibility / migration (optional)

Low risk; matches existing `Regex`-arm behavior.

## UI evidence (required for visual changes; otherwise N/A)

N/A

## Scope

- [x] This PR is focused on one change (no unrelated edits).
