### PR TITLE
Reparent tag onto string-prefix sibling instead of no-op

### DIFF
--- a/rslib/src/tags/reparent.rs
+++ b/rslib/src/tags/reparent.rs
@@ -101,10 +101,15 @@ fn old_to_new_names(
 /// Returns None if new parent is a child of the tag to be reparented.
 fn reparented_name(existing_name: &str, new_parent: Option<&str>) -> Option<String> {
     let existing_base = existing_name.rsplit("::").next().unwrap();
-    let existing_root = existing_name.split("::").next().unwrap();
     if let Some(new_parent) = new_parent {
-        let new_parent_root = new_parent.split("::").next().unwrap();
-        if new_parent.starts_with(existing_name) && new_parent_root == existing_root {
+        // Compare on :: component boundaries, so a sibling whose name merely
+        // shares a string prefix (e.g. foo::bar onto foo::barbaz) is not
+        // mistaken for a descendant and silently dropped.
+        let onto_self_or_descendant = new_parent == existing_name
+            || new_parent
+                .strip_prefix(existing_name)
+                .is_some_and(|rest| rest.starts_with("::"));
+        if onto_self_or_descendant {
             // foo onto foo::bar, or foo onto itself -> no-op
             None
         } else {
@@ -138,6 +143,19 @@ mod test {
             .into_iter()
             .map(|t| t.name)
             .collect()
+    }
+
+    #[test]
+    fn reparent_onto_prefix_sibling() {
+        // foo::bar onto its sibling foo::barbaz must reparent, not no-op: the
+        // names share a string prefix but barbaz is not a descendant of bar.
+        assert_eq!(
+            reparented_name("foo::bar", Some("foo::barbaz")),
+            Some("foo::barbaz::bar".to_string())
+        );
+        // a genuine descendant, or the tag itself, is still a no-op
+        assert_eq!(reparented_name("foo", Some("foo::bar")), None);
+        assert_eq!(reparented_name("foo::bar", Some("foo::bar")), None);
     }
 
     #[test]


### PR DESCRIPTION
## Linked issue (required)

Fixes #5230 (tag counterpart of the deck bug in #5183, fixed by #5188)

## Summary / motivation (required)

The tag reparent helper used `new_parent.starts_with(existing_name)` to detect a drop onto the tag itself or a descendant. Comparing the raw `::`-joined strings rather than component boundaries meant a sibling whose name merely shares a string prefix (e.g. `foo::bar` onto `foo::barbaz`) was misclassified as a descendant and the move became a silent no-op. This is the same class of bug as the deck-reparent fix.

The fix compares on `::` component boundaries so only the tag itself or a genuine descendant is a no-op.

## Steps to reproduce (required, use N/A if not applicable)

1. Create tags `foo::bar` and `foo::barbaz`.
2. Drag/rename `foo::bar` under `foo::barbaz`.
3. Observe the move is a silent no-op.

## How to test (required)

### Checklist (minimum)

- [x] I ran `./ninja check` or an equivalent relevant check locally.
- [x] I added or updated tests when the change is non-trivial or behavior changed.

### Details

Adds a regression test. Full CI (`check` on Linux/macOS/Windows, `format`, `minilints`) passed on this branch: https://github.com/krMaynard/anki-fork/actions/runs/30467601738 (the only failing step is the SARIF upload, which cannot succeed on forks).

## Before / after behavior (optional)

Before: reparenting a tag onto a string-prefix sibling is a silent no-op. After: it reparents correctly.

## Risk / compatibility / migration (optional)

Low risk.

## UI evidence (required for visual changes; otherwise N/A)

N/A

## Scope

- [x] This PR is focused on one change (no unrelated edits).
