### PR TITLE
fix: Guard `on_operation_did_execute` against deleted web views

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -28,7 +28,7 @@ support site, it would be great if you could add your name below as well.
 
 ********************
 
-AMBOSS MD Inc. <https://www.amboss.com/>
+AMBOSS MD Inc. <https://www.amboss.com/> 
 Aristotelis P.  <https://glutanimate.com/contact>
 Erez Volk <erez.volk@gmail.com>
 zjosua <zjosua@hotmail.com>

--- a/qt/aqt/webview.py
+++ b/qt/aqt/webview.py
@@ -964,6 +964,20 @@ html {{ {font} }}
     def on_operation_did_execute(
         self, changes: OpChanges, handler: object | None
     ) -> None:
+        # add-on webviews may be destroyed via Qt parent ownership without
+        # cleanup() being called; unsubscribe instead of erroring, deferring
+        # the removal to avoid mutating the hook list while it fires
+        if sip.isdeleted(self):
+            from aqt import mw
+
+            mw.progress.single_shot(
+                0,
+                lambda: gui_hooks.operation_did_execute.remove(
+                    self.on_operation_did_execute
+                ),
+                requires_collection=False,
+            )
+            return
         if handler is self.parentWidget():
             return
 

--- a/qt/aqt/webview.py
+++ b/qt/aqt/webview.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import dataclasses
 import json
+import logging
 import os
 import re
 import sys
@@ -26,6 +27,8 @@ from aqt.qt import *
 from aqt.qt import sip
 from aqt.theme import theme_manager
 from aqt.utils import askUser, is_gesture_or_zoom_event, openLink, showInfo, tr
+
+logger = logging.getLogger(__name__)
 
 serverbaseurl = re.compile(r"^.+:\/\/[^\/]+")
 
@@ -970,6 +973,12 @@ html {{ {font} }}
         if sip.isdeleted(self):
             from aqt import mw
 
+            logger.warning(
+                "%s (%s) was destroyed without a cleanup() call; "
+                "dropping operation_did_execute hook",
+                type(self).__name__,
+                self.kind.value,
+            )
             mw.progress.single_shot(
                 0,
                 lambda: gui_hooks.operation_did_execute.remove(


### PR DESCRIPTION
## Linked issue (required)

Fixes #5233 
## Summary / motivation (required)

Since #4029, every `AnkiWebView` subscribes to `gui_hooks.operation_did_execute` in `__init__`, and the subscription is only removed in `cleanup()`. Web views that are destroyed without a `cleanup()` call, which is common in add-ons that rely on Qt parent ownership for teardown, leave a dead handler behind, and the next `CollectionOp` then raises `RuntimeError: wrapped C/C++ object has been deleted`.

This was latent before #4029: `__init__` only registered on `theme_did_change` and `body_classes_need_update`, which fire rarely enough that a missed `cleanup()` had no practical consequences. `operation_did_execute` fires after every operation, so the same leak now produces an error dialog within seconds. This isn't specific to one add-on: QA against 26.08b2 reproduced the identical error with several popular add-ons (Card Stats, Remaining Time, Cloze Hide All, AJT Japanese), see the linked issue for details.

#5143 recently fixed the same crash class for the Find Duplicates dialog (#5140, there via `theme_did_change`) by adding the missing `cleanup()` call at the dialog's close site. That approach works for Anki's own dialogs, but there is no equivalent close site to patch for add-on web views that are destroyed through Qt parent ownership, so this gap needs to be covered in the handler itself.

This PR guards the handler with `sip.isdeleted(self)` and unsubscribes the dead handler, mirroring the existing guards for late web events in `_maybeRunActions` and `_shouldIgnoreWebEvent`. Unsubscribing (rather than just returning) means leaked web views don't accumulate in the hook list and their Python wrappers can be collected.

The removal is deferred via `mw.progress.single_shot(0, ...)` rather than done inline, because the generated hook code iterates `self._hooks` directly and an inline removal would skip the following handler for that firing.

## Steps to reproduce (required, use N/A if not applicable)

Tested against 26.08b2, no add-on needed:

1. Open the debug console and run:
   ```python
   from aqt.webview import AnkiWebView
   w = AnkiWebView(parent=mw)
   w.deleteLater()
   ```
2. Close the console and answer a card, or run any other `CollectionOp`
3. An error dialog appears with `RuntimeError: wrapped C/C++ object of type AnkiWebView has been deleted`

## How to test (required)

### Checklist (minimum)

- [x] I ran `./ninja check` or an equivalent relevant check locally.
- [ ] I added or updated tests when the change is non-trivial or behavior changed. (Qt lifetime behavior, not currently covered by the test harness - see below, and #5143 for precedent)

### Details

Manual verification via the repro steps above: after the fix, the operation completes without an error and the dead handler is removed from the hook (checkable via `len(gui_hooks.operation_did_execute._hooks)` in the debug console before and after).

No unit test added: the behavior depends on Qt object deletion timing and a running event loop, which the Python test suite doesn't currently cover (the existing `sip.isdeleted` guards in this file are in the same situation).

## Before / after behavior (optional)

Before: one error dialog per web view that was destroyed without `cleanup()`, raised on the next operation after the deletion, e.g. when answering the next card after closing a browser that hosted an add-on web view.

After: the dead handler is silently dropped and the operation completes normally.

## Risk / compatibility / migration (optional)

Low risk: a small guard with no behavior change for web views that are cleaned up properly. Add-ons are the beneficiaries, no add-on facing API changes.

## UI evidence (required for visual changes; otherwise N/A)

N/A

## Scope

- [x] This PR is focused on one change (no unrelated edits).
