### PR TITLE
Fix some inline styles not being filtered out in internal editor pastes

### DIFF
--- a/ts/lib/html-filter/index.test.ts
+++ b/ts/lib/html-filter/index.test.ts
@@ -21,6 +21,14 @@ describe("filterHTML", () => {
                 true,
             ),
         ).toBe("<div style=\"font-weight: bold;\"></div>");
+        // vertical align is filtered from images
+        expect(
+            filterHTML(
+                "<img src=\"test.png\" style=\"vertical-align: baseline;\"><div style=\"vertical-align: baseline;\">test</div>",
+                true,
+                true,
+            ),
+        ).toBe("<img src=\"test.png\" style=\"\"><div style=\"vertical-align: baseline;\">test</div>");
     });
     test("background color", () => {
         // transparent is stripped, other colors are not

--- a/ts/lib/html-filter/styling.ts
+++ b/ts/lib/html-filter/styling.ts
@@ -2,10 +2,11 @@
 // License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
 /** Keep property if true. */
-type StylingPredicate = (property: string, value: string) => boolean;
+type StylingPredicate = (element: HTMLElement, property: string, value: string) => boolean;
 
-const keep = (_key: string, _value: string) => true;
-const discard = (_key: string, _value: string) => false;
+const keep = (_element: HTMLElement, _key: string, _value: string) => true;
+const discard = (_element: HTMLElement, _key: string, _value: string) => false;
+const discardIfImage = (element: HTMLElement, _key: string, _value: string) => element.nodeName !== "IMG";
 
 /** Return a function that filters out certain styles.
    - If the style is listed in `exceptions`, the provided predicate is used.
@@ -21,7 +22,7 @@ function filterStyling(
             const key = element.style.item(i);
             const value = element.style.getPropertyValue(key);
             const predicate = exceptions[key] ?? defaultPredicate;
-            if (!predicate(key, value)) {
+            if (!predicate(element, key, value)) {
                 toRemove.push(key);
             }
         }
@@ -40,7 +41,7 @@ const nightModeExceptions = {
 export const filterStylingNightMode = filterStyling(discard, nightModeExceptions);
 export const filterStylingLightMode = filterStyling(discard, {
     color: keep,
-    "background-color": (_key: string, value: string) => value != "transparent",
+    "background-color": (_element: HTMLElement, _key: string, value: string) => value != "transparent",
     ...nightModeExceptions,
 });
 export const filterStylingInternal = filterStyling(keep, {
@@ -50,4 +51,5 @@ export const filterStylingInternal = filterStyling(keep, {
     height: discard,
     "max-width": discard,
     "max-height": discard,
+    "vertical-align": discardIfImage,
 });


### PR DESCRIPTION
## Linked issue

Closes #5227

## Summary / motivation (required)

#4029 added `vertical-align` to editor images, which is now copied in internal pastes. This PR adds the property to `filterStylingInternal` so it's stripped.

## Steps to reproduce (before)

1. Paste an image into a field.
2. Copy the image from the field and paste it into any field.
3. Notice `style="vertical-align: baseline;"` is now added to the `img` tag.

## How to test (after)

Repeat the same steps and confirm is vertical-align stripped from images.

### Checklist

- [x] I ran `./ninja check` or an equivalent relevant check locally.
- [x] I added or updated tests when the change is non-trivial or behavior changed.

