### PR TITLE
refactor: Remove unused paste handling

### DIFF
--- a/qt/aqt/editor_legacy.py
+++ b/qt/aqt/editor_legacy.py
@@ -1054,10 +1054,6 @@ require("anki/ui").loaded.then(() => require("anki/NoteEditor").instances[0].too
     removeTags = ["script", "iframe", "object", "style"]
 
     def _pastePreFilter(self, html: str, internal: bool) -> str:
-        # https://anki.tenderapp.com/discussions/ankidesktop/39543-anki-is-replacing-the-character-by-when-i-exit-the-html-edit-mode-ctrlshiftx
-        if html.find(">") < 0:
-            return html
-
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", UserWarning)
             doc = BeautifulSoup(html, "html.parser")

--- a/ts/lib/html-filter/index.ts
+++ b/ts/lib/html-filter/index.ts
@@ -33,11 +33,6 @@ const outputHTMLProcessors: Record<FilterMode, (outputHTML: string) => string> =
 };
 
 export function filterHTML(html: string, internal: boolean, extended: boolean): string {
-    // https://anki.tenderapp.com/discussions/ankidesktop/39543-anki-is-replacing-the-character-by-when-i-exit-the-html-edit-mode-ctrlshiftx
-    if (html.indexOf(">") < 0) {
-        return html;
-    }
-
     const template = document.createElement("template");
     template.innerHTML = html;
 


### PR DESCRIPTION
This just removes a dead branch in editor paste handling that I noticed while working on #5236.

Quoting the original [TenderApp report](https://anki.tenderapp.com/discussions/ankidesktop/39543-anki-is-replacing-the-character-by-when-i-exit-the-html-edit-mode-ctrlshiftx) from 2020 linked in the code:

> 
> I had I field like this: gtts_ZeitabschnittvonlängererDauer_de_slow.mp3
> 
> And after I open and close the HTML view mode (Ctrl+Shift+X), the contents of the field are replaced with: gtts_ZeitabschnittvonlÃ¤ngererDauer_de_slow.mp3
> 
> i.e., the ä is replaced by Ã¤

I couldn't reproduce this neither in the legacy nor new editor. The editor received significant updates since then, so I believe it's dead code now.
