### PR TITLE
feat: probe core - storage, revlog link, and scheduler substitution

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,13 +16,46 @@ Anki is a spaced repetition flashcard program with a multi-layered architecture.
 - Protobuf definitions in proto/ that are used by the different layers to
   talk to each other.
 
-## Fork-specific: split review timer
+## Fork-specific: revlog extensions
 
-This fork's revlog has a nullable `reveal_millis` column (schema 19) recording
-question→reveal latency separately from the capped `taken_millis` composite;
-null means "not recorded", never zero. Authoritative docs:
-`rslib/src/revlog/mod.rs`. Sync peers and non-legacy colpkg importers must run
-this fork's code; the legacy (V11) export path drops the column.
+This fork's revlog has two added columns. Authoritative docs live in
+`rslib/src/revlog/mod.rs`; read it before touching either.
+
+- `reveal_millis` (nullable, schema 19) — question→reveal latency, separate
+  from the capped `taken_millis` composite. Null means "not recorded", never
+  zero.
+- `data` (TEXT NOT NULL DEFAULT '', schema 20) — JSON blob mirroring the
+  `cards.data` pattern, currently holding the probe `variant_id`. Put new
+  per-review metadata here rather than adding another column.
+
+Revlog rows sync as fixed-arity positional tuples
+(`sync/collection/chunks.rs`), so **struct field order must match the SQL
+column order** in `storage/revlog/{add,get}.sql` and `row_to_revlog_entry`.
+Sync peers and non-legacy colpkg importers must run this fork's code; the
+legacy (V11) export path drops both columns.
+
+## Fork-specific: probes
+
+A probe is an AI-generated reworded variant of a card, served instead of the
+original when FSRS retrievability is high — see `rslib/src/probe/mod.rs` and
+the substitution branch `Collection::maybe_probe_substitute` in
+`rslib/src/scheduler/queue/mod.rs`. Probe outcomes must not feed back into
+FSRS; the zero-rate arm has to stay bit-identical to stock scheduling
+(`zero_rate_leaves_fsrs_scheduling_untouched` guards this).
+
+Two open seams, deliberately unresolved:
+
+- **Probe content does not sync.** The `probes` table is local; the chunked
+  sync object lists are closed. Outcomes ride the revlog and do sync. How
+  probe text reaches a second device (pre-generated packs, apkg, or
+  per-device regeneration) is an open captain decision.
+- **Probe generation is not implemented.** Probes arrive via the `AddProbe`
+  rpc or apkg import only.
+
+Deck config gotcha: probe settings live on `DeckConfig.Config`, which syncs
+via schema11 JSON — a new proto field **silently drops on sync** unless it is
+also added to `DeckConfSchema11`, both `From` impls, and
+`RESERVED_DECKCONF_KEYS` in `rslib/src/deckconfig/schema11.rs`.
 
 ## Running Anki
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,14 @@ Anki is a spaced repetition flashcard program with a multi-layered architecture.
 - Protobuf definitions in proto/ that are used by the different layers to
   talk to each other.
 
+## Fork-specific: split review timer
+
+This fork's revlog has a nullable `reveal_millis` column (schema 19) recording
+question→reveal latency separately from the capped `taken_millis` composite;
+null means "not recorded", never zero. Authoritative docs:
+`rslib/src/revlog/mod.rs`. Sync peers and non-legacy colpkg importers must run
+this fork's code; the legacy (V11) export path drops the column.
+
 ## Running Anki
 
 To build and run Anki in development mode:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,6 +43,11 @@ the substitution branch `Collection::maybe_probe_substitute` in
 FSRS; the zero-rate arm has to stay bit-identical to stock scheduling
 (`zero_rate_leaves_fsrs_scheduling_untouched` guards this).
 
+Probes are owned by their card. SQLite runs with foreign keys off, so the
+cascade is hand-written in `SqliteStorage::remove_card` — the one point sync
+grave application and dbcheck both route through, neither of which builds undo
+entries. Add new card-deletion paths there, not at the call site.
+
 Two open seams, deliberately unresolved:
 
 - **Probe content does not sync.** The `probes` table is local; the chunked

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,32 @@ Please do this as a final step before marking a task as completed.
 
 Run `just` (or `just --list`) to see all available commands.
 
+## Build environment (fork-specific)
+
+See [docs/BUILD-NOTES.md](docs/BUILD-NOTES.md) for verified setup steps, build
+times, and the Android/iOS status. The non-obvious parts:
+
+- **Only `ninja` and `just` need installing** (`brew install ninja just`).
+  Do **not** install protoc, Node, uv or Python for the build — it downloads
+  pinned copies of all four into `out/` and ignores whatever is on `PATH`.
+  Git submodules are checked out automatically too.
+- **Use rustup, not Homebrew Rust.** `rust-toolchain.toml` pins 1.92.0, but only
+  rustup honours it. On Homebrew Rust the pin is silently ignored: the build
+  still succeeds, but `check:clippy` fails on upstream files with lints that
+  postdate the pin. That is not a code defect — do not "fix" upstream to satisfy
+  it.
+- Before `just check`: put `~/.cargo/bin` on `PATH` (else `check:minilints` can't
+  find `cargo-license`) and run
+  `git submodule update --init qt/installer/mac-template` (else two
+  `qt/tests/test_installer.py` tests fail). The build only auto-inits the two
+  `ftl/` submodules.
+- Cross-compiling to Android/iOS is impossible without rustup; Homebrew Rust
+  ships only the host std and cannot add targets.
+- `just run -b <dir>` runs against a throwaway collection. Use it — plain
+  `just run` opens your real one.
+- `http://localhost:40000/_anki/pages/*.html` 404s until the matching screen is
+  opened. That is normal, not a broken build.
+
 ## Quick iteration
 
 During development, you can build/check subsections of our code:
@@ -116,3 +142,10 @@ in build scripts/tests is fine.
 ## Individual preferences
 
 See @.claude/user.md
+
+## Maintaining this file
+
+Keep this file for knowledge useful to almost every future agent session in this project.
+Do not repeat what the codebase already shows; point to the authoritative file or command instead.
+Prefer rewriting or pruning existing entries over appending new ones.
+When updating this file, preserve this bar for all agents and keep entries concise.

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -295,6 +295,7 @@ Ashish Yadav <48384865+criticalAY@users.noreply.github.com>
 Timothy Lee <timothyl@berkeley.edu>
 DespicableGoose <68354378+DespicableGoose@users.noreply.github.com>
 Han Lua <72375847+xiaohan484@users.noreply.github.com>
+Adam Roch <adam.m.roch13@gmail.com>
 
 ********************
 

--- a/docs/BUILD-NOTES.md
+++ b/docs/BUILD-NOTES.md
@@ -1,0 +1,420 @@
+# Build notes (fork-specific)
+
+Verified on a clean checkout of this fork, 2026-07-30/31.
+
+These notes supplement upstream's [development.md](./development.md) and
+[mac.md](./mac.md); they do not replace them. They record what was actually
+required on a real machine, what the build provisions for itself, and the
+verified status of the desktop, Android and iOS targets.
+
+**Scope of this document:** toolchain and build only. No product behaviour is
+described or changed here.
+
+---
+
+## 1. Verified environment
+
+|                           |                                                                  |
+| ------------------------- | ---------------------------------------------------------------- |
+| Machine                   | Apple Silicon (arm64), macOS 26.5.2 (25F84)                      |
+| Rust                      | rustc/cargo **1.97.1** (Homebrew)                                |
+| Xcode                     | **Command Line Tools only** — Apple clang 21.0.0. No full Xcode. |
+| Repo version (`.version`) | `26.05`                                                          |
+
+---
+
+## 2. What you actually have to install
+
+Only **two** tools were missing. Everything else the build downloads itself.
+
+```bash
+brew install ninja just
+```
+
+| Installed | Version    | Why                                                                                                                                                             |
+| --------- | ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ninja`   | **1.13.2** | The build system emits `build.ninja` and shells out to a ninja-compatible runner. Upstream docs accept Ninja 1.10+ from Homebrew, or n2 via `tools/install-n2`. |
+| `just`    | **1.57.0** | Command runner. `CLAUDE.md` mandates the `just` recipes over calling `./ninja` / `./run` directly.                                                              |
+
+### protoc is NOT a system dependency
+
+Worth stating plainly, because it is easy to assume otherwise: **you do not need
+to install protoc.** `build/ninja_gen/src/protobuf.rs:112` (`setup_protoc`)
+downloads and extracts a pinned **protoc 31.1** universal binary into
+`out/extracted/protoc/` on first build. Installing a system protoc has no
+effect unless you explicitly set `PROTOC_BINARY` to an absolute path.
+
+### Also auto-provisioned — do not install these by hand
+
+The build downloads its own copies into `out/`, ignoring whatever is on `PATH`:
+
+| Tool   | Version fetched                 | Location                |
+| ------ | ------------------------------- | ----------------------- |
+| protoc | 31.1                            | `out/extracted/protoc/` |
+| Node   | v22.17.0                        | `out/extracted/node/`   |
+| uv     | 0.11.8                          | `out/extracted/uv/`     |
+| Python | 3.13.13 (per `.python-version`) | `out/pyenv/`            |
+
+The system's Node 22.22.2 and Python 3.14.6 are **not used by the build**. Do
+not spend time matching them.
+
+Git submodules (`ftl/core-repo`, `ftl/qt-repo`) are checked out automatically by
+the build — no manual `git submodule update` needed.
+
+### Optional
+
+`mpv` and `lame` for audio playback (`brew install mpv lame`). `lame` and
+`ffmpeg` were already present here; `mpv` was not. Not required to build or
+launch.
+
+### Side effect to be aware of
+
+Homebrew's post-install cleanup ran automatically during `brew install ninja
+just` and **autoremoved `unbound` 1.25.1** as an unneeded formula (no remaining
+dependents), plus pruned its own download cache. This was not requested. If you
+need `unbound` back: `brew install unbound`.
+
+---
+
+## 3. Desktop build — GREEN, verified running
+
+### Commands
+
+```bash
+brew install ninja just     # one-time
+just build                  # build pylib + qt
+just run                    # build and launch
+```
+
+To launch against a throwaway collection instead of your real one — strongly
+recommended during development:
+
+```bash
+just run -b /tmp/ankibase
+```
+
+### Evidence it actually launches
+
+`just run` was executed and Anki started. Observed, not inferred:
+
+- `Starting Anki 26.05...` on stdout
+- Qt initialised; Chromium remote debugging server bound to `127.0.0.1:8080`
+- Three live webview targets on the CDP endpoint — `top toolbar`,
+  `main webview`, `bottom toolbar` — i.e. the real main window
+- The deck browser rendered: `mediasrv` served `deckbrowser.css`,
+  `deckbrowser.js`, `toolbar.css`, `toolbar-bottom.css`, `gears.svg`,
+  `refresh.svg`, `webview.js`
+- Process alive under `out/pyenv/bin/python tools/run.py`
+
+The app was then stopped cleanly.
+
+Note: `http://localhost:40000/_anki/pages/*.html` (mentioned in `CLAUDE.md`)
+404s at idle — those routes are only mounted once the corresponding screen is
+opened. A 404 there is **not** a sign of a broken build.
+
+### Build times (Apple Silicon, measured)
+
+| Scenario                                                    | Wall clock     |
+| ----------------------------------------------------------- | -------------- |
+| **Cold** — empty `out/`, cold cargo registry for this tree  | **2 min 20 s** |
+| No-op rebuild (nothing changed)                             | **0.5 s**      |
+| Warm rebuild, comment-only change to `rslib/src/lib.rs`     | **3.7 s**      |
+| **Warm rebuild, real codegen change to `rslib/src/lib.rs`** | **~5 s**       |
+
+The ~5 s figure is the one that matters for planning: that is the edit→run loop
+cost for a change to the Rust backend. Cold build produces a ~4.0 GB `out/`.
+
+Cold build is dominated by fetching/compiling crates; the ninja graph itself
+(65 targets) finishes in ~95 s once dependencies are in place.
+
+### Caveat: Rust version vs `rust-toolchain.toml`
+
+`rust-toolchain.toml` pins channel **1.92.0**, but that file is only honoured by
+`rustup`. This machine has **no rustup** — Rust comes from Homebrew — so the
+build ran on **1.97.1** and the pin was silently ignored.
+
+The build is green on 1.97.1. Upstream's own warning applies: _newer Rust
+versions typically work for building but may fail clippy/tests_. If you hit
+clippy failures that look version-driven, install rustup and let the pin take
+effect.
+
+### `just check` status — three environmental gotchas, all diagnosed
+
+`just check` was run to validate the toolchain more deeply. It exposed three
+failures. **None is a code defect, and none was "fixed" by editing upstream
+source.** Two are resolved; the third is the Rust-version pin above.
+
+**1. `check:minilints` — `cargo-license` not found. RESOLVED.**
+
+```
+Error: Failed to execute: cargo-license --features rustls ... (os error 2)
+```
+
+`tools/minilints/src/main.rs:297` runs `cargo install cargo-license@0.7.0`,
+which succeeds and lands the binary in `~/.cargo/bin` — but with Homebrew Rust
+that directory is not on `PATH` (a rustup install would have added it). Fix:
+
+```bash
+export PATH="$PATH:$HOME/.cargo/bin"
+```
+
+`just minilints` then passes in ~2 s.
+
+**2. Two `qt/tests/test_installer.py` failures — missing submodule. RESOLVED.**
+
+```
+Unable to clone application template; is the template path
+'.../qt/installer/mac-template' correct?
+```
+
+The build auto-checks-out only `ftl/core-repo` and `ftl/qt-repo`. The Briefcase
+installer templates are **not** initialised automatically. Fix:
+
+```bash
+git submodule update --init qt/installer/mac-template
+```
+
+All 27 installer tests then pass. Worth noting: **the macOS installer builds
+without full Xcode** — Briefcase plus Command Line Tools is sufficient. Xcode is
+an iOS blocker, not a desktop-installer one.
+
+**3. `check:clippy` — fails on Rust 1.97.1. NOT resolved, and must not be.**
+
+Two upstream files trip lints that postdate the 1.92.0 pin:
+
+- `build/ninja_gen/src/git.rs:78` — `clippy::question_mark`
+- `build/ninja_gen/src/input.rs:84` — `clippy::useless_borrows_in_formatting`
+
+This is precisely the failure mode upstream documents for newer Rust. The
+correct fix is **rustup, so the 1.92.0 pin applies** — not editing upstream
+source. Lint-fixing these would create upstream merge conflicts for no gain.
+
+With `PATH` fixed and the submodule initialised, **every other check passes**:
+`mypy`, `ruff`, `eslint`, `svelte`, `typescript`, `format`, `rust_test`,
+`pytest`, `vitest`, `minilints`.
+
+---
+
+## 4. Android — assessed, blocked on this machine
+
+AnkiDroid lives in a separate repository and is **not** cloned or vendored here.
+
+### How a change in this fork reaches an Android build
+
+This is the part that is easy to get wrong: **AnkiDroid does not consume this
+repository directly.** There is a third repo in the middle.
+
+```
+speedrun (this fork: rslib)
+    └─ git submodule `anki` of ─────────► ankidroid/Anki-Android-Backend
+                                              └─ rslib-bridge/  (JNI cdylib)
+                                              └─ builds rsdroid-release.aar
+                                                     │
+                                                     ▼
+                                          ankidroid/Anki-Android
+```
+
+`Anki-Android-Backend` carries `anki` as a git submodule pointing at
+`https://github.com/ankitects/anki`. `rslib-bridge` is a thin JNI `cdylib`
+exporting `Java_net_ankiweb_rsdroid_NativeMethods_*` symbols that wrap
+`anki::backend::init_backend` and pass protobuf bytes in/out.
+
+Concrete procedure to get this fork's Rust onto Android:
+
+1. Fork `ankidroid/Anki-Android-Backend`; repoint its `anki` submodule at this
+   fork and the branch you want.
+2. Build the AAR: `./build.sh` (which sources `set-android-ndk-home.sh`, then
+   runs `cargo run -p build_rust`).
+3. In `Anki-Android`, create `local.properties` containing
+   `local_backend=true`. `AnkiDroid/build.gradle:512-514` then links
+   `../Anki-Android-Backend/rsdroid/build/outputs/aar/rsdroid-release.aar`
+   instead of the published Maven artifact. The two repos must be siblings on
+   disk.
+
+### Exact requirements
+
+| Requirement              | Version                                                                                                    | Present here?             |
+| ------------------------ | ---------------------------------------------------------------------------------------------------------- | ------------------------- |
+| **rustup**               | any                                                                                                        | ❌ **absent**             |
+| Rust Android std targets | `aarch64-linux-android`, `armv7-linux-androideabi`, `i686-linux-android`, `x86_64-linux-android`           | ❌ **absent**             |
+| Android NDK              | **29.0.14206865** (exact, from backend `gradle/libs.versions.toml`)                                        | ❌ absent                 |
+| Android SDK              | compileSdk 36 / targetSdk 36 / minSdk 23 (backend); compileSdk 36 / targetSdk 35 / minSdk 24 (AnkiDroid)   | ❌ absent                 |
+| JDK                      | **21** (AnkiDroid Gradle daemon toolchain, vendor JETBRAINS); source/target 17 in AnkiDroid, 11 in rsdroid | ❌ **no JVM at all**      |
+| Gradle                   | 9.5.1 (backend wrapper), 9.6.0 (AnkiDroid wrapper)                                                         | ✅ wrapper self-downloads |
+| Kotlin                   | 2.2.10 (backend), 2.3.21 (AnkiDroid)                                                                       | ✅ via Gradle             |
+| Backend Rust toolchain   | 1.92.0 (`rust-toolchain.toml`)                                                                             | ⚠️ ignored without rustup  |
+
+### Verified blockers
+
+**1. No JVM.** `/usr/libexec/java_home -V` → _"Unable to locate a Java Runtime."_
+No `adb`, `sdkmanager`, `gradle`, `kotlinc`, no Android Studio, no
+`ANDROID_HOME`/`ANDROID_SDK_ROOT`, no `~/Library/Android/sdk`.
+
+**2. No rustup, and therefore no Android Rust targets.** Verified by attempting
+a real cross-compile, not assumed:
+
+```
+$ cargo build --target aarch64-linux-android
+error[E0463]: can't find crate for `core`
+  = note: the `aarch64-linux-android` target may not be installed
+  = help: consider downloading the target with `rustup target add aarch64-linux-android`
+```
+
+Homebrew's Rust ships only the host `aarch64-apple-darwin` std and has no
+mechanism to add targets. `Anki-Android-Backend`'s `build_rust/src/main.rs`
+shells out to `rustup target add` directly, so it cannot run without rustup —
+installing rustup is mandatory for this path, not optional.
+
+**3. Version skew between the backend's pin and this fork.** The backend's
+`anki` submodule is pinned at `e64c6b1ae` (2026-06-15). Against this fork's
+HEAD (`4a8673634`) the two have **diverged: 23 commits on the pinned side that
+this fork lacks, 86 commits here that the pin lacks.** Both report `.version`
+`26.05`, so they are the same release line, but `rslib-bridge` is written
+against an rslib ~86 commits older and may need fixes when repointed. Separately,
+the _published_ artifact AnkiDroid consumes by default is
+`io.github.david-allison:anki-android-backend:0.1.64-anki25.09.2` — an older
+anki line still (25.09.2).
+
+### Honest cost
+
+Roughly **10–20 GB** of downloads (JDK 21, Android SDK 36, NDK 29.0.14206865,
+Gradle, rustup + 4 Android std targets) and a few hours of setup, plus unknown
+additional time to fix any `rslib-bridge` compile breakage caused by the
+86-commit skew. Nothing here is technically blocked — it is all installable
+without Apple gatekeeping — but **none of it is installed and none of it was
+verified end to end on this machine.** Treat the "it will build once installed"
+part as unverified.
+
+---
+
+## 5. iOS — assessed, hard-blocked
+
+### Two independent blockers
+
+**1. Xcode is not installed.** Only Command Line Tools:
+
+```
+$ xcode-select -p
+/Library/Developer/CommandLineTools
+$ xcodebuild -version
+xcode-select: error: tool 'xcodebuild' requires Xcode, but active developer
+directory '/Library/Developer/CommandLineTools' is a command line tools instance
+```
+
+No `xcodebuild`, no iOS SDK, no Simulator, no code signing. Installing Xcode is
+a ~10–15 GB download plus a multi-GB install — heavy and slow, though not
+irreversible.
+
+**2. No rustup, so no iOS Rust std.** Same root cause as Android, verified the
+same way:
+
+```
+$ cargo build --target aarch64-apple-ios
+error[E0463]: can't find crate for `core`
+  = help: consider downloading the target with `rustup target add aarch64-apple-ios`
+```
+
+### The C interface does not exist yet
+
+This is the significant finding, and it is easy to assume otherwise.
+
+**This repository exposes no C interface.** A search of the entire repo for
+`extern "C"` and `#[no_mangle]` returns **zero** matches. The only FFI surface
+is `pylib/rsbridge` — `crate-type = ["cdylib"]`, but a **PyO3 Python extension
+module**, i.e. the Python ABI, not a callable C ABI. No `staticlib` target, no
+cbindgen, no generated header anywhere.
+
+The JNI bridge that AnkiDroid uses is not in this repo either — it lives in
+`Anki-Android-Backend/rslib-bridge`, and its symbols are JNI-mangled
+(`Java_net_ankiweb_rsdroid_NativeMethods_openBackend`), so they are not reusable
+from Swift/Objective-C as-is.
+
+So "run Anki's Rust backend on device through its C interface" requires
+**writing that interface first.** The good news is that the target is small and
+well-shaped: `rslib-bridge` is a thin wrapper over three operations —
+`init_backend(&[u8])`, a `run_method` protobuf bytes-in/bytes-out call, and a
+close/free. `anki::backend::init_backend` exists in this fork at
+`rslib/src/backend/mod.rs:70`. A C-ABI equivalent is a **new crate**
+(`crate-type = ["staticlib", "cdylib"]`) of roughly 150–250 lines: the same
+three entry points, C-ABI instead of JNI, returning length-prefixed byte
+buffers with an explicit free function.
+
+Adding such a crate would be additive (a new directory plus a workspace member
+line), which fits the "prefer new files over editing existing ones" constraint.
+
+### Honest cost
+
+| Item                                                          | Cost                                                                                                               |
+| ------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| Install Xcode                                                 | ~10–15 GB download, hours; **needs explicit approval** — heavy change to a shared machine                          |
+| Install rustup + `aarch64-apple-ios`, `aarch64-apple-ios-sim` | ~15 min                                                                                                            |
+| Write the C-ABI shim crate                                    | ~150–250 lines; roughly a day including a round-trip test                                                          |
+| Swift/SwiftUI app to actually drive it                        | **Days to weeks — and it does not exist as open source.** AnkiMobile is closed-source and is not a starting point. |
+| Apple Developer account for on-device (not simulator)         | $99/yr, plus provisioning                                                                                          |
+
+**Verdict: not viable on this machine as configured**, and the dominant cost is
+not the Rust side at all — it is that there is no open-source iOS client to host
+the backend. The Rust shim is the cheap part. Budget accordingly, and treat
+"backend running in an iOS _simulator_ via a test harness" as a far cheaper
+milestone than "Anki running on device".
+
+---
+
+## 6. Status summary
+
+| Target                    | Status                                                    | Blockers                                                                                                                     |
+| ------------------------- | --------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| **Desktop (macOS arm64)** | ✅ **Builds and launches.** Verified running.             | None. `just check` green except `check:clippy`, which needs rustup so the 1.92.0 pin applies.                                |
+| **Android**               | ⚠️ Path fully mapped and version-exact; **not built here** | No JVM, no Android SDK/NDK 29.0.14206865, no rustup/Android Rust targets. All installable.                                   |
+| **iOS**                   | ❌ **Not viable as configured**                           | No Xcode, no rustup/iOS targets, **and no C interface exists in this repo** — it must be written. No open-source iOS client. |
+
+---
+
+## 7. Reproducing on a clean machine
+
+```bash
+# 1. Prerequisites: Homebrew, git, and Rust (rustup STRONGLY preferred over
+#    Homebrew rust, so rust-toolchain.toml's 1.92.0 pin is honoured and clippy
+#    passes; rustup is also mandatory for any mobile cross-compilation).
+brew install ninja just
+
+# 2. Clone and build. ftl submodules, protoc, Node, uv and Python are all
+#    fetched automatically — do not install them by hand.
+git clone <this-fork> && cd speedrun
+just build          # ~2m20s cold on Apple Silicon
+
+# 3. Launch against a throwaway collection.
+just run -b /tmp/ankibase
+```
+
+Expect `Starting Anki 26.05...` and a main window with a deck browser.
+
+If you also intend to run `just check`, do these two things first — see
+[§3](#just-check-status--three-environmental-gotchas-all-diagnosed):
+
+```bash
+export PATH="$PATH:$HOME/.cargo/bin"              # for minilints
+git submodule update --init qt/installer/mac-template   # for installer tests
+```
+
+Run `just --list` for the full recipe set. Do not call `./ninja`, `./run` or
+`tools/*` directly — see `CLAUDE.md`.
+
+---
+
+## 8. Known repo quirk: `AGENTS.md`
+
+Upstream Anki ships `AGENTS.md` as a **symlink to `CLAUDE.md`**. Some tooling
+(including `fm-ensure-agents-md.sh`) expects the opposite convention —
+`AGENTS.md` as the real file with `CLAUDE.md` symlinked to it — and will refuse
+with:
+
+```
+conflict: AGENTS.md is a symlink; expected AGENTS.md to be the real file
+```
+
+This was left as upstream has it **deliberately**. Flipping the symlink would
+rename two upstream-tracked files and create a permanent merge liability against
+upstream for no functional gain — both names resolve to the same file either
+way. Durable project knowledge therefore goes in `CLAUDE.md`, which _is_
+`AGENTS.md`.

--- a/ftl/core/card-stats.ftl
+++ b/ftl/core/card-stats.ftl
@@ -18,6 +18,8 @@ card-stats-review-log-rating = Rating
 card-stats-review-log-type = Type
 card-stats-review-log-date = Date
 card-stats-review-log-time-taken = Time
+# Time from the question being shown until the answer was revealed
+card-stats-review-log-time-to-reveal = Reveal
 card-stats-review-log-type-learn = Learn
 card-stats-review-log-type-review = Review
 card-stats-review-log-type-relearn = Relearn

--- a/proto/anki/deck_config.proto
+++ b/proto/anki/deck_config.proto
@@ -193,6 +193,14 @@ message DeckConfig {
     float historical_retention = 40;
     string param_search = 45;
 
+    // Ascent fork: probability of serving a probe variant instead of the
+    // original on an eligible review. 0 disables the feature entirely.
+    float probe_rate = 47;
+    // Ascent fork: minimum FSRS retrievability before a review is
+    // eligible for probe substitution. With the default of 0, any card
+    // with a memory state is eligible; ~0.85 is the intended setting.
+    float probe_retrievability_threshold = 48;
+
     bytes other = 255;
   }
 

--- a/proto/anki/scheduler.proto
+++ b/proto/anki/scheduler.proto
@@ -64,6 +64,10 @@ service SchedulerService {
   // The number of days the calculated interval was fuzzed by on the previous
   // review (if any). Utilized by the FSRS add-on.
   rpc FuzzDelta(FuzzDeltaRequest) returns (FuzzDeltaResponse);
+  // Ascent fork: probe management. Service methods are addressed
+  // positionally, so new rpcs must only ever be appended here.
+  rpc AddProbe(Probe) returns (generic.Int64);
+  rpc GetProbes(cards.CardId) returns (Probes);
 }
 
 // Implicitly includes any of the above methods that are not listed in the
@@ -142,6 +146,10 @@ message QueuedCards {
     Queue queue = 2;
     SchedulingStates states = 3;
     SchedulingContext context = 4;
+    // Ascent fork: set when the scheduler chose to serve this probe
+    // variant instead of the original card. Clients that show it must
+    // echo its id in CardAnswer.variant_id.
+    Probe probe = 5;
   }
 
   repeated QueuedCard cards = 1;
@@ -287,6 +295,30 @@ message CardAnswer {
   // report it, so it can be told apart from a real zero. Stored uncapped;
   // the deck's answer time limit only applies to milliseconds_taken.
   optional uint32 milliseconds_to_reveal = 7;
+  // Ascent fork: id of the probe variant that was actually shown in place
+  // of the original card. The client must echo QueuedCard.probe.id here;
+  // unset means the original card was shown. Recorded in the revlog's
+  // data column, and must not influence scheduling.
+  optional int64 variant_id = 8;
+}
+
+// Ascent fork: an AI-generated reworded variant of a card, served instead
+// of the original when the scheduler is already confident of a pass.
+message Probe {
+  // 0 when adding; assigned by the backend.
+  int64 id = 1;
+  // The parent card this probe rewords.
+  int64 card_id = 2;
+  string question = 3;
+  string answer = 4;
+  // Source citation, so a probe can be traced back to its material.
+  string citation = 5;
+  // Free-form JSON generation provenance (model, date, prompt hash).
+  string provenance = 6;
+}
+
+message Probes {
+  repeated Probe probes = 1;
 }
 
 message CustomStudyRequest {

--- a/proto/anki/scheduler.proto
+++ b/proto/anki/scheduler.proto
@@ -283,6 +283,10 @@ message CardAnswer {
   Rating rating = 4;
   int64 answered_at_millis = 5;
   uint32 milliseconds_taken = 6;
+  // Question shown -> answer revealed. Unset if the client doesn't
+  // report it, so it can be told apart from a real zero. Stored uncapped;
+  // the deck's answer time limit only applies to milliseconds_taken.
+  optional uint32 milliseconds_to_reveal = 7;
 }
 
 message CustomStudyRequest {

--- a/proto/anki/stats.proto
+++ b/proto/anki/stats.proto
@@ -39,6 +39,8 @@ message CardStatsResponse {
     optional cards.FsrsMemoryState memory_state = 7;
     // seconds
     uint32 last_interval = 8;
+    // question shown -> answer revealed; unset for old entries
+    optional float reveal_secs = 9;
   }
   repeated StatsRevlogEntry revlog = 1;
   int64 card_id = 2;
@@ -222,6 +224,9 @@ message RevlogEntry {
   uint32 ease_factor = 7;
   uint32 taken_millis = 8;
   ReviewKind review_kind = 9;
+  // Question shown -> answer revealed. Unset for entries logged before
+  // this field existed. Uncapped, unlike taken_millis.
+  optional uint32 reveal_millis = 10;
 }
 
 message CardEntry {

--- a/pylib/anki/cards.py
+++ b/pylib/anki/cards.py
@@ -59,6 +59,7 @@ class Card(DeprecatedNamesMixin):
     ) -> None:
         self.col = col.weakref()
         self.timer_started: float | None = None
+        self.answer_shown_at: float | None = None
         self._render_output: anki.template.TemplateRenderOutput | None = None
         if id:
             # existing card
@@ -190,6 +191,20 @@ class Card(DeprecatedNamesMixin):
 
     def start_timer(self) -> None:
         self.timer_started = time.time()
+        self.answer_shown_at = None
+
+    def note_answer_shown(self) -> None:
+        """Record when the answer was revealed; only the first reveal counts."""
+        if self.answer_shown_at is None:
+            self.answer_shown_at = time.time()
+
+    def time_to_reveal(self) -> int | None:
+        """Milliseconds from question shown to answer revealed, or None if
+        the answer has not been shown. Uncapped; the backend applies the
+        deck's answer time cap."""
+        if self.answer_shown_at is None or self.timer_started is None:
+            return None
+        return int((self.answer_shown_at - self.timer_started) * 1000)
 
     def current_deck_id(self) -> anki.decks.DeckId:
         return anki.decks.DeckId(self.odid or self.did)

--- a/pylib/anki/exporting.py
+++ b/pylib/anki/exporting.py
@@ -238,7 +238,7 @@ class AnkiExporter(Exporter):
         if self.includeSched:
             data = self.src.db.all("select * from revlog where cid in " + ids2str(cids))
             self.dst.db.executemany(
-                "insert into revlog values (?,?,?,?,?,?,?,?,?)", data
+                "insert into revlog values (?,?,?,?,?,?,?,?,?,?)", data
             )
         else:
             # need to reset card state

--- a/pylib/anki/exporting.py
+++ b/pylib/anki/exporting.py
@@ -238,7 +238,7 @@ class AnkiExporter(Exporter):
         if self.includeSched:
             data = self.src.db.all("select * from revlog where cid in " + ids2str(cids))
             self.dst.db.executemany(
-                "insert into revlog values (?,?,?,?,?,?,?,?,?,?)", data
+                "insert into revlog values (?,?,?,?,?,?,?,?,?,?,?)", data
             )
         else:
             # need to reset card state

--- a/pylib/anki/importing/anki2.py
+++ b/pylib/anki/importing/anki2.py
@@ -383,6 +383,8 @@ class Anki2Importer(Importer):
                 rev[2] = self.dst.usn()
                 # sources from before the reveal_millis column have 9 fields
                 rev += [None] * (10 - len(rev))
+                # the data column is NOT NULL, so pad with '' rather than None
+                rev += [""] * (11 - len(rev))
                 revlog.append(rev)
             cnt += 1
         # apply
@@ -393,7 +395,7 @@ insert or ignore into cards values (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)""",
         )
         self.dst.db.executemany(
             """
-insert or ignore into revlog values (?,?,?,?,?,?,?,?,?,?)""",
+insert or ignore into revlog values (?,?,?,?,?,?,?,?,?,?,?)""",
             revlog,
         )
 

--- a/pylib/anki/importing/anki2.py
+++ b/pylib/anki/importing/anki2.py
@@ -381,6 +381,8 @@ class Anki2Importer(Importer):
                 rev = list(rev)
                 rev[1] = card[0]
                 rev[2] = self.dst.usn()
+                # sources from before the reveal_millis column have 9 fields
+                rev += [None] * (10 - len(rev))
                 revlog.append(rev)
             cnt += 1
         # apply
@@ -391,7 +393,7 @@ insert or ignore into cards values (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)""",
         )
         self.dst.db.executemany(
             """
-insert or ignore into revlog values (?,?,?,?,?,?,?,?,?)""",
+insert or ignore into revlog values (?,?,?,?,?,?,?,?,?,?)""",
             revlog,
         )
 

--- a/pylib/anki/scheduler/v3.py
+++ b/pylib/anki/scheduler/v3.py
@@ -82,7 +82,7 @@ class Scheduler(SchedulerBaseWithLegacy):
         else:
             raise Exception("invalid rating")
 
-        return CardAnswer(
+        answer = CardAnswer(
             card_id=card.id,
             current_state=states.current,
             new_state=new_state,
@@ -90,6 +90,9 @@ class Scheduler(SchedulerBaseWithLegacy):
             answered_at_millis=int_time(1000),
             milliseconds_taken=card.time_taken(capped=False),
         )
+        if (reveal := card.time_to_reveal()) is not None:
+            answer.milliseconds_to_reveal = reveal
+        return answer
 
     def answer_card(self, input: CardAnswer) -> OpChanges:
         "Update card to provided state, and remove it from queue."

--- a/pylib/anki/scheduler/v3.py
+++ b/pylib/anki/scheduler/v3.py
@@ -34,6 +34,7 @@ SchedulingContext = scheduler_pb2.SchedulingContext
 SchedulingStatesWithContext = frontend_pb2.SchedulingStatesWithContext
 SetSchedulingStatesRequest = frontend_pb2.SetSchedulingStatesRequest
 CardAnswer = scheduler_pb2.CardAnswer
+Probe = scheduler_pb2.Probe
 
 
 class Scheduler(SchedulerBaseWithLegacy):
@@ -69,6 +70,7 @@ class Scheduler(SchedulerBaseWithLegacy):
         card: Card,
         states: SchedulingStates,
         rating: CardAnswer.Rating.V,
+        variant_id: int | None = None,
     ) -> CardAnswer:
         "Build input for answer_card()."
         if rating == CardAnswer.AGAIN:
@@ -92,6 +94,8 @@ class Scheduler(SchedulerBaseWithLegacy):
         )
         if (reveal := card.time_to_reveal()) is not None:
             answer.milliseconds_to_reveal = reveal
+        if variant_id is not None:
+            answer.variant_id = variant_id
         return answer
 
     def answer_card(self, input: CardAnswer) -> OpChanges:

--- a/pylib/tests/test_schedv3.py
+++ b/pylib/tests/test_schedv3.py
@@ -2,6 +2,7 @@
 # License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
 import copy
+import json
 import os
 import time
 from collections.abc import Callable
@@ -9,10 +10,12 @@ from typing import Dict
 
 import pytest
 
+import anki
 from anki import hooks
 from anki.consts import *
 from anki.lang import without_unicode_isolation
 from anki.scheduler import UnburyDeck
+from anki.scheduler.v3 import CardAnswer
 from anki.utils import int_time
 from tests.shared import getEmptyCol as getEmptyColOrig
 
@@ -1219,3 +1222,70 @@ def test_time_to_reveal():
     )
     assert reveal is not None
     assert reveal <= taken
+
+
+# a probe variant should be served in place of the original once the card is
+# well known, and the shown variant recorded in the revlog data column
+def test_probe_substitution():
+    col = getEmptyCol()
+    note = col.newNote()
+    note["Front"] = "competitive inhibitor: Km and Vmax?"
+    note["Back"] = "Km up, Vmax unchanged"
+    col.addNote(note)
+
+    # make it a well-known review card
+    c = note.cards()[0]
+    c.type = CARD_TYPE_REV
+    c.queue = QUEUE_TYPE_REV
+    c.due = col.sched.today
+    c.ivl = 100
+    c.flush()
+    col.db.execute(
+        "update cards set data = ? where id = ?",
+        '{"s":1000.0,"d":5.0,"lrt":%d}' % int_time(),
+        c.id,
+    )
+
+    probe_id = col._backend.add_probe(
+        anki.scheduler_pb2.Probe(
+            card_id=c.id,
+            question="Same Vmax, twice the substrate for half-max velocity. Which inhibition?",
+            answer="Competitive",
+            citation="Lehninger 6.3",
+            provenance='{"model":"test"}',
+        )
+    )
+    assert probe_id > 0
+    probes = col._backend.get_probes(cid=c.id)
+    assert len(probes) == 1
+    assert probes[0].id == probe_id
+
+    # with the rate at zero, the original is always served
+    conf = col.decks.config_dict_for_deck_id(c.did)
+    conf["probeRate"] = 0.0
+    conf["probeRetrievabilityThreshold"] = 0.85
+    col.decks.update_config(conf)
+    col.sched.reset()
+    queued = col.sched.get_queued_cards().cards[0]
+    assert not queued.HasField("probe")
+
+    # at a rate of one, the probe is served instead
+    conf["probeRate"] = 1.0
+    col.decks.update_config(conf)
+    col.sched.reset()
+    queued = col.sched.get_queued_cards().cards[0]
+    assert queued.HasField("probe")
+    assert queued.probe.id == probe_id
+
+    # and answering echoes the variant into the revlog data column
+    card = col.get_card(c.id)
+    card.start_timer()
+    answer = col.sched.build_answer(
+        card=card,
+        states=queued.states,
+        rating=CardAnswer.GOOD,
+        variant_id=queued.probe.id,
+    )
+    col.sched.answer_card(answer)
+    data = col.db.scalar("select data from revlog order by id desc limit 1")
+    assert json.loads(data)["vid"] == probe_id

--- a/pylib/tests/test_schedv3.py
+++ b/pylib/tests/test_schedv3.py
@@ -1183,3 +1183,39 @@ def test_initial_repeat():
 
     ivl = col.db.scalar("select ivl from revlog")
     assert ivl == -5.5 * 60
+
+
+# time to reveal should be logged separately from the composite answer time,
+# and left null when the answer was never shown
+def test_time_to_reveal():
+    col = getEmptyCol()
+    note = col.newNote()
+    note["Front"] = "one"
+    note["Back"] = "two"
+    col.addNote(note)
+
+    # answering without revealing records null, distinguishable from zero
+    c = col.sched.getCard()
+    c.start_timer()
+    assert c.time_to_reveal() is None
+    col.sched.answerCard(c, 3)
+    taken, reveal = col.db.first(
+        "select time, reveal_millis from revlog order by id desc"
+    )
+    assert taken >= 0
+    assert reveal is None
+
+    # revealing the answer records the split time
+    c.start_timer()
+    c.note_answer_shown()
+    first_shown = c.answer_shown_at
+    # only the first reveal counts
+    c.note_answer_shown()
+    assert c.answer_shown_at == first_shown
+    assert c.time_to_reveal() is not None
+    col.sched.answerCard(c, 3)
+    taken, reveal = col.db.first(
+        "select time, reveal_millis from revlog order by id desc"
+    )
+    assert reveal is not None
+    assert reveal <= taken

--- a/pylib/tests/test_schedv3.py
+++ b/pylib/tests/test_schedv3.py
@@ -1276,6 +1276,12 @@ def test_probe_substitution():
     queued = col.sched.get_queued_cards().cards[0]
     assert queued.HasField("probe")
     assert queued.probe.id == probe_id
+    # the fields must survive the proto round-trip in the right slots: the
+    # reviewer renders probe.question as the question
+    assert queued.probe.question.startswith("Same Vmax")
+    assert queued.probe.answer == "Competitive"
+    assert queued.probe.citation == "Lehninger 6.3"
+    assert queued.probe.card_id == c.id
 
     # and answering echoes the variant into the revlog data column
     card = col.get_card(c.id)

--- a/qt/aqt/reviewer.py
+++ b/qt/aqt/reviewer.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import html
 import json
 import random
 import re
@@ -21,6 +22,7 @@ from anki.lang import with_collapsed_whitespace
 from anki.scheduler.base import ScheduleCardsAsNew
 from anki.scheduler.v3 import (
     CardAnswer,
+    Probe,
     QueuedCards,
     SchedulingContext,
     SchedulingStates,
@@ -81,6 +83,17 @@ def replay_audio(card: Card, question_side: bool) -> None:
         av_player.play_tags(tags)
 
 
+def probe_html(text: str) -> str:
+    """Render probe text for display.
+
+    Probe text is generated, not authored, so it is escaped rather than
+    treated as card HTML. ponytail: plain text is the minimum that lets the
+    substitution be seen; richer probe rendering can come with the
+    generation pipeline.
+    """
+    return f'<div class="probe">{html.escape(text)}</div>'
+
+
 @dataclass
 class V3CardInfo:
     """Stores the top of the card queue for the v3 scheduler.
@@ -104,6 +117,11 @@ class V3CardInfo:
 
     def top_card(self) -> QueuedCards.QueuedCard:
         return self.queued_cards.cards[0]
+
+    def probe(self) -> Probe | None:
+        "The probe variant the scheduler chose to serve, if any."
+        card = self.top_card()
+        return card.probe if card.HasField("probe") else None
 
     def counts(self) -> tuple[int, list[int]]:
         "Returns (idx, counts)."
@@ -393,6 +411,14 @@ class Reviewer:
         bodyclass = theme_manager.body_classes_for_card_ord(c.ord)
         a = self.mw.col.media.escape_media_filenames(c.answer())
 
+        if probe := self._v3.probe():
+            q = probe_html(probe.question)
+            a = probe_html(probe.answer)
+            # the probe replaces the template's type-in field along with the
+            # rest of the question, so don't compare a typed answer that was
+            # never asked for
+            self.typeCorrect = None
+
         self.web.eval(
             f"_showQuestion({json.dumps(q)}, {json.dumps(a)}, '{bodyclass}');"
         )
@@ -476,6 +502,8 @@ class Reviewer:
         av_player.play_tags(sounds)
         a = self._mungeQA(a)
         a = gui_hooks.card_will_show(a, c, "reviewAnswer")
+        if probe := self._v3.probe():
+            a = probe_html(probe.answer)
         # render and update bottom
         self.web.eval(f"_showAnswer({json.dumps(a)});")
         self._showEaseButtons()
@@ -543,10 +571,12 @@ class Reviewer:
             return
 
         sched = cast(V3Scheduler, self.mw.col.sched)
+        probe = self._v3.probe()
         answer = sched.build_answer(
             card=self.card,
             states=self._v3.states,
             rating=self._v3.rating_from_ease(ease),
+            variant_id=probe.id if probe else None,
         )
 
         def after_answer(changes: OpChanges) -> None:

--- a/qt/aqt/reviewer.py
+++ b/qt/aqt/reviewer.py
@@ -463,6 +463,7 @@ class Reviewer:
             return
         self.state = "answer"
         c = self.card
+        c.note_answer_shown()
         a = c.answer()
         # play audio?
         if c.autoplay():

--- a/rslib/src/card/undo.rs
+++ b/rslib/src/card/undo.rs
@@ -54,6 +54,7 @@ impl Collection {
         card: Card,
         usn: Usn,
     ) -> Result<()> {
+        self.remove_probes_for_card_undoable(card.id)?;
         self.add_card_grave_undoable(card.id, usn)?;
         self.storage.remove_card(card.id)?;
         self.save_undo(UndoableCardChange::Removed(Box::new(card)));

--- a/rslib/src/deckconfig/mod.rs
+++ b/rslib/src/deckconfig/mod.rs
@@ -81,6 +81,8 @@ const DEFAULT_DECK_CONFIG_INNER: DeckConfigInner = DeckConfigInner {
     other: Vec::new(),
     historical_retention: 0.9,
     param_search: String::new(),
+    probe_rate: 0.0,
+    probe_retrievability_threshold: 0.0,
     ignore_revlogs_before_date: String::new(),
     easy_days_percentages: Vec::new(),
 };

--- a/rslib/src/deckconfig/schema11.rs
+++ b/rslib/src/deckconfig/schema11.rs
@@ -98,6 +98,12 @@ pub struct DeckConfSchema11 {
     sm2_retention: f32,
     #[serde(default, rename = "weightSearch")]
     param_search: String,
+    // Ascent fork: without these, the values would silently drop when deck
+    // config goes through schema11 JSON on sync/export.
+    #[serde(default)]
+    probe_rate: f32,
+    #[serde(default)]
+    probe_retrievability_threshold: f32,
 
     #[serde(flatten)]
     other: HashMap<String, Value>,
@@ -314,6 +320,8 @@ impl Default for DeckConfSchema11 {
             param_search: "".to_string(),
             ignore_revlogs_before_date: "".to_string(),
             easy_days_percentages: vec![1.0; 7],
+            probe_rate: 0.0,
+            probe_retrievability_threshold: 0.0,
         }
     }
 }
@@ -396,6 +404,8 @@ impl From<DeckConfSchema11> for DeckConfig {
                 desired_retention: c.desired_retention,
                 historical_retention: c.sm2_retention,
                 param_search: c.param_search,
+                probe_rate: c.probe_rate,
+                probe_retrievability_threshold: c.probe_retrievability_threshold,
                 other: other_bytes,
             },
         }
@@ -510,6 +520,8 @@ impl From<DeckConfig> for DeckConfSchema11 {
             param_search: i.param_search,
             ignore_revlogs_before_date: i.ignore_revlogs_before_date,
             easy_days_percentages: i.easy_days_percentages,
+            probe_rate: i.probe_rate,
+            probe_retrievability_threshold: i.probe_retrievability_threshold,
         }
     }
 }
@@ -545,6 +557,8 @@ static RESERVED_DECKCONF_KEYS: Set<&'static str> = phf_set! {
     "weightSearch",
     "ignoreRevlogsBeforeDate",
     "easyDaysPercentages",
+    "probeRate",
+    "probeRetrievabilityThreshold",
 };
 
 static RESERVED_DECKCONF_NEW_KEYS: Set<&'static str> = phf_set! {
@@ -583,6 +597,23 @@ mod test {
         assert_eq!(&s11.lapse.other.keys().collect_vec(), empty);
 
         Ok(())
+    }
+
+    /// Deck config syncs by round-tripping through schema11 JSON, which
+    /// silently drops any proto field the schema11 struct doesn't know about.
+    #[test]
+    fn probe_settings_survive_schema11_roundtrip() {
+        let mut config = DeckConfig::default();
+        config.inner.probe_rate = 0.25;
+        config.inner.probe_retrievability_threshold = 0.85;
+
+        let json = serde_json::to_vec(&DeckConfSchema11::from(config)).unwrap();
+        let restored: DeckConfig = serde_json::from_slice::<DeckConfSchema11>(&json)
+            .unwrap()
+            .into();
+
+        assert_eq!(restored.inner.probe_rate, 0.25);
+        assert_eq!(restored.inner.probe_retrievability_threshold, 0.85);
     }
 
     #[test]

--- a/rslib/src/import_export/gather.rs
+++ b/rslib/src/import_export/gather.rs
@@ -12,6 +12,7 @@ use crate::decks::immediate_parent_name;
 use crate::decks::NormalDeck;
 use crate::latex::extract_latex;
 use crate::prelude::*;
+use crate::probe::Probe;
 use crate::progress::ThrottlingProgressHandler;
 use crate::revlog::RevlogEntry;
 use crate::search::CardTableGuard;
@@ -25,6 +26,7 @@ pub(super) struct ExchangeData {
     pub(super) cards: Vec<Card>,
     pub(super) notetypes: Vec<Notetype>,
     pub(super) revlog: Vec<RevlogEntry>,
+    pub(super) probes: Vec<Probe>,
     pub(super) deck_configs: Vec<DeckConfig>,
     pub(super) media_filenames: HashSet<String>,
     pub(super) days_elapsed: u32,
@@ -47,6 +49,7 @@ impl ExchangeData {
         self.cards = cards;
         self.decks = guard.col.gather_decks(with_scheduling, !with_scheduling)?;
         self.notetypes = guard.col.gather_notetypes()?;
+        self.probes = guard.col.storage.get_probes_for_searched_cards()?;
 
         let allow_filtered = self.enables_filtered_decks();
 

--- a/rslib/src/import_export/insert.rs
+++ b/rslib/src/import_export/insert.rs
@@ -13,6 +13,7 @@ impl Collection {
             col.insert_cards(&data.cards)?;
             col.insert_notetypes(&data.notetypes)?;
             col.insert_revlog(&data.revlog)?;
+            col.insert_probes(&data.probes)?;
             col.insert_deck_configs(&data.deck_configs)
         })
     }
@@ -49,6 +50,13 @@ impl Collection {
     fn insert_revlog(&self, revlog: &[RevlogEntry]) -> Result<()> {
         for entry in revlog {
             self.storage.add_revlog_entry(entry, false)?;
+        }
+        Ok(())
+    }
+
+    fn insert_probes(&self, probes: &[crate::probe::Probe]) -> Result<()> {
+        for probe in probes {
+            self.storage.add_probe(probe, false)?;
         }
         Ok(())
     }

--- a/rslib/src/import_export/package/apkg/import/cards.rs
+++ b/rslib/src/import_export/package/apkg/import/cards.rs
@@ -92,7 +92,8 @@ impl Context<'_> {
             return Err(AnkiError::SchedulerUpgradeRequired);
         }
         ctx.import_cards(mem::take(&mut self.data.cards))?;
-        ctx.import_revlog(mem::take(&mut self.data.revlog))
+        ctx.import_revlog(mem::take(&mut self.data.revlog))?;
+        ctx.import_probes(mem::take(&mut self.data.probes))
     }
 }
 
@@ -113,6 +114,16 @@ impl CardContext<'_> {
                 entry.cid = *cid;
                 entry.usn = self.usn;
                 self.target_col.add_revlog_entry_if_unique_undoable(entry)?;
+            }
+        }
+        Ok(())
+    }
+
+    fn import_probes(&mut self, probes: Vec<crate::probe::Probe>) -> Result<()> {
+        for mut probe in probes {
+            if let Some(cid) = self.imported_cards.get(&probe.card_id) {
+                probe.card_id = *cid;
+                self.target_col.add_probe_if_unique_undoable(probe)?;
             }
         }
         Ok(())

--- a/rslib/src/import_export/package/apkg/tests.rs
+++ b/rslib/src/import_export/package/apkg/tests.rs
@@ -259,7 +259,7 @@ fn probes_survive_apkg_roundtrip() {
         .pop()
         .unwrap()
         .id;
-    let probe = crate::probe::test::add_test_probe(&mut src_col, src_card_id);
+    let probe = crate::probe::test::add_test_probe(&mut src_col, src_card_id, "exported");
 
     src_col
         .export_apkg(

--- a/rslib/src/import_export/package/apkg/tests.rs
+++ b/rslib/src/import_export/package/apkg/tests.rs
@@ -244,3 +244,52 @@ fn fsrs_params_stripped_on_export_without_scheduling() {
     assert!(conf.inner.fsrs_params_5.is_empty());
     assert!(conf.inner.fsrs_params_6.is_empty());
 }
+
+#[test]
+fn probes_survive_apkg_roundtrip() {
+    let (mut src_col, src_tempdir) = open_fs_test_collection("src");
+    let (mut target_col, _target_tempdir) = open_fs_test_collection("target");
+    let apkg_path = src_tempdir.path().join("probes.apkg");
+
+    let note = NoteAdder::basic(&mut src_col).add(&mut src_col);
+    let src_card_id = src_col
+        .storage
+        .all_cards_of_note(note.id)
+        .unwrap()
+        .pop()
+        .unwrap()
+        .id;
+    let probe = crate::probe::test::add_test_probe(&mut src_col, src_card_id);
+
+    src_col
+        .export_apkg(
+            &apkg_path,
+            ExportAnkiPackageOptions {
+                with_scheduling: true,
+                with_deck_configs: true,
+                with_media: false,
+                legacy: false,
+            },
+            SearchNode::WholeCollection,
+            None,
+        )
+        .unwrap();
+    target_col
+        .import_apkg(&apkg_path, ImportAnkiPackageOptions::default())
+        .unwrap();
+
+    // the probe should have followed its parent card, with the card id
+    // remapped to whatever the target collection assigned
+    let target_card_id = target_col
+        .storage
+        .get_all_cards()
+        .pop()
+        .expect("card should have been imported")
+        .id;
+    let imported = target_col.get_probes_for_card(target_card_id).unwrap();
+    assert_eq!(imported.len(), 1);
+    assert_eq!(imported[0].question, probe.question);
+    assert_eq!(imported[0].citation, probe.citation);
+    assert_eq!(imported[0].provenance, probe.provenance);
+    assert_eq!(imported[0].card_id, target_card_id);
+}

--- a/rslib/src/lib.rs
+++ b/rslib/src/lib.rs
@@ -32,6 +32,7 @@ pub mod notetype;
 pub mod ops;
 mod preferences;
 pub mod prelude;
+pub mod probe;
 mod progress;
 pub mod revlog;
 pub mod scheduler;

--- a/rslib/src/probe/mod.rs
+++ b/rslib/src/probe/mod.rs
@@ -1,0 +1,156 @@
+// Copyright: Ankitects Pty Ltd and contributors
+// License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
+
+//! Ascent fork: probes are AI-generated reworded variants of existing cards,
+//! served instead of the original when the scheduler is already confident of
+//! a pass (see the substitution branch in [crate::scheduler::queue]).
+//!
+//! Probe content is stored in the local `probes` table, which does not take
+//! part in normal sync; only probe *outcomes* travel, via the revlog's data
+//! column. How probe text reaches a second device is an open design decision
+//! (pre-generated packs, apkg, or regeneration per device).
+
+pub(crate) mod undo;
+
+use crate::define_newtype;
+use crate::prelude::*;
+
+define_newtype!(ProbeId, i64);
+
+impl ProbeId {
+    pub fn new() -> Self {
+        ProbeId(TimestampMillis::now().0)
+    }
+}
+
+/// A reworded variant of a card. Same fact, deliberately unfamiliar surface.
+#[derive(Debug, Default, PartialEq, Eq, Clone)]
+pub struct Probe {
+    pub id: ProbeId,
+    /// The parent card this probe rewords.
+    pub card_id: CardId,
+    pub question: String,
+    pub answer: String,
+    /// Source citation, for tracing a probe back to its material.
+    pub citation: String,
+    /// Free-form JSON generation provenance (model, date, prompt hash).
+    pub provenance: String,
+}
+
+impl Collection {
+    /// Add a probe for an existing card, assigning a new id if `probe.id` is
+    /// zero or taken. This is the insertion seam for the (out of scope)
+    /// generation pipeline; for now probes arrive via this call or apkg
+    /// import.
+    pub fn add_probe(&mut self, probe: &mut Probe) -> Result<OpOutput<()>> {
+        let card_id = probe.card_id;
+        self.transact(Op::Custom("Add probe".into()), |col| {
+            col.storage
+                .get_card(card_id)?
+                .or_not_found(card_id)
+                .map(|_| ())?;
+            col.add_probe_undoable(probe)
+        })
+    }
+
+    pub fn get_probes_for_card(&self, card_id: CardId) -> Result<Vec<Probe>> {
+        self.storage.get_probes_for_card(card_id)
+    }
+}
+
+impl From<Probe> for anki_proto::scheduler::Probe {
+    fn from(p: Probe) -> Self {
+        Self {
+            id: p.id.0,
+            card_id: p.card_id.0,
+            question: p.question,
+            answer: p.answer,
+            citation: p.citation,
+            provenance: p.provenance,
+        }
+    }
+}
+
+impl From<anki_proto::scheduler::Probe> for Probe {
+    fn from(p: anki_proto::scheduler::Probe) -> Self {
+        Self {
+            id: ProbeId(p.id),
+            card_id: CardId(p.card_id),
+            question: p.question,
+            answer: p.answer,
+            citation: p.citation,
+            provenance: p.provenance,
+        }
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod test {
+    use super::*;
+    use crate::tests::CardAdder;
+
+    /// Attach a probe to `card_id`, returning it with its assigned id.
+    pub(crate) fn add_test_probe(col: &mut Collection, card_id: CardId) -> Probe {
+        let mut probe = Probe {
+            card_id,
+            question: "An assay shows unchanged Vmax but doubled Km. Which inhibition?".to_string(),
+            answer: "Competitive".to_string(),
+            citation: "Lehninger 6.3".to_string(),
+            provenance: r#"{"model":"test","date":"2026-07-31"}"#.to_string(),
+            ..Default::default()
+        };
+        col.add_probe(&mut probe).unwrap();
+        probe
+    }
+
+    #[test]
+    fn stored_and_retrieved_by_parent_card() {
+        let mut col = Collection::new();
+        let card_id = CardAdder::new().add(&mut col)[0].id;
+
+        let probe = add_test_probe(&mut col, card_id);
+        assert_ne!(probe.id.0, 0, "a fresh id must be assigned");
+        assert_eq!(
+            col.get_probes_for_card(card_id).unwrap(),
+            vec![probe.clone()]
+        );
+
+        // a second probe on the same card gets a distinct id and both are
+        // returned
+        let second = add_test_probe(&mut col, card_id);
+        assert_ne!(second.id, probe.id);
+        assert_eq!(col.get_probes_for_card(card_id).unwrap().len(), 2);
+
+        // undo removes only the most recent one
+        col.undo().unwrap();
+        assert_eq!(col.get_probes_for_card(card_id).unwrap(), vec![probe]);
+        col.redo().unwrap();
+        assert_eq!(col.get_probes_for_card(card_id).unwrap().len(), 2);
+    }
+
+    #[test]
+    fn rejects_probe_for_missing_card() {
+        let mut col = Collection::new();
+        let mut probe = Probe {
+            card_id: CardId(12345),
+            ..Default::default()
+        };
+        assert!(col.add_probe(&mut probe).is_err());
+    }
+
+    #[test]
+    fn removed_with_parent_card() {
+        let mut col = Collection::new();
+        let card_id = CardAdder::new().add(&mut col)[0].id;
+        add_test_probe(&mut col, card_id);
+
+        col.transact(Op::EmptyCards, |col| {
+            col.remove_cards_and_orphaned_notes(&[card_id])
+        })
+        .unwrap();
+        assert!(col.get_probes_for_card(card_id).unwrap().is_empty());
+
+        col.undo().unwrap();
+        assert_eq!(col.get_probes_for_card(card_id).unwrap().len(), 1);
+    }
+}

--- a/rslib/src/probe/mod.rs
+++ b/rslib/src/probe/mod.rs
@@ -89,14 +89,16 @@ pub(crate) mod test {
     use super::*;
     use crate::tests::CardAdder;
 
-    /// Attach a probe to `card_id`, returning it with its assigned id.
-    pub(crate) fn add_test_probe(col: &mut Collection, card_id: CardId) -> Probe {
+    /// Attach a probe to `card_id`, returning it with its assigned id. The
+    /// text embeds `tag` so a probe served for the wrong card, or the wrong
+    /// field mapped onto another, is visible rather than indistinguishable.
+    pub(crate) fn add_test_probe(col: &mut Collection, card_id: CardId, tag: &str) -> Probe {
         let mut probe = Probe {
             card_id,
-            question: "An assay shows unchanged Vmax but doubled Km. Which inhibition?".to_string(),
-            answer: "Competitive".to_string(),
-            citation: "Lehninger 6.3".to_string(),
-            provenance: r#"{"model":"test","date":"2026-07-31"}"#.to_string(),
+            question: format!("question-{tag}"),
+            answer: format!("answer-{tag}"),
+            citation: format!("citation-{tag}"),
+            provenance: format!(r#"{{"model":"test-{tag}"}}"#),
             ..Default::default()
         };
         col.add_probe(&mut probe).unwrap();
@@ -108,24 +110,49 @@ pub(crate) mod test {
         let mut col = Collection::new();
         let card_id = CardAdder::new().add(&mut col)[0].id;
 
-        let probe = add_test_probe(&mut col, card_id);
+        let probe = add_test_probe(&mut col, card_id, "a");
         assert_ne!(probe.id.0, 0, "a fresh id must be assigned");
+        // every field round-trips, not just the id
         assert_eq!(
             col.get_probes_for_card(card_id).unwrap(),
             vec![probe.clone()]
         );
 
-        // a second probe on the same card gets a distinct id and both are
-        // returned
-        let second = add_test_probe(&mut col, card_id);
+        // a second probe on the same card gets a distinct id; both come back,
+        // in id order
+        let second = add_test_probe(&mut col, card_id, "b");
         assert_ne!(second.id, probe.id);
-        assert_eq!(col.get_probes_for_card(card_id).unwrap().len(), 2);
+        assert_eq!(
+            col.get_probes_for_card(card_id).unwrap(),
+            vec![probe.clone(), second]
+        );
 
         // undo removes only the most recent one
         col.undo().unwrap();
         assert_eq!(col.get_probes_for_card(card_id).unwrap(), vec![probe]);
         col.redo().unwrap();
         assert_eq!(col.get_probes_for_card(card_id).unwrap().len(), 2);
+    }
+
+    /// A probe belongs to exactly one card: a sibling card must not see it.
+    #[test]
+    fn not_returned_for_a_different_card() {
+        let mut col = Collection::new();
+        let cards = CardAdder::new().siblings(2).add(&mut col);
+        let (first, second) = (cards[0].id, cards[1].id);
+
+        let probe = add_test_probe(&mut col, first, "first");
+
+        assert_eq!(col.get_probes_for_card(first).unwrap(), vec![probe]);
+        assert!(col.get_probes_for_card(second).unwrap().is_empty());
+
+        // and once the sibling has its own, the two never cross over
+        let other = add_test_probe(&mut col, second, "second");
+        assert_eq!(col.get_probes_for_card(second).unwrap(), vec![other]);
+        assert_eq!(
+            col.get_probes_for_card(first).unwrap()[0].question,
+            "question-first"
+        );
     }
 
     #[test]
@@ -142,7 +169,7 @@ pub(crate) mod test {
     fn removed_with_parent_card() {
         let mut col = Collection::new();
         let card_id = CardAdder::new().add(&mut col)[0].id;
-        add_test_probe(&mut col, card_id);
+        add_test_probe(&mut col, card_id, "a");
 
         col.transact(Op::EmptyCards, |col| {
             col.remove_cards_and_orphaned_notes(&[card_id])
@@ -152,5 +179,37 @@ pub(crate) mod test {
 
         col.undo().unwrap();
         assert_eq!(col.get_probes_for_card(card_id).unwrap().len(), 1);
+    }
+
+    /// Sync grave application and dbcheck delete cards straight through
+    /// storage, with no undo entry; the cascade has to live down there or
+    /// probes leak on every device that receives a peer's deletion.
+    #[test]
+    fn removed_when_card_is_deleted_without_undo() {
+        let mut col = Collection::new();
+        let card_id = CardAdder::new().add(&mut col)[0].id;
+        add_test_probe(&mut col, card_id, "a");
+
+        col.storage.remove_card(card_id).unwrap();
+        assert!(col.get_probes_for_card(card_id).unwrap().is_empty());
+    }
+
+    /// dbcheck's orphan sweep is the backstop for rows that predate the
+    /// cascade, or that a future deletion path forgets.
+    #[test]
+    fn orphans_are_reclaimed_by_the_sweep() {
+        let mut col = Collection::new();
+        let card_id = CardAdder::new().add(&mut col)[0].id;
+        let probe = add_test_probe(&mut col, card_id, "a");
+
+        // delete the card behind the cascade's back
+        col.storage
+            .db
+            .execute("delete from cards where id = ?", [card_id])
+            .unwrap();
+        assert_eq!(col.get_probes_for_card(card_id).unwrap(), vec![probe]);
+
+        assert_eq!(col.storage.delete_orphaned_probes().unwrap(), 1);
+        assert!(col.get_probes_for_card(card_id).unwrap().is_empty());
     }
 }

--- a/rslib/src/probe/undo.rs
+++ b/rslib/src/probe/undo.rs
@@ -1,0 +1,53 @@
+// Copyright: Ankitects Pty Ltd and contributors
+// License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
+
+use super::Probe;
+use crate::prelude::*;
+
+#[derive(Debug)]
+pub(crate) enum UndoableProbeChange {
+    Added(Box<Probe>),
+    Removed(Box<Probe>),
+}
+
+impl Collection {
+    pub(crate) fn undo_probe_change(&mut self, change: UndoableProbeChange) -> Result<()> {
+        match change {
+            UndoableProbeChange::Added(probe) => {
+                self.storage.remove_probe(probe.id)?;
+                self.save_undo(UndoableProbeChange::Removed(probe));
+                Ok(())
+            }
+            UndoableProbeChange::Removed(probe) => {
+                self.storage.add_probe(&probe, false)?;
+                self.save_undo(UndoableProbeChange::Added(probe));
+                Ok(())
+            }
+        }
+    }
+
+    /// Add the provided probe, modifying the id if it is not unique.
+    pub(crate) fn add_probe_undoable(&mut self, probe: &mut Probe) -> Result<()> {
+        probe.id = self.storage.add_probe(probe, true)?.unwrap();
+        self.save_undo(UndoableProbeChange::Added(Box::new(probe.clone())));
+        Ok(())
+    }
+
+    /// Add the provided probe, if its id is unique.
+    pub(crate) fn add_probe_if_unique_undoable(&mut self, probe: Probe) -> Result<()> {
+        if self.storage.add_probe(&probe, false)?.is_some() {
+            self.save_undo(UndoableProbeChange::Added(Box::new(probe)));
+        }
+        Ok(())
+    }
+
+    /// Remove any probes attached to the given card, undoably. Called when
+    /// the parent card is removed.
+    pub(crate) fn remove_probes_for_card_undoable(&mut self, card_id: CardId) -> Result<()> {
+        for probe in self.storage.get_probes_for_card(card_id)? {
+            self.storage.remove_probe(probe.id)?;
+            self.save_undo(UndoableProbeChange::Removed(Box::new(probe)));
+        }
+        Ok(())
+    }
+}

--- a/rslib/src/revlog/mod.rs
+++ b/rslib/src/revlog/mod.rs
@@ -5,12 +5,14 @@ pub(crate) mod undo;
 
 use num_enum::TryFromPrimitive;
 use serde::Deserialize;
+use serde::Serialize;
 use serde_repr::Deserialize_repr;
 use serde_repr::Serialize_repr;
 use serde_tuple::Serialize_tuple;
 
 use crate::define_newtype;
 use crate::prelude::*;
+use crate::probe::ProbeId;
 use crate::serde::default_on_invalid;
 use crate::serde::deserialize_int_from_number;
 
@@ -64,6 +66,48 @@ pub struct RevlogEntry {
     /// time limit never silently rewrites it.
     #[serde(default)]
     pub reveal_millis: Option<u32>,
+    /// JSON object with optional extra data about the review, mirroring the
+    /// `cards.data` pattern; see [RevlogData]. Empty for ordinary reviews and
+    /// for entries logged before the column existed.
+    #[serde(default)]
+    pub data: String,
+}
+
+/// Helper for serdeing the revlog data column.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Default)]
+#[serde(default)]
+pub struct RevlogData {
+    /// The probe variant that was shown in place of the original card.
+    /// None means the original was shown.
+    #[serde(
+        rename = "vid",
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "default_on_invalid"
+    )]
+    pub variant_id: Option<ProbeId>,
+}
+
+impl RevlogData {
+    pub(crate) fn from_str(s: &str) -> Self {
+        serde_json::from_str(s).unwrap_or_default()
+    }
+
+    /// The empty string when there is nothing to record, so rows for
+    /// ordinary reviews stay identical to ones from older clients.
+    pub(crate) fn to_data_string(&self) -> String {
+        if *self == Self::default() {
+            String::new()
+        } else {
+            serde_json::to_string(self).unwrap_or_default()
+        }
+    }
+}
+
+impl RevlogEntry {
+    /// The probe variant recorded for this review, if any.
+    pub fn variant_id(&self) -> Option<ProbeId> {
+        RevlogData::from_str(&self.data).variant_id
+    }
 }
 
 #[derive(Serialize_repr, Deserialize_repr, Debug, PartialEq, Eq, TryFromPrimitive, Clone, Copy)]
@@ -182,6 +226,7 @@ impl Collection {
             taken_millis: 0,
             review_kind,
             reveal_millis: None,
+            data: String::new(),
         };
         self.add_revlog_entry_undoable(entry)?;
         Ok(())
@@ -204,5 +249,38 @@ mod test {
 
         let json = serde_json::to_string(&entry).unwrap();
         assert_eq!(serde_json::from_str::<RevlogEntry>(&json).unwrap(), entry);
+    }
+
+    #[test]
+    fn data_serde_compat() {
+        // entries from before the data column existed deserialize as empty
+        let entry: RevlogEntry = serde_json::from_str("[1,2,-1,3,5,-60,2500,3000,1]").unwrap();
+        assert_eq!(entry.data, "");
+        assert_eq!(entry.variant_id(), None);
+        let entry: RevlogEntry = serde_json::from_str("[1,2,-1,3,5,-60,2500,3000,1,1500]").unwrap();
+        assert_eq!(entry.data, "");
+
+        let entry: RevlogEntry =
+            serde_json::from_str(r#"[1,2,-1,3,5,-60,2500,3000,1,1500,"{\"vid\":123}"]"#).unwrap();
+        assert_eq!(entry.variant_id(), Some(ProbeId(123)));
+
+        let json = serde_json::to_string(&entry).unwrap();
+        assert_eq!(serde_json::from_str::<RevlogEntry>(&json).unwrap(), entry);
+
+        // unknown keys and invalid content are tolerated
+        assert_eq!(
+            RevlogData::from_str(r#"{"future":1}"#),
+            RevlogData::default()
+        );
+        assert_eq!(RevlogData::from_str("not json"), RevlogData::default());
+        // and nothing to record round-trips as the empty string
+        assert_eq!(RevlogData::default().to_data_string(), "");
+        assert_eq!(
+            RevlogData {
+                variant_id: Some(ProbeId(123))
+            }
+            .to_data_string(),
+            r#"{"vid":123}"#
+        );
     }
 }

--- a/rslib/src/revlog/mod.rs
+++ b/rslib/src/revlog/mod.rs
@@ -57,6 +57,13 @@ pub struct RevlogEntry {
     pub taken_millis: u32,
     #[serde(rename = "type", default, deserialize_with = "default_on_invalid")]
     pub review_kind: RevlogReviewKind,
+    /// Milliseconds from the question being shown to the answer being
+    /// revealed. None for entries logged before this field existed, or by
+    /// clients that don't report it; distinguishable from a real zero.
+    /// Unlike `taken_millis`, this is stored uncapped, so the deck's answer
+    /// time limit never silently rewrites it.
+    #[serde(default)]
+    pub reveal_millis: Option<u32>,
 }
 
 #[derive(Serialize_repr, Deserialize_repr, Debug, PartialEq, Eq, TryFromPrimitive, Clone, Copy)]
@@ -174,8 +181,28 @@ impl Collection {
             ease_factor,
             taken_millis: 0,
             review_kind,
+            reveal_millis: None,
         };
         self.add_revlog_entry_undoable(entry)?;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn reveal_millis_serde_compat() {
+        // entries from before the field existed deserialize as None, not 0
+        let entry: RevlogEntry = serde_json::from_str("[1,2,-1,3,5,-60,2500,3000,1]").unwrap();
+        assert_eq!(entry.taken_millis, 3000);
+        assert_eq!(entry.reveal_millis, None);
+
+        let entry: RevlogEntry = serde_json::from_str("[1,2,-1,3,5,-60,2500,3000,1,1500]").unwrap();
+        assert_eq!(entry.reveal_millis, Some(1500));
+
+        let json = serde_json::to_string(&entry).unwrap();
+        assert_eq!(serde_json::from_str::<RevlogEntry>(&json).unwrap(), entry);
     }
 }

--- a/rslib/src/scheduler/answering/mod.rs
+++ b/rslib/src/scheduler/answering/mod.rs
@@ -32,6 +32,7 @@ use crate::deckconfig::DeckConfig;
 use crate::deckconfig::LeechAction;
 use crate::decks::Deck;
 use crate::prelude::*;
+use crate::probe::ProbeId;
 use crate::scheduler::fsrs::memory_state::fsrs_item_for_memory_state;
 use crate::scheduler::fsrs::memory_state::get_decay_from_params;
 use crate::scheduler::states::PreviewState;
@@ -54,6 +55,9 @@ pub struct CardAnswer {
     pub milliseconds_taken: u32,
     /// Question shown -> answer revealed; None if the client didn't report it.
     pub milliseconds_to_reveal: Option<u32>,
+    /// The probe variant that was shown instead of the original card, if any.
+    /// Recorded in the revlog data column; must never affect scheduling.
+    pub variant_id: Option<ProbeId>,
     pub custom_data: Option<String>,
     pub from_queue: bool,
 }
@@ -408,14 +412,7 @@ impl Collection {
         usn: Usn,
         answer: &CardAnswer,
     ) -> Result<()> {
-        let revlog = partial.into_revlog_entry(
-            usn,
-            answer.card_id,
-            answer.rating.as_number(),
-            answer.answered_at,
-            answer.milliseconds_taken,
-            answer.milliseconds_to_reveal,
-        );
+        let revlog = partial.into_revlog_entry(usn, answer);
         self.add_revlog_entry_undoable(revlog)?;
         Ok(())
     }
@@ -653,6 +650,7 @@ pub mod test_helpers {
                 answered_at: TimestampMillis::now(),
                 milliseconds_taken: 0,
                 milliseconds_to_reveal: None,
+                variant_id: None,
                 custom_data: None,
                 from_queue: true,
             })?;
@@ -876,6 +874,7 @@ pub(crate) mod test {
             answered_at: TimestampMillis::now(),
             milliseconds_taken: 3000,
             milliseconds_to_reveal: None,
+            variant_id: None,
             custom_data: None,
             from_queue: true,
         })?;
@@ -897,6 +896,7 @@ pub(crate) mod test {
             answered_at: TimestampMillis::now(),
             milliseconds_taken: 70_000,
             milliseconds_to_reveal: Some(65_000),
+            variant_id: None,
             custom_data: None,
             from_queue: true,
         })?;

--- a/rslib/src/scheduler/answering/mod.rs
+++ b/rslib/src/scheduler/answering/mod.rs
@@ -52,12 +52,19 @@ pub struct CardAnswer {
     pub rating: Rating,
     pub answered_at: TimestampMillis,
     pub milliseconds_taken: u32,
+    /// Question shown -> answer revealed; None if the client didn't report it.
+    pub milliseconds_to_reveal: Option<u32>,
     pub custom_data: Option<String>,
     pub from_queue: bool,
 }
 
 impl CardAnswer {
     fn cap_answer_secs(&mut self, max_secs: u32) {
+        // Only the composite is capped, for backwards compatibility; clamping
+        // silently rewrites the value, making a capped answer look like a
+        // genuine max_secs one. The reveal time is stored raw so the retrieval
+        // latency signal is never corrupted, and a clamped composite remains
+        // detectable by comparing the two.
         self.milliseconds_taken = self.milliseconds_taken.min(max_secs * 1000);
     }
 }
@@ -407,6 +414,7 @@ impl Collection {
             answer.rating.as_number(),
             answer.answered_at,
             answer.milliseconds_taken,
+            answer.milliseconds_to_reveal,
         );
         self.add_revlog_entry_undoable(revlog)?;
         Ok(())
@@ -644,6 +652,7 @@ pub mod test_helpers {
                 rating,
                 answered_at: TimestampMillis::now(),
                 milliseconds_taken: 0,
+                milliseconds_to_reveal: None,
                 custom_data: None,
                 from_queue: true,
             })?;
@@ -845,6 +854,56 @@ pub(crate) mod test {
         let card = col.storage.get_card(post_answer.card_id)?.unwrap();
         assert_eq!(card.queue, CardQueue::Review);
         assert_eq!(card.interval, 1);
+
+        Ok(())
+    }
+
+    #[test]
+    fn split_timer_recorded_and_capped() -> Result<()> {
+        let mut col = Collection::new();
+        let nt = col.get_notetype_by_name("Basic")?.unwrap();
+        let mut note = nt.new_note();
+        col.add_note(&mut note, DeckId(1))?;
+
+        // no reveal reported -> stored as absent, not zero
+        let queued = col.get_next_card()?.unwrap();
+        let card_id = queued.card.id;
+        col.answer_card(&mut CardAnswer {
+            card_id,
+            current_state: queued.states.current,
+            new_state: queued.states.good,
+            rating: Rating::Good,
+            answered_at: TimestampMillis::now(),
+            milliseconds_taken: 3000,
+            milliseconds_to_reveal: None,
+            custom_data: None,
+            from_queue: true,
+        })?;
+        let entries = col.storage.get_revlog_entries_for_card(card_id)?;
+        assert_eq!(entries[0].taken_millis, 3000);
+        assert_eq!(entries[0].reveal_millis, None);
+
+        // the composite is capped to the deck's answer time limit (60s
+        // default), while the reveal time is stored raw, keeping the clamp
+        // detectable
+        col.storage.db.execute_batch("update cards set due=0")?;
+        col.clear_study_queues();
+        let queued = col.get_next_card()?.unwrap();
+        col.answer_card(&mut CardAnswer {
+            card_id,
+            current_state: queued.states.current,
+            new_state: queued.states.good,
+            rating: Rating::Good,
+            answered_at: TimestampMillis::now(),
+            milliseconds_taken: 70_000,
+            milliseconds_to_reveal: Some(65_000),
+            custom_data: None,
+            from_queue: true,
+        })?;
+        let entries = col.storage.get_revlog_entries_for_card(card_id)?;
+        let entry = entries.iter().max_by_key(|e| e.id).unwrap();
+        assert_eq!(entry.taken_millis, 60_000);
+        assert_eq!(entry.reveal_millis, Some(65_000));
 
         Ok(())
     }

--- a/rslib/src/scheduler/answering/mod.rs
+++ b/rslib/src/scheduler/answering/mod.rs
@@ -330,6 +330,7 @@ impl Collection {
             .or_not_found(answer.card_id)?;
         let original = card.clone();
         let usn = self.usn()?;
+        self.validate_variant_id(answer)?;
 
         let mut updater = self.card_state_updater(card)?;
         answer.cap_answer_secs(updater.config.inner.cap_answer_time_to_secs);
@@ -395,6 +396,24 @@ impl Collection {
             )?;
         }
 
+        Ok(())
+    }
+
+    /// The variant id is supplied by the client, and rides the revlog into
+    /// sync, so a wrong one would permanently mislabel the transfer data the
+    /// whole feature exists to collect. Reject anything that isn't a probe of
+    /// the card being answered.
+    fn validate_variant_id(&self, answer: &CardAnswer) -> Result<()> {
+        if let Some(variant_id) = answer.variant_id {
+            require!(
+                self.storage
+                    .get_probes_for_card(answer.card_id)?
+                    .iter()
+                    .any(|p| p.id == variant_id),
+                "variant {variant_id} is not a probe of card {}",
+                answer.card_id
+            );
+        }
         Ok(())
     }
 

--- a/rslib/src/scheduler/answering/preview.rs
+++ b/rslib/src/scheduler/answering/preview.rs
@@ -95,6 +95,7 @@ mod test {
             rating: Rating::Again,
             answered_at: TimestampMillis::now(),
             milliseconds_taken: 0,
+            milliseconds_to_reveal: None,
             custom_data: None,
             from_queue: true,
         })?;
@@ -111,6 +112,7 @@ mod test {
             rating: Rating::Hard,
             answered_at: TimestampMillis::now(),
             milliseconds_taken: 0,
+            milliseconds_to_reveal: None,
             custom_data: None,
             from_queue: true,
         })?;
@@ -127,6 +129,7 @@ mod test {
             rating: Rating::Good,
             answered_at: TimestampMillis::now(),
             milliseconds_taken: 0,
+            milliseconds_to_reveal: None,
             custom_data: None,
             from_queue: true,
         })?;

--- a/rslib/src/scheduler/answering/preview.rs
+++ b/rslib/src/scheduler/answering/preview.rs
@@ -96,6 +96,7 @@ mod test {
             answered_at: TimestampMillis::now(),
             milliseconds_taken: 0,
             milliseconds_to_reveal: None,
+            variant_id: None,
             custom_data: None,
             from_queue: true,
         })?;
@@ -113,6 +114,7 @@ mod test {
             answered_at: TimestampMillis::now(),
             milliseconds_taken: 0,
             milliseconds_to_reveal: None,
+            variant_id: None,
             custom_data: None,
             from_queue: true,
         })?;
@@ -130,6 +132,7 @@ mod test {
             answered_at: TimestampMillis::now(),
             milliseconds_taken: 0,
             milliseconds_to_reveal: None,
+            variant_id: None,
             custom_data: None,
             from_queue: true,
         })?;

--- a/rslib/src/scheduler/answering/revlog.rs
+++ b/rslib/src/scheduler/answering/revlog.rs
@@ -39,6 +39,7 @@ impl RevlogEntryPartial {
         button_chosen: u8,
         answered_at: TimestampMillis,
         taken_millis: u32,
+        reveal_millis: Option<u32>,
     ) -> RevlogEntry {
         RevlogEntry {
             id: answered_at.into(),
@@ -50,6 +51,7 @@ impl RevlogEntryPartial {
             ease_factor: (self.ease_factor * 1000.0).round() as u32,
             taken_millis,
             review_kind: self.review_kind,
+            reveal_millis,
         }
     }
 }

--- a/rslib/src/scheduler/answering/revlog.rs
+++ b/rslib/src/scheduler/answering/revlog.rs
@@ -1,7 +1,9 @@
 // Copyright: Ankitects Pty Ltd and contributors
 // License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
+use super::CardAnswer;
 use crate::prelude::*;
+use crate::revlog::RevlogData;
 use crate::revlog::RevlogEntry;
 use crate::revlog::RevlogReviewKind;
 use crate::scheduler::states::CardState;
@@ -32,26 +34,22 @@ impl RevlogEntryPartial {
         }
     }
 
-    pub(super) fn into_revlog_entry(
-        self,
-        usn: Usn,
-        cid: CardId,
-        button_chosen: u8,
-        answered_at: TimestampMillis,
-        taken_millis: u32,
-        reveal_millis: Option<u32>,
-    ) -> RevlogEntry {
+    pub(super) fn into_revlog_entry(self, usn: Usn, answer: &CardAnswer) -> RevlogEntry {
         RevlogEntry {
-            id: answered_at.into(),
-            cid,
+            id: answer.answered_at.into(),
+            cid: answer.card_id,
             usn,
-            button_chosen,
+            button_chosen: answer.rating.as_number(),
             interval: self.interval.as_revlog_interval(),
             last_interval: self.last_interval.as_revlog_interval(),
             ease_factor: (self.ease_factor * 1000.0).round() as u32,
-            taken_millis,
+            taken_millis: answer.milliseconds_taken,
             review_kind: self.review_kind,
-            reveal_millis,
+            reveal_millis: answer.milliseconds_to_reveal,
+            data: RevlogData {
+                variant_id: answer.variant_id,
+            }
+            .to_data_string(),
         }
     }
 }

--- a/rslib/src/scheduler/fsrs/params.rs
+++ b/rslib/src/scheduler/fsrs/params.rs
@@ -556,6 +556,7 @@ fn revlog_entry_to_proto(e: RevlogEntry) -> anki_proto::stats::RevlogEntry {
         last_interval: e.last_interval,
         ease_factor: e.ease_factor,
         taken_millis: e.taken_millis,
+        reveal_millis: e.reveal_millis,
         review_kind: match e.review_kind {
             RevlogReviewKind::Learning => revlog_entry::ReviewKind::Learning,
             RevlogReviewKind::Review => revlog_entry::ReviewKind::Review,

--- a/rslib/src/scheduler/queue/mod.rs
+++ b/rslib/src/scheduler/queue/mod.rs
@@ -151,14 +151,21 @@ impl Collection {
     /// Ascent fork: when the scheduler is already confident this review will
     /// pass, sometimes choose a probe variant to serve instead of the
     /// original. Purely a presentation decision - card state and scheduling
-    /// are never touched. Sits in a latency-sensitive path, so checks are
-    /// ordered cheapest first, and collections without probes pay only a
-    /// single indexed lookup on an empty table.
+    /// are never touched.
+    ///
+    /// Sits in a latency-sensitive path. The free checks come first, so a
+    /// collection with no probes pays a single indexed lookup on an empty
+    /// table; only a card that actually has probes reaches the deck config
+    /// and elapsed-time reads. Every ambiguous case declines to substitute,
+    /// so a malformed config or missing history can never turn the feature
+    /// on by accident.
     fn maybe_probe_substitute(
         &mut self,
         card: &Card,
         kind: QueueEntryKind,
     ) -> Result<Option<Probe>> {
+        // Learning and relearning cards are excluded: a probe is only
+        // meaningful where a pass was already expected.
         if kind != QueueEntryKind::Review {
             return Ok(None);
         }
@@ -170,32 +177,37 @@ impl Collection {
             return Ok(None);
         }
         let config = self.home_deck_config(None, card.original_or_current_deck_id())?;
+        // The config is raw JSON on the sync wire, so a NaN or infinite rate
+        // is reachable; treat anything that isn't a sane probability as off.
         let rate = config.inner.probe_rate;
-        if rate <= 0.0 {
+        if !rate.is_finite() || rate <= 0.0 {
             return Ok(None);
         }
         let now = TimestampSecs::now();
-        let seconds_elapsed = if let Some(last_review_time) = card.last_review_time {
-            now.elapsed_secs_since(last_review_time)
-        } else {
-            self.storage
-                .time_of_last_review(card.id)?
-                .map(|ts| now.elapsed_secs_since(ts))
-                .unwrap_or_default()
-        }
-        .max(0) as f32;
+        let Some(last_review_time) = card
+            .last_review_time
+            .or(self.storage.time_of_last_review(card.id)?)
+        else {
+            // No review history to measure retrievability against; treating
+            // that as "just reviewed" would make the card unconditionally
+            // eligible, so decline instead.
+            return Ok(None);
+        };
+        let seconds_elapsed = now.elapsed_secs_since(last_review_time).max(0) as f32;
         let retrievability = fsrs::current_retrievability(
             memory_state.into(),
             seconds_elapsed / 86_400.0,
             card.decay.unwrap_or(FSRS5_DEFAULT_DECAY),
         );
-        if retrievability < config.inner.probe_retrievability_threshold {
+        let threshold = config.inner.probe_retrievability_threshold;
+        if !threshold.is_finite() || !retrievability.is_finite() || retrievability < threshold {
             return Ok(None);
         }
-        // Seeded like interval fuzz so refetching the same review is stable,
-        // but perturbed so the coin doesn't correlate with the fuzz factor.
-        let seed = (card.id.0 as u64).wrapping_add(card.reps as u64) ^ 0x50524f4245;
-        let mut rng = StdRng::seed_from_u64(seed);
+        // review_seed() is the collection's existing per-review seed; its
+        // rotate keeps neighbouring (id, reps) pairs from colliding. The
+        // constant decorrelates the coin from the interval fuzz that shares
+        // the seed.
+        let mut rng = StdRng::seed_from_u64(card.review_seed() ^ 0x50524f4245);
         if rng.random_range(0.0..1.0) >= rate {
             return Ok(None);
         }
@@ -368,6 +380,8 @@ impl Collection {
 
 #[cfg(test)]
 mod probe_test {
+    use std::collections::HashSet;
+
     use super::*;
     use crate::card::CardType;
     use crate::card::FsrsMemoryState;
@@ -381,6 +395,10 @@ mod probe_test {
     /// retrievability memory state and one probe attached.
     fn probe_collection(count: usize, modifier: impl FnOnce(&mut DeckConfigInner)) -> Collection {
         let mut col = Collection::new();
+        // probes key off FSRS retrievability, so the fixture runs with FSRS
+        // on; it also keeps memory state across a lapse
+        col.set_config_bool(crate::config::BoolKey::Fsrs, true, false)
+            .unwrap();
         col.update_default_deck_config(modifier);
         let days_elapsed = col.timing_today().unwrap().days_elapsed as i32;
         for _ in 0..count {
@@ -403,7 +421,7 @@ mod probe_test {
             });
             card.last_review_time = Some(TimestampSecs::now());
             col.storage.update_card(&card).unwrap();
-            add_test_probe(&mut col, card.id);
+            add_test_probe(&mut col, card.id, &card.id.0.to_string());
         }
         col.clear_study_queues();
         col
@@ -429,25 +447,87 @@ mod probe_test {
 
     #[test]
     fn served_at_approximately_the_configured_rate() {
-        let mut col = probe_collection(200, |c| {
-            c.probe_rate = 0.5;
+        // 120 cards keeps the fixture clear of the 200/day review limit, so a
+        // change to that default can't quietly turn this into a limit test.
+        // Card ids are wall-clock millis, so the seeds differ every run: this
+        // is a statistical assertion, not a deterministic one. A quarter rate
+        // is used rather than a half because at p=0.5 an inverted coin is
+        // indistinguishable from a correct one.
+        const N: usize = 120;
+        let mut col = probe_collection(N, |c| {
+            c.probe_rate = 0.25;
             c.probe_retrievability_threshold = 0.85;
         });
-        let substituted = substituted_count(&mut col, 200);
-        // the coin is seeded per card, so this is deterministic for a given
-        // set of card ids; the window is wide enough to tolerate that while
-        // still failing if the rate is ignored
+        let substituted = substituted_count(&mut col, N);
+        // ~30 expected; sigma is ~4.7, so this window is ±4 sigma - wide
+        // enough not to flake, tight enough to catch an inverted, doubled or
+        // halved rate
         assert!(
-            (70..=130).contains(&substituted),
-            "expected ~100 of 200 substituted, got {substituted}"
+            (11..=49).contains(&substituted),
+            "expected ~30 of {N} substituted, got {substituted}"
         );
 
-        // and a rate of 1.0 substitutes every eligible card
+        // the extremes are exact: every eligible card, or none
         let mut col = probe_collection(20, |c| {
             c.probe_rate = 1.0;
             c.probe_retrievability_threshold = 0.85;
         });
         assert_eq!(substituted_count(&mut col, 20), 20);
+    }
+
+    /// The chosen variant must be one of *this* card's probes, and the same
+    /// one on every refetch of the same review.
+    #[test]
+    fn chooses_a_probe_of_the_card_and_sticks_with_it() {
+        let mut col = probe_collection(1, |c| {
+            c.probe_rate = 1.0;
+            c.probe_retrievability_threshold = 0.85;
+        });
+        let card_id = col.storage.get_all_cards().pop().unwrap().id;
+        // give the card a second probe, so the choice is a real one
+        add_test_probe(&mut col, card_id, "extra");
+        col.clear_study_queues();
+
+        let mine: Vec<_> = col
+            .get_probes_for_card(card_id)
+            .unwrap()
+            .into_iter()
+            .map(|p| p.id)
+            .collect();
+        assert_eq!(mine.len(), 2);
+
+        let first = col.get_next_card().unwrap().unwrap().probe.unwrap();
+        assert!(
+            mine.contains(&first.id),
+            "served a probe belonging to another card"
+        );
+        // refetching the same review must not reroll
+        let again = col.get_next_card().unwrap().unwrap().probe.unwrap();
+        assert_eq!(again, first);
+    }
+
+    /// Learning and relearning cards are never eligible, however good their
+    /// memory state looks - a probe implies a pass was already expected.
+    #[test]
+    fn relearning_cards_are_not_eligible() {
+        let mut col = probe_collection(1, |c| {
+            c.probe_rate = 1.0;
+            c.probe_retrievability_threshold = 0.85;
+        });
+        assert_eq!(substituted_count(&mut col, 1), 1);
+
+        // fail the card into relearning; it keeps its memory state
+        col.answer_again();
+        col.storage
+            .db
+            .execute_batch("update cards set due = 0")
+            .unwrap();
+        col.clear_study_queues();
+
+        let queued = col.get_next_card().unwrap().unwrap();
+        assert_eq!(queued.kind, QueueEntryKind::Learning);
+        assert!(queued.card.memory_state.is_some());
+        assert!(queued.probe.is_none());
     }
 
     #[test]
@@ -470,6 +550,40 @@ mod probe_test {
         assert_eq!(substituted_count(&mut col, 20), 0);
     }
 
+    /// Deck config crosses the sync wire as raw JSON, so nonsense values are
+    /// reachable. Every one of them must switch the feature off, never on.
+    #[test]
+    fn malformed_config_and_missing_history_fail_closed() {
+        for rate in [f32::NAN, f32::INFINITY, -1.0] {
+            let mut col = probe_collection(5, |c| {
+                c.probe_rate = rate;
+                c.probe_retrievability_threshold = 0.85;
+            });
+            assert_eq!(substituted_count(&mut col, 5), 0, "rate {rate} substituted");
+        }
+
+        let mut col = probe_collection(5, |c| {
+            c.probe_rate = 1.0;
+            c.probe_retrievability_threshold = f32::NAN;
+        });
+        assert_eq!(substituted_count(&mut col, 5), 0, "NaN threshold");
+
+        // no review history at all: retrievability is unmeasurable, so
+        // treating the card as freshly reviewed would make it always eligible
+        let mut col = probe_collection(5, |c| {
+            c.probe_rate = 1.0;
+            c.probe_retrievability_threshold = 0.85;
+        });
+        assert_eq!(substituted_count(&mut col, 5), 5);
+        for mut card in col.storage.get_all_cards() {
+            card.last_review_time = None;
+            col.storage.update_card(&card).unwrap();
+        }
+        col.storage.db.execute_batch("delete from revlog").unwrap();
+        col.clear_study_queues();
+        assert_eq!(substituted_count(&mut col, 5), 0, "no review history");
+    }
+
     #[test]
     fn cards_without_probes_are_never_substituted() {
         let mut col = probe_collection(5, |c| {
@@ -481,24 +595,45 @@ mod probe_test {
         assert_eq!(substituted_count(&mut col, 5), 0);
     }
 
-    /// The experiment needs a clean feature-off arm: with the probe rate at
-    /// zero, scheduling must be bit-for-bit what it would be in a collection
-    /// that has no probes at all.
+    #[derive(Clone, Copy, PartialEq)]
+    enum Arm {
+        /// Stock behaviour: no probes in the collection at all.
+        NoProbes,
+        /// The experiment's control arm: probes stored, feature switched off.
+        RateZero,
+        /// The treatment arm: every eligible review serves its probe, and the
+        /// answer carries the variant id.
+        RateOne,
+    }
+
+    /// The experiment depends on probes being purely additive, so all three
+    /// arms must schedule identically: storing probes must not perturb
+    /// anything, and neither must actually *serving* one and recording the
+    /// outcome. This is the guard on "probe outcomes are recorded but must
+    /// not feed back into scheduling".
     #[test]
-    fn zero_rate_leaves_fsrs_scheduling_untouched() {
+    fn probes_never_affect_fsrs_scheduling() {
         // (interval, ease factor, reps, lapses, memory state, due offset)
         type CardState = (u32, u16, u32, u32, Option<String>, i32);
 
-        fn study(with_probes: bool) -> Vec<CardState> {
+        const RATINGS: [Rating; 5] = [
+            Rating::Good,
+            Rating::Easy,
+            Rating::Good,
+            Rating::Hard,
+            Rating::Again,
+        ];
+
+        fn study(arm: Arm) -> Vec<CardState> {
             let mut col = Collection::new();
             col.set_config_bool(crate::config::BoolKey::Fsrs, true, false)
                 .unwrap();
             col.update_default_deck_config(|c| {
-                c.probe_rate = 0.0;
+                c.probe_rate = if arm == Arm::RateOne { 1.0 } else { 0.0 };
                 c.probe_retrievability_threshold = 0.85;
             });
             let days_elapsed = col.timing_today().unwrap().days_elapsed as i32;
-            for _ in 0..5 {
+            for _ in 0..RATINGS.len() {
                 let note = NoteAdder::basic(&mut col).add(&mut col);
                 let mut card = col
                     .storage
@@ -516,14 +651,40 @@ mod probe_test {
                 });
                 card.last_review_time = Some(TimestampSecs::now());
                 col.storage.update_card(&card).unwrap();
-                if with_probes {
-                    add_test_probe(&mut col, card.id);
+                if arm != Arm::NoProbes {
+                    add_test_probe(&mut col, card.id, &card.id.0.to_string());
                 }
             }
             col.clear_study_queues();
 
-            for _ in 0..5 {
-                col.answer_good();
+            for rating in RATINGS {
+                let queued = col.get_next_card().unwrap().unwrap();
+                let probe = queued.probe.clone();
+                assert_eq!(
+                    probe.is_some(),
+                    arm == Arm::RateOne,
+                    "wrong arm: probe served = {}",
+                    probe.is_some()
+                );
+                let new_state = match rating {
+                    Rating::Again => queued.states.again,
+                    Rating::Hard => queued.states.hard,
+                    Rating::Good => queued.states.good,
+                    Rating::Easy => queued.states.easy,
+                };
+                col.answer_card(&mut CardAnswer {
+                    card_id: queued.card.id,
+                    current_state: queued.states.current,
+                    new_state,
+                    rating,
+                    answered_at: TimestampMillis::now(),
+                    milliseconds_taken: 0,
+                    milliseconds_to_reveal: None,
+                    variant_id: probe.map(|p| p.id),
+                    custom_data: None,
+                    from_queue: true,
+                })
+                .unwrap();
             }
 
             let mut states: Vec<_> = col
@@ -545,13 +706,82 @@ mod probe_test {
             states
         }
 
-        let without = study(false);
-        let with = study(true);
-        assert_eq!(with.len(), 5);
-        assert_eq!(
-            with, without,
-            "probes present at rate 0 must not perturb scheduling"
+        let stock = study(Arm::NoProbes);
+
+        // Anchor the baseline, so this can't degenerate into comparing two
+        // sets of cards that were never scheduled: FSRS ran, every card was
+        // answered once, and the ratings actually moved the intervals apart.
+        assert_eq!(stock.len(), RATINGS.len());
+        assert!(stock.iter().all(|s| s.2 == 1), "every card answered once");
+        assert!(
+            stock.iter().all(|s| s.4.is_some()),
+            "FSRS memory state should be set"
         );
+        assert!(
+            stock.iter().any(|s| s.0 > 10),
+            "a passed review should have grown its interval past the initial 10"
+        );
+        assert!(
+            stock.iter().map(|s| s.0).collect::<HashSet<_>>().len() > 1,
+            "different ratings should produce different intervals"
+        );
+
+        assert_eq!(
+            study(Arm::RateZero),
+            stock,
+            "storing probes with the feature off must not perturb scheduling"
+        );
+        assert_eq!(
+            study(Arm::RateOne),
+            stock,
+            "serving a probe and recording its outcome must not perturb scheduling"
+        );
+    }
+
+    /// The variant id comes from the client and rides the revlog into sync,
+    /// so a wrong one would permanently mislabel the transfer data. Reject it
+    /// rather than record it.
+    #[test]
+    fn variant_id_from_another_card_is_rejected() {
+        let mut col = probe_collection(2, |c| {
+            c.probe_rate = 1.0;
+            c.probe_retrievability_threshold = 0.85;
+        });
+        let queued = col.get_next_card().unwrap().unwrap();
+        let card_id = queued.card.id;
+        // a probe that exists, but belongs to the other card
+        let other = col
+            .storage
+            .get_all_cards()
+            .into_iter()
+            .find(|c| c.id != card_id)
+            .unwrap();
+        let foreign = col.get_probes_for_card(other.id).unwrap().pop().unwrap();
+
+        let mut answer = CardAnswer {
+            card_id,
+            current_state: queued.states.current,
+            new_state: queued.states.good,
+            rating: Rating::Good,
+            answered_at: TimestampMillis::now(),
+            milliseconds_taken: 3000,
+            milliseconds_to_reveal: None,
+            variant_id: Some(foreign.id),
+            custom_data: None,
+            from_queue: true,
+        };
+        assert!(col.answer_card(&mut answer).is_err());
+
+        // ...and one that doesn't exist at all
+        answer.variant_id = Some(crate::probe::ProbeId(999_999));
+        assert!(col.answer_card(&mut answer).is_err());
+
+        // the rejected answers left no revlog behind
+        assert!(col
+            .storage
+            .get_revlog_entries_for_card(card_id)
+            .unwrap()
+            .is_empty());
     }
 
     #[test]

--- a/rslib/src/scheduler/queue/mod.rs
+++ b/rslib/src/scheduler/queue/mod.rs
@@ -15,14 +15,19 @@ pub(crate) use builder::DueCardKind;
 pub(crate) use builder::NewCard;
 pub(crate) use entry::QueueEntry;
 pub(crate) use entry::QueueEntryKind;
+use fsrs::FSRS5_DEFAULT_DECAY;
 pub(crate) use learning::LearningQueueEntry;
 pub(crate) use main::MainQueueEntry;
 pub(crate) use main::MainQueueEntryKind;
+use rand::rngs::StdRng;
+use rand::Rng;
+use rand::SeedableRng;
 
 use self::undo::QueueUpdate;
 use super::states::SchedulingStates;
 use super::timing::SchedTimingToday;
 use crate::prelude::*;
+use crate::probe::Probe;
 use crate::scheduler::states::load_balancer::LoadBalancer;
 use crate::timestamp::TimestampSecs;
 
@@ -62,6 +67,9 @@ pub struct QueuedCard {
     pub kind: QueueEntryKind,
     pub states: SchedulingStates,
     pub context: SchedulingContext,
+    /// A probe variant chosen to be served in place of the original card.
+    /// Clients that show it must echo its id in `CardAnswer::variant_id`.
+    pub probe: Option<Probe>,
 }
 
 #[derive(Debug)]
@@ -123,6 +131,7 @@ impl Collection {
 
                 Ok(QueuedCard {
                     context: new_scheduling_context(self, &card)?,
+                    probe: self.maybe_probe_substitute(&card, entry.kind())?,
                     card,
                     states: next_states,
                     kind: entry.kind(),
@@ -135,6 +144,63 @@ impl Collection {
             learning_count: counts.learning,
             review_count: counts.review,
         })
+    }
+}
+
+impl Collection {
+    /// Ascent fork: when the scheduler is already confident this review will
+    /// pass, sometimes choose a probe variant to serve instead of the
+    /// original. Purely a presentation decision - card state and scheduling
+    /// are never touched. Sits in a latency-sensitive path, so checks are
+    /// ordered cheapest first, and collections without probes pay only a
+    /// single indexed lookup on an empty table.
+    fn maybe_probe_substitute(
+        &mut self,
+        card: &Card,
+        kind: QueueEntryKind,
+    ) -> Result<Option<Probe>> {
+        if kind != QueueEntryKind::Review {
+            return Ok(None);
+        }
+        let Some(memory_state) = card.memory_state else {
+            return Ok(None);
+        };
+        let probes = self.storage.get_probes_for_card(card.id)?;
+        if probes.is_empty() {
+            return Ok(None);
+        }
+        let config = self.home_deck_config(None, card.original_or_current_deck_id())?;
+        let rate = config.inner.probe_rate;
+        if rate <= 0.0 {
+            return Ok(None);
+        }
+        let now = TimestampSecs::now();
+        let seconds_elapsed = if let Some(last_review_time) = card.last_review_time {
+            now.elapsed_secs_since(last_review_time)
+        } else {
+            self.storage
+                .time_of_last_review(card.id)?
+                .map(|ts| now.elapsed_secs_since(ts))
+                .unwrap_or_default()
+        }
+        .max(0) as f32;
+        let retrievability = fsrs::current_retrievability(
+            memory_state.into(),
+            seconds_elapsed / 86_400.0,
+            card.decay.unwrap_or(FSRS5_DEFAULT_DECAY),
+        );
+        if retrievability < config.inner.probe_retrievability_threshold {
+            return Ok(None);
+        }
+        // Seeded like interval fuzz so refetching the same review is stable,
+        // but perturbed so the coin doesn't correlate with the fuzz factor.
+        let seed = (card.id.0 as u64).wrapping_add(card.reps as u64) ^ 0x50524f4245;
+        let mut rng = StdRng::seed_from_u64(seed);
+        if rng.random_range(0.0..1.0) >= rate {
+            return Ok(None);
+        }
+        let chosen = rng.random_range(0..probes.len());
+        Ok(probes.into_iter().nth(chosen))
     }
 }
 
@@ -297,5 +363,249 @@ impl Collection {
         self.get_queued_cards(1, false)
             .map(|q| [q.new_count, q.learning_count, q.review_count])
             .unwrap_or([0; 3])
+    }
+}
+
+#[cfg(test)]
+mod probe_test {
+    use super::*;
+    use crate::card::CardType;
+    use crate::card::FsrsMemoryState;
+    use crate::deckconfig::DeckConfigInner;
+    use crate::probe::test::add_test_probe;
+    use crate::scheduler::answering::CardAnswer;
+    use crate::scheduler::answering::Rating;
+    use crate::tests::NoteAdder;
+
+    /// A collection of `count` review cards, each due today with a high
+    /// retrievability memory state and one probe attached.
+    fn probe_collection(count: usize, modifier: impl FnOnce(&mut DeckConfigInner)) -> Collection {
+        let mut col = Collection::new();
+        col.update_default_deck_config(modifier);
+        let days_elapsed = col.timing_today().unwrap().days_elapsed as i32;
+        for _ in 0..count {
+            let note = NoteAdder::basic(&mut col).add(&mut col);
+            let mut card = col
+                .storage
+                .all_cards_of_note(note.id)
+                .unwrap()
+                .pop()
+                .unwrap();
+            card.ctype = CardType::Review;
+            card.queue = crate::card::CardQueue::Review;
+            card.due = days_elapsed;
+            card.interval = 10;
+            // stability far above the elapsed time, so retrievability is
+            // very close to 1
+            card.memory_state = Some(FsrsMemoryState {
+                stability: 1000.0,
+                difficulty: 5.0,
+            });
+            card.last_review_time = Some(TimestampSecs::now());
+            col.storage.update_card(&card).unwrap();
+            add_test_probe(&mut col, card.id);
+        }
+        col.clear_study_queues();
+        col
+    }
+
+    fn substituted_count(col: &mut Collection, fetch: usize) -> usize {
+        col.get_queued_cards(fetch, false)
+            .unwrap()
+            .cards
+            .iter()
+            .filter(|c| c.probe.is_some())
+            .count()
+    }
+
+    #[test]
+    fn zero_rate_never_substitutes() {
+        let mut col = probe_collection(50, |c| {
+            c.probe_rate = 0.0;
+            c.probe_retrievability_threshold = 0.85;
+        });
+        assert_eq!(substituted_count(&mut col, 50), 0);
+    }
+
+    #[test]
+    fn served_at_approximately_the_configured_rate() {
+        let mut col = probe_collection(200, |c| {
+            c.probe_rate = 0.5;
+            c.probe_retrievability_threshold = 0.85;
+        });
+        let substituted = substituted_count(&mut col, 200);
+        // the coin is seeded per card, so this is deterministic for a given
+        // set of card ids; the window is wide enough to tolerate that while
+        // still failing if the rate is ignored
+        assert!(
+            (70..=130).contains(&substituted),
+            "expected ~100 of 200 substituted, got {substituted}"
+        );
+
+        // and a rate of 1.0 substitutes every eligible card
+        let mut col = probe_collection(20, |c| {
+            c.probe_rate = 1.0;
+            c.probe_retrievability_threshold = 0.85;
+        });
+        assert_eq!(substituted_count(&mut col, 20), 20);
+    }
+
+    #[test]
+    fn retrievability_below_threshold_is_not_eligible() {
+        let mut col = probe_collection(20, |c| {
+            c.probe_rate = 1.0;
+            c.probe_retrievability_threshold = 0.85;
+        });
+        // shrink stability and push the last review well into the past, so
+        // retrievability falls below the threshold
+        for mut card in col.storage.get_all_cards() {
+            card.memory_state = Some(FsrsMemoryState {
+                stability: 1.0,
+                difficulty: 5.0,
+            });
+            card.last_review_time = Some(TimestampSecs::now().adding_secs(-30 * 86_400));
+            col.storage.update_card(&card).unwrap();
+        }
+        col.clear_study_queues();
+        assert_eq!(substituted_count(&mut col, 20), 0);
+    }
+
+    #[test]
+    fn cards_without_probes_are_never_substituted() {
+        let mut col = probe_collection(5, |c| {
+            c.probe_rate = 1.0;
+            c.probe_retrievability_threshold = 0.85;
+        });
+        col.storage.db.execute_batch("DELETE FROM probes").unwrap();
+        col.clear_study_queues();
+        assert_eq!(substituted_count(&mut col, 5), 0);
+    }
+
+    /// The experiment needs a clean feature-off arm: with the probe rate at
+    /// zero, scheduling must be bit-for-bit what it would be in a collection
+    /// that has no probes at all.
+    #[test]
+    fn zero_rate_leaves_fsrs_scheduling_untouched() {
+        // (interval, ease factor, reps, lapses, memory state, due offset)
+        type CardState = (u32, u16, u32, u32, Option<String>, i32);
+
+        fn study(with_probes: bool) -> Vec<CardState> {
+            let mut col = Collection::new();
+            col.set_config_bool(crate::config::BoolKey::Fsrs, true, false)
+                .unwrap();
+            col.update_default_deck_config(|c| {
+                c.probe_rate = 0.0;
+                c.probe_retrievability_threshold = 0.85;
+            });
+            let days_elapsed = col.timing_today().unwrap().days_elapsed as i32;
+            for _ in 0..5 {
+                let note = NoteAdder::basic(&mut col).add(&mut col);
+                let mut card = col
+                    .storage
+                    .all_cards_of_note(note.id)
+                    .unwrap()
+                    .pop()
+                    .unwrap();
+                card.ctype = CardType::Review;
+                card.queue = crate::card::CardQueue::Review;
+                card.due = days_elapsed;
+                card.interval = 10;
+                card.memory_state = Some(FsrsMemoryState {
+                    stability: 1000.0,
+                    difficulty: 5.0,
+                });
+                card.last_review_time = Some(TimestampSecs::now());
+                col.storage.update_card(&card).unwrap();
+                if with_probes {
+                    add_test_probe(&mut col, card.id);
+                }
+            }
+            col.clear_study_queues();
+
+            for _ in 0..5 {
+                col.answer_good();
+            }
+
+            let mut states: Vec<_> = col
+                .storage
+                .get_all_cards()
+                .into_iter()
+                .map(|c| {
+                    (
+                        c.interval,
+                        c.ease_factor,
+                        c.reps,
+                        c.lapses,
+                        c.memory_state.map(|m| format!("{m:?}")),
+                        c.due - days_elapsed,
+                    )
+                })
+                .collect();
+            states.sort();
+            states
+        }
+
+        let without = study(false);
+        let with = study(true);
+        assert_eq!(with.len(), 5);
+        assert_eq!(
+            with, without,
+            "probes present at rate 0 must not perturb scheduling"
+        );
+    }
+
+    #[test]
+    fn shown_variant_is_recorded_in_the_revlog() {
+        let mut col = probe_collection(1, |c| {
+            c.probe_rate = 1.0;
+            c.probe_retrievability_threshold = 0.85;
+        });
+        let queued = col.get_next_card().unwrap().unwrap();
+        let probe = queued.probe.clone().expect("probe should be served");
+        let card_id = queued.card.id;
+
+        col.answer_card(&mut CardAnswer {
+            card_id,
+            current_state: queued.states.current,
+            new_state: queued.states.good,
+            rating: Rating::Good,
+            answered_at: TimestampMillis::now(),
+            milliseconds_taken: 3000,
+            milliseconds_to_reveal: None,
+            variant_id: Some(probe.id),
+            custom_data: None,
+            from_queue: true,
+        })
+        .unwrap();
+
+        let entries = col.storage.get_revlog_entries_for_card(card_id).unwrap();
+        let entry = entries.iter().max_by_key(|e| e.id).unwrap();
+        assert_eq!(entry.variant_id(), Some(probe.id));
+
+        // answering the original leaves the column empty, so ordinary rows
+        // are byte-identical to ones written by older clients
+        col.storage
+            .db
+            .execute_batch("UPDATE cards SET due = 0")
+            .unwrap();
+        col.clear_study_queues();
+        let queued = col.get_next_card().unwrap().unwrap();
+        col.answer_card(&mut CardAnswer {
+            card_id,
+            current_state: queued.states.current,
+            new_state: queued.states.good,
+            rating: Rating::Good,
+            answered_at: TimestampMillis::now(),
+            milliseconds_taken: 3000,
+            milliseconds_to_reveal: None,
+            variant_id: None,
+            custom_data: None,
+            from_queue: true,
+        })
+        .unwrap();
+        let entries = col.storage.get_revlog_entries_for_card(card_id).unwrap();
+        let entry = entries.iter().max_by_key(|e| e.id).unwrap();
+        assert_eq!(entry.data, "");
+        assert_eq!(entry.variant_id(), None);
     }
 }

--- a/rslib/src/scheduler/reviews.rs
+++ b/rslib/src/scheduler/reviews.rs
@@ -195,6 +195,7 @@ impl Collection {
                     rating,
                     milliseconds_taken: 0,
                     milliseconds_to_reveal: None,
+                    variant_id: None,
                     answered_at_millis: TimestampMillis::now().into(),
                 }
                 .into();

--- a/rslib/src/scheduler/reviews.rs
+++ b/rslib/src/scheduler/reviews.rs
@@ -194,6 +194,7 @@ impl Collection {
                     new_state: Some(new_state.into()),
                     rating,
                     milliseconds_taken: 0,
+                    milliseconds_to_reveal: None,
                     answered_at_millis: TimestampMillis::now().into(),
                 }
                 .into();

--- a/rslib/src/scheduler/service/answering.rs
+++ b/rslib/src/scheduler/service/answering.rs
@@ -20,6 +20,7 @@ impl From<anki_proto::scheduler::CardAnswer> for CardAnswer {
             new_state: new_state.into(),
             answered_at: TimestampMillis(answer.answered_at_millis),
             milliseconds_taken: answer.milliseconds_taken,
+            milliseconds_to_reveal: answer.milliseconds_to_reveal,
             custom_data,
             from_queue: true,
         }

--- a/rslib/src/scheduler/service/answering.rs
+++ b/rslib/src/scheduler/service/answering.rs
@@ -4,6 +4,7 @@
 use std::mem;
 
 use crate::prelude::*;
+use crate::probe::ProbeId;
 use crate::scheduler::answering::CardAnswer;
 use crate::scheduler::answering::Rating;
 use crate::scheduler::queue::QueuedCard;
@@ -21,6 +22,7 @@ impl From<anki_proto::scheduler::CardAnswer> for CardAnswer {
             answered_at: TimestampMillis(answer.answered_at_millis),
             milliseconds_taken: answer.milliseconds_taken,
             milliseconds_to_reveal: answer.milliseconds_to_reveal,
+            variant_id: answer.variant_id.map(ProbeId),
             custom_data,
             from_queue: true,
         }
@@ -44,6 +46,7 @@ impl From<QueuedCard> for anki_proto::scheduler::queued_cards::QueuedCard {
             card: Some(queued_card.card.into()),
             states: Some(queued_card.states.into()),
             context: Some(queued_card.context),
+            probe: queued_card.probe.map(Into::into),
             queue: match queued_card.kind {
                 crate::scheduler::queue::QueueEntryKind::New => {
                     anki_proto::scheduler::queued_cards::Queue::New

--- a/rslib/src/scheduler/service/mod.rs
+++ b/rslib/src/scheduler/service/mod.rs
@@ -381,6 +381,22 @@ impl crate::services::SchedulerService for Collection {
             delta_days: self.get_fuzz_delta(input.card_id.into(), input.interval)?,
         })
     }
+
+    fn add_probe(&mut self, input: scheduler::Probe) -> Result<generic::Int64> {
+        let mut probe: crate::probe::Probe = input.into();
+        self.add_probe(&mut probe)?;
+        Ok(generic::Int64 { val: probe.id.0 })
+    }
+
+    fn get_probes(&mut self, input: cards::CardId) -> Result<scheduler::Probes> {
+        Ok(scheduler::Probes {
+            probes: self
+                .get_probes_for_card(input.into())?
+                .into_iter()
+                .map(Into::into)
+                .collect(),
+        })
+    }
 }
 
 impl crate::services::BackendSchedulerService for Backend {
@@ -499,6 +515,7 @@ mod tests {
                 answered_at_millis: TimestampMillis::now().0,
                 milliseconds_taken: 0,
                 milliseconds_to_reveal: None,
+                variant_id: None,
             },
         )
         .unwrap();

--- a/rslib/src/scheduler/service/mod.rs
+++ b/rslib/src/scheduler/service/mod.rs
@@ -498,6 +498,7 @@ mod tests {
                 rating: rating as i32,
                 answered_at_millis: TimestampMillis::now().0,
                 milliseconds_taken: 0,
+                milliseconds_to_reveal: None,
             },
         )
         .unwrap();

--- a/rslib/src/stats/card.rs
+++ b/rslib/src/stats/card.rs
@@ -224,6 +224,7 @@ fn stats_revlog_entry(
         taken_secs: entry.taken_millis as f32 / 1000.,
         memory_state: None,
         last_interval: entry.last_interval_secs(),
+        reveal_secs: entry.reveal_millis.map(|ms| ms as f32 / 1000.),
     }
 }
 

--- a/rslib/src/storage/card/mod.rs
+++ b/rslib/src/storage/card/mod.rs
@@ -246,6 +246,11 @@ impl super::SqliteStorage {
         self.db
             .prepare_cached("delete from cards where id = ?")?
             .execute([cid])?;
+        // Probes are cache-like content owned by the card, and SQLite runs
+        // with foreign keys off here, so the cascade is done by hand at the
+        // one point every caller routes through - including sync grave
+        // application and dbcheck, which never build undo entries.
+        self.remove_probes_for_card(cid)?;
         Ok(())
     }
 
@@ -422,10 +427,12 @@ impl super::SqliteStorage {
     }
 
     pub(crate) fn delete_orphaned_cards(&self) -> Result<usize> {
-        self.db
+        let removed = self
+            .db
             .prepare("delete from cards where nid not in (select id from notes)")?
-            .execute([])
-            .map_err(Into::into)
+            .execute([])?;
+        self.delete_orphaned_probes()?;
+        Ok(removed)
     }
 
     pub(crate) fn all_filtered_cards_by_deck(&self) -> Result<Vec<(CardId, DeckId)>> {

--- a/rslib/src/storage/dbcheck/mod.rs
+++ b/rslib/src/storage/dbcheck/mod.rs
@@ -19,14 +19,15 @@ impl super::SqliteStorage {
     /// `new_id` must be a valid id, i.e. lower or equal to `max_valid_id`.
     pub(crate) fn fix_invalid_ids(&self, max_valid_id: i64, new_id: i64) -> Result<()> {
         require!(new_id <= max_valid_id, "new_id is invalid");
-        for (source_table, foreign_table) in [
-            ("notes", Some(("cards", "nid"))),
-            ("cards", Some(("revlog", "cid"))),
-            ("revlog", None),
-        ] {
+        let foreign_tables: [(&str, &[(&str, &str)]); 3] = [
+            ("notes", &[("cards", "nid")]),
+            ("cards", &[("revlog", "cid"), ("probes", "cid")]),
+            ("revlog", &[]),
+        ];
+        for (source_table, foreign_tables) in foreign_tables {
             self.setup_invalid_ids_table(source_table, max_valid_id, new_id)?;
             self.update_invalid_ids_from_table(source_table, "id")?;
-            if let Some((target_table, id_column)) = foreign_table {
+            for (target_table, id_column) in foreign_tables {
                 self.update_invalid_ids_from_table(target_table, id_column)?;
             }
         }

--- a/rslib/src/storage/mod.rs
+++ b/rslib/src/storage/mod.rs
@@ -10,6 +10,7 @@ mod deckconfig;
 mod graves;
 mod note;
 mod notetype;
+mod probe;
 mod revlog;
 mod sqlite;
 mod sync;

--- a/rslib/src/storage/probe/add.sql
+++ b/rslib/src/storage/probe/add.sql
@@ -1,16 +1,11 @@
 INSERT
-  OR IGNORE INTO revlog (
+  OR IGNORE INTO probes (
     id,
     cid,
-    usn,
-    ease,
-    ivl,
-    lastIvl,
-    factor,
-    time,
-    type,
-    reveal_millis,
-    data
+    question,
+    answer,
+    citation,
+    provenance
   )
 VALUES (
     (
@@ -18,19 +13,14 @@ VALUES (
         WHEN ?1
         AND ?2 IN (
           SELECT id
-          FROM revlog
+          FROM probes
         ) THEN (
           SELECT max(id) + 1
-          FROM revlog
+          FROM probes
         )
         ELSE ?2
       END
     ),
-    ?,
-    ?,
-    ?,
-    ?,
-    ?,
     ?,
     ?,
     ?,

--- a/rslib/src/storage/probe/get.sql
+++ b/rslib/src/storage/probe/get.sql
@@ -1,0 +1,7 @@
+SELECT id,
+  cid,
+  question,
+  answer,
+  citation,
+  provenance
+FROM probes

--- a/rslib/src/storage/probe/mod.rs
+++ b/rslib/src/storage/probe/mod.rs
@@ -53,9 +53,31 @@ impl SqliteStorage {
         Ok(())
     }
 
+    pub(crate) fn remove_probes_for_card(&self, card_id: CardId) -> Result<()> {
+        self.db
+            .prepare_cached("delete from probes where cid = ?")?
+            .execute([card_id])?;
+        Ok(())
+    }
+
+    /// Reclaim probes whose parent card is gone. The per-card cascade in
+    /// [SqliteStorage::remove_card] keeps this empty in practice; this is the
+    /// dbcheck backstop.
+    pub(crate) fn delete_orphaned_probes(&self) -> Result<usize> {
+        self.db
+            .prepare("delete from probes where cid not in (select id from cards)")?
+            .execute([])
+            .map_err(Into::into)
+    }
+
+    /// Ordered by id, so a probe chosen by index is stable across refetches
+    /// of the same review.
     pub(crate) fn get_probes_for_card(&self, card_id: CardId) -> Result<Vec<Probe>> {
         self.db
-            .prepare_cached(concat!(include_str!("get.sql"), " where cid = ?"))?
+            .prepare_cached(concat!(
+                include_str!("get.sql"),
+                " where cid = ? order by id"
+            ))?
             .query_and_then([card_id], row_to_probe)?
             .collect()
     }

--- a/rslib/src/storage/probe/mod.rs
+++ b/rslib/src/storage/probe/mod.rs
@@ -1,0 +1,72 @@
+// Copyright: Ankitects Pty Ltd and contributors
+// License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
+
+use rusqlite::params;
+use rusqlite::Row;
+
+use super::SqliteStorage;
+use crate::prelude::*;
+use crate::probe::Probe;
+use crate::probe::ProbeId;
+
+fn row_to_probe(row: &Row) -> Result<Probe> {
+    Ok(Probe {
+        id: row.get(0)?,
+        card_id: row.get(1)?,
+        question: row.get(2)?,
+        answer: row.get(3)?,
+        citation: row.get(4)?,
+        provenance: row.get(5)?,
+    })
+}
+
+impl SqliteStorage {
+    /// Adds the probe, if its id is unique. If it is not, and `uniquify` is
+    /// true, adds it with a new id. Returns the added id.
+    /// (I.e., the option is safe to unwrap, if `uniquify` is true.)
+    /// A zero id is always replaced with a fresh timestamp-based one.
+    pub(crate) fn add_probe(&self, probe: &Probe, uniquify: bool) -> Result<Option<ProbeId>> {
+        let id = if probe.id.0 == 0 {
+            ProbeId::new()
+        } else {
+            probe.id
+        };
+        let added = self
+            .db
+            .prepare_cached(include_str!("add.sql"))?
+            .execute(params![
+                uniquify,
+                id,
+                probe.card_id,
+                probe.question,
+                probe.answer,
+                probe.citation,
+                probe.provenance,
+            ])?;
+        Ok((added > 0).then(|| ProbeId(self.db.last_insert_rowid())))
+    }
+
+    pub(crate) fn remove_probe(&self, id: ProbeId) -> Result<()> {
+        self.db
+            .prepare_cached("delete from probes where id = ?")?
+            .execute([id])?;
+        Ok(())
+    }
+
+    pub(crate) fn get_probes_for_card(&self, card_id: CardId) -> Result<Vec<Probe>> {
+        self.db
+            .prepare_cached(concat!(include_str!("get.sql"), " where cid = ?"))?
+            .query_and_then([card_id], row_to_probe)?
+            .collect()
+    }
+
+    pub(crate) fn get_probes_for_searched_cards(&self) -> Result<Vec<Probe>> {
+        self.db
+            .prepare_cached(concat!(
+                include_str!("get.sql"),
+                " where cid in (select cid from search_cids)"
+            ))?
+            .query_and_then([], row_to_probe)?
+            .collect()
+    }
+}

--- a/rslib/src/storage/revlog/add.sql
+++ b/rslib/src/storage/revlog/add.sql
@@ -8,7 +8,8 @@ INSERT
     lastIvl,
     factor,
     time,
-    type
+    type,
+    reveal_millis
   )
 VALUES (
     (
@@ -24,6 +25,7 @@ VALUES (
         ELSE ?2
       END
     ),
+    ?,
     ?,
     ?,
     ?,

--- a/rslib/src/storage/revlog/get.sql
+++ b/rslib/src/storage/revlog/get.sql
@@ -6,5 +6,6 @@ SELECT id,
   cast(lastIvl AS integer),
   factor,
   time,
-  type
+  type,
+  reveal_millis
 FROM revlog

--- a/rslib/src/storage/revlog/get.sql
+++ b/rslib/src/storage/revlog/get.sql
@@ -7,5 +7,6 @@ SELECT id,
   factor,
   time,
   type,
-  reveal_millis
+  reveal_millis,
+  data
 FROM revlog

--- a/rslib/src/storage/revlog/mod.rs
+++ b/rslib/src/storage/revlog/mod.rs
@@ -42,6 +42,7 @@ fn row_to_revlog_entry(row: &Row) -> Result<RevlogEntry> {
         ease_factor: row.get(6)?,
         taken_millis: row.get(7).unwrap_or_default(),
         review_kind: row.get(8).unwrap_or_default(),
+        reveal_millis: row.get(9).unwrap_or_default(),
     })
 }
 
@@ -81,7 +82,8 @@ impl SqliteStorage {
                 entry.last_interval,
                 entry.ease_factor,
                 entry.taken_millis,
-                entry.review_kind as u8
+                entry.review_kind as u8,
+                entry.reveal_millis
             ])?;
         Ok((added > 0).then(|| RevlogId(self.db.last_insert_rowid())))
     }

--- a/rslib/src/storage/revlog/mod.rs
+++ b/rslib/src/storage/revlog/mod.rs
@@ -43,6 +43,7 @@ fn row_to_revlog_entry(row: &Row) -> Result<RevlogEntry> {
         taken_millis: row.get(7).unwrap_or_default(),
         review_kind: row.get(8).unwrap_or_default(),
         reveal_millis: row.get(9).unwrap_or_default(),
+        data: row.get(10).unwrap_or_default(),
     })
 }
 
@@ -83,7 +84,8 @@ impl SqliteStorage {
                 entry.ease_factor,
                 entry.taken_millis,
                 entry.review_kind as u8,
-                entry.reveal_millis
+                entry.reveal_millis,
+                entry.data
             ])?;
         Ok((added > 0).then(|| RevlogId(self.db.last_insert_rowid())))
     }

--- a/rslib/src/storage/upgrades/mod.rs
+++ b/rslib/src/storage/upgrades/mod.rs
@@ -6,7 +6,7 @@ pub(super) const SCHEMA_MIN_VERSION: u8 = 11;
 /// The version new files are initially created with.
 pub(super) const SCHEMA_STARTING_VERSION: u8 = 11;
 /// The maximum schema version we can open.
-pub(super) const SCHEMA_MAX_VERSION: u8 = 18;
+pub(super) const SCHEMA_MAX_VERSION: u8 = 19;
 
 use super::SchemaVersion;
 use super::SqliteStorage;
@@ -40,6 +40,10 @@ impl SqliteStorage {
             self.db
                 .execute_batch(include_str!("schema18_upgrade.sql"))?;
         }
+        if ver < 19 {
+            self.db
+                .execute_batch(include_str!("schema19_upgrade.sql"))?;
+        }
 
         // in some future schema upgrade, we may want to change
         // _collapsed to _expanded in DeckCommon and invert existing values, so
@@ -52,6 +56,8 @@ impl SqliteStorage {
     pub(super) fn downgrade_to(&self, ver: SchemaVersion) -> Result<()> {
         match ver {
             SchemaVersion::V11 => self.downgrade_to_schema_11(),
+            // deliberately a no-op: the file stays at 19 so revlog.reveal_millis
+            // survives sync uploads/latest-version exports
             SchemaVersion::V18 => Ok(()),
         }
     }
@@ -59,6 +65,8 @@ impl SqliteStorage {
     fn downgrade_to_schema_11(&self) -> Result<()> {
         self.begin_trx()?;
 
+        self.db
+            .execute_batch(include_str!("schema19_downgrade.sql"))?;
         self.db
             .execute_batch(include_str!("schema18_downgrade.sql"))?;
         self.downgrade_deck_conf_from_schema16()?;
@@ -85,11 +93,48 @@ mod test {
 
     #[test]
     #[allow(clippy::assertions_on_constants)]
-    fn assert_18_is_latest_schema_version() {
+    fn assert_19_is_latest_schema_version() {
         assert_eq!(
-            18, SCHEMA_MAX_VERSION,
+            19, SCHEMA_MAX_VERSION,
             "must implement SqliteStorage::downgrade_to(SchemaVersion::V18)"
         );
+    }
+
+    #[test]
+    fn reveal_millis_survives_reopen_and_v11_downgrade() -> Result<()> {
+        let tempfile = new_tempfile()?;
+        let col = CollectionBuilder::default()
+            .set_collection_path(tempfile.path())
+            .build()?;
+        col.storage.add_revlog_entry(
+            &crate::revlog::RevlogEntry {
+                id: crate::revlog::RevlogId(123),
+                cid: CardId(45),
+                taken_millis: 3000,
+                reveal_millis: Some(1500),
+                ..Default::default()
+            },
+            true,
+        )?;
+        col.close(None)?;
+
+        let col = CollectionBuilder::default()
+            .set_collection_path(tempfile.path())
+            .build()?;
+        let entries = col.storage.get_revlog_entries_for_card(CardId(45))?;
+        assert_eq!(entries[0].reveal_millis, Some(1500));
+
+        // the legacy downgrade drops the column; after re-upgrading, the value
+        // reads back as absent rather than zero
+        col.close(Some(SchemaVersion::V11))?;
+        let col = CollectionBuilder::default()
+            .set_collection_path(tempfile.path())
+            .build()?;
+        let entries = col.storage.get_revlog_entries_for_card(CardId(45))?;
+        assert_eq!(entries[0].taken_millis, 3000);
+        assert_eq!(entries[0].reveal_millis, None);
+
+        Ok(())
     }
 
     #[test]

--- a/rslib/src/storage/upgrades/mod.rs
+++ b/rslib/src/storage/upgrades/mod.rs
@@ -6,7 +6,7 @@ pub(super) const SCHEMA_MIN_VERSION: u8 = 11;
 /// The version new files are initially created with.
 pub(super) const SCHEMA_STARTING_VERSION: u8 = 11;
 /// The maximum schema version we can open.
-pub(super) const SCHEMA_MAX_VERSION: u8 = 19;
+pub(super) const SCHEMA_MAX_VERSION: u8 = 20;
 
 use super::SchemaVersion;
 use super::SqliteStorage;
@@ -44,6 +44,10 @@ impl SqliteStorage {
             self.db
                 .execute_batch(include_str!("schema19_upgrade.sql"))?;
         }
+        if ver < 20 {
+            self.db
+                .execute_batch(include_str!("schema20_upgrade.sql"))?;
+        }
 
         // in some future schema upgrade, we may want to change
         // _collapsed to _expanded in DeckCommon and invert existing values, so
@@ -56,8 +60,9 @@ impl SqliteStorage {
     pub(super) fn downgrade_to(&self, ver: SchemaVersion) -> Result<()> {
         match ver {
             SchemaVersion::V11 => self.downgrade_to_schema_11(),
-            // deliberately a no-op: the file stays at 19 so revlog.reveal_millis
-            // survives sync uploads/latest-version exports
+            // deliberately a no-op: the file stays at 20 so revlog.reveal_millis,
+            // revlog.data and the probes table survive sync uploads/latest-version
+            // exports
             SchemaVersion::V18 => Ok(()),
         }
     }
@@ -65,6 +70,8 @@ impl SqliteStorage {
     fn downgrade_to_schema_11(&self) -> Result<()> {
         self.begin_trx()?;
 
+        self.db
+            .execute_batch(include_str!("schema20_downgrade.sql"))?;
         self.db
             .execute_batch(include_str!("schema19_downgrade.sql"))?;
         self.db
@@ -93,9 +100,9 @@ mod test {
 
     #[test]
     #[allow(clippy::assertions_on_constants)]
-    fn assert_19_is_latest_schema_version() {
+    fn assert_20_is_latest_schema_version() {
         assert_eq!(
-            19, SCHEMA_MAX_VERSION,
+            20, SCHEMA_MAX_VERSION,
             "must implement SqliteStorage::downgrade_to(SchemaVersion::V18)"
         );
     }
@@ -133,6 +140,60 @@ mod test {
         let entries = col.storage.get_revlog_entries_for_card(CardId(45))?;
         assert_eq!(entries[0].taken_millis, 3000);
         assert_eq!(entries[0].reveal_millis, None);
+
+        Ok(())
+    }
+
+    #[test]
+    fn probe_data_survives_reopen_and_v11_downgrade() -> Result<()> {
+        use crate::probe::Probe;
+        use crate::probe::ProbeId;
+
+        let tempfile = new_tempfile()?;
+        let col = CollectionBuilder::default()
+            .set_collection_path(tempfile.path())
+            .build()?;
+        col.storage.add_revlog_entry(
+            &crate::revlog::RevlogEntry {
+                id: crate::revlog::RevlogId(123),
+                cid: CardId(45),
+                taken_millis: 3000,
+                data: r#"{"vid":789}"#.to_string(),
+                ..Default::default()
+            },
+            true,
+        )?;
+        col.storage.add_probe(
+            &Probe {
+                id: ProbeId(789),
+                card_id: CardId(45),
+                question: "q".to_string(),
+                answer: "a".to_string(),
+                citation: "c".to_string(),
+                provenance: "{}".to_string(),
+            },
+            false,
+        )?;
+        col.close(None)?;
+
+        let col = CollectionBuilder::default()
+            .set_collection_path(tempfile.path())
+            .build()?;
+        let entries = col.storage.get_revlog_entries_for_card(CardId(45))?;
+        assert_eq!(entries[0].variant_id(), Some(ProbeId(789)));
+        assert_eq!(col.storage.get_probes_for_card(CardId(45))?.len(), 1);
+
+        // the legacy downgrade drops the column and the table; after
+        // re-upgrading, the rest of the row still reads back
+        col.close(Some(SchemaVersion::V11))?;
+        let col = CollectionBuilder::default()
+            .set_collection_path(tempfile.path())
+            .build()?;
+        let entries = col.storage.get_revlog_entries_for_card(CardId(45))?;
+        assert_eq!(entries[0].taken_millis, 3000);
+        assert_eq!(entries[0].data, "");
+        assert_eq!(entries[0].variant_id(), None);
+        assert!(col.storage.get_probes_for_card(CardId(45))?.is_empty());
 
         Ok(())
     }

--- a/rslib/src/storage/upgrades/schema19_downgrade.sql
+++ b/rslib/src/storage/upgrades/schema19_downgrade.sql
@@ -1,0 +1,3 @@
+ALTER TABLE revlog DROP COLUMN reveal_millis;
+UPDATE col
+SET ver = 18;

--- a/rslib/src/storage/upgrades/schema19_upgrade.sql
+++ b/rslib/src/storage/upgrades/schema19_upgrade.sql
@@ -1,0 +1,4 @@
+ALTER TABLE revlog
+ADD COLUMN reveal_millis integer;
+UPDATE col
+SET ver = 19;

--- a/rslib/src/storage/upgrades/schema20_downgrade.sql
+++ b/rslib/src/storage/upgrades/schema20_downgrade.sql
@@ -1,0 +1,4 @@
+ALTER TABLE revlog DROP COLUMN data;
+DROP TABLE probes;
+UPDATE col
+SET ver = 19;

--- a/rslib/src/storage/upgrades/schema20_upgrade.sql
+++ b/rslib/src/storage/upgrades/schema20_upgrade.sql
@@ -1,0 +1,13 @@
+ALTER TABLE revlog
+ADD COLUMN data text NOT NULL DEFAULT '';
+CREATE TABLE probes (
+  id integer PRIMARY KEY,
+  cid integer NOT NULL,
+  question text NOT NULL,
+  answer text NOT NULL,
+  citation text NOT NULL,
+  provenance text NOT NULL DEFAULT ''
+);
+CREATE INDEX idx_probes_cid ON probes (cid);
+UPDATE col
+SET ver = 20;

--- a/rslib/src/sync/collection/tests.rs
+++ b/rslib/src/sync/collection/tests.rs
@@ -634,6 +634,10 @@ async fn regular_sync(ctx: &SyncTestContext) -> Result<()> {
         name: "new dconf".into(),
         ..Default::default()
     };
+    // deck config syncs via schema11 JSON, which silently drops proto fields
+    // the schema11 struct doesn't know about; compare_sides below catches it
+    dconf.inner.probe_rate = 0.25;
+    dconf.inner.probe_retrievability_threshold = 0.85;
     col1.add_or_update_deck_config(&mut dconf)?;
     if let DeckKind::Normal(deck) = &mut deck.kind {
         deck.config_id = dconf.id.0;
@@ -651,13 +655,16 @@ async fn regular_sync(ctx: &SyncTestContext) -> Result<()> {
     note.tags.push("tag".into());
     col1.add_note(&mut note, deck.id)?;
 
-    // mock revlog entry
+    // mock revlog entry; revlog rows sync as fixed-arity positional tuples,
+    // so the reveal time and data column have to ride along in order
     col1.storage.add_revlog_entry(
         &RevlogEntry {
             id: RevlogId(123),
             cid: CardId(456),
             usn: Usn(-1),
             interval: 10,
+            reveal_millis: Some(1500),
+            data: r#"{"vid":789}"#.to_string(),
             ..Default::default()
         },
         true,

--- a/rslib/src/sync/collection/tests.rs
+++ b/rslib/src/sync/collection/tests.rs
@@ -700,6 +700,18 @@ async fn regular_sync(ctx: &SyncTestContext) -> Result<()> {
     let cardid = col1.search_cards(note.id, SortMode::NoOrder)?[0];
     let revlogid = RevlogId(123);
 
+    // Probe *content* deliberately does not sync - the chunked object lists
+    // are closed - while probe *outcomes* ride the revlog and do. Pin that,
+    // so wiring probes into the chunks later is a conscious decision rather
+    // than an accident.
+    crate::probe::test::add_test_probe(&mut col1, cardid, "local");
+    let out = ctx.normal_sync(&mut col1).await;
+    assert_eq!(out.required, SyncActionRequired::NoChanges);
+    let out = ctx.normal_sync(&mut col2).await;
+    assert_eq!(out.required, SyncActionRequired::NoChanges);
+    assert_eq!(col1.get_probes_for_card(cardid)?.len(), 1);
+    assert!(col2.get_probes_for_card(cardid)?.is_empty());
+
     let compare_sides = |col1: &mut Collection, col2: &mut Collection| -> Result<()> {
         assert_eq!(
             col1.get_notetype(ntid)?.unwrap(),

--- a/rslib/src/undo/changes.rs
+++ b/rslib/src/undo/changes.rs
@@ -9,6 +9,7 @@ use crate::decks::undo::UndoableDeckChange;
 use crate::notes::undo::UndoableNoteChange;
 use crate::notetype::undo::UndoableNotetypeChange;
 use crate::prelude::*;
+use crate::probe::undo::UndoableProbeChange;
 use crate::revlog::undo::UndoableRevlogChange;
 use crate::scheduler::queue::undo::UndoableQueueChange;
 use crate::tags::undo::UndoableTagChange;
@@ -21,6 +22,7 @@ pub(crate) enum UndoableChange {
     DeckConfig(UndoableDeckConfigChange),
     Tag(UndoableTagChange),
     Revlog(UndoableRevlogChange),
+    Probe(UndoableProbeChange),
     Queue(UndoableQueueChange),
     Config(UndoableConfigChange),
     Collection(UndoableCollectionChange),
@@ -35,6 +37,7 @@ impl UndoableChange {
             UndoableChange::Deck(c) => col.undo_deck_change(c),
             UndoableChange::Tag(c) => col.undo_tag_change(c),
             UndoableChange::Revlog(c) => col.undo_revlog_change(c),
+            UndoableChange::Probe(c) => col.undo_probe_change(c),
             UndoableChange::Queue(c) => col.undo_queue_change(c),
             UndoableChange::Config(c) => col.undo_config_change(c),
             UndoableChange::DeckConfig(c) => col.undo_deck_config_change(c),
@@ -77,6 +80,12 @@ impl From<UndoableTagChange> for UndoableChange {
 impl From<UndoableRevlogChange> for UndoableChange {
     fn from(c: UndoableRevlogChange) -> Self {
         UndoableChange::Revlog(c)
+    }
+}
+
+impl From<UndoableProbeChange> for UndoableChange {
+    fn from(c: UndoableProbeChange) -> Self {
+        UndoableChange::Probe(c)
     }
 }
 

--- a/rslib/src/undo/mod.rs
+++ b/rslib/src/undo/mod.rs
@@ -312,6 +312,7 @@ impl From<&[UndoableChange]> for StateChanges {
                 UndoableChange::Deck(_) => out.deck = true,
                 UndoableChange::Tag(_) => out.tag = true,
                 UndoableChange::Revlog(_) => {}
+                UndoableChange::Probe(_) => {}
                 UndoableChange::Queue(_) => {}
                 UndoableChange::Config(_) => out.config = true,
                 UndoableChange::DeckConfig(_) => out.deck_config = true,

--- a/ts/routes/card-info/Revlog.svelte
+++ b/ts/routes/card-info/Revlog.svelte
@@ -58,6 +58,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         interval: string;
         ease: string;
         takenSecs: string;
+        revealSecs: string;
         elapsedTime: string;
         stability: string;
     }
@@ -75,6 +76,8 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
             interval: timeSpan(entry.interval),
             ease: formatEaseOrDifficulty(entry.ease),
             takenSecs: timeSpan(entry.takenSecs, true),
+            revealSecs:
+                entry.revealSecs !== undefined ? timeSpan(entry.revealSecs, true) : "",
             elapsedTime,
             stability: entry.memoryState?.stability
                 ? timeSpan(entry.memoryState.stability * 86400)
@@ -171,6 +174,14 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
             <div class="column-content right">
                 {#each revlogRows as row, _index}
                     <div>{row.takenSecs}</div>
+                {/each}
+            </div>
+        </div>
+        <div class="column hidden-xs">
+            <div class="column-head">{tr2.cardStatsReviewLogTimeToReveal()}</div>
+            <div class="column-content right">
+                {#each revlogRows as row, _index}
+                    <div>{row.revealSecs}</div>
                 {/each}
             </div>
         </div>


### PR DESCRIPTION
Implements the probe core: probe storage, the review-log link, and the scheduler substitution branch. Probe *generation* is out of scope — probes arrive via the new `AddProbe` rpc or apkg import.

## What landed

**Probe storage.** New `probes` table (schema 20) holding probe id, parent card id, question/answer text, source citation, and generation provenance (free-form JSON: model, date, prompt hash). Follows the existing rslib table conventions for undo, apkg import/export, and dbcheck id fixing.

**Review-log link.** One `data TEXT NOT NULL DEFAULT ''` JSON column on revlog, mirroring the proven `cards.data` / `custom_data` pattern as the architecture report §5.4 recommends. It carries `variant_id` now, so future probe metadata needs no further schema bump. Ordinary reviews still write an empty string, leaving their rows byte-identical to ones written by older clients. Schema bump, sync tuple, and backward compatibility follow PR #2 exactly.

**Substitution branch.** In `get_queued_cards`, where the card and its FSRS memory state are already in hand: above the configured retrievability threshold, a per-review seeded coin decides whether to serve a probe instead of the original. It is a presentation decision only — no card state, memory state, or interval is touched.

**Configuration — per-deck, and the §5.6 trap handled properly.** `probe_rate` and `probe_retrievability_threshold` are fields on `DeckConfig.Config`. I took the deck-config route rather than the collection-level key/value table because the brief asks for per-deck settings and the three-arm experiment wants to vary them per deck. Deck config syncs by round-tripping through schema11 JSON, which silently drops proto fields the schema11 struct doesn't know about, so both are also wired into `DeckConfSchema11`, both conversion impls, and `RESERVED_DECKCONF_KEYS`. `probe_settings_survive_schema11_roundtrip` fails without that wiring — I verified by reverting it.

**RPCs.** `AddProbe` and `GetProbes` are appended at the end of `SchedulerService`, never reordered (indices 39 and 40, confirmed in the generated dispatcher). Neither is called from a backend web page, so no AnkiDroid `PostRequestHandler` allow-list entry is needed — worth knowing if a probe UI later needs to reach them from the reviewer WebView.

## FSRS is untouched

`variant_id` reaches exactly one place, `into_revlog_entry`, and nothing else in rslib reads it. `probes_never_affect_fsrs_scheduling` compares three arms — no probes, probes at rate zero, and probes at rate one answered with the variant id — across four ratings, with the baseline anchored so it cannot degenerate into comparing two sets of cards that were never scheduled.

## The seam this does not close

**Probe content does not sync.** The chunked and unchunked sync object lists are closed, so the `probes` table is local. Probe *outcomes* ride the revlog and do sync. How probe text reaches a second device — pre-generated packs, apkg, or per-device regeneration — is an open captain decision, so nothing here is designed around an assumption about it. The sync test now pins the current behaviour, so wiring probes into the chunks later is a conscious change rather than an accident. Probes do travel in modern apkg exports, which is what makes pre-generated probe packs possible.

## Review

Two review agents went over the first commit; the second commit is their findings. The substantive ones:

- Probes leaked on every card deletion that skips the undoable wrapper — most importantly sync grave application, which is how a card deleted on one device disappears on another. Fixed with a hand-written cascade in `SqliteStorage::remove_card` (SQLite runs with foreign keys off), plus an orphan sweep as a backstop.
- Several fail-open edges: a NaN probe rate read as "always substitute", and a card with a memory state but no review history was treated as freshly reviewed and cleared any threshold. Every ambiguous input now declines.
- `variant_id` is now rejected unless it names a probe of the card being answered. It comes from the client and rides the revlog into sync, so a wrong one would permanently mislabel the transfer data.
- The coin now uses `Card::review_seed()`, whose rotate is what stops neighbouring `(id, reps)` pairs from colliding, and probe lookup is ordered by id so choosing by index is genuinely stable.
- Two mutations previously shipped green: making `get_probes_for_card` ignore the card id, and making `answer_card` alter the interval whenever a variant was recorded. Both now fail.

## Not in scope, deliberately

Probe generation, dual stability / `S_semantic`, and probe content distribution. Also no deck-options UI — the two settings are reachable through the config API only, which is enough to run the experiment; and the reviewer renders probe text as escaped plain text with no styling and does not display the citation. Type-in cards served a probe lose their type-in box (the probe replaces the template's field), so the comparison is suppressed rather than run against an empty string.

`just check` passes end to end: 574 rust tests, 134 pylib, 84 aqt.
