### PR TITLE
fix: preload mathjax

### DIFF
--- a/ts/reviewer/index.ts
+++ b/ts/reviewer/index.ts
@@ -26,7 +26,7 @@ declare const MathJax: any;
 
 let mathjaxLoading: Promise<void> | null = null;
 
-function _ensureMathJaxLoaded(): Promise<void> {
+function _lazyLoadMathJax(): Promise<void> {
     return mathjaxLoading || (mathjaxLoading = new Promise((resolve, reject) => {
         const configScript = document.createElement("script");
         configScript.src = "/_anki/js/mathjax.js";
@@ -160,7 +160,7 @@ export async function _updateQA(
     const containsMathJax = _containsMathjax(html);
     if (containsMathJax) {
         try {
-            await _ensureMathJaxLoaded();
+            await _lazyLoadMathJax();
         } catch (error) {
             console.error(error);
         }
@@ -215,7 +215,7 @@ export function _showQuestion(q: string, a: string, bodyclass: string): void {
                     typeans.focus();
                 }
                 if (!mathjaxLoading && _containsMathjax(a)) {
-                    _ensureMathJaxLoaded();
+                    _lazyLoadMathJax();
                 }
                 // preload images
                 allImagesLoaded().then(() => preloadAnswerImages(a));

--- a/ts/reviewer/index.ts
+++ b/ts/reviewer/index.ts
@@ -27,13 +27,7 @@ declare const MathJax: any;
 let mathjaxLoading: Promise<void> | null = null;
 
 function _ensureMathJaxLoaded(): Promise<void> {
-    if (mathjaxLoading) {
-        return mathjaxLoading;
-    }
-    if (typeof MathJax !== "undefined" && MathJax.startup) {
-        return Promise.resolve();
-    }
-    mathjaxLoading = new Promise((resolve, reject) => {
+    return mathjaxLoading || (mathjaxLoading = new Promise((resolve, reject) => {
         const configScript = document.createElement("script");
         configScript.src = "/_anki/js/mathjax.js";
         configScript.onload = () => {
@@ -45,8 +39,7 @@ function _ensureMathJaxLoaded(): Promise<void> {
         };
         configScript.onerror = () => reject(new Error("Failed to load MathJax config"));
         document.head.appendChild(configScript);
-    });
-    return mathjaxLoading;
+    }));
 }
 
 // follows mathjaxBlockDelimiterPattern and mathjaxInlineDelimiterPattern

--- a/ts/reviewer/index.ts
+++ b/ts/reviewer/index.ts
@@ -164,6 +164,14 @@ export async function _updateQA(
 
     const qa = document.getElementById("qa")!;
 
+    const containsMathJax = _containsMathjax(html);
+    if (containsMathJax) {
+        try {
+            await _ensureMathJaxLoaded();
+        } catch (error) {
+            console.error(error);
+        }
+    }
     await preloadResources(html);
 
     qa.style.opacity = "0";
@@ -178,14 +186,6 @@ export async function _updateQA(
 
     // dynamic toolbar background
     bridgeCommand("updateToolbar");
-
-    if (_containsMathjax(html)) {
-        try {
-            await _ensureMathJaxLoaded();
-        } catch (error) {
-            console.error(error);
-        }
-    }
 
     if (typeof MathJax !== "undefined" && MathJax.startup) {
         // wait for mathjax to ready

--- a/ts/reviewer/index.ts
+++ b/ts/reviewer/index.ts
@@ -221,6 +221,9 @@ export function _showQuestion(q: string, a: string, bodyclass: string): void {
                 if (typeans) {
                     typeans.focus();
                 }
+                if (!mathjaxLoading && _containsMathjax(a)) {
+                    _ensureMathJaxLoaded();
+                }
                 // preload images
                 allImagesLoaded().then(() => preloadAnswerImages(a));
             },

--- a/ts/reviewer/index.ts
+++ b/ts/reviewer/index.ts
@@ -49,7 +49,8 @@ function _ensureMathJaxLoaded(): Promise<void> {
     return mathjaxLoading;
 }
 
-const mathjaxRegex = /\\\[|\\\(|\\ce\{/;
+// follows mathjaxBlockDelimiterPattern and mathjaxInlineDelimiterPattern
+const mathjaxRegex = /\\\[(.*?)\\\]|\\\((.*?)\\\)/su;
 
 function _containsMathjax(html: string): boolean {
     return mathjaxRegex.test(html);

--- a/ts/reviewer/index.ts
+++ b/ts/reviewer/index.ts
@@ -187,7 +187,7 @@ export async function _updateQA(
     // dynamic toolbar background
     bridgeCommand("updateToolbar");
 
-    if (typeof MathJax !== "undefined" && MathJax.startup) {
+    if (containsMathJax && typeof MathJax !== "undefined" && MathJax.startup) {
         // wait for mathjax to ready
         await MathJax.startup.promise
             .then(() => {


### PR DESCRIPTION
## Linked issue (required)

Refs: #5235

## Summary / motivation (required)

This pr preloads mathjax before updating card content and before flipping if needed

## Steps to reproduce (required, use N/A if not applicable)

See linked issue

## How to test (required)

Tested with with a mix of notes with(out) mathjax

### Checklist (minimum)

- [x] I ran `./ninja check` or an equivalent relevant check locally.
- [ ] I added or updated tests when the change is non-trivial or behavior changed.

## Scope

- [x] This PR is focused on one change (no unrelated edits).
