### PR TITLE
fix: unhook AnkiWebView when destroyed

### DIFF
--- a/qt/aqt/main.py
+++ b/qt/aqt/main.py
@@ -610,6 +610,9 @@ class AnkiQt(QMainWindow):
         self.mediaServer.shutdown()
         # Rust background jobs are not awaited implicitly
         self.backend.await_backup_completion()
+        self.toolbarWeb.cleanup()
+        self.web.cleanup()
+        self.bottomWeb.cleanup()
         self.deleteLater()
         app = self.app
         app._unset_windows_shutdown_block_reason()

--- a/qt/aqt/webview.py
+++ b/qt/aqt/webview.py
@@ -388,10 +388,24 @@ class AnkiWebView(QWebEngineView):
 
         self.resetHandlers()
         self._filterSet = False
-        gui_hooks.theme_did_change.append(self.on_theme_did_change)
-        gui_hooks.body_classes_need_update.append(self.on_body_classes_need_update)
-        gui_hooks.operation_did_execute.append(self.on_operation_did_execute)
 
+        self._hook_subscriptions = subscriptions = [
+            (gui_hooks.theme_did_change, self.on_theme_did_change),
+            (gui_hooks.body_classes_need_update, self.on_body_classes_need_update),
+            (gui_hooks.operation_did_execute, self.on_operation_did_execute),
+        ]
+        for hook, handler in subscriptions:
+            hook.append(handler)
+
+        def unhook(_obj: QObject | None = None) -> None:
+            try:
+                while subscriptions:
+                    hook, handler = subscriptions.pop()
+                    hook.remove(handler)
+            except Exception:
+                pass  # app/interpreter teardown
+
+        qconnect(self.destroyed, unhook)
         qconnect(self.loadFinished, self._on_load_finished)
 
     def _on_load_finished(self) -> None:
@@ -920,9 +934,9 @@ html {{ {font} }}
             # this will fail when __del__ is called during app shutdown
             return
 
-        gui_hooks.theme_did_change.remove(self.on_theme_did_change)
-        gui_hooks.body_classes_need_update.remove(self.on_body_classes_need_update)
-        gui_hooks.operation_did_execute.remove(self.on_operation_did_execute)
+        while self._hook_subscriptions:
+            hook, handler = self._hook_subscriptions.pop()
+            hook.remove(handler)
         # defer page cleanup so that in-flight requests have a chance to complete first
         # https://forums.ankiweb.net/t/error-when-exiting-browsing-when-the-software-is-installed-in-the-path-c-program-files-anki/38363
         mw.progress.single_shot(5000, lambda: mw.mediaServer.clear_page_html(id(self)))

--- a/qt/aqt/webview.py
+++ b/qt/aqt/webview.py
@@ -389,13 +389,14 @@ class AnkiWebView(QWebEngineView):
         self.resetHandlers()
         self._filterSet = False
 
-        self._hook_subscriptions = subscriptions = [
+        subscriptions: list[tuple[Any, Callable[..., Any]]] = [
             (gui_hooks.theme_did_change, self.on_theme_did_change),
             (gui_hooks.body_classes_need_update, self.on_body_classes_need_update),
             (gui_hooks.operation_did_execute, self.on_operation_did_execute),
         ]
         for hook, handler in subscriptions:
             hook.append(handler)
+        self._hook_subscriptions = subscriptions
 
         def unhook(_obj: QObject | None = None) -> None:
             try:

--- a/qt/aqt/webview.py
+++ b/qt/aqt/webview.py
@@ -982,26 +982,6 @@ html {{ {font} }}
     def on_operation_did_execute(
         self, changes: OpChanges, handler: object | None
     ) -> None:
-        # add-on webviews may be destroyed via Qt parent ownership without
-        # cleanup() being called; unsubscribe instead of erroring, deferring
-        # the removal to avoid mutating the hook list while it fires
-        if sip.isdeleted(self):
-            from aqt import mw
-
-            logger.warning(
-                "%s (%s) was destroyed without a cleanup() call; "
-                "dropping operation_did_execute hook",
-                type(self).__name__,
-                self.kind.value,
-            )
-            mw.progress.single_shot(
-                0,
-                lambda: gui_hooks.operation_did_execute.remove(
-                    self.on_operation_did_execute
-                ),
-                requires_collection=False,
-            )
-            return
         if handler is self.parentWidget():
             return
 

--- a/qt/aqt/webview.py
+++ b/qt/aqt/webview.py
@@ -397,9 +397,17 @@ class AnkiWebView(QWebEngineView):
         for hook, handler in subscriptions:
             hook.append(handler)
         self._hook_subscriptions = subscriptions
+        name = type(self).__name__
 
+        # add-on webviews may be destroyed without cleanup() being called
         def unhook(_obj: QObject | None = None) -> None:
             try:
+                if subscriptions:
+                    logger.warning(
+                        "%s (%s) was destroyed without a cleanup() call",
+                        name,
+                        kind.value,
+                    )
                 while subscriptions:
                     hook, handler = subscriptions.pop()
                     hook.remove(handler)

--- a/qt/aqt/webview.py
+++ b/qt/aqt/webview.py
@@ -389,6 +389,7 @@ class AnkiWebView(QWebEngineView):
         self.resetHandlers()
         self._filterSet = False
 
+        # NOTE: avoiding the use of self in `unhook` is load-bearing!
         subscriptions: list[tuple[Any, Callable[..., Any]]] = [
             (gui_hooks.theme_did_change, self.on_theme_did_change),
             (gui_hooks.body_classes_need_update, self.on_body_classes_need_update),


### PR DESCRIPTION
## Linked issue (required)

Refs: #5234

## Summary / motivation (required)

#5234 handled the `on_operation_did_execute` hook but the other 2 hooks could still be run after the webview is destroyed (e.g. on system theme change). With this pr, they're cleaned up when the webview is destroyed

## Steps to reproduce (required, use N/A if not applicable)

See linked pr

## How to test (required)

Revert #5143 and #5234 and verify that this is an alternative fix for both

### Checklist (minimum)

- [x] I ran `./ninja check` or an equivalent relevant check locally.
- [ ] I added or updated tests when the change is non-trivial or behavior changed.

## Scope

- [x] This PR is focused on one change (no unrelated edits).
