### PR TITLE
Fix(#5257) Allow to change the case of a field Fix

### DIFF
--- a/pylib/tests/test_models.py
+++ b/pylib/tests/test_models.py
@@ -90,6 +90,21 @@ def test_fields():
     assert col.get_note(col.models.nids(m)[0]).fields == ["", "2", "1"]
 
 
+def test_rename_field_case_only_rename_updates_templates():
+    col = getEmptyCol()
+    note = col.newNote()
+    note["Front"] = "1"
+    note["Back"] = "2"
+    col.addNote(note)
+    m = col.models.current()
+
+    col.models.renameField(m, m["flds"][0], "front")
+
+    assert m["flds"][0]["name"] == "front"
+    assert "{{front}}" in m["tmpls"][0]["qfmt"]
+    assert col.get_note(col.models.nids(m)[0])["front"] == "1"
+
+
 def test_templates():
     col = getEmptyCol()
     m = col.models.current()

--- a/qt/aqt/fields.py
+++ b/qt/aqt/fields.py
@@ -129,6 +129,7 @@ class FieldDialog(QDialog):
         self.loadField(idx)
 
     def _uniqueName(self, prompt: str, old: str = "") -> str | None:
+        """Asks the user for a name for a field. Returns the name, cleaned up so that it can be used. If it can't be used, return None and shows a warning explaining why."""
         txt = getOnlyText(prompt, default=old).replace('"', "").strip()
         if not txt:
             return None
@@ -139,10 +140,10 @@ class FieldDialog(QDialog):
             if letter in txt:
                 show_warning(tr.fields_name_invalid_letter())
                 return None
-        if txt.casefold() == old.casefold():
+        if txt == old:
             return None
         for f in self.model["flds"]:
-            if f["name"].casefold() == txt.casefold():
+            if f["name"].casefold() == txt.casefold() and f["name"] != old:
                 show_warning(tr.fields_that_field_name_is_already_used())
                 return None
         return txt

--- a/qt/tests/test_fields.py
+++ b/qt/tests/test_fields.py
@@ -1,0 +1,33 @@
+# Copyright: Ankitects Pty Ltd and contributors
+# License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
+
+from aqt.fields import FieldDialog
+
+
+def test_unique_name_allows_case_only_rename(monkeypatch):
+    dialog = FieldDialog.__new__(FieldDialog)
+    dialog.model = {"flds": [{"name": "A"}, {"name": "b"}]}
+
+    monkeypatch.setattr("aqt.fields.getOnlyText", lambda prompt, default="": "a")
+
+    assert dialog._uniqueName("prompt", "A") == "a"
+
+
+def test_unique_name_rejects_duplicate_case_insensitive_names(monkeypatch):
+    dialog = FieldDialog.__new__(FieldDialog)
+    dialog.model = {"flds": [{"name": "A"}, {"name": "b"}]}
+
+    monkeypatch.setattr("aqt.fields.getOnlyText", lambda prompt, default="": "a")
+    monkeypatch.setattr(
+        "aqt.fields.tr.fields_that_field_name_is_already_used",
+        lambda: "field name already used",
+    )
+    warned = {"called": False}
+
+    def fake_warning(message):
+        warned["called"] = True
+
+    monkeypatch.setattr("aqt.fields.show_warning", fake_warning)
+
+    assert dialog._uniqueName("prompt", "") is None
+    assert warned["called"] is True


### PR DESCRIPTION
## Linked issue (required)

 Fixes #5257

## Summary / motivation (required)

If the user renamed Front to front, it would be detected as the same name and the renaming operation would be aborted. This commit fixes that, ensuring that the renaming occurs.

## Steps to reproduce (required, use N/A if not applicable)

See the bug

## How to test (required)

Try to reproduce the bug after the fix

### Checklist (minimum)

- [x] I ran `./ninja check` or an equivalent relevant check locally.
- [x] I added or updated tests when the change is non-trivial or behavior changed.

## Scope

- [x] This PR is focused on one change (no unrelated edits).

If we assume that documenting the function I touch is a single change, then yes