### PR TITLE
chore: Add `rust-analyzer` component to .rust-toolchain.toml

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,4 @@
 [toolchain]
 # older versions may fail to compile; newer versions may fail the clippy tests
 channel = "1.92.0"
+components = ["rust-analyzer"]


### PR DESCRIPTION
Required for the VS Code extension now.
<img width="558" height="178" alt="Screenshot 2026-07-29 201752" src="https://github.com/user-attachments/assets/19c8f0e9-2bca-4593-9987-fdb114160499" />
