### PR TITLE
i18n: browse empty/error state strings

### DIFF
--- a/ftl/core/browsing.ftl
+++ b/ftl/core/browsing.ftl
@@ -142,11 +142,6 @@ browsing-note-count =
         [one] { $count } note
        *[other] { $count } notes
     }
-browsing-card-count =
-    { $count ->
-        [one] { $count } card
-       *[other] { $count } cards
-    }
 browsing-notes-updated =
     { $count ->
         [one] { $count } note updated.

--- a/ftl/core/browsing.ftl
+++ b/ftl/core/browsing.ftl
@@ -39,6 +39,22 @@ browsing-current-note-type = Current note type:
 browsing-delete-notes = Delete Notes
 browsing-duplicate = duplicate
 browsing-ease = Ease
+# Button that clears the browse search
+browsing-empty-clear-search = Clear search
+# Title when the collection has no cards
+# $notes-mode is "yes" when browsing notes instead of cards
+browsing-empty-collection-title =
+    { $notes-mode ->
+        [yes] No notes yet
+       *[other] No cards yet
+    }
+# Title when a valid search matches nothing
+# $notes-mode is "yes" when browsing notes instead of cards
+browsing-empty-no-match-title =
+    { $notes-mode ->
+        [yes] No notes match this search
+       *[other] No cards match this search
+    }
 browsing-enter-tags-to-add = Enter tags to add:
 browsing-enter-tags-to-delete = Enter tags to delete:
 browsing-filtered = (filtered)
@@ -87,6 +103,8 @@ browsing-search-quick = Quick filters
 browsing-search-quick-flagged = Flagged
 browsing-search-quick-leeches = Leeches
 browsing-search-recent = Recent
+# Shown above browse results when the current search is invalid
+browsing-search-results-unchanged = Results unchanged until the search is valid
 browsing-search-suggestions = Suggestions
 browsing-search-syntax-mode = Syntax mode
 browsing-search-text-match = Search "{ $query }"
@@ -123,6 +141,11 @@ browsing-note-count =
     { $count ->
         [one] { $count } note
        *[other] { $count } notes
+    }
+browsing-card-count =
+    { $count ->
+        [one] { $count } card
+       *[other] { $count } cards
     }
 browsing-notes-updated =
     { $count ->


### PR DESCRIPTION
## Summary
- Add core browse strings for empty search / empty collection titles, Clear search, and an invalid-search “results unchanged” banner (AnkiMobile Issue 17 - https://github.com/ankitects/ankimobile/issues/17).
- Cards/notes variants via `$notes-mode`.
- Mobile-specific recovery copy (“filter above”, “Decks screen”) stays in ankimobile-ftl.
- Does **not** add `browsing-card-count` — reuse `card-templates-card-count` (same as #5130).

## Test plan
- [ ] Confirm new keys in `ftl/core/browsing.ftl`
- [ ] Generated i18n APIs expose the new methods
- [ ] No desktop UI regressions (strings unused on desktop for now)