### PR TITLE
feat: Add {{type:ci:}} modifier for case-insensitive answer checking

### DIFF
--- a/docs-site/manual/templates/fields.mdx
+++ b/docs-site/manual/templates/fields.mdx
@@ -483,3 +483,24 @@ If you don't want Anki to compare accents on characters in your typed input with
 
 This makes sure a difference in accents isn't marked as incorrect by Anki.
 For example, `بطيخ` would be treated the same as `بَطِّيخ` or `elite` would be treated same as `élite`.
+
+### Ignoring Capitalization
+
+If capitalization isn't what you're testing, you can use `type:ci` to make the
+comparison case-insensitive.
+
+```text
+{{type:ci:Front}}
+```
+
+With this, typing `paris` when the field contains `Paris` is not marked as
+incorrect. The correct answer is still shown with its original capitalization.
+
+The modifiers can be combined, in any order, so that both accents and
+capitalization are ignored:
+
+```text
+{{type:nc:ci:Front}}
+```
+
+They can be combined with `cloze` as well, e.g. `{{type:cloze:ci:Text}}`.

--- a/proto/anki/card_rendering.proto
+++ b/proto/anki/card_rendering.proto
@@ -167,6 +167,7 @@ message CompareAnswerRequest {
   string expected = 1;
   string provided = 2;
   bool combining = 3;
+  bool ignore_case = 4;
 }
 
 message ExtractClozeForTypingRequest {

--- a/pylib/anki/collection.py
+++ b/pylib/anki/collection.py
@@ -1191,10 +1191,17 @@ class Collection(DeprecatedNamesMixin):
         return self._backend.render_markdown(markdown=text, sanitize=sanitize)
 
     def compare_answer(
-        self, expected: str, provided: str, combining: bool = True
+        self,
+        expected: str,
+        provided: str,
+        combining: bool = True,
+        ignore_case: bool = False,
     ) -> str:
         return self._backend.compare_answer(
-            expected=expected, provided=provided, combining=combining
+            expected=expected,
+            provided=provided,
+            combining=combining,
+            ignore_case=ignore_case,
         )
 
     def extract_cloze_for_typing(self, text: str, ordinal: int) -> str:

--- a/qt/aqt/reviewer.py
+++ b/qt/aqt/reviewer.py
@@ -155,6 +155,7 @@ class Reviewer:
         self._answeredIds: list[CardId] = []
         self._recordedAudio: str | None = None
         self._combining: bool = True
+        self._ignore_case: bool = False
         self.typeCorrect: str | None = None  # web init happens before this is set
         self.state: Literal["question", "answer", "transition"] | None = None
         self._refresh_needed: RefreshNeeded | None = None
@@ -705,20 +706,24 @@ class Reviewer:
 
     def typeAnsQuestionFilter(self, buf: str) -> str:
         self._combining = True
+        self._ignore_case = False
         self.typeCorrect = None
         clozeIdx = None
         m = re.search(self.typeAnsPat, buf)
         if not m:
             return buf
         fld = m.group(1)
-        # if it's a cloze, extract data
-        if fld.startswith("cloze:"):
-            # get field and cloze position
-            clozeIdx = self.card.ord + 1
-            fld = fld.split(":")[1]
-        if fld.startswith("nc:"):
-            self._combining = False
-            fld = fld.split(":")[1]
+        # strip any modifiers preceding the field name (field names can't
+        # contain a colon, so anything before the last one is a modifier)
+        modifiers, _, fld = fld.rpartition(":")
+        for modifier in modifiers.split(":"):
+            if modifier == "cloze":
+                # get cloze position
+                clozeIdx = self.card.ord + 1
+            elif modifier == "nc":
+                self._combining = False
+            elif modifier == "ci":
+                self._ignore_case = True
         # loop through fields for a match
         for f in self.card.note_type()["flds"]:
             if f["name"] == fld:
@@ -765,7 +770,9 @@ class Reviewer:
             (initial_expected, initial_provided), type_pattern
         )
 
-        output = self.mw.col.compare_answer(expected, provided, self._combining)
+        output = self.mw.col.compare_answer(
+            expected, provided, self._combining, self._ignore_case
+        )
         output = gui_hooks.reviewer_will_render_compared_answer(
             output,
             initial_expected,

--- a/rslib/src/card_rendering/service.rs
+++ b/rslib/src/card_rendering/service.rs
@@ -167,7 +167,13 @@ impl crate::services::CardRenderingService for Collection {
         &mut self,
         input: anki_proto::card_rendering::CompareAnswerRequest,
     ) -> Result<generic::String> {
-        Ok(compare_answer(&input.expected, &input.provided, input.combining).into())
+        Ok(compare_answer(
+            &input.expected,
+            &input.provided,
+            input.combining,
+            input.ignore_case,
+        )
+        .into())
     }
 
     fn extract_cloze_for_typing(

--- a/rslib/src/template_filters.rs
+++ b/rslib/src/template_filters.rs
@@ -16,6 +16,10 @@ use crate::text::strip_html;
 // Filtering
 //----------------------------------------
 
+/// Modifiers that may precede the field name of a type: reference, in the
+/// order they are written into the resulting placeholder.
+const TYPE_MODIFIERS: [&str; 3] = ["cloze", "nc", "ci"];
+
 /// Applies built in filters, returning the resulting text and remaining
 /// filters.
 ///
@@ -28,16 +32,13 @@ pub(crate) fn apply_filters<'a>(
     field_name: &str,
     context: &RenderContext,
 ) -> (Cow<'a, str>, Vec<String>) {
-    let mut text: Cow<str> = text.into();
+    // an outer type: is handled specially: recognized modifiers like cloze and
+    // nc are folded into the placeholder, and any other filters are ignored
+    if let [modifiers @ .., "type"] = filters {
+        return (type_filter(field_name, modifiers), vec![]);
+    }
 
-    // type:cloze & type:nc are handled specially
-    // other type: are passed as the default one
-    let filters = match filters {
-        ["cloze", "type"] => &["type-cloze"],
-        ["nc", "type"] => &["type-nc"],
-        [.., "type"] => &["type"],
-        _ => filters,
-    };
+    let mut text: Cow<str> = text.into();
 
     for (idx, &filter_name) in filters.iter().enumerate() {
         match apply_filter(filter_name, text.as_ref(), field_name, context) {
@@ -80,9 +81,12 @@ fn apply_filter(
         "furigana" => furigana_filter(text),
         "kanji" => kanji_filter(text),
         "kana" => kana_filter(text),
-        "type" => type_filter(field_name),
-        "type-cloze" => type_cloze_filter(field_name),
-        "type-nc" => type_nc_filter(field_name),
+        // only reached when type: is not the outermost filter
+        "type" => type_filter(field_name, &[]),
+        // these were originally an implementation detail of the handling
+        // above, but are usable in templates, so are kept working
+        "type-cloze" => type_filter(field_name, &["cloze"]),
+        "type-nc" => type_filter(field_name, &["nc"]),
         "hint" => hint_filter(text, field_name),
         "cloze" => cloze_filter(text, context),
         "cloze-only" => cloze_only_filter(text, context),
@@ -163,17 +167,15 @@ fn furigana_filter(text: &str) -> Cow<'_, str> {
 // Other filters
 //----------------------------------------
 
-/// convert to [[type:...]] for the gui code to process
-fn type_filter<'a>(field_name: &str) -> Cow<'a, str> {
-    format!("[[type:{field_name}]]").into()
-}
-
-fn type_cloze_filter<'a>(field_name: &str) -> Cow<'a, str> {
-    format!("[[type:cloze:{field_name}]]").into()
-}
-
-fn type_nc_filter<'a>(field_name: &str) -> Cow<'a, str> {
-    format!("[[type:nc:{field_name}]]").into()
+/// convert to [[type:...]] for the gui code to process, keeping any recognized
+/// modifiers in a canonical order and discarding the rest
+fn type_filter<'a>(field_name: &str, modifiers: &[&str]) -> Cow<'a, str> {
+    let prefix: String = TYPE_MODIFIERS
+        .iter()
+        .filter(|modifier| modifiers.contains(*modifier))
+        .map(|modifier| format!("{modifier}:"))
+        .collect();
+    format!("[[type:{prefix}{field_name}]]").into()
 }
 
 fn hint_filter<'a>(text: &'a str, field_name: &str) -> Cow<'a, str> {
@@ -240,9 +242,12 @@ field</a>
 
     #[test]
     fn typing() {
-        assert_eq!(type_filter("Front"), "[[type:Front]]");
-        assert_eq!(type_cloze_filter("Front"), "[[type:cloze:Front]]");
-        assert_eq!(type_nc_filter("Front"), "[[type:nc:Front]]");
+        assert_eq!(type_filter("Front", &[]), "[[type:Front]]");
+        assert_eq!(type_filter("Front", &["cloze"]), "[[type:cloze:Front]]");
+        assert_eq!(type_filter("Front", &["nc"]), "[[type:nc:Front]]");
+        assert_eq!(type_filter("Front", &["ci"]), "[[type:ci:Front]]");
+        // modifiers are output in a canonical order
+        assert_eq!(type_filter("Front", &["ci", "nc"]), "[[type:nc:ci:Front]]");
         let ctx = RenderContext {
             fields: &Default::default(),
             nonempty_fields: &Default::default(),
@@ -259,8 +264,21 @@ field</a>
             ("[[type:nc:Text]]".into(), vec![])
         );
         assert_eq!(
+            apply_filters("ignored", &["ci", "type"], "Text", &ctx),
+            ("[[type:ci:Text]]".into(), vec![])
+        );
+        // {{type:ci:nc:Text}}
+        assert_eq!(
+            apply_filters("ignored", &["nc", "ci", "type"], "Text", &ctx),
+            ("[[type:nc:ci:Text]]".into(), vec![])
+        );
+        assert_eq!(
             apply_filters("ignored", &["some", "unknown", "type"], "Text", &ctx),
             ("[[type:Text]]".into(), vec![])
+        );
+        assert_eq!(
+            apply_filters("ignored", &["type-nc"], "Text", &ctx),
+            ("[[type:nc:Text]]".into(), vec![])
         );
     }
 

--- a/rslib/src/typeanswer.rs
+++ b/rslib/src/typeanswer.rs
@@ -35,13 +35,13 @@ macro_rules! format_typeans {
 }
 
 // Public API
-pub fn compare_answer(expected: &str, typed: &str, combining: bool) -> String {
+pub fn compare_answer(expected: &str, typed: &str, combining: bool, ignore_case: bool) -> String {
     let stripped = strip_expected(expected);
 
     match typed.is_empty() {
         true => format_typeans!(htmlescape::encode_minimal(&stripped)),
-        false if combining => Diff::new(&stripped, typed).to_html(),
-        false => DiffNonCombining::new(&stripped, typed).to_html(),
+        false if combining => Diff::new(&stripped, typed, ignore_case).to_html(),
+        false => DiffNonCombining::new(&stripped, typed, ignore_case).to_html(),
     }
 }
 
@@ -50,12 +50,17 @@ trait DiffTrait {
     fn get_typed(&self) -> &[char];
     fn get_expected(&self) -> &[char];
     fn get_expected_original(&self) -> Cow<'_, str>;
+    /// The text the diff is calculated on, which is case-folded if case is
+    /// being ignored. Indices into it are valid for [Self::get_typed].
+    fn get_typed_for_diff(&self) -> &[char];
+    /// See [Self::get_typed_for_diff].
+    fn get_expected_for_diff(&self) -> &[char];
 
-    fn new(expected: &str, typed: &str) -> Self;
+    fn new(expected: &str, typed: &str, ignore_case: bool) -> Self;
 
     // Entry Point
     fn to_html(&self) -> String {
-        if self.get_typed() == self.get_expected() {
+        if self.get_typed_for_diff() == self.get_expected_for_diff() {
             format_typeans!(format!(
                 "<span class=typeGood>{}</span>",
                 htmlescape::encode_minimal(&self.get_expected_original())
@@ -72,7 +77,8 @@ trait DiffTrait {
     }
 
     fn to_tokens(&self) -> DiffTokens {
-        let mut matcher = SequenceMatcher::new(self.get_typed(), self.get_expected());
+        let mut matcher =
+            SequenceMatcher::new(self.get_typed_for_diff(), self.get_expected_for_diff());
         let mut typed_tokens = Vec::new();
         let mut expected_tokens = Vec::new();
 
@@ -111,6 +117,22 @@ trait DiffTrait {
 // Utility Functions
 fn normalize(string: &str) -> Vec<char> {
     normalize_to_nfc(string).chars().collect()
+}
+
+/// Lowercases each character individually. The few characters that lowercase
+/// to multiple ones (e.g. İ) are mapped to the first of them, so that the
+/// output stays aligned with the input.
+fn fold_case(chars: &[char]) -> Vec<char> {
+    chars
+        .iter()
+        .map(|&c| match c {
+            // these are already lowercase, so they need mapping to the form
+            // their uppercase (Σ, S) lowercases to
+            'ς' => 'σ',
+            'ſ' => 's',
+            _ => c.to_lowercase().next().unwrap_or(c),
+        })
+        .collect()
 }
 
 fn slice(chars: &[char], start: usize, end: usize) -> String {
@@ -152,6 +174,28 @@ fn isolate_leading_mark(text: &str) -> Cow<'_, str> {
 struct Diff {
     typed: Vec<char>,
     expected: Vec<char>,
+    /// Case-folded copies used for the diff, if case is being ignored. The
+    /// original text is still what gets rendered.
+    folded: Option<FoldedChars>,
+}
+
+struct FoldedChars {
+    typed: Vec<char>,
+    expected: Vec<char>,
+}
+
+impl Diff {
+    fn from_chars(typed: Vec<char>, expected: Vec<char>, ignore_case: bool) -> Self {
+        let folded = ignore_case.then(|| FoldedChars {
+            typed: fold_case(&typed),
+            expected: fold_case(&expected),
+        });
+        Self {
+            typed,
+            expected,
+            folded,
+        }
+    }
 }
 
 impl DiffTrait for Diff {
@@ -164,12 +208,21 @@ impl DiffTrait for Diff {
     fn get_expected_original(&self) -> Cow<'_, str> {
         Cow::Owned(self.get_expected().iter().collect::<String>())
     }
-
-    fn new(expected: &str, typed: &str) -> Self {
-        Self {
-            typed: normalize(typed),
-            expected: normalize(expected),
+    fn get_typed_for_diff(&self) -> &[char] {
+        match &self.folded {
+            Some(folded) => &folded.typed,
+            None => &self.typed,
         }
+    }
+    fn get_expected_for_diff(&self) -> &[char] {
+        match &self.folded {
+            Some(folded) => &folded.expected,
+            None => &self.expected,
+        }
+    }
+
+    fn new(expected: &str, typed: &str, ignore_case: bool) -> Self {
+        Self::from_chars(normalize(typed), normalize(expected), ignore_case)
     }
 
     fn render_expected_tokens(&self, tokens: &[DiffToken]) -> String {
@@ -194,8 +247,14 @@ impl DiffTrait for DiffNonCombining {
     fn get_expected_original(&self) -> Cow<'_, str> {
         Cow::Borrowed(&self.expected_original)
     }
+    fn get_typed_for_diff(&self) -> &[char] {
+        self.base.get_typed_for_diff()
+    }
+    fn get_expected_for_diff(&self) -> &[char] {
+        self.base.get_expected_for_diff()
+    }
 
-    fn new(expected: &str, typed: &str) -> Self {
+    fn new(expected: &str, typed: &str, ignore_case: bool) -> Self {
         // filter out combining elements
         let typed_stripped: Vec<char> = typed.nfkd().filter(|&c| !is_combining_mark(c)).collect();
         let mut expected_stripped: Vec<char> = Vec::new();
@@ -214,10 +273,7 @@ impl DiffTrait for DiffNonCombining {
         }
 
         Self {
-            base: Diff {
-                typed: typed_stripped,
-                expected: expected_stripped,
-            },
+            base: Diff::from_chars(typed_stripped, expected_stripped, ignore_case),
             expected_split,
             expected_original: expected.to_string(),
         }
@@ -299,7 +355,11 @@ mod test {
 
     #[test]
     fn tokens() {
-        let ctx = Diff::new("¿Y ahora qué vamos a hacer?", "y ahora qe vamosa hacer");
+        let ctx = Diff::new(
+            "¿Y ahora qué vamos a hacer?",
+            "y ahora qe vamosa hacer",
+            false,
+        );
         let output = ctx.to_tokens();
         assert_eq!(
             output.typed_tokens,
@@ -330,22 +390,22 @@ mod test {
     #[test]
     fn html_and_media() {
         let stripped = strip_expected("[sound:foo.mp3]<b>1</b> &nbsp;2");
-        let ctx = Diff::new(&stripped, "1  2");
+        let ctx = Diff::new(&stripped, "1  2", false);
         // the spacing is handled by wrapping html output in white-space: pre-wrap
         assert_eq!(ctx.to_tokens().expected_tokens, &[good("1  2")]);
     }
 
     #[test]
     fn missed_chars_only_shown_in_typed_when_after_good() {
-        let ctx = Diff::new("1", "23");
+        let ctx = Diff::new("1", "23", false);
         assert_eq!(ctx.to_tokens().typed_tokens, &[bad("23")]);
-        let ctx = Diff::new("12", "1");
+        let ctx = Diff::new("12", "1", false);
         assert_eq!(ctx.to_tokens().typed_tokens, &[good("1"), missing("-"),]);
     }
 
     #[test]
     fn missed_chars_counted_correctly() {
-        let ctx = Diff::new("нос", "нс");
+        let ctx = Diff::new("нос", "нс", false);
         assert_eq!(
             ctx.to_tokens().typed_tokens,
             &[good("н"), missing("-"), good("с")]
@@ -355,7 +415,7 @@ mod test {
     #[test]
     fn handles_certain_unicode_as_expected() {
         // this was not parsed as expected with dissimilar 1.0.4
-        let ctx = Diff::new("쓰다듬다", "스다뜸다");
+        let ctx = Diff::new("쓰다듬다", "스다뜸다", false);
         assert_eq!(
             ctx.to_tokens().typed_tokens,
             &[bad("스"), good("다"), bad("뜸"), good("다"),]
@@ -371,6 +431,7 @@ mod test {
                 "Single responsibility Сущность выполняет только одну задачу.",
                 "Повод для изменения сущности только один."
             ),
+            false,
         );
         ctx.to_tokens();
     }
@@ -380,20 +441,24 @@ mod test {
         let stripped = strip_expected("<div>123</div>");
         assert_eq!(stripped, "123");
         assert_eq!(
-            Diff::new(&stripped, "123").to_html(),
+            Diff::new(&stripped, "123", false).to_html(),
             "<code id=typeans><span class=typeGood>123</span></code>"
         );
     }
 
     #[test]
     fn empty_input_shows_as_code() {
-        let ctx = compare_answer("<div>123</div>", "", true);
+        let ctx = compare_answer("<div>123</div>", "", true, false);
         assert_eq!(ctx, "<code id=typeans>123</code>");
     }
 
     #[test]
     fn correct_input_is_escaped() {
-        let ctx = Diff::new("source <dir>/bin/activate", "source <dir>/bin/activate");
+        let ctx = Diff::new(
+            "source <dir>/bin/activate",
+            "source <dir>/bin/activate",
+            false,
+        );
         assert_eq!(
             ctx.to_html(),
             "<code id=typeans><span class=typeGood>source &lt;dir&gt;/bin/activate</span></code>"
@@ -402,7 +467,7 @@ mod test {
 
     #[test]
     fn correct_input_is_collapsed() {
-        let ctx = Diff::new("123", "123");
+        let ctx = Diff::new("123", "123", false);
         assert_eq!(
             ctx.to_html(),
             "<code id=typeans><span class=typeGood>123</span></code>"
@@ -411,7 +476,7 @@ mod test {
 
     #[test]
     fn incorrect_input_is_not_collapsed() {
-        let ctx = Diff::new("123", "1123");
+        let ctx = Diff::new("123", "1123", false);
         assert_eq!(
             ctx.to_html(),
             "<code id=typeans><span class=typeBad>1</span><span class=typeGood>123</span><br><span id=typearrow>&darr;</span><br><span class=typeGood>123</span></code>"
@@ -419,17 +484,54 @@ mod test {
     }
 
     #[test]
+    fn case_insensitive_comparison() {
+        // the expected text is shown with its original casing
+        assert_eq!(
+            compare_answer("Paris", "paris", true, true),
+            "<code id=typeans><span class=typeGood>Paris</span></code>"
+        );
+        // case is folded one character at a time, so ß is not equal to SS
+        assert_eq!(
+            compare_answer("Straße", "STRASSE", true, true),
+            "<code id=typeans><span class=typeGood>STRA</span><span class=typeBad>SS</span><span class=typeGood>E</span><br><span id=typearrow>&darr;</span><br><span class=typeGood>Stra</span><span class=typeMissed>ß</span><span class=typeGood>e</span></code>"
+        );
+        // a word-final sigma is the same letter as Σ
+        assert_eq!(
+            compare_answer("φως", "ΦΩΣ", true, true),
+            "<code id=typeans><span class=typeGood>φως</span></code>"
+        );
+        // only case is ignored; other differences are still shown
+        assert_eq!(
+            compare_answer("Paris", "parls", true, true),
+            "<code id=typeans><span class=typeGood>par</span><span class=typeBad>l</span><span class=typeGood>s</span><br><span id=typearrow>&darr;</span><br><span class=typeGood>Par</span><span class=typeMissed>i</span><span class=typeGood>s</span></code>"
+        );
+        // and it remains significant when not requested
+        assert_eq!(
+            compare_answer("Paris", "paris", true, false),
+            "<code id=typeans><span class=typeBad>p</span><span class=typeGood>aris</span><br><span id=typearrow>&darr;</span><br><span class=typeMissed>P</span><span class=typeGood>aris</span></code>"
+        );
+    }
+
+    #[test]
+    fn case_insensitive_noncombining_comparison() {
+        assert_eq!(
+            compare_answer("Ábaco", "abaco", false, true),
+            "<code id=typeans><span class=typeGood>Ábaco</span></code>"
+        );
+    }
+
+    #[test]
     fn noncombining_comparison() {
         assert_eq!(
-            compare_answer("שִׁנּוּן", "שנון", false),
+            compare_answer("שִׁנּוּן", "שנון", false, false),
             "<code id=typeans><span class=typeGood>שִׁנּוּן</span></code>"
         );
         assert_eq!(
-            compare_answer("חוֹף", "חופ", false),
+            compare_answer("חוֹף", "חופ", false, false),
             "<code id=typeans><span class=typeGood>חו</span><span class=typeBad>פ</span><br><span id=typearrow>&darr;</span><br><span class=typeGood>חוֹ</span><span class=typeMissed>ף</span></code>"
         );
         assert_eq!(
-            compare_answer("ば", "は", false),
+            compare_answer("ば", "は", false, false),
             "<code id=typeans><span class=typeGood>ば</span></code>"
         );
     }


### PR DESCRIPTION



## Linked issue (required)
- Fixes #5168

## Summary / motivation (required)

Typing "paris" for a field containing "Paris" was marked wrong, so decks that aren't testing capitalization had to either memorize arbitrary casing or learn to ignore the red highlight. {{type:ci:Field}} opts out of the case comparison.

type: modifiers are now collected generically rather than matched as exact pairs, so they combine in any order and with cloze:, e.g. {{type:nc:ci:Front}} or {{type:cloze:ci:Text}}. Any such combination previously degraded to a plain case-sensitive {{type:Field}} with no warning.

Case is folded one character at a time so diff offsets stay aligned with the original text, which is what continues to be rendered. Final sigma and long s are mapped explicitly, since they are already lowercase and so would not otherwise match Σ and S. The undocumented {{type-nc:}} and {{type-cloze:}} filter names are kept working, as they were reachable from templates.

<!-- What this PR does and why. For larger changes, add enough context for reviewers. -->


## How to test (required)
You can modify the card and after typing something case sensitive it should work fine i.e. it will be a correct match

### Checklist (minimum)

- [x] I ran `./ninja check` or an equivalent relevant check locally.
- [x] I added or updated tests when the change is non-trivial or behavior changed.

### Details

<!-- Commands, manual steps, edge cases, and what you observed -->

## Before / after behavior (optional)
Before: The type in was case sensitive
After: Now it can be ignored 

## Risk / compatibility / migration (optional)

<!-- Breaking changes, rollout notes, or N/A for small / low-risk PRs -->

## UI evidence (required for visual changes; otherwise N/A)
<img width="662" height="570" alt="Screenshot 2026-08-04 at 11 22 37 AM" src="https://github.com/user-attachments/assets/258dc3a9-80ef-4f18-a16e-9d0dfeeb15f1" />
<img width="661" height="567" alt="Screenshot 2026-08-04 at 11 22 46 AM" src="https://github.com/user-attachments/assets/fa6571e2-7b9f-4973-9a7f-00a049ce31ae" />


## Scope

- [x] This PR is focused on one change (no unrelated edits).
