### PR TITLE
fix: Set CARGO_TARGET_DIR for coverage-rust scripts

### DIFF
--- a/tools/coverage/coverage-rust
+++ b/tools/coverage/coverage-rust
@@ -9,6 +9,8 @@ LLVMCOVPATH="out/bin"
 
 mkdir -p $outdir $LLVMCOVPATH
 
+export CARGO_TARGET_DIR="${CARGO_TARGET_DIR:-out/rust}"
+
 if [[ "${CI:-}" == "true" ]]; then
     # prebuilt binary shouldve been installed
     cargo_cmd="cargo"

--- a/tools/coverage/coverage-rust.bat
+++ b/tools/coverage/coverage-rust.bat
@@ -14,6 +14,8 @@ set "LLVMCOVPATH=out\bin"
 
 if not exist %outdir% mkdir %outdir%
 
+if "%CARGO_TARGET_DIR%"=="" set "CARGO_TARGET_DIR=out\rust"
+
 if "%CI%"=="true" (
   rem prebuilt binary shouldve been installed earlier
   set "CARGO_CMD=cargo"


### PR DESCRIPTION
The coverage-rust scripts didn't set `CARGO_TARGET_DIR` to `out/rust` similar to the ninja scripts, so caching was ineffective.