### PR TITLE
Fix documentation typos

### DIFF
--- a/docs-site/addons/support.mdx
+++ b/docs-site/addons/support.mdx
@@ -5,7 +5,7 @@ title: "Support"
 This document contains some hints to get you started, but it is not a
 comprehensive guide. To actually write an add-on, you will need to
 familiarize yourself with Anki’s source code, and the source code of
-other add-ons that do similiar things to what you are trying to
+other add-ons that do similar things to what you are trying to
 accomplish.
 
 Because of our limited resources, **no official support is available for

--- a/docs-site/developers/development.mdx
+++ b/docs-site/developers/development.mdx
@@ -162,7 +162,7 @@ Windows, Yarn cache can be found in `%LOCALAPPDATA%\Yarn`.
 
 If you invoke Rust outside of the build scripts (eg by running cargo, or
 with Rust Analyzer), output files will go into `target/` unless you have
-overriden the default output location.
+overridden the default output location.
 
 ## IDEs
 

--- a/docs-site/faqs/can-i-use-anki-in-a-company-or-school.mdx
+++ b/docs-site/faqs/can-i-use-anki-in-a-company-or-school.mdx
@@ -20,6 +20,6 @@ We do not have the resources to create custom versions of Anki, AnkiMobile, or A
 
 AnkiWeb is intended for individual users. People in a school or company are welcome to sign up for their own accounts, but teachers or company staff should not create accounts in bulk for people. AnkiWeb does not currently provide any means of monitoring activity on students' accounts.
 
-Because AnkiWeb is a free service targeted at end users, we do not have the resources to sign data processing agreements and similar documents with schools or companies. If you require such documents, alternative products like Quizlet may be better able to accomodate you.
+Because AnkiWeb is a free service targeted at end users, we do not have the resources to sign data processing agreements and similar documents with schools or companies. If you require such documents, alternative products like Quizlet may be better able to accommodate you.
 
 AnkiWeb's privacy policy can be found here: [https://ankiweb.net/account/privacy](https://ankiweb.net/account/privacy)

--- a/docs-site/faqs/merging-or-combining-two-decks.mdx
+++ b/docs-site/faqs/merging-or-combining-two-decks.mdx
@@ -9,4 +9,4 @@ Anki does not have an explicit feature to combine decks, but you can accomplish 
 3. If you want to merge more than two decks, repeat steps 1 and 2 as necessary until you have only one deck remaining.
 4. Close the browser to return to the deck list and delete the now-empty deck(s) by clicking the settings button to the right of each. (Anki will warn you if you try to delete a deck that still has cards in it.)
 
-See also [How do I move cards between decks?](/faqs/how-do-i-move-cards-between-decks?highlight=mergin#how-do-i-move-cards-between-decks).
+See also [How do I move cards between decks?](/faqs/how-do-i-move-cards-between-decks?highlight=merging#how-do-i-move-cards-between-decks).

--- a/docs-site/faqs/what-spaced-repetition-algorithm.mdx
+++ b/docs-site/faqs/what-spaced-repetition-algorithm.mdx
@@ -98,7 +98,7 @@ section of the manual for the options that are mentioned in _italics_):
 If you press…​
 
 - Again  
-  Moves the card back to the first step setted in [Learning/Relearning Steps.](/manual/deck-options?#learning-steps)
+  Moves the card back to the first step set in [Learning/Relearning Steps.](/manual/deck-options?#learning-steps)
 
 - Hard  
   Repeats the current step after the first step, and is the average of

--- a/docs-site/manual/files.mdx
+++ b/docs-site/manual/files.mdx
@@ -80,7 +80,7 @@ Removing that folder will cause the launcher to behave like a fresh install.
 The `AnkiProgramFiles` contains all the files needed to run Anki aside from
 the launcher. You can copy it to a different folder or system, and start
 Anki from the new location by opening `AnkiProgramFiles/.venv/bin/anki` (or
-`AnkiProgramFiles\.venv\scripts\anki` on Windows). If placed in the standard location on a new computer, the launcher will also be able to re-use the existing files, provided the files were copied with modification times preserved.
+`AnkiProgramFiles\.venv\scripts\anki` on Windows). If placed in the standard location on a new computer, the launcher will also be able to reuse the existing files, provided the files were copied with modification times preserved.
 
 See the flash drive section below for more.
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -160,7 +160,7 @@ Windows, Yarn cache can be found in `%LOCALAPPDATA%\Yarn`.
 
 If you invoke Rust outside of the build scripts (eg by running cargo, or
 with Rust Analyzer), output files will go into `target/` unless you have
-overriden the default output location.
+overridden the default output location.
 
 ## IDEs
 


### PR DESCRIPTION
## Summary

- Fix spelling errors in the developer and add-on documentation.
- Correct small wording errors in the FAQ and manual pages.

## Verification

- `uvx codespell docs README.md SECURITY.md docs-site/developers docs-site/addons docs-site/faqs docs-site/manual docs-site/ankimobile docs-site/index.mdx docs-site/README.md --skip='docs-site/releases/*,docs-site/*/manual/intro.mdx' --ignore-words-list=optionA`
- `git diff --check`

Closes #5270