### PR TITLE
fix: Update list of RTL languages in SvelteKit pages

### DIFF
--- a/ts/lib/tslib/i18n/utils.test.ts
+++ b/ts/lib/tslib/i18n/utils.test.ts
@@ -11,7 +11,7 @@ function setLanguage(lang: string): void {
 }
 
 test("Arabic-script languages mirror the question mark", () => {
-    for (const lang of ["ar", "ar-SA", "fa", "fa-IR"]) {
+    for (const lang of ["ar", "ar-SA", "fa", "fa-IR", "ug", "ug-CN"]) {
         setLanguage(lang);
         expect(usesArabicScript()).toBe(true);
     }

--- a/ts/lib/tslib/i18n/utils.ts
+++ b/ts/lib/tslib/i18n/utils.ts
@@ -27,11 +27,7 @@ export function supportsVerticalText(): boolean {
 
 export function direction(): "ltr" | "rtl" {
     const firstLang = firstLanguage();
-    if (
-        firstLang.startsWith("ar")
-        || firstLang.startsWith("he")
-        || firstLang.startsWith("fa")
-    ) {
+    if (["he", "ar", "fa", "ug", "yi"].some(lang => firstLang.startsWith(lang))) {
         return "rtl";
     } else {
         return "ltr";

--- a/ts/lib/tslib/i18n/utils.ts
+++ b/ts/lib/tslib/i18n/utils.ts
@@ -10,10 +10,7 @@ import { firstLanguage, setBundles } from "@generated/ftl";
 
 export function usesArabicScript(): boolean {
     const firstLang = firstLanguage();
-    return (
-        firstLang.startsWith("ar")
-        || firstLang.startsWith("fa")
-    );
+    return ["ar", "fa", "ug"].some(lang => firstLang.startsWith(lang));
 }
 
 export function supportsVerticalText(): boolean {


### PR DESCRIPTION

## Linked issue

Noted in https://github.com/ankitects/anki/pull/5105#pullrequestreview-4861060987

## Summary

RTL languages are tracked in two separate places (pylib/anki/lang.py:is_rtl and ts/lib/tslib/i18n/utils.ts:direction) but they are out of sync.

## Steps to reproduce (before)

- Run with Uyghur set as language: `./run -l ug`.
- Open the Deck Options screen and notice the page's direction is left-to-right.

## How to test (after)

Confirm the Deck Options screen is displayed right-to-left for Uyghur.

### Checklist (minimum)

- [x] I ran `./ninja check` or an equivalent relevant check locally.
- [x] I added or updated tests when the change is non-trivial or behavior changed.

### Details

A better solution is to keep a single list in the backend or detects the directionality of the locale name (see [example in AnkiDroid](https://github.com/ankidroid/Anki-Android/blob/eb22e1e6ad7e245d6fe34eceb75954792f6fe7ab/AnkiDroid/src/main/java/com/ichi2/anki/LanguageUtils.kt#L47)). Both requires moving anki.lang.langs to the backend, which I don't think is worth the effort.

## UI evidence

### Before
<img width="1406" height="654" alt="image" src="https://github.com/user-attachments/assets/e9e8aa75-e6b1-4a27-85d5-cfda16c16314" />

### After
<img width="1425" height="777" alt="image" src="https://github.com/user-attachments/assets/48994c54-8209-4c6b-821e-c734c85e96e2" />

## Scope

- [x] This PR is focused on one change (no unrelated edits).
