### PR TITLE
fix: broken OK button in help modals

### DIFF
--- a/ts/lib/components/HelpModal.svelte
+++ b/ts/lib/components/HelpModal.svelte
@@ -124,7 +124,17 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         </Row>
     </div>
     <div slot="footer" class="modal-footer">
-        <button type="button" class="btn btn-primary" on:click={modal.onOkClicked}>
+        <button
+            type="button"
+            class="btn btn-primary"
+            on:click={() => {
+                if (modal.onOkClicked) {
+                    modal.onOkClicked();
+                } else {
+                    modal.hide();
+                }
+            }}
+        >
             {tr.helpOk()}
         </button>
     </div>

--- a/ts/lib/components/HelpModal.svelte
+++ b/ts/lib/components/HelpModal.svelte
@@ -124,17 +124,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
         </Row>
     </div>
     <div slot="footer" class="modal-footer">
-        <button
-            type="button"
-            class="btn btn-primary"
-            on:click={() => {
-                if (modal.onOkClicked) {
-                    modal.onOkClicked();
-                } else {
-                    modal.hide();
-                }
-            }}
-        >
+        <button type="button" class="btn btn-primary" on:click={modal.acceptHandler}>
             {tr.helpOk()}
         </button>
     </div>


### PR DESCRIPTION


## Linked issue

Closes #5276

## Summary

Fix broken OK button in help modals (e.g. in the Deck Options screen).

## Steps to reproduce (before)

1. Open the Deck Options screen.
2. Click on any of the "?" icons.
3. Click "OK" and notice the modal is not closed.

## How to test (after)

Confirm the modal is closed.
