### PR TITLE
chore(ci): reduce dependabot noise with quarterly schedule and major grouping

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,14 +5,19 @@ updates:
     directory: "/"
     schedule:
       interval: "quarterly"
-    open-pull-requests-limit: 1
+    open-pull-requests-limit: 2
     cooldown:
       default-days: 7
+      semver-major-days: 30
     groups:
       rust-minor-patch:
         applies-to: version-updates
         patterns: ["*"]
         update-types: ["minor", "patch"]
+      rust-major:
+        applies-to: version-updates
+        patterns: ["*"]
+        update-types: ["major"]
     commit-message:
       prefix: "chore(deps)"
 
@@ -20,14 +25,19 @@ updates:
     directory: "/"
     schedule:
       interval: "quarterly"
-    open-pull-requests-limit: 1
+    open-pull-requests-limit: 2
     cooldown:
       default-days: 7
+      semver-major-days: 30
     groups:
       npm-minor-patch:
         applies-to: version-updates
         patterns: ["*"]
         update-types: ["minor", "patch"]
+      npm-major:
+        applies-to: version-updates
+        patterns: ["*"]
+        update-types: ["major"]
     commit-message:
       prefix: "chore(deps)"
 
@@ -35,14 +45,19 @@ updates:
     directory: "/"
     schedule:
       interval: "quarterly"
-    open-pull-requests-limit: 1
+    open-pull-requests-limit: 2
     cooldown:
       default-days: 7
+      semver-major-days: 30
     groups:
       python-minor-patch:
         applies-to: version-updates
         patterns: ["*"]
         update-types: ["minor", "patch"]
+      python-major:
+        applies-to: version-updates
+        patterns: ["*"]
+        update-types: ["major"]
     commit-message:
       prefix: "chore(deps)"
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,8 @@ updates:
   - package-ecosystem: "cargo"
     directory: "/"
     schedule:
-      interval: "monthly"
-    open-pull-requests-limit: 3
+      interval: "quarterly"
+    open-pull-requests-limit: 1
     cooldown:
       default-days: 7
     groups:
@@ -19,12 +19,12 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "monthly"
-    open-pull-requests-limit: 3
+      interval: "quarterly"
+    open-pull-requests-limit: 1
     cooldown:
       default-days: 7
     groups:
-      js-minor-patch:
+      npm-minor-patch:
         applies-to: version-updates
         patterns: ["*"]
         update-types: ["minor", "patch"]
@@ -34,8 +34,8 @@ updates:
   - package-ecosystem: "uv"
     directory: "/"
     schedule:
-      interval: "monthly"
-    open-pull-requests-limit: 3
+      interval: "quarterly"
+    open-pull-requests-limit: 1
     cooldown:
       default-days: 7
     groups:
@@ -49,8 +49,8 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "monthly"
-    open-pull-requests-limit: 3
+      interval: "quarterly"
+    open-pull-requests-limit: 1
     cooldown:
       default-days: 7
     groups:


### PR DESCRIPTION
## What

- Change dependabot `interval` from `monthly` to `quarterly` for all ecosystems (Cargo, npm, Python, GitHub Actions)
- Add separate groups for major bumps (`rust-major`, `npm-major`, `python-major`) so they arrive as a single grouped PR instead of individual ones
- Add `semver-major-days: 30` cooldown for major bumps on all versioned ecosystems

## Why

Version update PRs were accumulating faster than the team could review them. Two issues were causing this:

1. Minor/patch grouped PRs were opened monthly. Try moving it to quarterly may match the actual review cadence better
2. Major bumps fell outside the minor/patch group and opened as individual PRs per package, adding noise

Security updates are unaffected: they still open immediately regardless of the schedule, as they bypass the interval setting by design.