### PR TITLE
fix: Browse Add-ons URL

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -296,6 +296,7 @@ Ashish Yadav <48384865+criticalAY@users.noreply.github.com>
 Timothy Lee <timothyl@berkeley.edu>
 DespicableGoose <68354378+DespicableGoose@users.noreply.github.com>
 Han Lua <72375847+xiaohan484@users.noreply.github.com>
+Andreas U. Schmidhauser <github.com/schmidhauser>
 
 ********************
 

--- a/qt/aqt/addons.py
+++ b/qt/aqt/addons.py
@@ -1083,7 +1083,7 @@ class GetAddons(QDialog):
         saveGeom(self, "getaddons")
 
     def onBrowse(self) -> None:
-        openLink(f"{aqt.appShared}addons/2.1")
+        openLink(f"{aqt.appShared}addons")
 
     def accept(self) -> None:
         # get codes


### PR DESCRIPTION
## Linked issue (required)

Fixes #5289

## Summary / motivation (required)

Updates the Browse Add-ons link to use the current `/shared/addons` URL
directly instead of the legacy `/shared/addons/2.1` URL, which redirects
to it.

## Steps to reproduce (required, use N/A if not applicable)

1. Open Tools → Add-ons.
2. Click Get Add-ons…
3. Click Browse Add-ons.
4. Observe that `/shared/addons/2.1` is opened and redirects to
   `/shared/addons`.

## How to test (required)

### Checklist (minimum)

- [ ] I ran `./ninja check` or an equivalent relevant check locally.
- [ ] I added or updated tests when the change is non-trivial or behavior changed.

### Details

Manually verified that `/shared/addons/2.1` redirects to `/shared/addons`,
and that `/shared/addons` loads directly. No local build or automated checks
were run; the change was made using GitHub's web editor.

## Before / after behavior (optional)

Before: Browse Add-ons opens the legacy `/shared/addons/2.1` URL and relies
on a redirect.

After: Browse Add-ons opens `/shared/addons` directly.

## Risk / compatibility / migration (optional)

N/A. This is a one-line URL change.

## UI evidence (required for visual changes; otherwise N/A)

N/A

## Scope

- [x] This PR is focused on one change (no unrelated edits).
