### PR TITLE
Fix: Ignore cards reviewed before settable to future values

### DIFF
--- a/rslib/src/deckconfig/update.rs
+++ b/rslib/src/deckconfig/update.rs
@@ -160,7 +160,11 @@ impl Collection {
         require!(!req.configs.is_empty(), "config not provided");
         let configs_before_update = self.storage.get_deck_config_map()?;
         let mut configs_after_update = configs_before_update.clone();
-        let today = TimestampSecs::now().date_string();
+        let today = self
+            .timing_today()?
+            .next_day_at
+            .adding_secs(-24 * 60 * 60)
+            .date_string();
 
         // handle removals first
         for dcid in &req.removed_config_ids {
@@ -174,10 +178,10 @@ impl Collection {
 
         // add/update provided configs
         for conf in &mut req.configs {
-            require!(
-                conf.inner.ignore_revlogs_before_date <= today,
-                "ignore_revlogs_before_date cannot be later than today"
-            );
+            if conf.inner.ignore_revlogs_before_date > today {
+                today.clone_into(&mut conf.inner.ignore_revlogs_before_date);
+            }
+
             // If the user has provided empty FSRS6 params, zero out any
             // old params as well, so we don't fall back on them, which would
             // be surprising as they're not shown in the GUI.
@@ -452,7 +456,6 @@ fn update_day_limit(day_limit: &mut Option<DayLimit>, new_limit: Option<u32>, to
 mod test {
     use super::*;
     use crate::deckconfig::NewCardInsertOrder;
-    use crate::error::AnkiError;
     use crate::tests::open_test_collection_with_learning_card;
     use crate::tests::open_test_collection_with_relearning_card;
     use crate::timestamp::TimestampSecs;
@@ -622,10 +625,11 @@ mod test {
     }
 
     #[test]
-    fn should_reject_ignore_revlogs_before_date_later_than_today() {
+    fn should_clamp_ignore_revlogs_before_date_to_today() {
         let mut col = Collection::new();
+        let today = TimestampSecs::now().date_string();
         let output = col.get_deck_configs_for_update(DeckId(1)).unwrap();
-        let mut input = UpdateDeckConfigsRequest {
+        let base_input = UpdateDeckConfigsRequest {
             target_deck_id: DeckId(1),
             configs: output
                 .all_config
@@ -643,18 +647,31 @@ mod test {
             fsrs_health_check: true,
         };
 
-        let mut input2 = input.clone();
-        let mut input3 = input.clone();
-        input.configs[0].inner.ignore_revlogs_before_date =
+        // future date should be clamped to today
+        let mut future_input = base_input.clone();
+        future_input.configs[0].inner.ignore_revlogs_before_date =
             TimestampSecs::now().adding_secs(86_400).date_string();
+        assert!(col.update_deck_configs(future_input).is_ok());
 
-        let err = col.update_deck_configs(input).unwrap_err();
-        assert!(matches!(err, AnkiError::InvalidInput { .. }));
+        let updated = col.get_deck_configs_for_update(DeckId(1)).unwrap();
+        let updated_config: DeckConfig = updated.all_config[0].config.clone().unwrap().into();
+        assert_eq!(updated_config.inner.ignore_revlogs_before_date, today);
 
-        input2.configs[0].inner.ignore_revlogs_before_date = TimestampSecs::now().date_string();
-        assert!(col.update_deck_configs(input2).is_ok());
+        // past dates should be left unchanged
+        let past_date = TimestampSecs::now().adding_secs(-86_400).date_string();
+        let mut past_input = base_input.clone();
+        past_input.configs[0].inner.ignore_revlogs_before_date = past_date.clone();
+        assert!(col.update_deck_configs(past_input).is_ok());
+        let updated2 = col.get_deck_configs_for_update(DeckId(1)).unwrap();
+        let updated_config2: DeckConfig = updated2.all_config[0].config.clone().unwrap().into();
+        assert_eq!(updated_config2.inner.ignore_revlogs_before_date, past_date);
 
-        input3.configs[0].inner.ignore_revlogs_before_date = "".to_string();
-        assert!(col.update_deck_configs(input3).is_ok());
+        // today's date should also be left unchanged
+        let mut today_input = base_input;
+        today_input.configs[0].inner.ignore_revlogs_before_date = today.clone();
+        assert!(col.update_deck_configs(today_input).is_ok());
+        let updated3 = col.get_deck_configs_for_update(DeckId(1)).unwrap();
+        let updated_config3: DeckConfig = updated3.all_config[0].config.clone().unwrap().into();
+        assert_eq!(updated_config3.inner.ignore_revlogs_before_date, today);
     }
 }

--- a/rslib/src/deckconfig/update.rs
+++ b/rslib/src/deckconfig/update.rs
@@ -174,12 +174,10 @@ impl Collection {
 
         // add/update provided configs
         for conf in &mut req.configs {
-            if !conf.inner.ignore_revlogs_before_date.is_empty() {
-                require!(
-                    conf.inner.ignore_revlogs_before_date <= today,
-                    "ignore_revlogs_before_date cannot be later than today"
-                );
-            }
+            require!(
+                conf.inner.ignore_revlogs_before_date <= today,
+                "ignore_revlogs_before_date cannot be later than today"
+            );
             // If the user has provided empty FSRS6 params, zero out any
             // old params as well, so we don't fall back on them, which would
             // be surprising as they're not shown in the GUI.
@@ -646,6 +644,7 @@ mod test {
         };
 
         let mut input2 = input.clone();
+        let mut input3 = input.clone();
         input.configs[0].inner.ignore_revlogs_before_date =
             TimestampSecs::now().adding_secs(86_400).date_string();
 
@@ -653,7 +652,9 @@ mod test {
         assert!(matches!(err, AnkiError::InvalidInput { .. }));
 
         input2.configs[0].inner.ignore_revlogs_before_date = TimestampSecs::now().date_string();
-
         assert!(col.update_deck_configs(input2).is_ok());
+
+        input3.configs[0].inner.ignore_revlogs_before_date = "".to_string();
+        assert!(col.update_deck_configs(input3).is_ok());
     }
 }

--- a/rslib/src/deckconfig/update.rs
+++ b/rslib/src/deckconfig/update.rs
@@ -627,7 +627,12 @@ mod test {
     #[test]
     fn should_clamp_ignore_revlogs_before_date_to_today() {
         let mut col = Collection::new();
-        let today = col.timing_today().unwrap().next_day_at.adding_secs(-24 * 60 * 60).date_string();
+        let today = col
+            .timing_today()
+            .unwrap()
+            .next_day_at
+            .adding_secs(-24 * 60 * 60)
+            .date_string();
         let output = col.get_deck_configs_for_update(DeckId(1)).unwrap();
         let base_input = UpdateDeckConfigsRequest {
             target_deck_id: DeckId(1),
@@ -674,12 +679,16 @@ mod test {
         let updated_config3: DeckConfig = updated3.all_config[0].config.clone().unwrap().into();
         assert_eq!(updated_config3.inner.ignore_revlogs_before_date, today);
 
-        // empty dates should be saved as is and handled by ignore_revlogs_before_date_to_ms
+        // empty dates should be saved as is and handled by
+        // ignore_revlogs_before_date_to_ms
         let mut today_input = base_input;
         today_input.configs[0].inner.ignore_revlogs_before_date = "".to_string();
         assert!(col.update_deck_configs(today_input).is_ok());
         let updated3 = col.get_deck_configs_for_update(DeckId(1)).unwrap();
         let updated_config3: DeckConfig = updated3.all_config[0].config.clone().unwrap().into();
-        assert_eq!(updated_config3.inner.ignore_revlogs_before_date, "".to_string());
+        assert_eq!(
+            updated_config3.inner.ignore_revlogs_before_date,
+            "".to_string()
+        );
     }
 }

--- a/rslib/src/deckconfig/update.rs
+++ b/rslib/src/deckconfig/update.rs
@@ -160,6 +160,7 @@ impl Collection {
         require!(!req.configs.is_empty(), "config not provided");
         let configs_before_update = self.storage.get_deck_config_map()?;
         let mut configs_after_update = configs_before_update.clone();
+        let today = TimestampSecs::now().date_string();
 
         // handle removals first
         for dcid in &req.removed_config_ids {
@@ -173,6 +174,12 @@ impl Collection {
 
         // add/update provided configs
         for conf in &mut req.configs {
+            if !conf.inner.ignore_revlogs_before_date.is_empty() {
+                require!(
+                    conf.inner.ignore_revlogs_before_date <= today,
+                    "ignore_revlogs_before_date cannot be later than today"
+                );
+            }
             // If the user has provided empty FSRS6 params, zero out any
             // old params as well, so we don't fall back on them, which would
             // be surprising as they're not shown in the GUI.
@@ -447,8 +454,10 @@ fn update_day_limit(day_limit: &mut Option<DayLimit>, new_limit: Option<u32>, to
 mod test {
     use super::*;
     use crate::deckconfig::NewCardInsertOrder;
+    use crate::error::AnkiError;
     use crate::tests::open_test_collection_with_learning_card;
     use crate::tests::open_test_collection_with_relearning_card;
+    use crate::timestamp::TimestampSecs;
 
     #[test]
     fn updating() -> Result<()> {
@@ -612,5 +621,39 @@ mod test {
         col.answer_good();
         col.set_default_relearn_steps(vec![1.]);
         assert_eq!(col.get_first_card().remaining_steps, 1);
+    }
+
+    #[test]
+    fn should_reject_ignore_revlogs_before_date_later_than_today() {
+        let mut col = Collection::new();
+        let output = col.get_deck_configs_for_update(DeckId(1)).unwrap();
+        let mut input = UpdateDeckConfigsRequest {
+            target_deck_id: DeckId(1),
+            configs: output
+                .all_config
+                .into_iter()
+                .map(|c| c.config.unwrap().into())
+                .collect(),
+            removed_config_ids: vec![],
+            mode: UpdateDeckConfigsMode::Normal,
+            card_state_customizer: "".to_string(),
+            limits: Limits::default(),
+            new_cards_ignore_review_limit: false,
+            apply_all_parent_limits: false,
+            fsrs: false,
+            fsrs_reschedule: false,
+            fsrs_health_check: true,
+        };
+
+        let mut input2 = input.clone();
+        input.configs[0].inner.ignore_revlogs_before_date =
+            TimestampSecs::now().adding_secs(86_400).date_string();
+
+        let err = col.update_deck_configs(input).unwrap_err();
+        assert!(matches!(err, AnkiError::InvalidInput { .. }));
+
+        input2.configs[0].inner.ignore_revlogs_before_date = TimestampSecs::now().date_string();
+
+        assert!(col.update_deck_configs(input2).is_ok());
     }
 }

--- a/rslib/src/deckconfig/update.rs
+++ b/rslib/src/deckconfig/update.rs
@@ -667,11 +667,19 @@ mod test {
         assert_eq!(updated_config2.inner.ignore_revlogs_before_date, past_date);
 
         // today's date should also be left unchanged
-        let mut today_input = base_input;
+        let mut today_input = base_input.clone();
         today_input.configs[0].inner.ignore_revlogs_before_date = today.clone();
         assert!(col.update_deck_configs(today_input).is_ok());
         let updated3 = col.get_deck_configs_for_update(DeckId(1)).unwrap();
         let updated_config3: DeckConfig = updated3.all_config[0].config.clone().unwrap().into();
         assert_eq!(updated_config3.inner.ignore_revlogs_before_date, today);
+
+        // empty dates should be saved as is and handled by ignore_revlogs_before_date_to_ms
+        let mut today_input = base_input;
+        today_input.configs[0].inner.ignore_revlogs_before_date = "".to_string();
+        assert!(col.update_deck_configs(today_input).is_ok());
+        let updated3 = col.get_deck_configs_for_update(DeckId(1)).unwrap();
+        let updated_config3: DeckConfig = updated3.all_config[0].config.clone().unwrap().into();
+        assert_eq!(updated_config3.inner.ignore_revlogs_before_date, "".to_string());
     }
 }

--- a/rslib/src/deckconfig/update.rs
+++ b/rslib/src/deckconfig/update.rs
@@ -627,7 +627,7 @@ mod test {
     #[test]
     fn should_clamp_ignore_revlogs_before_date_to_today() {
         let mut col = Collection::new();
-        let today = TimestampSecs::now().date_string();
+        let today = col.timing_today().unwrap().next_day_at.adding_secs(-24 * 60 * 60).date_string();
         let output = col.get_deck_configs_for_update(DeckId(1)).unwrap();
         let base_input = UpdateDeckConfigsRequest {
             target_deck_id: DeckId(1),

--- a/ts/routes/deck-options/AdvancedOptions.svelte
+++ b/ts/routes/deck-options/AdvancedOptions.svelte
@@ -305,7 +305,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
             <Item>
                 <DateInput
                     bind:date={$config.ignoreRevlogsBeforeDate}
-                    max={new Date().toISOString().split("T")[0]}
+                    max={new Date().toLocaleDateString("en-CA")}
                 >
                     <SettingTitle
                         on:click={() =>

--- a/ts/routes/deck-options/AdvancedOptions.svelte
+++ b/ts/routes/deck-options/AdvancedOptions.svelte
@@ -303,7 +303,10 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
             </SpinBoxFloatRow>
 
             <Item>
-                <DateInput bind:date={$config.ignoreRevlogsBeforeDate}>
+                <DateInput
+                    bind:date={$config.ignoreRevlogsBeforeDate}
+                    max={new Date().toISOString().split("T")[0]}
+                >
                     <SettingTitle
                         on:click={() =>
                             openHelpModal(

--- a/ts/routes/deck-options/DateInput.svelte
+++ b/ts/routes/deck-options/DateInput.svelte
@@ -8,6 +8,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     import Row from "$lib/components/Row.svelte";
 
     export let date;
+    export let max = undefined;
     $: date = date ? date : "1970-01-01";
 </script>
 
@@ -18,7 +19,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
                 <slot />
             </Col>
             <Col --col-size={6} breakpoint="xs">
-                <input bind:value={date} type="date" />
+                <input bind:value={date} type="date" {max} />
             </Col>
         </Row>
     </ConfigInput>


### PR DESCRIPTION
closes #5284

> (self quote) As I see it. I can't think of a use for setting the ignore_reviews_before value in the future. It also seems to result in undefined behaviour so I think we should prevent it from being set like that.