### PR TITLE
fix: Improve GitHub API error reporting

### DIFF
--- a/rslib/src/backend/github.rs
+++ b/rslib/src/backend/github.rs
@@ -18,6 +18,7 @@ use crate::prelude::*;
 use crate::services::BackendGithubService;
 use crate::updates::download_file;
 use crate::updates::release_path;
+use crate::updates::reqwest_error_to_anki_error;
 use crate::updates::updates_dir;
 use crate::updates::user_agent;
 use crate::updates::DownloadUpdateProgress;
@@ -76,8 +77,10 @@ impl BackendGithubService for Backend {
                 .header("User-Agent", user_agent())
                 .timeout(Duration::from_secs(60))
                 .send()
-                .await?
-                .error_for_status()?;
+                .await
+                .map_err(reqwest_error_to_anki_error)?
+                .error_for_status()
+                .map_err(reqwest_error_to_anki_error)?;
             let release_info: Value;
             if input.include_prerelease {
                 let json: Value = response.json().await?;

--- a/rslib/src/updates.rs
+++ b/rslib/src/updates.rs
@@ -10,6 +10,8 @@ use sha2::Digest;
 use tokio::io::AsyncWriteExt;
 
 use crate::error::AnkiError;
+use crate::error::NetworkError;
+use crate::error::NetworkErrorKind;
 use crate::error::OrInvalid;
 use crate::error::Result;
 use crate::progress::ThrottlingProgressHandler;
@@ -43,6 +45,25 @@ pub fn user_agent() -> String {
     format!("Anki {}", version())
 }
 
+pub fn reqwest_error_to_anki_error(err: reqwest::Error) -> AnkiError {
+    let info = err.to_string();
+    if err.is_timeout() {
+        AnkiError::NetworkError {
+            source: NetworkError {
+                info,
+                kind: NetworkErrorKind::Timeout,
+            },
+        }
+    } else {
+        AnkiError::NetworkError {
+            source: NetworkError {
+                info,
+                kind: NetworkErrorKind::Other,
+            },
+        }
+    }
+}
+
 pub async fn download_file(
     client: &reqwest::Client,
     progress: &mut ThrottlingProgressHandler<DownloadUpdateProgress>,
@@ -54,8 +75,10 @@ pub async fn download_file(
         .get(url)
         .header("User-Agent", user_agent())
         .send()
-        .await?
-        .error_for_status()?;
+        .await
+        .map_err(reqwest_error_to_anki_error)?
+        .error_for_status()
+        .map_err(reqwest_error_to_anki_error)?;
     let content_length = response.content_length().unwrap_or_default();
     let output_path = release_path(filename)?;
     let mut stream = response.bytes_stream();


### PR DESCRIPTION
## Linked issue

Closes #5293

## Summary / motivation

GitHub API errors were handled by the `From<&reqwest::Error>` impl, which is intended for AnkiWeb. This adds a basic error handler for GitHub API requests (showing the raw error messages for most errors).

## Steps to reproduce

The issue was showing when GitHub rate-limits our requests - `403 Forbidden` is returned in that case, and the default error handler interprets that as an AnkiWeb authentication error and displays "Email or password was incorrect; please try again.".

See https://docs.github.com/en/rest/using-the-rest-api/troubleshooting-the-rest-api?apiVersion=2026-03-10#rate-limit-errors

