### PR TITLE
Update VS Code's settings.json

### DIFF
--- a/.vscode.dist/extensions.json
+++ b/.vscode.dist/extensions.json
@@ -2,6 +2,7 @@
     "recommendations": [
         "dprint.dprint",
         "ms-python.python",
+        "ms-python.mypy-type-checker",
         "charliermarsh.ruff",
         "rust-lang.rust-analyzer",
         "svelte.svelte-vscode",

--- a/.vscode.dist/extensions.json
+++ b/.vscode.dist/extensions.json
@@ -8,6 +8,7 @@
         "svelte.svelte-vscode",
         "zxh404.vscode-proto3",
         "usernamehw.errorlens",
-        "eamodio.gitlens"
+        "eamodio.gitlens",
+        "unifiedjs.vscode-mdx"
     ]
 }

--- a/.vscode.dist/extensions.json
+++ b/.vscode.dist/extensions.json
@@ -2,7 +2,6 @@
     "recommendations": [
         "dprint.dprint",
         "ms-python.python",
-        "ms-python.mypy-type-checker",
         "charliermarsh.ruff",
         "rust-lang.rust-analyzer",
         "svelte.svelte-vscode",

--- a/.vscode.dist/settings.json
+++ b/.vscode.dist/settings.json
@@ -3,7 +3,8 @@
     "[python]": {
         "editor.codeActionsOnSave": {
             "source.organizeImports": "explicit"
-        }
+        },
+        "editor.defaultFormatter": "charliermarsh.ruff"
     },
     "files.watcherExclude": {
         "**/.git/objects/**": true,
@@ -18,7 +19,6 @@
         "out/qt",
         "qt"
     ],
-    "python.formatting.provider": "charliermarsh.ruff",
     "python.linting.mypyEnabled": false,
     "python.analysis.diagnosticSeverityOverrides": {
         "reportMissingModuleSource": "none"

--- a/.vscode.dist/settings.json
+++ b/.vscode.dist/settings.json
@@ -19,7 +19,13 @@
         "out/qt",
         "qt"
     ],
-    "python.linting.mypyEnabled": false,
+    "python.useEnvironmentsExtension": true,
+    "mypy-type-checker.extraPaths": ["pylib", "qt", "out/pylib", "out/qt"],
+    "mypy-type-checker.interpreter": [],
+    "mypy-type-checker.importStrategy": "fromEnvironment",
+    "mypy-type-checker.preferDaemon": false,
+    "mypy-type-checker.args": ["--config-file=${workspaceFolder}/.mypy.ini"],
+    "mypy-type-checker.reportingScope": "file",
     "python.analysis.diagnosticSeverityOverrides": {
         "reportMissingModuleSource": "none"
     },

--- a/.vscode.dist/settings.json
+++ b/.vscode.dist/settings.json
@@ -10,7 +10,7 @@
         "**/.git/objects/**": true,
         "**/.git/subtree-cache/**": true,
         "**/node_modules/*/**": true,
-        ".bazel/**": true
+        "out/**": true
     },
     "python.analysis.extraPaths": [
         "./pylib",
@@ -24,14 +24,14 @@
         "reportMissingModuleSource": "none"
     },
     "rust-analyzer.check.allTargets": false,
-    "rust-analyzer.files.excludeDirs": [".bazel", "node_modules"],
+    "rust-analyzer.files.excludeDirs": ["out", "node_modules"],
     "rust-analyzer.procMacro.enable": true,
     // this formats 'use' blocks in a nicer way, but requires you to run
     // 'rustup install nightly'.
     "rust-analyzer.rustfmt.extraArgs": ["+nightly"],
     "search.exclude": {
         "**/node_modules": true,
-        ".bazel/**": true
+        "out/**": true
     },
     "rust-analyzer.cargo.buildScripts.enable": true,
     "python.analysis.typeCheckingMode": "off",

--- a/.vscode.dist/settings.json
+++ b/.vscode.dist/settings.json
@@ -21,12 +21,6 @@
     ],
     "python.useEnvironmentsExtension": true,
     "python-envs.workspaceSearchPaths": ["out/pyenv"],
-    "mypy-type-checker.extraPaths": ["pylib", "qt", "out/pylib", "out/qt"],
-    "mypy-type-checker.interpreter": [],
-    "mypy-type-checker.importStrategy": "fromEnvironment",
-    "mypy-type-checker.preferDaemon": false,
-    "mypy-type-checker.args": ["--config-file=${workspaceFolder}/.mypy.ini"],
-    "mypy-type-checker.reportingScope": "file",
     "python.analysis.diagnosticSeverityOverrides": {
         "reportMissingModuleSource": "none"
     },

--- a/.vscode.dist/settings.json
+++ b/.vscode.dist/settings.json
@@ -30,7 +30,7 @@
         "reportMissingModuleSource": "none"
     },
     "rust-analyzer.check.allTargets": false,
-    "rust-analyzer.files.excludeDirs": ["out", "node_modules"],
+    "rust-analyzer.files.exclude": ["out", "node_modules"],
     "rust-analyzer.procMacro.enable": true,
     // this formats 'use' blocks in a nicer way, but requires you to run
     // 'rustup install nightly'.

--- a/.vscode.dist/settings.json
+++ b/.vscode.dist/settings.json
@@ -20,6 +20,7 @@
         "qt"
     ],
     "python.useEnvironmentsExtension": true,
+    "python-envs.workspaceSearchPaths": ["out/pyenv"],
     "mypy-type-checker.extraPaths": ["pylib", "qt", "out/pylib", "out/qt"],
     "mypy-type-checker.interpreter": [],
     "mypy-type-checker.importStrategy": "fromEnvironment",


### PR DESCRIPTION
## Linked issue

Fixes #5302

## Summary

This updates the VS Code settings:
- Set Ruff as a Python formatter (`python.formatting.provider` is no longer used).
- Replace references to the old `.bazel` with `out`.
- Remove unused `python.linting.mypyEnabled` (mypy is no longer part of the base Python extension).
- Add `unifiedjs.vscode-mdx` to recommended extensions for MDX highlighting.
- Update `rust-analyzer.files.excludeDirs` to `rust-analyzer.files.exclude`.
- Set `python-envs.workspaceSearchPaths` to help the Python Environments extension detect `out/pyenv`.

## How to test

Copy .vscode.dist/settings.json to .vscode/