### PR TITLE
fix: minilints exclusion for docs changes is not working

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,8 +35,8 @@ jobs:
           files: |
             **
           files_ignore: |
-            **.md
-            **.mdx
+            **/*.md
+            **/*.mdx
             docs/**/*.png
             docs/**/*.svg
             docs-site/**/*.png

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,8 @@ jobs:
         id: non-doc-changes
         uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 #v47.0.6
         with:
+          files: |
+            **
           files_ignore: |
             **.md
             **.mdx


### PR DESCRIPTION


## Linked issue

Follow-up fixes to #5267

## Summary

#5267 didn't work reliably as can be seen in #5158 due to two issues:
1. The `files` option is not set, which made `any_changed` always evaluate to `true`.
2. The `*.md` and `*.mdx` patterns only matched root files.


## How to test

Hard to verify locally, but here's a POC written by Claude. Save as `micromatch-files-ignore-poc.cjs` in the root directory and run using: `npm install micromatch && node micromatch-files-ignore-poc.cjs`.

<details>

<summary>POC</summary>

```js
// POC: tj-actions/changed-files' `files_ignore`-only config never filters
// anything, because it hands micromatch an array of ONLY negated patterns.
//
// Run with:
//   node micromatch-files-ignore-poc.cjs
//
// Requires the `micromatch` package to be resolvable (the version actually
// used by tj-actions/changed-files@v47.0.6 is 4.0.8). If you don't have it
// globally, run this from inside a project that depends on it (e.g. the
// anki repo root), or `npm install micromatch` next to this file first.

const mm = require("micromatch");

function assert(cond, msg) {
  if (!cond) {
    throw new Error("FAILED: " + msg);
  }
  console.log("ok   - " + msg);
}

// This mirrors ci.yml's `Check for non-documentation changes` step, which
// sets only `files_ignore` (no `files`), and the 14 files actually changed
// in https://github.com/ankitects/anki/pull/5158 ("docs: fix typos").
const changedFiles = [
  "docs-site/addons/support.mdx",
  "docs-site/developers/development.mdx",
  "docs/development.md",
  "rslib/backend/lib.rs", // stand-in for a real, non-doc source file
];

// Copied verbatim from .github/workflows/ci.yml's files_ignore list.
const filesIgnoreOnly = [
  "!**.md",
  "!**.mdx",
  "!docs/**/*.png",
  "!docs/**/*.svg",
  "!docs-site/**/*.png",
  "!docs-site/**/*.jpg",
  "!docs-site/**/*.svg",
  "!docs-site/**/*.mp4",
];

// This is the exact call tj-actions/changed-files makes internally
// (getFilteredChangedFiles in dist/index.js) to decide which changed files
// "count" for the `any_changed` output.
const matchOpts = { dot: true, windows: false, noext: true };

console.log("--- Bug 1: files_ignore with no positive `files` pattern ---");
const filteredIgnoreOnly = mm(changedFiles, filesIgnoreOnly, matchOpts);
console.log("input files:   ", changedFiles);
console.log("filesIgnore:   ", filesIgnoreOnly);
console.log("matched (kept):", filteredIgnoreOnly);
assert(
  filteredIgnoreOnly.length === changedFiles.length,
  "an ignore-only pattern array matches EVERY file, including the ones " +
  "it was supposed to exclude (docs/*.md, docs-site/*.mdx) -- any_changed " +
  "is always 'true'",
);

console.log();
console.log("--- Bug 2: adding a positive base, but keeping bare `**.md` ---");
const filesWithBadGlobstar = [
  "**", // positive base pattern, as tj-actions' own README recommends pairing
  ...filesIgnoreOnly,
];
const filteredBadGlobstar = mm(changedFiles, filesWithBadGlobstar, matchOpts);
console.log("patterns:      ", filesWithBadGlobstar);
console.log("matched (kept):", filteredBadGlobstar);
assert(
  filteredBadGlobstar.includes("docs/development.md"),
  "bare `**.md` (globstar with no following '/') fails to exclude a " +
  "nested path once it's negated inside an array match -- " +
  "'docs/development.md' incorrectly survives",
);

console.log();
console.log("--- Fix: positive `**` base + `**/*.md` (slash before the star) ---");
const filesFixed = [
  "**",
  "!**/*.md",
  "!**/*.mdx",
  "!docs/**/*.png",
  "!docs/**/*.svg",
  "!docs-site/**/*.png",
  "!docs-site/**/*.jpg",
  "!docs-site/**/*.svg",
  "!docs-site/**/*.mp4",
];
const filteredFixed = mm(changedFiles, filesFixed, matchOpts);
console.log("patterns:      ", filesFixed);
console.log("matched (kept):", filteredFixed);
assert(
  filteredFixed.length === 1 && filteredFixed[0] === "rslib/backend/lib.rs",
  "with a positive `**` base and `**/*.ext` patterns, only the real " +
  "non-doc file survives -- any_changed correctly becomes 'false' for " +
  "docs-only PRs like #5158",
);

console.log();
console.log("All assertions passed: files_ignore-only config in ci.yml never");
console.log("filters anything, so minilints can never actually be skipped.");

```

</details>
