### PR TITLE
chore: Configure mypy extension for VS Code

### DIFF
--- a/.mypy.ini
+++ b/.mypy.ini
@@ -19,6 +19,15 @@ mypy_path =
     pylib/tools,
     python
 exclude = (pylib/anki/_vendor)
+files =
+    pylib,
+    qt/aqt,
+    qt/tools,
+    out/pylib/anki,
+    out/qt/_aqt,
+    python,
+    tools
+cache_dir = out/tests/mypy
 
 [mypy-anki.*]
 disallow_untyped_defs = True

--- a/.vscode.dist/extensions.json
+++ b/.vscode.dist/extensions.json
@@ -2,6 +2,7 @@
     "recommendations": [
         "dprint.dprint",
         "ms-python.python",
+        "ms-python.mypy-type-checker",
         "charliermarsh.ruff",
         "rust-lang.rust-analyzer",
         "svelte.svelte-vscode",

--- a/.vscode.dist/settings.json
+++ b/.vscode.dist/settings.json
@@ -21,6 +21,12 @@
     ],
     "python.useEnvironmentsExtension": true,
     "python-envs.workspaceSearchPaths": ["out/pyenv"],
+    "mypy-type-checker.importStrategy": "fromEnvironment",
+    "mypy-type-checker.preferDaemon": true,
+    "mypy-type-checker.reportingScope": "custom",
+    "mypy-type-checker.args": ["--config-file=${workspaceFolder}/.mypy.ini"],
+    // extraPaths is required despite mypy_path being set in .mypy.ini
+    "mypy-type-checker.extraPaths": ["pylib", "out/pylib", "qt", "out/qt", "ftl", "pylib/tools", "python"],
     "python.analysis.diagnosticSeverityOverrides": {
         "reportMissingModuleSource": "none"
     },

--- a/build/configure/src/python.rs
+++ b/build/configure/src/python.rs
@@ -192,15 +192,6 @@ pub fn check_python(build: &mut Build) -> Result<()> {
     build.add_action(
         "check:mypy",
         PythonTypecheck {
-            folders: &[
-                "pylib",
-                "qt/aqt",
-                "qt/tools",
-                "out/pylib/anki",
-                "out/qt/_aqt",
-                "python",
-                "tools",
-            ],
             deps: inputs![
                 glob!["{pylib,ftl,qt}/**/*.{py,pyi}"],
                 ":pylib:anki",

--- a/build/ninja_gen/src/python.rs
+++ b/build/ninja_gen/src/python.rs
@@ -156,23 +156,19 @@ impl BuildAction for PythonEnvironment {
 }
 
 pub struct PythonTypecheck {
-    pub folders: &'static [&'static str],
     pub deps: BuildInput,
 }
 
 impl BuildAction for PythonTypecheck {
     fn command(&self) -> &str {
-        "$mypy $folders"
+        "$mypy"
     }
 
     fn files(&mut self, build: &mut impl crate::build::FilesHandle) {
         build.add_inputs("", &self.deps);
         build.add_inputs("mypy", inputs![":pyenv:mypy"]);
         build.add_inputs("", inputs![".mypy.ini"]);
-        build.add_variable("folders", self.folders.join(" "));
-
-        let hash = simple_hash(self.folders);
-        build.add_output_stamp(format!("tests/python_typecheck.{hash}"));
+        build.add_output_stamp("tests/python_typecheck");
     }
 
     fn hide_progress(&self) -> bool {

--- a/build/runner/src/build.rs
+++ b/build/runner/src/build.rs
@@ -64,10 +64,6 @@ pub fn run_build(args: BuildArgs) {
         .args(ninja_args)
         .env("PATH", &path)
         .env(
-            "MYPY_CACHE_DIR",
-            build_root.join("tests").join("mypy").into_string(),
-        )
-        .env(
             "PYTHONPYCACHEPREFIX",
             std::path::absolute(build_root.join("pycache")).unwrap(),
         )


### PR DESCRIPTION
## Linked issue

Closes #5304

## Summary

This configures the official VS Code extension for mypy to run in daemon mode.

## How to test

- Install the `ms-python.mypy-type-checker` extension and **switch to the pre-release version** (This is important for daemon mode to work according to my tests).
- Copy .vscode.dist/settings.json to .vscode/
- Restart the MyPy server using the "MyPy: Restart server" command.
- Edit any Python code to add a typing error and confirm the error is visually reported. (Note: initial mypy run might take a few seconds).



<img width="1305" height="361" alt="image" src="https://github.com/user-attachments/assets/e8f431b0-b2ae-483d-b305-cf19c9dd013d" />
