### PR TITLE
fix: play audio immediately when attached in the editor

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -298,6 +298,7 @@ DespicableGoose <68354378+DespicableGoose@users.noreply.github.com>
 Han Lua <72375847+xiaohan484@users.noreply.github.com>
 Andreas U. Schmidhauser <github.com/schmidhauser>
 Peter Szilvasi <peti.szilvasi95@gmail.com>
+JaksonSouza <jaksonsouza.dev@gmail.com>
 ********************
 
 The text of the 3 clause BSD license follows:

--- a/proto/anki/frontend.proto
+++ b/proto/anki/frontend.proto
@@ -38,6 +38,7 @@ service FrontendService {
   rpc OpenMedia(generic.String) returns (generic.Empty);
   rpc ShowInMediaFolder(generic.String) returns (generic.Empty);
   rpc RecordAudio(generic.Empty) returns (generic.String);
+  rpc PlayFile(generic.String) returns (generic.Empty);
   rpc CloseAddCards(generic.Bool) returns (generic.Empty);
   rpc CloseEditCurrent(generic.Empty) returns (generic.Empty);
   rpc OpenLink(generic.String) returns (generic.Empty);

--- a/qt/aqt/mediasrv.py
+++ b/qt/aqt/mediasrv.py
@@ -902,6 +902,30 @@ async def record_audio() -> bytes:
     return generic_pb2.String(val=path if path else "").SerializeToString()
 
 
+def play_file() -> bytes:
+    from aqt.editor import NewEditor
+    from aqt.sound import av_player
+
+    req = generic_pb2.String()
+    req.ParseFromString(request.data)
+    path = os.path.join(aqt.mw.col.media.dir(), req.val)
+
+    def handle_on_main() -> None:
+        window = aqt.mw.app.activeWindow()
+        if (
+            window is not None
+            and hasattr(window, "editor")
+            and isinstance(window.editor, NewEditor)
+        ):
+            av_player.play_file_with_caller(path, window.editor.editorMode)
+        else:
+            av_player.play_file(path)
+
+    aqt.mw.taskman.run_on_main(handle_on_main)
+
+    return b""
+
+
 def read_clipboard() -> bytes:
     req = frontend_pb2.ReadClipboardRequest()
     req.ParseFromString(request.data)
@@ -1080,6 +1104,7 @@ post_handler_list = [
     open_media,
     show_in_media_folder,
     record_audio,
+    play_file,
     read_clipboard,
     write_clipboard,
     close_add_cards,

--- a/ts/routes/editor/editor-toolbar/TemplateButtons.svelte
+++ b/ts/routes/editor/editor-toolbar/TemplateButtons.svelte
@@ -24,9 +24,10 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     import LatexButton from "./LatexButton.svelte";
     import {
         filenameToLink,
+        isAudio,
         openFilePickerForMedia,
     } from "../rich-text-input/data-transfer";
-    import { addMediaFromPath, recordAudio } from "@generated/backend";
+    import { addMediaFromPath, playFile, recordAudio } from "@generated/backend";
 
     const { focusedInput } = context.get();
 
@@ -35,6 +36,9 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     async function attachPath(path: string) {
         const filename = (await addMediaFromPath({ path })).val;
         setFormat("inserthtml", filenameToLink(filename));
+        if (isAudio(filename)) {
+            await playFile({ val: filename });
+        }
     }
 
     async function attachMediaOnFocus(): Promise<void> {

--- a/ts/routes/editor/rich-text-input/data-transfer.test.ts
+++ b/ts/routes/editor/rich-text-input/data-transfer.test.ts
@@ -1,0 +1,26 @@
+// Copyright: Ankitects Pty Ltd and contributors
+// License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
+// @vitest-environment jsdom
+
+import { expect, test } from "vitest";
+
+import { filenameToLink, isAudio } from "./data-transfer";
+
+test("isAudio recognizes audio/video suffixes regardless of case", () => {
+    expect(isAudio("clip.mp3")).toBe(true);
+    expect(isAudio("clip.MP3")).toBe(true);
+    expect(isAudio("clip.wav")).toBe(true);
+    expect(isAudio("clip.mp4")).toBe(true);
+});
+
+test("isAudio returns false for images and files without a matching suffix", () => {
+    expect(isAudio("photo.png")).toBe(false);
+    expect(isAudio("photo.jpg")).toBe(false);
+    expect(isAudio("notes.txt")).toBe(false);
+});
+
+test("filenameToLink and isAudio agree on what counts as audio", () => {
+    const link = filenameToLink("clip.mp3");
+    expect(link).toBe("[sound:clip.mp3]");
+    expect(isAudio("clip.mp3")).toBe(true);
+});

--- a/ts/routes/editor/rich-text-input/data-transfer.ts
+++ b/ts/routes/editor/rich-text-input/data-transfer.ts
@@ -145,14 +145,22 @@ async function urlToFile(url: string, allowedSuffixes = mediaSuffixes): Promise<
     return null;
 }
 
-export function filenameToLink(filename: string): string {
+function extToLowerCase(filename: string): string {
     const filenameParts = filename.split(".");
-    const ext = filenameParts[filenameParts.length - 1].toLowerCase();
+    return filenameParts[filenameParts.length - 1].toLowerCase();
+}
+
+export function filenameToLink(filename: string): string {
+    const ext = extToLowerCase(filename);
     if (imageSuffixes.includes(ext)) {
         return `<img src="${encodeURI(filename)}">`;
     } else {
         return `[sound:${escapeHtml(filename, false)}]`;
     }
+}
+
+export function isAudio(filename: string): boolean {
+    return audioSuffixes.includes(extToLowerCase(filename));
 }
 
 async function urlToLink(url: string, allowedSuffixes: string[] = mediaSuffixes): Promise<string> {


### PR DESCRIPTION
## Linked issue (required)

Closes #5321

## Summary / motivation (required)

In the old Qt-based editor, attaching an audio file (paperclip button or the mic recording button) played the file immediately, before the card was saved. This was handled by `Editor.fnameToLink()` in `qt/aqt/editor.py`, which called `av_player.play_file_with_caller()` right after building the `[sound:...]` tag.

That method was removed in 4dd402334 ("Remove legacy editor code") once the editor moved to the Svelte/TS implementation. Its replacement, `filenameToLink()` in `ts/routes/editor/rich-text-input/data-transfer.ts`, only builds the `[sound:...]` string and never carried the playback call forward. So today, attaching audio inserts the tag silently and you only hear it after saving and reopening the card (or opening the Cards preview).

This restores the immediate playback, using the same `av_player` mechanism the rest of the app uses (so it respects the configured audio backend/volume), by:

- Adding a `PlayFile` RPC to `FrontendService` in `frontend.proto`, following the same pattern as the existing Python-only `RecordAudio`/`OpenMedia` RPCs (no Rust implementation needed, `FrontendService` is filtered out of Rust codegen in `rslib/rust_interface.rs`).
- Implementing `play_file()` in `qt/aqt/mediasrv.py`. It resolves the path relative to the media folder the same way `open_media`/`show_in_media_folder` do, then plays it on the main thread. When the active window is the editor, it uses `av_player.play_file_with_caller(path, window.editor.editorMode)` instead of a plain `play_file()`, the same pattern already used by `open_cards_dialog`/`open_fields_dialog` in the same file. This ties playback to `Editor.cleanup()`'s existing `av_player.stop_and_clear_queue_if_caller(self.editorMode)` call, so the sound is stopped if the editor closes mid-playback.
- Calling the new `playFile()` binding from `attachPath()` in `TemplateButtons.svelte` right after the media is inserted, only when the attached file is audio (added an `isAudio()` helper next to `filenameToLink()`, reusing the existing `audioSuffixes` list).

## Steps to reproduce (required, use N/A if not applicable)

1. Open the Add or Edit dialog for a note.
2. Click the paperclip (attach) button in the field toolbar.
3. Pick an audio file.
4. Notice nothing plays. The `[sound:...]` tag is inserted silently, and you only hear the audio after saving/reviewing or opening the Cards preview.

## How to test (required)

### Checklist (minimum)

- [x] I ran `./ninja check` or an equivalent relevant check locally.
- [x] I added or updated tests when the change is non-trivial or behavior changed.

### Details

Ran `just check` locally, everything passed, including a new vitest covering `isAudio()` in `data-transfer.test.ts`. Manually verified in `just run`: opened Add dialog, attached an audio file via the paperclip button and it plays as soon as it's inserted into the field, before saving. Also tested the mic recording button (F5), which goes through the same `attachPath()` function; recording and playback both work as expected.

## Before / after behavior (optional)

Before: attaching audio via the paperclip inserts the `[sound:...]` tag silently.
After: the audio plays immediately after being inserted, matching the old Qt editor's behavior.

## Risk / compatibility / migration (optional)

Low risk. New RPC is additive (no changes to existing `FrontendService` methods), and playback only triggers for files already classified as audio/video by the existing suffix list used elsewhere in the same file.

## UI evidence (required for visual changes; otherwise N/A)

N/A, behavior-only change (audio playback), nothing visual to show.

## Scope

- [x] This PR is focused on one change (no unrelated edits).
