### PR TITLE
fix: new editor not playing pasted/dropped audio

### DIFF
--- a/ts/routes/editor/rich-text-input/data-transfer.test.ts
+++ b/ts/routes/editor/rich-text-input/data-transfer.test.ts
@@ -3,9 +3,13 @@
 // @vitest-environment jsdom
 
 import { playFile } from "@generated/backend";
-import { expect, test, vi } from "vitest";
+import { beforeEach, expect, test, vi } from "vitest";
 
 import { filenameToLink, isAudio } from "./data-transfer";
+
+beforeEach(() => {
+    vi.clearAllMocks();
+});
 
 vi.mock("@generated/backend", async (importOriginal) => ({
     ...(await importOriginal<object>()),
@@ -30,4 +34,10 @@ test("filenameToLink and isAudio agree on what counts as audio", () => {
     expect(link).toBe("[sound:clip.mp3]");
     expect(isAudio("clip.mp3")).toBe(true);
     expect(vi.mocked(playFile)).toHaveBeenCalledWith({ val: "clip.mp3" });
+});
+
+test("filenameToLink returns bare filename if unrecognized", () => {
+    const link = filenameToLink("test.foo");
+    expect(link).toBe("test.foo");
+    expect(vi.mocked(playFile)).toHaveBeenCalledTimes(0);
 });

--- a/ts/routes/editor/rich-text-input/data-transfer.test.ts
+++ b/ts/routes/editor/rich-text-input/data-transfer.test.ts
@@ -2,9 +2,15 @@
 // License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 // @vitest-environment jsdom
 
-import { expect, test } from "vitest";
+import { playFile } from "@generated/backend";
+import { expect, test, vi } from "vitest";
 
 import { filenameToLink, isAudio } from "./data-transfer";
+
+vi.mock("@generated/backend", async (importOriginal) => ({
+    ...(await importOriginal<object>()),
+    playFile: vi.fn(),
+}));
 
 test("isAudio recognizes audio/video suffixes regardless of case", () => {
     expect(isAudio("clip.mp3")).toBe(true);
@@ -23,4 +29,5 @@ test("filenameToLink and isAudio agree on what counts as audio", () => {
     const link = filenameToLink("clip.mp3");
     expect(link).toBe("[sound:clip.mp3]");
     expect(isAudio("clip.mp3")).toBe(true);
+    expect(vi.mocked(playFile)).toHaveBeenCalledWith({ val: "clip.mp3" });
 });

--- a/ts/routes/editor/rich-text-input/data-transfer.ts
+++ b/ts/routes/editor/rich-text-input/data-transfer.ts
@@ -155,9 +155,11 @@ export function filenameToLink(filename: string): string {
     const ext = extToLowerCase(filename);
     if (imageSuffixes.includes(ext)) {
         return `<img src="${encodeURI(filename)}">`;
-    } else {
+    } else if (audioSuffixes.includes(ext)) {
         playFile({ val: filename });
         return `[sound:${escapeHtml(filename, false)}]`;
+    } else {
+        return filename;
     }
 }
 

--- a/ts/routes/editor/rich-text-input/data-transfer.ts
+++ b/ts/routes/editor/rich-text-input/data-transfer.ts
@@ -11,6 +11,7 @@ import {
     getAbsoluteMediaPath,
     getConfigBool,
     openFilePicker,
+    playFile,
     readClipboard,
     writeClipboard,
 } from "@generated/backend";
@@ -155,6 +156,7 @@ export function filenameToLink(filename: string): string {
     if (imageSuffixes.includes(ext)) {
         return `<img src="${encodeURI(filename)}">`;
     } else {
+        playFile({ val: filename });
         return `[sound:${escapeHtml(filename, false)}]`;
     }
 }


### PR DESCRIPTION
## Linked issue

A small follow-up to #5320

## Summary

#5320 fixed autoplay for attached files and recordings but missed pasted/dropped files.

## How to test

Paste and drag & drop of audio files is currently broken (#5203) so there's no easy way to test this right now.
