### PR TITLE
docs: Update e2e docs

### DIFF
--- a/docs-site/developers/e2e-testing.mdx
+++ b/docs-site/developers/e2e-testing.mdx
@@ -74,7 +74,7 @@ generated type from `ts/lib/generated/`.
 
 ## Accessing Anki pages
 
-Anki's mediasrv serves the following page families over HTTP:
+Anki's mediasrv serves the following pages over HTTP (non-exhaustive):
 
 | URL pattern                  | Description                   |
 | ---------------------------- | ----------------------------- |
@@ -83,7 +83,7 @@ Anki's mediasrv serves the following page families over HTTP:
 | `/congrats`                  | Post-study screen (SvelteKit) |
 | `/card-info/[cardId]`        | Card info (SvelteKit)         |
 | `/editor/?mode=[mode]`       | Editor (SvelteKit)            |
-| `/_anki/pages/congrats.html` | Legacy congrats page          |
+| `/congrats`                  | Congrats page (SvelteKit)     |
 | `/favicon.ico`               | Mediasrv liveness probe       |
 
 ## CI

--- a/docs-site/developers/e2e-testing.mdx
+++ b/docs-site/developers/e2e-testing.mdx
@@ -76,15 +76,15 @@ generated type from `ts/lib/generated/`.
 
 Anki's mediasrv serves the following pages over HTTP (non-exhaustive):
 
-| URL pattern                  | Description                   |
-| ---------------------------- | ----------------------------- |
-| `/graphs`                    | Statistics graphs (SvelteKit) |
-| `/deck-options/[deckId]`     | Deck options (SvelteKit)      |
-| `/congrats`                  | Post-study screen (SvelteKit) |
-| `/card-info/[cardId]`        | Card info (SvelteKit)         |
-| `/editor/?mode=[mode]`       | Editor (SvelteKit)            |
-| `/congrats`                  | Congrats page (SvelteKit)     |
-| `/favicon.ico`               | Mediasrv liveness probe       |
+| URL pattern              | Description                   |
+| ------------------------ | ----------------------------- |
+| `/graphs`                | Statistics graphs (SvelteKit) |
+| `/deck-options/[deckId]` | Deck options (SvelteKit)      |
+| `/congrats`              | Post-study screen (SvelteKit) |
+| `/card-info/[cardId]`    | Card info (SvelteKit)         |
+| `/editor/?mode=[mode]`   | Editor (SvelteKit)            |
+| `/congrats`              | Congrats page (SvelteKit)     |
+| `/favicon.ico`           | Mediasrv liveness probe       |
 
 ## CI
 

--- a/docs-site/developers/e2e-testing.mdx
+++ b/docs-site/developers/e2e-testing.mdx
@@ -1,12 +1,6 @@
-<!-- DO NOT MANUALLY EDIT THIS FILE -->
-<!-- This file is copied from docs-site/developers/e2e-testing.mdx automatically -->
-
-# End-to-End Testing with Playwright
-
-<!-- <<<cog
-from cogdocs import get_file_contents
-cog.out(get_file_contents("e2e-testing"))
->>> -->
+---
+title: "End-to-End Testing with Playwright"
+---
 
 Playwright drives a real headless Anki instance via its mediasrv HTTP API.
 Tests live in `ts/tests/e2e/` and are entirely separate from the Vitest unit tests.
@@ -100,5 +94,3 @@ editor-as-web-page work (issue #3830) is merged.
 The e2e tests run as part of the `check-linux` job in `.github/workflows/ci.yml`,
 after the regular build and test steps. Screenshots and traces from failed runs
 are uploaded as artifacts and kept for 7 days.
-
-<!-- <<<end>>> -->

--- a/docs-site/developers/e2e-testing.mdx
+++ b/docs-site/developers/e2e-testing.mdx
@@ -82,12 +82,9 @@ Anki's mediasrv serves the following page families over HTTP:
 | `/deck-options/[deckId]`     | Deck options (SvelteKit)      |
 | `/congrats`                  | Post-study screen (SvelteKit) |
 | `/card-info/[cardId]`        | Card info (SvelteKit)         |
+| `/editor/?mode=[mode]`       | Editor (SvelteKit)            |
 | `/_anki/pages/congrats.html` | Legacy congrats page          |
 | `/favicon.ico`               | Mediasrv liveness probe       |
-
-The add-card editor (`/editor/?mode=add`) requires a dedicated HTTP endpoint
-that is not yet present in upstream Anki. It will be available once the
-editor-as-web-page work (issue #3830) is merged.
 
 ## CI
 

--- a/docs-site/docs.json
+++ b/docs-site/docs.json
@@ -338,7 +338,7 @@
                     {
                         "group": "Core Development",
                         "pages": [
-                          "developers/development",
+                            "developers/development",
                             "developers/api-python",
                             "developers/api-rust",
                             "developers/architecture",
@@ -349,12 +349,13 @@
                             "developers/language_bridge",
                             "developers/linux",
                             "developers/mac",
+                            "developers/windows",
                             "developers/ninja",
                             "developers/protobuf",
                             "developers/releasing",
                             "developers/syncserver",
                             "developers/testing-coverage",
-                            "developers/windows"
+                            "developers/e2e-testing"
                         ]
                     }
                 ]

--- a/docs/e2e-testing.md
+++ b/docs/e2e-testing.md
@@ -82,15 +82,15 @@ generated type from `ts/lib/generated/`.
 
 Anki's mediasrv serves the following pages over HTTP (non-exhaustive):
 
-| URL pattern                  | Description                   |
-| ---------------------------- | ----------------------------- |
-| `/graphs`                    | Statistics graphs (SvelteKit) |
-| `/deck-options/[deckId]`     | Deck options (SvelteKit)      |
-| `/congrats`                  | Post-study screen (SvelteKit) |
-| `/card-info/[cardId]`        | Card info (SvelteKit)         |
-| `/editor/?mode=[mode]`       | Editor (SvelteKit)            |
-| `/congrats`                  | Congrats page (SvelteKit)     |
-| `/favicon.ico`               | Mediasrv liveness probe       |
+| URL pattern              | Description                   |
+| ------------------------ | ----------------------------- |
+| `/graphs`                | Statistics graphs (SvelteKit) |
+| `/deck-options/[deckId]` | Deck options (SvelteKit)      |
+| `/congrats`              | Post-study screen (SvelteKit) |
+| `/card-info/[cardId]`    | Card info (SvelteKit)         |
+| `/editor/?mode=[mode]`   | Editor (SvelteKit)            |
+| `/congrats`              | Congrats page (SvelteKit)     |
+| `/favicon.ico`           | Mediasrv liveness probe       |
 
 ## CI
 

--- a/docs/e2e-testing.md
+++ b/docs/e2e-testing.md
@@ -88,12 +88,9 @@ Anki's mediasrv serves the following page families over HTTP:
 | `/deck-options/[deckId]`     | Deck options (SvelteKit)      |
 | `/congrats`                  | Post-study screen (SvelteKit) |
 | `/card-info/[cardId]`        | Card info (SvelteKit)         |
+| `/editor/?mode=[mode]`       | Editor (SvelteKit)            |
 | `/_anki/pages/congrats.html` | Legacy congrats page          |
 | `/favicon.ico`               | Mediasrv liveness probe       |
-
-The add-card editor (`/editor/?mode=add`) requires a dedicated HTTP endpoint
-that is not yet present in upstream Anki. It will be available once the
-editor-as-web-page work (issue #3830) is merged.
 
 ## CI
 

--- a/docs/e2e-testing.md
+++ b/docs/e2e-testing.md
@@ -80,7 +80,7 @@ generated type from `ts/lib/generated/`.
 
 ## Accessing Anki pages
 
-Anki's mediasrv serves the following page families over HTTP:
+Anki's mediasrv serves the following pages over HTTP (non-exhaustive):
 
 | URL pattern                  | Description                   |
 | ---------------------------- | ----------------------------- |
@@ -89,7 +89,7 @@ Anki's mediasrv serves the following page families over HTTP:
 | `/congrats`                  | Post-study screen (SvelteKit) |
 | `/card-info/[cardId]`        | Card info (SvelteKit)         |
 | `/editor/?mode=[mode]`       | Editor (SvelteKit)            |
-| `/_anki/pages/congrats.html` | Legacy congrats page          |
+| `/congrats`                  | Congrats page (SvelteKit)     |
 | `/favicon.ico`               | Mediasrv liveness probe       |
 
 ## CI


### PR DESCRIPTION
This moves docs/e2e-testing.md to docs-site/developers/e2e-testing.mdx and updates some notes about the editor/congrats page.