### PR TITLE
Fix: Recompute FSRS data after changing deck

### DIFF
--- a/rslib/Cargo.toml
+++ b/rslib/Cargo.toml
@@ -19,6 +19,11 @@ name = "benchmark"
 harness = false
 required-features = ["bench"]
 
+[[bench]]
+name = "fsrs"
+harness = false
+required-features = ["bench"]
+
 [build-dependencies]
 anki_io.workspace = true
 anki_proto.workspace = true

--- a/rslib/benches/fsrs.rs
+++ b/rslib/benches/fsrs.rs
@@ -1,0 +1,95 @@
+// Copyright: Ankitects Pty Ltd and contributors
+// License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
+
+use std::time::Duration;
+use std::time::Instant;
+
+use anki::collection::CollectionBuilder;
+use anki::notes::AddNoteRequest;
+use anki::prelude::BoolKey;
+use anki::prelude::CardId;
+use anki::prelude::DeckId;
+use anki::search::SortMode;
+use criterion::criterion_group;
+use criterion::criterion_main;
+use criterion::Criterion;
+
+const CARD_COUNT: usize = 100_000;
+
+struct TransferBenchState {
+    col: anki::collection::Collection,
+    card_ids: Vec<CardId>,
+    source_deck_id: DeckId,
+    target_deck_id: DeckId,
+}
+
+fn setup_transfer_state() -> TransferBenchState {
+    let mut col = CollectionBuilder::default().build().unwrap();
+    col.set_config_bool(BoolKey::Fsrs, true, false).unwrap();
+
+    let source_deck = col.get_or_create_normal_deck("fsrs-source").unwrap();
+    let target_deck = col.get_or_create_normal_deck("fsrs-target").unwrap();
+
+    let notetype = col.get_notetype_by_name("Basic").unwrap().unwrap();
+
+    const BATCH_SIZE: usize = 1_000;
+    for batch_start in (0..CARD_COUNT).step_by(BATCH_SIZE) {
+        let batch_end = (batch_start + BATCH_SIZE).min(CARD_COUNT);
+        let mut requests = Vec::with_capacity(batch_end - batch_start);
+
+        for idx in batch_start..batch_end {
+            let mut note = notetype.new_note();
+            note.set_field(0, format!("front {idx}")).unwrap();
+            note.set_field(1, format!("back {idx}")).unwrap();
+            requests.push(AddNoteRequest {
+                note,
+                deck_id: source_deck.id,
+            });
+        }
+
+        col.add_notes(&mut requests).unwrap();
+    }
+
+    let card_ids = col
+        .search_cards("deck:fsrs-source", SortMode::NoOrder)
+        .unwrap();
+    col.set_due_date(&card_ids, "1", None).unwrap();
+
+    TransferBenchState {
+        col,
+        card_ids,
+        source_deck_id: source_deck.id,
+        target_deck_id: target_deck.id,
+    }
+}
+
+fn bench_transfer_100k_fsrs(c: &mut Criterion) {
+    let mut state = setup_transfer_state();
+
+    let mut group = c.benchmark_group("fsrs_deck_transfer");
+    group.sample_size(10);
+    group.measurement_time(Duration::from_secs(30));
+    group.bench_function("move_100k_cards_between_decks", |b| {
+        b.iter_custom(|iters| {
+            let mut elapsed = Duration::ZERO;
+            for _ in 0..iters {
+                let start = Instant::now();
+                state
+                    .col
+                    .set_deck(&state.card_ids, state.target_deck_id)
+                    .unwrap();
+                elapsed += start.elapsed();
+
+                state
+                    .col
+                    .set_deck(&state.card_ids, state.source_deck_id)
+                    .unwrap();
+            }
+            elapsed
+        })
+    });
+    group.finish();
+}
+
+criterion_group!(benches, bench_transfer_100k_fsrs);
+criterion_main!(benches);

--- a/rslib/benches/fsrs.rs
+++ b/rslib/benches/fsrs.rs
@@ -53,7 +53,9 @@ fn setup_transfer_state() -> TransferBenchState {
     let card_ids = col
         .search_cards("deck:fsrs-source", SortMode::NoOrder)
         .unwrap();
-    col.set_due_date(&card_ids, "1", None).unwrap();
+    col.grade_now(&card_ids, 1).unwrap();
+    col.grade_now(&card_ids, 3).unwrap();
+    col.grade_now(&card_ids, 3).unwrap();
 
     TransferBenchState {
         col,

--- a/rslib/src/card/mod.rs
+++ b/rslib/src/card/mod.rs
@@ -28,8 +28,7 @@ use crate::prelude::*;
 use crate::scheduler::fsrs::memory_state::UpdateMemoryStateEntry;
 use crate::scheduler::fsrs::memory_state::UpdateMemoryStateRequest;
 use crate::scheduler::fsrs::params::ignore_revlogs_before_ms_from_config;
-use crate::search::SearchNode;
-use crate::storage::comma_separated_ids;
+use crate::search::Negated;
 use crate::timestamp::TimestampSecs;
 use crate::types::Usn;
 
@@ -384,23 +383,22 @@ impl Collection {
         let usn = self.usn()?;
         self.transact(Op::SetCardDeck, |col| {
             let mut count = 0;
-            let mut card_ids_needing_fsrs_recompute = Vec::new();
             for mut card in col.all_cards_for_ids(cards, false)? {
                 if card.deck_id == deck_id {
                     continue;
                 }
                 count += 1;
-                if fsrs_enabled && card.ctype != CardType::New {
-                    card_ids_needing_fsrs_recompute.push(card.id);
-                }
                 let original = card.clone();
                 steps_adjuster.adjust_remaining_steps(col, &mut card)?;
                 card.set_deck(deck_id);
                 col.update_card_inner(&mut card, original, usn)?;
             }
-            if !card_ids_needing_fsrs_recompute.is_empty() {
+            if fsrs_enabled {
                 let desired_retention = deck.effective_desired_retention(&config);
                 let deck_desired_retention = [(deck_id, desired_retention)].into();
+
+                use crate::search::SearchNode::*;
+
                 col.update_memory_state(vec![UpdateMemoryStateEntry {
                     req: Some(UpdateMemoryStateRequest {
                         params: config.fsrs_params().clone(),
@@ -410,9 +408,12 @@ impl Collection {
                         reschedule: false,
                         deck_desired_retention,
                     }),
-                    search: SearchNode::CardIds(comma_separated_ids(
-                        &card_ids_needing_fsrs_recompute,
-                    )),
+                    search: SearchBuilder::all(vec![
+                        DeckIdsWithoutChildren(deck_id.to_string()).into(),
+                        HasMemoryState.negated(),
+                    ])
+                    .try_into_search()
+                    .unwrap(),
                     ignore_before: ignore_revlogs_before_ms_from_config(&config)?,
                 }])?;
             }

--- a/rslib/src/card/mod.rs
+++ b/rslib/src/card/mod.rs
@@ -416,8 +416,7 @@ impl Collection {
                         DeckIdsWithoutChildren(deck_id.to_string()).into(),
                         HasMemoryState.negated(),
                     ])
-                    .try_into_search()
-                    .unwrap(),
+                    .try_into_search()?,
                     ignore_before: ignore_revlogs_before_ms_from_config(&config)?,
                 }])?;
             }

--- a/rslib/src/card/mod.rs
+++ b/rslib/src/card/mod.rs
@@ -536,6 +536,7 @@ impl From<MemoryState> for FsrsMemoryState {
 
 #[cfg(test)]
 mod test {
+    use crate::config::BoolKey;
     use crate::prelude::*;
     use crate::tests::open_test_collection_with_learning_card;
     use crate::tests::open_test_collection_with_relearning_card;
@@ -583,6 +584,42 @@ mod test {
 
         assert_eq!(col.get_first_card().remaining_steps, 1);
 
+        Ok(())
+    }
+
+    #[test]
+    fn recalculate_memory_state_on_set_deck() -> Result<()> {
+        let mut col = Collection::new();
+
+        let nt = col.get_notetype_by_name("Basic")?.unwrap();
+        let mut note = nt.new_note();
+        col.add_note(&mut note, DeckId(1))?;
+
+        // Graduate card to review without FSRS so it has an interval but no memory
+        // state
+        col.answer_easy();
+
+        col.set_config_bool(BoolKey::Fsrs, true, false)?;
+
+        let card_id = col.get_first_card().id;
+        assert!(col
+            .storage
+            .get_card(card_id)?
+            .unwrap()
+            .memory_state
+            .is_none());
+
+        // Moving the card should trigger FSRS memory state calculation for cards
+        // without it
+        let target = DeckAdder::new("target").add(&mut col);
+        col.set_deck(&[card_id], target.id)?;
+
+        assert!(col
+            .storage
+            .get_card(card_id)?
+            .unwrap()
+            .memory_state
+            .is_some());
         Ok(())
     }
 }

--- a/rslib/src/card/mod.rs
+++ b/rslib/src/card/mod.rs
@@ -605,15 +605,143 @@ mod test {
         col.set_config_bool(BoolKey::Fsrs, true, false)?;
 
         let card_id = col.get_first_card().id;
+        let card = col.storage.get_card(card_id)?.unwrap();
+        assert!(card.memory_state.is_none());
+        assert!(card.desired_retention.is_none());
+        assert!(card.decay.is_none());
+
+        // Moving the card should trigger FSRS memory state calculation for cards
+        // lacking them, and store them in the card.
+        let target = DeckAdder::new("target").add(&mut col);
+        col.set_deck(&[card_id], target.id)?;
+
+        let card = col.storage.get_card(card_id)?.unwrap();
+        assert!(card.memory_state.is_some());
+        assert!(card.desired_retention.is_some());
+        assert!(card.decay.is_some());
+
+        // The original bug (#5327): moving a card that already has a memory
+        // state must recompute it, not leave it cleared.
+        let target2 = DeckAdder::new("target2").add(&mut col);
+        col.set_deck(&[card_id], target2.id)?;
+
+        assert!(col
+            .storage
+            .get_card(card_id)?
+            .unwrap()
+            .memory_state
+            .is_some());
+        Ok(())
+    }
+
+    // Moving cards that are already in the target deck is a no-op and must not
+    // trigger a recompute of other memory-state-less cards in that deck.
+    #[test]
+    fn set_deck_noop_does_not_recompute() -> Result<()> {
+        let mut col = Collection::new();
+        let nt = col.get_notetype_by_name("Basic")?.unwrap();
+        let mut note = nt.new_note();
+        col.add_note(&mut note, DeckId(1))?;
+        col.answer_easy(); // review card, still without a memory state
+        col.set_config_bool(BoolKey::Fsrs, true, false)?;
+
+        let card_id = col.get_first_card().id;
+        // "Move" to the deck it is already in (DeckId(1)) -> count == 0
+        col.set_deck(&[card_id], DeckId(1))?;
+
         assert!(col
             .storage
             .get_card(card_id)?
             .unwrap()
             .memory_state
             .is_none());
+        Ok(())
+    }
 
-        // Moving the card should trigger FSRS memory state calculation for cards
-        // without it
+    // The recompute must be scoped to the target deck: a memory-state-less card
+    // in a different deck must not be touched.
+    #[test]
+    fn set_deck_recompute_is_scoped_to_target() -> Result<()> {
+        let mut col = Collection::new();
+        let nt = col.get_notetype_by_name("Basic")?.unwrap();
+
+        // Card A and card B, both review cards in the default deck.
+        let mut a = nt.new_note();
+        col.add_note(&mut a, DeckId(1))?;
+        col.answer_easy();
+        let mut b = nt.new_note();
+        col.add_note(&mut b, DeckId(1))?;
+        col.answer_easy();
+
+        col.set_config_bool(BoolKey::Fsrs, true, false)?;
+        let cards = col.storage.get_all_cards();
+        let (a_id, b_id) = (cards[0].id, cards[1].id);
+
+        let target = DeckAdder::new("target").add(&mut col);
+        col.set_deck(&[a_id], target.id)?; // only A moves
+
+        assert!(col.storage.get_card(a_id)?.unwrap().memory_state.is_some());
+        // B stays in the default deck and must remain without a memory state.
+        assert!(col.storage.get_card(b_id)?.unwrap().memory_state.is_none());
+        Ok(())
+    }
+
+    // Moving a deck recomputes the memory state but must not reschedule the
+    // card (reschedule: false): due date and interval stay unchanged.
+    #[test]
+    fn set_deck_does_not_reschedule() -> Result<()> {
+        let mut col = Collection::new();
+        let nt = col.get_notetype_by_name("Basic")?.unwrap();
+        let mut note = nt.new_note();
+        col.add_note(&mut note, DeckId(1))?;
+        col.answer_easy();
+        col.set_config_bool(BoolKey::Fsrs, true, false)?;
+
+        let before = col.get_first_card();
+        let target = DeckAdder::new("target").add(&mut col);
+        col.set_deck(&[before.id], target.id)?;
+
+        let after = col.storage.get_card(before.id)?.unwrap();
+        assert_eq!(after.due, before.due);
+        assert_eq!(after.interval, before.interval);
+        // The memory state was still recomputed, though.
+        assert!(after.memory_state.is_some());
+        Ok(())
+    }
+
+    // The recompute must use the target preset's parameters, not the source's.
+    // Verified through the desired retention stored on the card.
+    #[test]
+    fn set_deck_uses_target_preset_desired_retention() -> Result<()> {
+        let mut col = Collection::new();
+        let nt = col.get_notetype_by_name("Basic")?.unwrap();
+        let mut note = nt.new_note();
+        col.add_note(&mut note, DeckId(1))?;
+        col.answer_easy();
+        col.set_config_bool(BoolKey::Fsrs, true, false)?;
+
+        let card_id = col.get_first_card().id;
+        // Target deck with a desired retention distinct from the default (0.9).
+        let target = DeckAdder::new("target")
+            .with_config(|c| c.inner.desired_retention = 0.95)
+            .add(&mut col);
+        col.set_deck(&[card_id], target.id)?;
+
+        let dr = col.storage.get_card(card_id)?.unwrap().desired_retention;
+        assert_eq!(dr, Some(0.95));
+        Ok(())
+    }
+
+    // With FSRS disabled, moving a card must not compute any memory state.
+    #[test]
+    fn set_deck_without_fsrs_does_not_compute() -> Result<()> {
+        let mut col = Collection::new();
+        let nt = col.get_notetype_by_name("Basic")?.unwrap();
+        let mut note = nt.new_note();
+        col.add_note(&mut note, DeckId(1))?;
+        col.answer_easy(); // review card, FSRS stays disabled
+
+        let card_id = col.get_first_card().id;
         let target = DeckAdder::new("target").add(&mut col);
         col.set_deck(&[card_id], target.id)?;
 
@@ -622,7 +750,29 @@ mod test {
             .get_card(card_id)?
             .unwrap()
             .memory_state
-            .is_some());
+            .is_none());
+        Ok(())
+    }
+
+    // New cards have no review history and must never be given a memory state.
+    #[test]
+    fn set_deck_leaves_new_cards_without_memory_state() -> Result<()> {
+        let mut col = Collection::new();
+        let nt = col.get_notetype_by_name("Basic")?.unwrap();
+        let mut note = nt.new_note();
+        col.add_note(&mut note, DeckId(1))?; // never answered -> still New
+        col.set_config_bool(BoolKey::Fsrs, true, false)?;
+
+        let card_id = col.get_first_card().id;
+        let target = DeckAdder::new("target").add(&mut col);
+        col.set_deck(&[card_id], target.id)?;
+
+        assert!(col
+            .storage
+            .get_card(card_id)?
+            .unwrap()
+            .memory_state
+            .is_none());
         Ok(())
     }
 }

--- a/rslib/src/card/mod.rs
+++ b/rslib/src/card/mod.rs
@@ -14,6 +14,7 @@ use serde_repr::Deserialize_repr;
 use serde_repr::Serialize_repr;
 
 use crate::collection::Collection;
+use crate::config::BoolKey;
 use crate::config::SchedulerVersion;
 use crate::deckconfig::DeckConfig;
 use crate::decks::DeckId;
@@ -24,6 +25,10 @@ use crate::error::Result;
 use crate::notes::NoteId;
 use crate::ops::StateChanges;
 use crate::prelude::*;
+use crate::scheduler::fsrs::memory_state::UpdateMemoryStateEntry;
+use crate::scheduler::fsrs::memory_state::UpdateMemoryStateRequest;
+use crate::scheduler::fsrs::params::ignore_revlogs_before_ms_from_config;
+use crate::storage::comma_separated_ids;
 use crate::timestamp::TimestampSecs;
 use crate::types::Usn;
 
@@ -373,19 +378,42 @@ impl Collection {
             source: FilteredDeckError::CanNotMoveCardsInto,
         })?;
         let config = self.get_deck_config(config_id, true)?.unwrap();
+        let fsrs_enabled = self.get_config_bool(BoolKey::Fsrs);
         let mut steps_adjuster = RemainingStepsAdjuster::new(&config);
         let usn = self.usn()?;
         self.transact(Op::SetCardDeck, |col| {
             let mut count = 0;
+            let mut card_ids_needing_fsrs_recompute = Vec::new();
             for mut card in col.all_cards_for_ids(cards, false)? {
                 if card.deck_id == deck_id {
                     continue;
                 }
                 count += 1;
+                if fsrs_enabled && card.ctype != CardType::New {
+                    card_ids_needing_fsrs_recompute.push(card.id);
+                }
                 let original = card.clone();
                 steps_adjuster.adjust_remaining_steps(col, &mut card)?;
                 card.set_deck(deck_id);
                 col.update_card_inner(&mut card, original, usn)?;
+            }
+            if !card_ids_needing_fsrs_recompute.is_empty() {
+                let desired_retention = deck.effective_desired_retention(&config);
+                let deck_desired_retention = [(deck_id, desired_retention)].into();
+                col.update_memory_state(vec![UpdateMemoryStateEntry {
+                    req: Some(UpdateMemoryStateRequest {
+                        params: config.fsrs_params().clone(),
+                        preset_desired_retention: config.inner.desired_retention,
+                        historical_retention: config.inner.historical_retention,
+                        max_interval: config.inner.maximum_review_interval,
+                        reschedule: false,
+                        deck_desired_retention,
+                    }),
+                    search: SearchNode::CardIds(comma_separated_ids(
+                        &card_ids_needing_fsrs_recompute,
+                    )),
+                    ignore_before: ignore_revlogs_before_ms_from_config(&config)?,
+                }])?;
             }
             Ok(count)
         })

--- a/rslib/src/card/mod.rs
+++ b/rslib/src/card/mod.rs
@@ -28,6 +28,7 @@ use crate::prelude::*;
 use crate::scheduler::fsrs::memory_state::UpdateMemoryStateEntry;
 use crate::scheduler::fsrs::memory_state::UpdateMemoryStateRequest;
 use crate::scheduler::fsrs::params::ignore_revlogs_before_ms_from_config;
+use crate::search::SearchNode;
 use crate::storage::comma_separated_ids;
 use crate::timestamp::TimestampSecs;
 use crate::types::Usn;

--- a/rslib/src/card/mod.rs
+++ b/rslib/src/card/mod.rs
@@ -393,7 +393,11 @@ impl Collection {
                 card.set_deck(deck_id);
                 col.update_card_inner(&mut card, original, usn)?;
             }
-            if fsrs_enabled {
+            // Only recompute when at least one card actually moved. Besides
+            // avoiding wasted work on a no-op, this prevents a set_deck call on
+            // cards already in the target deck from triggering a recompute of
+            // *other* memory-state-less cards in that deck.
+            if fsrs_enabled && count > 0 {
                 let desired_retention = deck.effective_desired_retention(&config);
                 let deck_desired_retention = [(deck_id, desired_retention)].into();
 

--- a/rslib/src/deckconfig/update.rs
+++ b/rslib/src/deckconfig/update.rs
@@ -25,6 +25,7 @@ use crate::scheduler::fsrs::params::ignore_revlogs_before_ms_from_config;
 use crate::scheduler::fsrs::params::ComputeParamsRequest;
 use crate::search::JoinSearches;
 use crate::search::Negated;
+use crate::search::Node;
 use crate::search::SearchNode;
 use crate::search::StateKind;
 use crate::storage::comma_separated_ids;
@@ -294,7 +295,9 @@ impl Collection {
                     });
                     Ok(UpdateMemoryStateEntry {
                         req: params,
-                        search: SearchNode::DeckIdsWithoutChildren(comma_separated_ids(&search)),
+                        search: Node::Search(SearchNode::DeckIdsWithoutChildren(
+                            comma_separated_ids(&search),
+                        )),
                         ignore_before: config
                             .map(ignore_revlogs_before_ms_from_config)
                             .unwrap_or(Ok(0.into()))?,

--- a/rslib/src/scheduler/fsrs/memory_state.rs
+++ b/rslib/src/scheduler/fsrs/memory_state.rs
@@ -24,6 +24,7 @@ use crate::scheduler::fsrs::params::Params;
 use crate::scheduler::states::fuzz::minimum_review_fuzz_interval;
 use crate::scheduler::states::fuzz::with_review_fuzz;
 use crate::search::Negated;
+use crate::search::Node;
 use crate::search::SearchNode;
 use crate::search::StateKind;
 
@@ -57,7 +58,7 @@ pub(crate) struct UpdateMemoryStateRequest {
 
 pub(crate) struct UpdateMemoryStateEntry {
     pub req: Option<UpdateMemoryStateRequest>,
-    pub search: SearchNode,
+    pub search: Node,
     pub ignore_before: TimestampMillis,
 }
 
@@ -91,8 +92,7 @@ impl Collection {
             ignore_before,
         } in entries
         {
-            let search =
-                SearchBuilder::all([search.into(), SearchNode::State(StateKind::New).negated()]);
+            let search = SearchBuilder::all([search, SearchNode::State(StateKind::New).negated()]);
             let revlog = self.revlog_for_srs(search)?;
 
             let Some(req) = &req else {
@@ -717,7 +717,7 @@ mod tests {
 
             let entry = UpdateMemoryStateEntry {
                 req: None,
-                search: SearchNode::WholeCollection,
+                search: Node::Search(SearchNode::WholeCollection),
                 ignore_before: TimestampMillis(0),
             };
             col.transact(Op::UpdateDeckConfig, |col| {

--- a/rslib/src/search/parser.rs
+++ b/rslib/src/search/parser.rs
@@ -86,6 +86,8 @@ pub enum SearchNode {
     /// Matches cards in a deck or its children (original_deck_id is not
     /// checked, so filtered cards are not matched).
     DeckIdWithChildren(DeckId),
+    /// checks if the card has an fsrs memory state
+    HasMemoryState,
     IntroducedInDays(u32),
     NotetypeId(NotetypeId),
     Notetype(String),

--- a/rslib/src/search/sqlwriter.rs
+++ b/rslib/src/search/sqlwriter.rs
@@ -196,6 +196,9 @@ impl SqlWriter<'_> {
             SearchNode::CustomData(key) => self.write_custom_data(key)?,
             SearchNode::WholeCollection => write!(self.sql, "true").unwrap(),
             SearchNode::Preset(name) => self.write_deck_preset(name)?,
+            SearchNode::HasMemoryState => {
+                write!(self.sql, "extract_fsrs_variable(c.data, 's') is not null").unwrap();
+            }
         };
         Ok(())
     }
@@ -1094,6 +1097,7 @@ impl SearchNode {
             SearchNode::Property { .. } => RequiredTable::Cards,
             SearchNode::CustomData { .. } => RequiredTable::Cards,
             SearchNode::Preset(_) => RequiredTable::Cards,
+            SearchNode::HasMemoryState => RequiredTable::Cards,
 
             SearchNode::UnqualifiedText(_) => RequiredTable::Notes,
             SearchNode::SingleField { .. } => RequiredTable::Notes,

--- a/rslib/src/search/writer.rs
+++ b/rslib/src/search/writer.rs
@@ -75,8 +75,6 @@ fn write_search_node(node: &SearchNode) -> String {
         CardTemplate(t) => write_template(t),
         Deck(s) => maybe_quote(&format!("deck:{s}")),
         DeckIdsWithoutChildren(s) => format!("did:{s}"),
-        // not exposed on the GUI end
-        DeckIdWithChildren(_) => "".to_string(),
         NotetypeId(NotetypeIdType(i)) => format!("mid:{i}"),
         Notetype(s) => maybe_quote(&format!("note:{s}")),
         Rated { days, ease } => write_rated(days, ease),
@@ -94,6 +92,10 @@ fn write_search_node(node: &SearchNode) -> String {
         WordBoundary(s) => maybe_quote(&format!("w:{s}")),
         CustomData(k) => maybe_quote(&format!("has-cd:{k}")),
         Preset(s) => maybe_quote(&format!("preset:{s}")),
+
+        // not exposed on the GUI end
+        DeckIdWithChildren(_) => "".to_string(),
+        HasMemoryState => "".to_string(),
     }
 }
 


### PR DESCRIPTION
## Linked issue (required)

Fixes https://github.com/ankitects/anki/issues/5327

## Summary / motivation (required)

Moving cards between decks used to clear the old FSRS data, without recomputing the new FSRS data. This led to some unwanted behavior like absence of memory states in card info, inaccurate searching and sorting in the browser, etc.

## Steps to reproduce (required, use N/A if not applicable)

1. Move some cards from one deck to another
2. The browser doesn't show any memory states.

## How to test (required)

<!--- How to test: how you verified the change (checks, unit tests, manual steps, edge cases — the "after" or general validation). --->

### Checklist (minimum)

- [ ] I ran `./ninja check` or an equivalent relevant check locally.
- [ ] I added or updated tests when the change is non-trivial or behavior changed.

### Details

<!-- Commands, manual steps, edge cases, and what you observed -->

## Before / after behavior (optional)

<!-- For bugfixes: behavior before vs after. For other types: N/A or a short note. -->

## Risk / compatibility / migration (optional)

<!-- Breaking changes, rollout notes, or N/A for small / low-risk PRs -->

## UI evidence (required for visual changes; otherwise N/A)

<!-- Screenshot or short video -->

## Scope

- [x] This PR is focused on one change (no unrelated edits).