### PR TITLE
Add missing dependencies to ninja's cog actions

### DIFF
--- a/build/configure/src/cog.rs
+++ b/build/configure/src/cog.rs
@@ -11,6 +11,11 @@ pub fn check_cog(build: &mut Build) -> Result<()> {
         build,
         "docs",
         inputs!["docs-site/addons/hooks-reference.mdx", glob!["docs/*.md"]],
-        inputs!["pylib/tools/genhooks.py", "tools/mintlify_hooks.py"],
+        inputs![
+            "pylib/tools/genhooks.py",
+            "tools/mintlify_hooks.py",
+            glob!["docs-site/**/*.mdx"],
+            glob!["docs/**/*"],
+        ],
     )
 }

--- a/build/configure/src/cog.rs
+++ b/build/configure/src/cog.rs
@@ -14,8 +14,8 @@ pub fn check_cog(build: &mut Build) -> Result<()> {
         inputs![
             "pylib/tools/genhooks.py",
             "tools/mintlify_hooks.py",
-            glob!["docs-site/**/*.mdx"],
-            glob!["docs/**/*"],
+            "docs/cogdocs.py",
+            glob!["docs-site/developers/*.mdx"],
         ],
     )
 }


### PR DESCRIPTION
The `check:format:cog` and `format:cog` Ninja actions did not rerun after changes to docs/, docs-site/. This fixes it.