### PR TITLE
template, cloze: fast-scan delimiter candidates in tokenizers

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -299,6 +299,7 @@ Han Lua <72375847+xiaohan484@users.noreply.github.com>
 Andreas U. Schmidhauser <github.com/schmidhauser>
 Peter Szilvasi <peti.szilvasi95@gmail.com>
 JaksonSouza <jaksonsouza.dev@gmail.com>
+pierspad <https://github.com/pierspad>
 ********************
 
 The text of the 3 clause BSD license follows:

--- a/rslib/src/cloze.rs
+++ b/rslib/src/cloze.rs
@@ -93,12 +93,15 @@ fn tokenize(mut text: &str) -> impl Iterator<Item = Token<'_>> {
         }
         let mut other_token = alt((open_cloze, close_cloze));
         // start with the no-match case
+        let mut search_from = 0;
         let mut index = text.len();
-        for (idx, _) in text.char_indices() {
+        while let Some(pos) = text[search_from..].find(['{', '}']) {
+            let idx = search_from + pos;
             if other_token.parse(&text[idx..]).is_ok() {
                 index = idx;
                 break;
             }
+            search_from = idx + 1;
         }
         Ok((&text[index..], Token::Text(&text[0..index])))
     }

--- a/rslib/src/template.rs
+++ b/rslib/src/template.rs
@@ -78,8 +78,12 @@ impl TemplateMode {
             return None;
         }
 
-        // Loop, starting from the first character
-        for (i, _) in input.char_indices() {
+        let mut search_from = 0;
+        while let Some(pos) = match self {
+            TemplateMode::Standard => input[search_from..].find(['{', '<']),
+            TemplateMode::LegacyAltSyntax => input[search_from..].find('<'),
+        } {
+            let i = search_from + pos;
             let remaining = &input[i..];
 
             // Valid handlebar clause?
@@ -101,6 +105,8 @@ impl TemplateMode {
                     (remaining, Token::Text(&input[..i]))
                 });
             }
+
+            search_from = i + 1;
         }
 
         // If no matches, return the entire input as text, with nothing remaining


### PR DESCRIPTION
## Linked issue (required)

Closes #5345

## Summary 

`TemplateMode::next_token` and `cloze::normal_text` previously iterated over every character with `char_indices()`, running parser combinators at each index. On templates and notes containing large HTML/CSS blocks, this resulted in thousands of failed parser attempts per card.

Since tokens always start with specific delimiters (`{`, `<`, or `}`), this patch uses `str::find` to jump directly to candidate locations instead of scanning character by character.

### Benchmarks (release build)

- **Template tokenizer**
  - Small (~150B): 0.78 µs -> 0.50 µs (1.5x)
  - Medium (~800B): 5.82 µs -> 2.45 µs (2.4x)
  - Large (~3.5KB): 21.36 µs -> 7.05 µs (3.0x)

- **Cloze tokenizer**
  - Text with HTML (~700B): 7.77 µs -> 3.63 µs (2.1x)

## Steps to reproduce (required, use N/A if not applicable)

N/A

## How to test (required)

### Checklist (minimum)

- [x] I ran `./ninja check` or an equivalent relevant check locally.
- [x] I added or updated tests when the change is non-trivial or behavior changed.

### Details

Ran unit tests covering template parsing, cloze tokenization, and card rendering:
```bash
cargo test --package anki --lib template:: cloze:: card_rendering::