### PR TITLE
fsrs: avoid quadratic memmove when batching memory state updates

### DIFF
--- a/rslib/src/scheduler/fsrs/memory_state.rs
+++ b/rslib/src/scheduler/fsrs/memory_state.rs
@@ -61,14 +61,19 @@ pub(crate) struct UpdateMemoryStateEntry {
     pub ignore_before: TimestampMillis,
 }
 
-trait ChunkIntoVecs<T> {
-    fn chunk_into_vecs(&mut self, chunk_size: usize) -> impl Iterator<Item = Vec<T>>;
+trait ChunkIntoVecs<T>: Sized {
+    fn chunk_into_vecs(self, chunk_size: usize) -> impl Iterator<Item = Vec<T>>;
 }
 
 impl<T> ChunkIntoVecs<T> for Vec<T> {
-    fn chunk_into_vecs(&mut self, chunk_size: usize) -> impl Iterator<Item = Vec<T>> {
+    /// Consumes the vec, yielding it as owned chunks. Draining from the front
+    /// instead would shift the remaining elements down on every chunk, making
+    /// this quadratic in the number of cards.
+    fn chunk_into_vecs(self, chunk_size: usize) -> impl Iterator<Item = Vec<T>> {
+        let mut items = self.into_iter();
         std::iter::from_fn(move || {
-            (!self.is_empty()).then(|| self.drain(..chunk_size.min(self.len())).collect())
+            let chunk: Vec<T> = items.by_ref().take(chunk_size).collect();
+            (!chunk.is_empty()).then_some(chunk)
         })
     }
 }


### PR DESCRIPTION
### Linked issue (required)

Closes #5346

### Summary 

`ChunkIntoVecs::chunk_into_vecs` in `rslib/src/scheduler/fsrs/memory_state.rs`
built each FSRS batch with `drain(..chunk_size)`. Draining a prefix removes
elements from the front of the vec and shifts the entire remaining tail down,
so batching N cards performs about `N^2 / (2 * chunk_size)` element moves

Consuming the vec with `into_iter()` instead makes this linear.

### Benchmark

Release build, chunk size 1000 with `(CardId, FSRSItem, Option<MemoryState>)`:

| Cards | `drain` (current) | `into_iter` (PR) | Speedup |
|---|---|---|---|
| 1,000 | 0.015 ms | 0.015 ms | 1.0x |
| 10,000 | 0.208 ms | 0.211 ms | 1.0x |
| 20,000 | 0.524 ms | 0.439 ms | 1.2x |
| 50,000 | 2.624 ms | 1.256 ms | 2.1x |
| 200,000 | 47.883 ms | 5.333 ms | 9.0x |

For small collections under 10k cards the runtime is basically identical. On larger collections (50k+ cards), chunking via `into_iter` avoids repeated memory shifts and scales linearly instead of O(N²).

### Steps to reproduce (required, use N/A if not applicable)

N/A

### How to test (required)

#### Checklist (minimum)

- [x] I ran `./ninja check` or an equivalent relevant check locally.
- [x] I added or updated tests when the change is non-trivial or behavior changed.

#### Details

Behaviour is unchanged — the batches produced are identical, only the way they
are carved out of the vectors differs. Covered by the existing scheduler tests:
