### PR TITLE
fix: Ensure editor is initialized before triggering browser hooks

### DIFF
--- a/qt/aqt/browser/browser.py
+++ b/qt/aqt/browser/browser.py
@@ -152,8 +152,8 @@ class Browser(QMainWindow):
         self.setupSidebar()
         self.setup_table()
         self.setupMenus()
-        self.setupHooks()
         self.setupEditor()
+        self.setupHooks()
         gui_hooks.browser_will_show(self)
 
         # restoreXXX() should be called after all child widgets have been created


### PR DESCRIPTION
## Linked issue

https://community.ankihub.net/t/error/607154

## Summary

The browser adds its hooks (setupHooks) before the editor is initialized (setupEditor). The operation_did_execute hook's handler assumes the editor is already initialized and tries to access it, triggering an AttributeError in rare cases.
Moving the setupHooks() call down one line should guard against this (assuming it's not the case of some add-on patching `Browser.editor`).

## Steps to reproduce

No reliable way to reproduce it, but I managed to trigger it once by installing the following add-ons and clicking the AnkiHub sync button (or just calling `aqt.mw.reset()`):

```
1322529746 1102281552 1374772155 1556734708 1709973686 1730200873 1746010116 1771074083 1788670778 1810938259 2040501954 24411424 300884351 374005964 46611790 594329229 613684242 738807903
```
