### PR TITLE
docs: development.md links fix

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -299,6 +299,7 @@ Han Lua <72375847+xiaohan484@users.noreply.github.com>
 Andreas U. Schmidhauser <github.com/schmidhauser>
 Peter Szilvasi <peti.szilvasi95@gmail.com>
 JaksonSouza <jaksonsouza.dev@gmail.com>
+Denis <d.ibragimov05@gmail.com>
 ********************
 
 The text of the 3 clause BSD license follows:

--- a/docs/development.md
+++ b/docs/development.md
@@ -56,9 +56,9 @@ On all platforms, you will need to install:
 
 Platform-specific requirements:
 
-- [Windows](https://anki.mintlify.app/windows)
-- [Mac](https://anki.mintlify.app/mac)
-- [Linux](https://anki.mintlify.app/linux)
+- [Windows](https://anki.mintlify.app/manual/platform/windows/installing#requirements)
+- [Mac](https://anki.mintlify.app/manual/platform/mac/installing#requirements)
+- [Linux](https://anki.mintlify.app/manual/platform/linux/installing#requirements)
 
 ## Running Anki during development
 
@@ -185,11 +185,11 @@ may delete the `target/` folder (if any) as that's no longer used.
 
 ## IDEs
 
-Please see [this separate page](https://anki.mintlify.app/editing) for setting up an editor/IDE.
+Please see [this separate page](https://anki.mintlify.app/developers/editing#editing-ides) for setting up an editor/IDE.
 
 ## Making changes to the build
 
-See [this page](https://anki.mintlify.app/build)
+See [this page](https://anki.mintlify.app/developers/build)
 
 ## Generating documentation
 


### PR DESCRIPTION
<!--
Title (for the Pull Request title field at the top):
Use a short prefix so the change type is obvious. You do not need to repeat it in the body below.

Examples:
- fix: — bugfix
- feat: — feature
- refactor: — internal change without user-facing feature
- docs: — documentation only
- chore: — tooling, CI, deps, build housekeeping
- test: — tests only
-->

## Linked issue (required)

<!-- Fixes #123 / Closes #123 / Refs #123 -->

Closes #5335 

## Summary / motivation (required)

<!-- What this PR does and why. For larger changes, add enough context for reviewers. -->

I'm an Anki user and wanted to contribute back to the project while also gaining my first open-source contribution experience. 

This PR fixes broken links in `docs/development.md` that were still pointing to the old documentation structure (anki.mintlify.app). Updated them to follow the new structure by adding `/developers/` to the URLs.

## Steps to reproduce (required, use N/A if not applicable)

<!-- Steps to reproduce: how to trigger the bug in the broken state (the "before").
 - Mainly for bugfixes;
    - For bugs: numbered steps before the fix. For non-bugs: write N/A.
 - use N/A for features, refactors, docs, chore, etc.
-->

1. Open `docs/development.md`
2. Click on any broken link pointing to anki.mintlify.app
3. Observe 404 error

## How to test (required)

<!--- How to test: how you verified the change (checks, unit tests, manual steps, edge cases — the "after" or general validation). --->

. Opened `docs/development.md` locally
2. Verified all updated links now point to the correct `/developers/` paths
3. Confirmed all links resolve properly without 404 errors

### Checklist (minimum)

- [ ] I ran `./ninja check` or an equivalent relevant check locally.
- [ ] I added or updated tests when the change is non-trivial or behavior changed.

### Details

<!-- Commands, manual steps, edge cases, and what you observed -->

Documentation-only change. All broken links in `docs/development.md` have been updated to the new structure by adding `/developers/` to the URL paths.

## Before / after behavior (optional)

<!-- For bugfixes: behavior before vs after. For other types: N/A or a short note. -->

Before: Links in `docs/development.md` returned 404 errors due to outdated doc-site structure
After: All links correctly point to the new `/developers/` paths and work as expected

## Risk / compatibility / migration (optional)

<!-- Breaking changes, rollout notes, or N/A for small / low-risk PRs -->

N/A - documentation only, no code changes

## UI evidence (required for visual changes; otherwise N/A)

<!-- Screenshot or short video -->

N/A - no visual UI changes

## Scope

- [x] This PR is focused on one change (no unrelated edits).
