### PR TITLE
fix: replace asserts inside except clauses with explicit error handling

### DIFF
--- a/qt/aqt/addons.py
+++ b/qt/aqt/addons.py
@@ -1118,7 +1118,10 @@ def download_addon(client: HttpClient, id: int) -> DownloadOk | DownloadError:
         match = re.match(
             "attachment; filename=(.+)", resp.headers["content-disposition"]
         )
-        assert match is not None
+        if match is None:
+            raise ValueError(
+                f"Unexpected content-disposition header: {resp.headers.get('content-disposition')}"
+            )
         fname = match.group(1)
 
         meta = extract_meta_from_download_url(resp.url)

--- a/qt/aqt/editor_legacy.py
+++ b/qt/aqt/editor_legacy.py
@@ -1142,7 +1142,9 @@ require("anki/ui").loaded.then(() => require("anki/NoteEditor").instances[0].too
                     image_path=image_path, notetype_id=0
                 )
             else:
-                assert self.note is not None
+                if self.note is None:
+                    showWarning(tr.browsing_no_selection())
+                    return
                 self.setup_mask_editor_for_existing_note(
                     note_id=self.note.id, image_path=image_path
                 )

--- a/qt/tests/test_addons.py
+++ b/qt/tests/test_addons.py
@@ -8,7 +8,7 @@ from zipfile import ZipFile
 import pytest
 from mock import MagicMock
 
-from aqt.addons import AddonManager, package_name_valid
+from aqt.addons import AddonManager, DownloadError, download_addon, package_name_valid
 
 
 def test_readMinimalManifest():
@@ -97,3 +97,18 @@ def test_install_extracts_safe_files(tmp_path, addon_manager):
     assert os.path.exists(os.path.join(addon_dir, "main.py"))
     assert os.path.exists(os.path.join(addon_dir, "subdir", "helper.py"))
     assert not os.path.exists(os.path.join(tmp_path, "unsafe.txt"))
+
+
+def test_download_addon_rejects_bad_content_disposition():
+    client = MagicMock()
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.headers = {"content-disposition": "inline; not-a-filename"}
+    client.get.return_value = resp
+    client.stream_content.return_value = b"data"
+
+    result = download_addon(client, 123)
+
+    assert isinstance(result, DownloadError)
+    assert isinstance(result.exception, ValueError)
+    assert "content-disposition" in str(result.exception)


### PR DESCRIPTION
## Linked issue 

Fixes #5355

## Summary / motivation

Two locations used `assert` statements inside broad `except` blocks, flagged by SonarCloud rule [python:S5779](https://sonarcloud.io/project/issues?rules=python%3AS5779&issueStatuses=OPEN%2CCONFIRMED&id=ankitects_anki). This is problematic because:

- `AssertionError` is caught by the surrounding `except`, so the assertion is silently swallowed instead of surfacing a meaningful error.
- Under `python -O`, `assert` statements are stripped entirely, so the check disappears in optimized builds and the failure resurfaces later as an opaque `AttributeError`.

Changes:

- **`qt/aqt/addons.py`** (`download_addon`): replace `assert match is not None` with `if match is None: raise ValueError(...)` naming the unexpected `content-disposition` header. The raise is still caught by the existing handler and returned as a `DownloadError`, now with a descriptive message.
- **`qt/aqt/editor_legacy.py`** (`setup_mask_editor`): replace `assert self.note is not None` with a guard that warns the user (`tr.browsing_no_selection()`) and returns early.

## How to test (required)

### Details

- `just lint` ✅
- `just test-py` ✅ — includes a new regression test, `test_download_addon_rejects_bad_content_disposition`, covering the malformed `content-disposition` path in `download_addon`.
- No test added for the `editor_legacy.py` guard: it defends an effectively unreachable state (a missing note while editing an existing note), and that Qt-side method isn't reachable from the web e2e harness.

## Before / after behavior

- **addons.py** — Before: malformed header → empty/opaque `DownloadError` (or `AttributeError` under `-O`). After: `DownloadError` carrying a `ValueError` that names the offending header.
- **editor_legacy.py** — Before: missing note → empty warning dialog (blank `AssertionError` message). After: a clear warning, and early return.

## Scope

- [x] This PR is focused on one change (no unrelated edits).