### PR TITLE
fix: avoid KeyError on missing Content-type header in mediasrv

### DIFF
--- a/qt/aqt/mediasrv.py
+++ b/qt/aqt/mediasrv.py
@@ -1271,7 +1271,7 @@ def _check_dynamic_request_permissions():
         )
 
     # check content type header to ensure this isn't an opaque request from another origin
-    if request.headers["Content-type"] != "application/binary":
+    if request.headers.get("Content-type") != "application/binary":
         aqt.mw.taskman.run_on_main(warn)
         abort(403)
 

--- a/qt/tests/test_mediasrv.py
+++ b/qt/tests/test_mediasrv.py
@@ -201,6 +201,24 @@ class TestMediaFileCSP:
             assert _get_csp(resp) is None
 
 
+class TestCheckDynamicRequestPermissions:
+    """A missing Content-type header must abort(403), not raise KeyError."""
+
+    def test_missing_content_type_header_aborts_403(self, monkeypatch) -> None:
+        from unittest import mock
+
+        from werkzeug.exceptions import Forbidden
+
+        import aqt
+        from aqt.mediasrv import _check_dynamic_request_permissions, app
+
+        monkeypatch.setattr(aqt, "mw", mock.Mock(), raising=False)
+
+        with app.test_request_context(method="POST"):
+            with pytest.raises(Forbidden):
+                _check_dynamic_request_permissions()
+
+
 class TestEditorPageCSP:
     def test_editor_csp_does_not_block_user_embeds(self) -> None:
         csp = _legacy_editor_content_security_policy(port=12345)


### PR DESCRIPTION
## Linked issue

Fixes #5353

## Summary / motivation

`_check_dynamic_request_permissions` in `qt/aqt/mediasrv.py` read the `Content-type` header via direct indexing:

```python
if request.headers["Content-type"] != "application/binary":
```

When a request omits that header, `Headers.__getitem__` raises a `KeyError`, which surfaces as an unhandled `500 Internal Server Error` instead of the intended `abort(403)`. Flagged by SonarCloud rule [python:S8371](https://sonarcloud.io/project/issues?rules=python%3AS8371&issueStatuses=OPEN%2CCONFIRMED&id=ankitects_anki) (unsafe direct header access).

The fix uses `.get()`, which returns None for a missing header. Since `None != "application/binary"`, a request without the header now correctly falls through to the `403` rejection path — the desired behavior for an opaque cross-origin request.

## Steps to reproduce 
1. Send a non-GET request to a dynamic /_anki/ endpoint (e.g. a POST) without a Content-type header.
2. Server hits request.headers["Content-type"] and raises KeyError.
3. Client receives 500 Internal Server Error instead of 403 Forbidden.

## How to test 
### Details
- Ran `just fmt`, `just lint`, and `just test-py` — all pass.
- Added `TestCheckDynamicRequestPermissions` in qt/tests/test_mediasrv.py, asserting a POST without a `Content-type` header raises `Forbidden` (403) rather than `KeyError`.

## Before / after behavior 

**Before**: request with no `Content-type` header → unhandled `KeyError` → `500`.

**After**: same request → `abort(403)` as intended.
