### PR TITLE
chore: set `strict_optional = True` for editor_legacy.py

### DIFF
--- a/.mypy.ini
+++ b/.mypy.ini
@@ -45,6 +45,8 @@ strict_optional = True
 strict_optional = True
 [mypy-aqt.editor]
 strict_optional = True
+[mypy-aqt.editor_legacy]
+strict_optional = True
 [mypy-aqt.preferences]
 strict_optional = True
 [mypy-aqt.overview]


### PR DESCRIPTION
This fixes a small type checking regression introduced by #4029 that I noticed while checking #5365