### PR TITLE
CI: Remove RELEASE_TOKEN GHA secret

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -697,7 +697,7 @@ jobs:
             ${notes_start_tag:+--notes-start-tag "$notes_start_tag"} \
             ${prerelease_flag:+"$prerelease_flag"}
         env:
-          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
           TAG_NAME: ${{ needs.prepare.outputs.tag_name }}
           RELEASE_NAME: ${{ needs.prepare.outputs.release_name }}
           IS_PRERELEASE: ${{ needs.prepare.outputs.is_prerelease }}


### PR DESCRIPTION
## Linked issue

A follow-up to #5273

## Summary / motivation

#5273 replaced the prepare-release.yml workflow with a script that can be run locally, which removed the need for the RELEASE_TOKEN personal access token. This removes the last usage of the token for creating the draft release, which was not necessary in any case as the default `github.token` has the necessary permissions to create releases.

## Before / after behavior

- The release author will now be `github-actions[bot]` instead of @andrewsanchez 
- Some release events won't fire, but we don't rely on any at the moment: https://github.com/orgs/community/discussions/16244
