### PR TITLE
feat: replace use of activeWindow by manually tracking via focus

### DIFF
--- a/qt/aqt/__init__.py
+++ b/qt/aqt/__init__.py
@@ -9,6 +9,7 @@ import logging
 import os
 import sys
 from collections.abc import Callable
+from inspect import isclass
 from typing import TYPE_CHECKING, Any, Union, cast
 
 try:
@@ -129,6 +130,8 @@ class DialogManager:
         "Preferences": [preferences.Preferences, None],
         "sync_log": [mediasync.MediaSyncDialog, None],
     }
+    _classes = set(filter(isclass, (v[0] for _, v in _dialogs.items())))
+    _activeWindow = None
 
     def open(self, name: str, *args: Any, **kwargs: Any) -> Any:
         (creator, instance) = self._dialogs[name]
@@ -146,6 +149,21 @@ class DialogManager:
             self._dialogs[name][1] = instance
         gui_hooks.dialog_manager_did_open_dialog(self, name, instance)
         return instance
+
+    def _on_focus_did_change(self, new: QWidget | None):
+        if (
+            new
+            and (window := new.window())
+            and any(isinstance(window, klass) for klass in self._classes)
+        ):
+            self._activeWindow = window
+
+    def activeWindow(self) -> QWidget:
+        if not self._activeWindow or sip.isdeleted(self._activeWindow):
+            self._activeWindow = None
+            return aqt.mw.app.activeWindow() or aqt.mw
+        else:
+            return self._activeWindow
 
     def markClosed(self, name: str) -> None:
         self._dialogs[name] = [self._dialogs[name][0], None]

--- a/qt/aqt/__init__.py
+++ b/qt/aqt/__init__.py
@@ -165,6 +165,12 @@ class DialogManager:
         else:
             return self._activeWindow
 
+    def getInstance(self, name: str):
+        if not (res := self._dialogs.get(name)):
+            return
+        (_, instance) = res
+        return instance
+
     def markClosed(self, name: str) -> None:
         self._dialogs[name] = [self._dialogs[name][0], None]
 

--- a/qt/aqt/addcards.py
+++ b/qt/aqt/addcards.py
@@ -41,6 +41,7 @@ class NewAddCards(QMainWindow):
         if not is_mac:
             self.setMenuBar(None)
         self.show()
+        self.setFocus()
 
     def set_note(self, note: Note, deck_id: DeckId | None = None) -> None:
         """Set tags, field contents and notetype according to `note`. Deck is set

--- a/qt/aqt/main.py
+++ b/qt/aqt/main.py
@@ -274,6 +274,7 @@ class AnkiQt(QMainWindow):
         qconnect(self.app.focusChanged, self.on_focus_changed)
 
     def on_focus_changed(self, old: QWidget, new: QWidget) -> None:
+        aqt.dialogs._on_focus_did_change(new)
         gui_hooks.focus_did_change(new, old)
 
     # Profiles

--- a/qt/aqt/mediasrv.py
+++ b/qt/aqt/mediasrv.py
@@ -40,6 +40,7 @@ from anki.collection import (
 from anki.decks import UpdateDeckConfigs, UpdateDeckConfigsMode
 from anki.scheduler.v3 import SchedulingStatesWithContext, SetSchedulingStatesRequest
 from anki.utils import dev_mode, from_json_bytes, to_json_bytes
+from aqt import gui_hooks
 from aqt.changenotetype import ChangeNotetypeDialog
 from aqt.deckoptions import DeckOptionsDialog
 from aqt.operations import on_op_finished
@@ -833,8 +834,20 @@ class AsyncRequestHandler(Generic[AsyncRequestReturnType]):
         return await self.future
 
 
+_activeWindow = None
+
+
+def _on_focus_did_change(new: QWidget | None, _old: QWidget | None):
+    global _activeWindow
+    if new:
+        _activeWindow = new.window()
+
+
+gui_hooks.focus_did_change.append(_on_focus_did_change)
+
+
 def active_window_or_main() -> QWidget:
-    return aqt.mw.app.activeWindow() or aqt.mw
+    return _activeWindow or aqt.mw.app.activeWindow() or aqt.mw
 
 
 async def open_file_picker() -> bytes:

--- a/qt/aqt/mediasrv.py
+++ b/qt/aqt/mediasrv.py
@@ -911,7 +911,7 @@ def play_file() -> bytes:
     path = os.path.join(aqt.mw.col.media.dir(), req.val)
 
     def handle_on_main() -> None:
-        window = active_window_or_main()
+        window = aqt.dialogs.activeWindow()
         if (
             window is not None
             and hasattr(window, "editor")
@@ -1050,7 +1050,7 @@ def open_fields_dialog() -> bytes:
     def handle_on_main() -> None:
         from aqt.editor import NewEditor
 
-        window = active_window_or_main()
+        window = aqt.dialogs.activeWindow()
         assert window is not None
         if hasattr(window, "editor") and isinstance(window.editor, NewEditor):
             window.editor.onFields()
@@ -1063,7 +1063,7 @@ def open_cards_dialog() -> bytes:
     def handle_on_main() -> None:
         from aqt.editor import NewEditor
 
-        window = active_window_or_main()
+        window = aqt.dialogs.activeWindow()
         assert window is not None
         if hasattr(window, "editor") and isinstance(window.editor, NewEditor):
             window.editor.onCardLayout()

--- a/qt/aqt/mediasrv.py
+++ b/qt/aqt/mediasrv.py
@@ -924,7 +924,7 @@ def play_file() -> bytes:
     path = os.path.join(aqt.mw.col.media.dir(), req.val)
 
     def handle_on_main() -> None:
-        window = aqt.mw.app.activeWindow()
+        window = active_window_or_main()
         if (
             window is not None
             and hasattr(window, "editor")
@@ -972,7 +972,7 @@ def close_add_cards() -> bytes:
     def handle_on_main() -> None:
         from aqt.addcards import NewAddCards
 
-        window = aqt.mw.app.activeWindow()
+        window = active_window_or_main()
         if isinstance(window, NewAddCards):
             window._close_if_user_wants_to_discard_changes(req.val)
 
@@ -984,7 +984,7 @@ def close_edit_current() -> bytes:
     def handle_on_main() -> None:
         from aqt.editcurrent import NewEditCurrent
 
-        window = aqt.mw.app.activeWindow()
+        window = active_window_or_main()
         if isinstance(window, NewEditCurrent):
             window.close()
 
@@ -1065,7 +1065,7 @@ def open_fields_dialog() -> bytes:
     def handle_on_main() -> None:
         from aqt.editor import NewEditor
 
-        window = aqt.mw.app.activeWindow()
+        window = active_window_or_main()
         assert window is not None
         if hasattr(window, "editor") and isinstance(window.editor, NewEditor):
             window.editor.onFields()
@@ -1078,7 +1078,7 @@ def open_cards_dialog() -> bytes:
     def handle_on_main() -> None:
         from aqt.editor import NewEditor
 
-        window = aqt.mw.app.activeWindow()
+        window = active_window_or_main()
         assert window is not None
         if hasattr(window, "editor") and isinstance(window.editor, NewEditor):
             window.editor.onCardLayout()
@@ -1226,7 +1226,7 @@ def raw_backend_request(endpoint: str) -> Callable[[], bytes]:
                 raise ValueError(f"unhandled op changes level: {op_changes_type}")
 
             def handle_on_main() -> None:
-                handler = aqt.mw.app.activeWindow()
+                handler = active_window_or_main()
                 on_op_finished(aqt.mw, changes, handler)
 
             aqt.mw.taskman.run_on_main(handle_on_main)

--- a/qt/aqt/mediasrv.py
+++ b/qt/aqt/mediasrv.py
@@ -850,7 +850,7 @@ def active_window_or_main() -> QWidget:
     global _activeWindow
     if not _activeWindow or sip.isdeleted(_activeWindow):
         _activeWindow = None
-        return aqt.mw.app.activeWindow() or mw
+        return aqt.mw.app.activeWindow() or aqt.mw
     else:
         return _activeWindow
 

--- a/qt/aqt/mediasrv.py
+++ b/qt/aqt/mediasrv.py
@@ -847,7 +847,12 @@ gui_hooks.focus_did_change.append(_on_focus_did_change)
 
 
 def active_window_or_main() -> QWidget:
-    return _activeWindow or aqt.mw.app.activeWindow() or aqt.mw
+    global _activeWindow
+    if not _activeWindow or sip.isdeleted(_activeWindow):
+        _activeWindow = None
+        return aqt.mw.app.activeWindow() or mw
+    else:
+        return _activeWindow
 
 
 async def open_file_picker() -> bytes:

--- a/qt/aqt/mediasrv.py
+++ b/qt/aqt/mediasrv.py
@@ -40,7 +40,6 @@ from anki.collection import (
 from anki.decks import UpdateDeckConfigs, UpdateDeckConfigsMode
 from anki.scheduler.v3 import SchedulingStatesWithContext, SetSchedulingStatesRequest
 from anki.utils import dev_mode, from_json_bytes, to_json_bytes
-from aqt import gui_hooks
 from aqt.changenotetype import ChangeNotetypeDialog
 from aqt.deckoptions import DeckOptionsDialog
 from aqt.operations import on_op_finished
@@ -834,25 +833,8 @@ class AsyncRequestHandler(Generic[AsyncRequestReturnType]):
         return await self.future
 
 
-_activeWindow = None
-
-
-def _on_focus_did_change(new: QWidget | None, _old: QWidget | None):
-    global _activeWindow
-    if new:
-        _activeWindow = new.window()
-
-
-gui_hooks.focus_did_change.append(_on_focus_did_change)
-
-
 def active_window_or_main() -> QWidget:
-    global _activeWindow
-    if not _activeWindow or sip.isdeleted(_activeWindow):
-        _activeWindow = None
-        return aqt.mw.app.activeWindow() or aqt.mw
-    else:
-        return _activeWindow
+    return aqt.mw.app.activeWindow() or aqt.mw
 
 
 async def open_file_picker() -> bytes:

--- a/qt/aqt/mediasrv.py
+++ b/qt/aqt/mediasrv.py
@@ -959,8 +959,7 @@ def close_add_cards() -> bytes:
     def handle_on_main() -> None:
         from aqt.addcards import NewAddCards
 
-        window = active_window_or_main()
-        if isinstance(window, NewAddCards):
+        if window := aqt.dialogs.getInstance(NewAddCards.__name__):
             window._close_if_user_wants_to_discard_changes(req.val)
 
     aqt.mw.taskman.run_on_main(lambda: QTimer.singleShot(0, handle_on_main))
@@ -971,8 +970,7 @@ def close_edit_current() -> bytes:
     def handle_on_main() -> None:
         from aqt.editcurrent import NewEditCurrent
 
-        window = active_window_or_main()
-        if isinstance(window, NewEditCurrent):
+        if window := aqt.dialogs.getInstance(NewEditCurrent.__name__):
             window.close()
 
     aqt.mw.taskman.run_on_main(lambda: QTimer.singleShot(0, handle_on_main))


### PR DESCRIPTION
## Linked issue (required)

Ref: #5201

## Summary / motivation (required)

This essentially duplicates qt's active window tracking, but the difference is that we don't unset it unless it's actually destroyed

## Steps to reproduce (required, use N/A if not applicable)

See linked issue

## How to test (required)

Try opening the file picker on the new add/edit windows and closing those windows

### Checklist (minimum)

- [x] I ran `./ninja check` or an equivalent relevant check locally.
- [ ] I added or updated tests when the change is non-trivial or behavior changed.

## Scope

- [x] This PR is focused on one change (no unrelated edits).
