### PR TITLE
fix: Preserve scroll position after collapsing/expanding decks

### DIFF
--- a/qt/aqt/deckbrowser.py
+++ b/qt/aqt/deckbrowser.py
@@ -354,7 +354,7 @@ class DeckBrowser:
                 deck_id=did,
                 collapsed=node.collapsed,
                 scope=DeckCollapseScope.REVIEWER,
-            ).run_in_background()
+            ).run_in_background(initiator=self)
             self._renderPage(reuse=True)
 
     def _handle_drag_and_drop(self, source: DeckId, target: DeckId) -> None:


### PR DESCRIPTION
## Linked issue

Closes #5377

## Summary

The deck browser was unnecessarily refreshing the page after the set_deck_collapsed() operation is called. The fix is to call the operation with `run_in_background(initiator=self)` so that the refresh is skipped in `op_executed()`.

## Steps to reproduce (before)

Follow reproduction steps in the forums: https://forums.ankiweb.net/t/deck-list-jumps-to-top-every-time-i-collapse-expand-a-deck/70715/3?u=abdo

## How to test (after)

Confirm scroll position is preserved after collapsing/expanding decks
