### PR TITLE
feat(search): add prop:forgotten-rate property key

### DIFF
--- a/docs-site/manual/searching.mdx
+++ b/docs-site/manual/searching.mdx
@@ -331,6 +331,12 @@ cards that have been answered less than 10 times.
 `prop:lapses>3`\
 cards that have lapsed more than 3 times.
 
+`prop:forgotten-rate>0.3`\
+cards whose forgotten rate (lapses divided by reps) is greater than 0.3,
+i.e. more than 30% of their reviews ended in a lapse. Cards that have never
+been reviewed (reps = 0) are ignored, as their rate is undefined. `prop:fr`
+is an alias for `prop:forgotten-rate`.
+
 `prop:ease!=2.5`\
 cards easier or harder than default ease.
 

--- a/pylib/tests/test_find.py
+++ b/pylib/tests/test_find.py
@@ -190,6 +190,20 @@ def test_find_cards():
     assert len(col.find_cards("prop:ease=2.2")) == 1
     assert len(col.find_cards("prop:ease>2")) == 1
     assert len(col.find_cards("-prop:ease>2")) > 1
+    # forgotten rate (lapses / reps); only valid when reps > 0
+    forgottenId = col.db.scalar("select id from cards where reps = 0 limit 1")
+    col.db.execute(
+        "update cards set queue=2, reps=10, lapses=4 where id = ?", forgottenId
+    )
+    # a card with 4 lapses in 10 reviews has a rate of 0.4
+    assert len(col.find_cards("prop:forgotten-rate=0.4")) == 1
+    assert len(col.find_cards("prop:fr=0.4")) == 1
+    assert len(col.find_cards("prop:forgotten-rate>0.4")) == 0
+    # the earlier review card (20 reps, no lapses) has a rate of 0
+    assert len(col.find_cards("prop:forgotten-rate=0")) == 1
+    # never-reviewed cards (reps = 0) are excluded, so only the two reviewed
+    # cards match, not the whole collection
+    assert len(col.find_cards("prop:forgotten-rate>=0")) == 2
     # recently failed
     if not isNearCutoff():
         # rated

--- a/rslib/src/search/parser.rs
+++ b/rslib/src/search/parser.rs
@@ -126,14 +126,22 @@ pub enum PropertyKind {
     Interval(u32),
     Reps(u32),
     Lapses(u32),
+    /// Forgotten rate (lapses / reps), only meaningful when reps > 0
+    ForgottenRate(f32),
     Ease(f32),
     Position(u32),
     Rated(i32, RatingKind),
     Stability(f32),
     Difficulty(f32),
     Retrievability(f32),
-    CustomDataNumber { key: String, value: f32 },
-    CustomDataString { key: String, value: String },
+    CustomDataNumber {
+        key: String,
+        value: f32,
+    },
+    CustomDataString {
+        key: String,
+        value: String,
+    },
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]
@@ -445,6 +453,8 @@ fn parse_resched(s: &str) -> ParseResult<'_, SearchNode> {
 /// eg prop:ivl>3, prop:ease!=2.5
 fn parse_prop(prop_clause: &str) -> ParseResult<'_, SearchNode> {
     let (tail, prop) = alt((
+        tag("forgotten-rate"),
+        tag("fr"),
         tag("ivl"),
         tag("due"),
         tag("reps"),
@@ -498,6 +508,7 @@ fn parse_prop(prop_clause: &str) -> ParseResult<'_, SearchNode> {
         "ivl" => PropertyKind::Interval(parse_u32(num, prop_clause)?),
         "reps" => PropertyKind::Reps(parse_u32(num, prop_clause)?),
         "lapses" => PropertyKind::Lapses(parse_u32(num, prop_clause)?),
+        "forgotten-rate" | "fr" => PropertyKind::ForgottenRate(parse_f32(num, prop_clause)?),
         "pos" => PropertyKind::Position(parse_u32(num, prop_clause)?),
         "s" => PropertyKind::Stability(parse_f32(num, prop_clause)?),
         "d" => PropertyKind::Difficulty(parse_f32(num, prop_clause)?),
@@ -1007,6 +1018,21 @@ mod test {
             vec![Search(Property {
                 operator: "<=".into(),
                 kind: PropertyKind::Ease(3.3)
+            })]
+        );
+        assert_eq!(
+            parse("prop:forgotten-rate>0.3")?,
+            vec![Search(Property {
+                operator: ">".into(),
+                kind: PropertyKind::ForgottenRate(0.3)
+            })]
+        );
+        // fr is an alias for forgotten-rate
+        assert_eq!(
+            parse("prop:fr>0.3")?,
+            vec![Search(Property {
+                operator: ">".into(),
+                kind: PropertyKind::ForgottenRate(0.3)
             })]
         );
         assert_eq!(

--- a/rslib/src/search/sqlwriter.rs
+++ b/rslib/src/search/sqlwriter.rs
@@ -407,6 +407,12 @@ impl SqlWriter<'_> {
             PropertyKind::Interval(ivl) => write!(self.sql, "ivl {op} {ivl}").unwrap(),
             PropertyKind::Reps(reps) => write!(self.sql, "reps {op} {reps}").unwrap(),
             PropertyKind::Lapses(days) => write!(self.sql, "lapses {op} {days}").unwrap(),
+            // forgotten rate = lapses / reps; only valid for cards that have
+            // been reviewed at least once (reps > 0). The 1.0 * forces a
+            // floating point division instead of SQLite's integer division.
+            PropertyKind::ForgottenRate(rate) => {
+                write!(self.sql, "(reps > 0 and (1.0 * lapses / reps) {op} {rate})").unwrap()
+            }
             PropertyKind::Ease(ease) => {
                 write!(self.sql, "factor {} {}", op, (ease * 1000.0) as u32).unwrap()
             }
@@ -1351,6 +1357,19 @@ mod test {
 
         // props
         assert_eq!(s(ctx, "prop:lapses=3").0, "(lapses = 3)".to_string());
+        assert_eq!(
+            s(ctx, "prop:forgotten-rate>0.3").0,
+            "((reps > 0 and (1.0 * lapses / reps) > 0.3))".to_string()
+        );
+        assert_eq!(
+            s(ctx, "prop:forgotten-rate<=0.5").0,
+            "((reps > 0 and (1.0 * lapses / reps) <= 0.5))".to_string()
+        );
+        // fr is an alias for forgotten-rate
+        assert_eq!(
+            s(ctx, "prop:fr<=0.5").0,
+            "((reps > 0 and (1.0 * lapses / reps) <= 0.5))".to_string()
+        );
         assert_eq!(s(ctx, "prop:ease>=2.5").0, "(factor >= 2500)".to_string());
         assert_eq!(
             s(ctx, "prop:due!=-1").0,

--- a/rslib/src/search/writer.rs
+++ b/rslib/src/search/writer.rs
@@ -179,6 +179,7 @@ fn write_property(operator: &str, kind: &PropertyKind) -> String {
         Interval(u) => format!("prop:ivl{operator}{u}"),
         Reps(u) => format!("prop:reps{operator}{u}"),
         Lapses(u) => format!("prop:lapses{operator}{u}"),
+        ForgottenRate(f) => format!("prop:forgotten-rate{operator}{f}"),
         Ease(f) => format!("prop:ease{operator}{f}"),
         Position(u) => format!("prop:pos{operator}{u}"),
         Stability(u) => format!("prop:s{operator}{u}"),
@@ -235,6 +236,15 @@ mod test {
         assert_eq!(r#""aNd" "oR""#, normalize_search(r#""aNd" "oR""#).unwrap());
         // normalize numbers
         assert_eq!("prop:ease>1", normalize_search("prop:ease>1.0").unwrap());
+        assert_eq!(
+            "prop:forgotten-rate>0.3",
+            normalize_search("prop:forgotten-rate>0.30").unwrap()
+        );
+        // fr alias normalizes to the full name
+        assert_eq!(
+            "prop:forgotten-rate>0.3",
+            normalize_search("prop:fr>0.3").unwrap()
+        );
     }
 
     #[test]


### PR DESCRIPTION
This adds a 'forgotten-rate' property search key that filters cards by their lapse ratio (lapses / reps), making it easy to find cards that are frequently forgotten, e.g. 'prop:forgotten-rate>0.3'.

A short alias 'prop:fr' is also provided, so 'prop:fr>0.3' is exactly equivalent to the full form.

The computation is guarded by 'reps > 0', so cards with no reviews are excluded. The alias is normalized to the full name on write, keeping storage and sorting consistent regardless of which form is typed.

Changes:
- rslib/src/search/parser.rs: parse 'forgotten-rate' and its 'fr' alias
- rslib/src/search/sqlwriter.rs: emit '(reps > 0 and (1.0 * lapses / reps) ...)'
- rslib/src/search/writer.rs: normalize 'fr' to 'forgotten-rate'
- docs-site/manual/searching.mdx: document the key and its alias
- pylib/tests/test_find.py: add end-to-end assertions

<!--
Title (for the Pull Request title field at the top):
Use a short prefix so the change type is obvious. You do not need to repeat it in the body below.

Examples:
- fix: — bugfix
- feat: — feature
- refactor: — internal change without user-facing feature
- docs: — documentation only
- chore: — tooling, CI, deps, build housekeeping
- test: — tests only
-->

## Linked issue (required)

<!-- Fixes #123 / Closes #123 / Refs #123 -->
Closes #5401

## Summary / motivation (required)

<!-- What this PR does and why. For larger changes, add enough context for reviewers. -->

## Steps to reproduce (required, use N/A if not applicable)

<!-- Steps to reproduce: how to trigger the bug in the broken state (the "before").
 - Mainly for bugfixes;
    - For bugs: numbered steps before the fix. For non-bugs: write N/A.
 - use N/A for features, refactors, docs, chore, etc.
-->

1.
2.
3.

## How to test (required)

<!--- How to test: how you verified the change (checks, unit tests, manual steps, edge cases — the "after" or general validation). --->

### Checklist (minimum)

- [ ] I ran `./ninja check` or an equivalent relevant check locally.
- [ ] I added or updated tests when the change is non-trivial or behavior changed.

### Details

<!-- Commands, manual steps, edge cases, and what you observed -->

## Before / after behavior (optional)

<!-- For bugfixes: behavior before vs after. For other types: N/A or a short note. -->

## Risk / compatibility / migration (optional)

<!-- Breaking changes, rollout notes, or N/A for small / low-risk PRs -->

## UI evidence (required for visual changes; otherwise N/A)

<!-- Screenshot or short video -->

## Scope

- [x] This PR is focused on one change (no unrelated edits).
