### PR TITLE
chore: Get linked issues using the GitHub API

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,7 +13,7 @@ Examples:
 
 ## Linked issue (required)
 
-<!-- Fixes #123 / Closes #123 / Refs #123 -->
+<!-- Fixes #123 / Closes #123 -->
 
 ## Summary / motivation (required)
 

--- a/.github/workflows/auto-close-missing-issue.yml
+++ b/.github/workflows/auto-close-missing-issue.yml
@@ -76,7 +76,33 @@ jobs:
                   }
                 }
               `, { owner, repo, number: pr.number });
-              if (result.repository.pullRequest.closingIssuesReferences.totalCount > 0) continue;
+              if (result.repository.pullRequest.closingIssuesReferences.totalCount > 0) {
+                // An issue was linked without an event that re-runs the check
+                // workflow (e.g. via the Development sidebar), so clean up here.
+                await github.rest.issues.removeLabel({
+                  owner,
+                  repo,
+                  issue_number: pr.number,
+                  name: 'missing-issue',
+                });
+
+                const comments = await github.paginate(github.rest.issues.listComments, {
+                  owner,
+                  repo,
+                  issue_number: pr.number,
+                  per_page: 100,
+                });
+                for (const comment of comments) {
+                  if (comment.user.type === 'Bot' && comment.body.includes('To link an issue, edit the PR description')) {
+                    await github.rest.issues.deleteComment({
+                      owner,
+                      repo,
+                      comment_id: comment.id,
+                    });
+                  }
+                }
+                continue;
+              }
 
               await github.rest.pulls.update({
                 owner,

--- a/.github/workflows/auto-close-missing-issue.yml
+++ b/.github/workflows/auto-close-missing-issue.yml
@@ -37,6 +37,14 @@ jobs:
 
               if (isExempt) continue;
 
+              const isCollaborator = await github.rest.repos.checkCollaborator({
+                owner,
+                repo,
+                username: pr.user.login,
+              }).then(() => true).catch(() => false);
+
+              if (isCollaborator) continue;
+
               // Find when the missing-issue label was applied
               const events = await github.paginate(github.rest.issues.listEventsForTimeline, {
                 owner,

--- a/.github/workflows/auto-close-missing-issue.yml
+++ b/.github/workflows/auto-close-missing-issue.yml
@@ -65,8 +65,18 @@ jobs:
               const currentLabels = currentPr.data.labels.map(l => l.name);
               if (!currentLabels.includes('missing-issue')) continue;
 
-              const linkedIssuePattern = /\b(closes|close|closed|fixes|fix|fixed|resolves|resolve|resolved|refs|ref|references):?\s+(?:(?:[a-zA-Z0-9_.-]+\/[a-zA-Z0-9_.-]+)?#\d+|https?:\/\/github\.com\/[a-zA-Z0-9_.-]+\/[a-zA-Z0-9_.-]+\/(?:issues|pull)\/\d+)/i;
-              if (linkedIssuePattern.test(currentPr.data.body || '')) continue;
+              const result = await github.graphql(`
+                query($owner: String!, $repo: String!, $number: Int!) {
+                  repository(owner: $owner, name: $repo) {
+                    pullRequest(number: $number) {
+                      closingIssuesReferences(first: 1) {
+                        totalCount
+                      }
+                    }
+                  }
+                }
+              `, { owner, repo, number: pr.number });
+              if (result.repository.pullRequest.closingIssuesReferences.totalCount > 0) continue;
 
               await github.rest.pulls.update({
                 owner,

--- a/.github/workflows/check-linked-issue.yml
+++ b/.github/workflows/check-linked-issue.yml
@@ -19,7 +19,6 @@ jobs:
           script: |
             const { owner, repo } = context.repo;
             const pr = context.payload.pull_request;
-            const body = pr.body || '';
             const author = pr.user.login;
             const labels = pr.labels.map(l => l.name);
 
@@ -42,8 +41,19 @@ jobs:
             }
             core.setOutput('exempt', 'false');
 
-            const linkedIssuePattern = /\b(closes|close|closed|fixes|fix|fixed|resolves|resolve|resolved|refs|ref|references):?\s+(?:(?:[a-zA-Z0-9_.-]+\/[a-zA-Z0-9_.-]+)?#\d+|https?:\/\/github\.com\/[a-zA-Z0-9_.-]+\/[a-zA-Z0-9_.-]+\/(?:issues|pull)\/\d+)/i;
-            const hasLinkedIssue = linkedIssuePattern.test(body);
+            const result = await github.graphql(`
+              query($owner: String!, $repo: String!, $number: Int!) {
+                repository(owner: $owner, name: $repo) {
+                  pullRequest(number: $number) {
+                    closingIssuesReferences(first: 1) {
+                      totalCount
+                    }
+                  }
+                }
+              }
+            `, { owner, repo, number: pr.number });
+            const hasLinkedIssue =
+              result.repository.pullRequest.closingIssuesReferences.totalCount > 0;
             core.setOutput('has_linked_issue', hasLinkedIssue);
 
       - name: Apply missing-issue label and comment

--- a/.github/workflows/check-linked-issue.yml
+++ b/.github/workflows/check-linked-issue.yml
@@ -2,7 +2,7 @@ name: Check Linked Issue
 
 on:
   pull_request_target:
-    types: [opened, edited, labeled]
+    types: [opened, edited, labeled, reopened]
 
 jobs:
   check-linked-issue:


### PR DESCRIPTION
Instead of using a fragile regex-based approach for the check-linked-issue workflow, we can use the GitHub GraphQL API to get linked issues as recognized by [supported keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue).

Closes #5380

API reference: https://docs.github.com/en/graphql/reference/pulls?versionId=free-pro-team%40latest&page=issues#object-pullrequest