### PR TITLE
fix(ci): ignore HTML comments when detecting linked issues

### DIFF
--- a/.github/workflows/auto-close-missing-issue.yml
+++ b/.github/workflows/auto-close-missing-issue.yml
@@ -66,7 +66,10 @@ jobs:
               if (!currentLabels.includes('missing-issue')) continue;
 
               const linkedIssuePattern = /\b(closes|close|closed|fixes|fix|fixed|resolves|resolve|resolved|refs|ref|references):?\s+(?:(?:[a-zA-Z0-9_.-]+\/[a-zA-Z0-9_.-]+)?#\d+|https?:\/\/github\.com\/[a-zA-Z0-9_.-]+\/[a-zA-Z0-9_.-]+\/(?:issues|pull)\/\d+)/i;
-              if (linkedIssuePattern.test(currentPr.data.body || '')) continue;
+              // Strip HTML comments to match check-linked-issue: the PR template
+              // ships an example reference that would otherwise pass the check.
+              const currentBody = (currentPr.data.body || '').replace(/<!--[\s\S]*?-->/g, '');
+              if (linkedIssuePattern.test(currentBody)) continue;
 
               await github.rest.pulls.update({
                 owner,

--- a/.github/workflows/check-linked-issue.yml
+++ b/.github/workflows/check-linked-issue.yml
@@ -19,7 +19,10 @@ jobs:
           script: |
             const { owner, repo } = context.repo;
             const pr = context.payload.pull_request;
-            const body = pr.body || '';
+            // Strip HTML comments: the PR template ships an example
+            // "<!-- Fixes #123 / Closes #123 / Refs #123 -->" that would
+            // otherwise satisfy the check for anyone who leaves it in place.
+            const body = (pr.body || '').replace(/<!--[\s\S]*?-->/g, '');
             const author = pr.user.login;
             const labels = pr.labels.map(l => l.name);
 


### PR DESCRIPTION
## Linked issue

Refs #5189

## Summary / motivation

The linked-issue check reads the raw PR body, which includes HTML comments. Our own PR template ships this example on the line right under the "Linked issue" heading:

    <!-- Fixes #123 / Closes #123 / Refs #123 -->

The regex matches `Fixes #123` inside that comment, so **any PR that leaves the template comments in place passes the check** — regardless of whether an issue was actually linked. The comment is invisible in the rendered PR view, which is why this went unnoticed.

## Steps to reproduce

1. Open a PR using the repository template.
2. Leave the `<!-- Fixes #123 / Closes #123 / Refs #123 -->` comment untouched and do not add any issue reference.
3. The `Check Linked Issue` workflow succeeds and no `missing-issue` label is applied, despite there being no linked issue.

## How to test 

### Details

Strips HTML comments before running the pattern, in both workflows so they stay in agreement:

    const body = (pr.body || '').replace(/<!--[\s\S]*?-->/g, '');

## Before / after behavior

**Before**: any PR retaining the template's example comment silently passed the linked-issue check.
**After**: only references the author actually wrote count; the template example is ignored.
