### PR TITLE
docs: sync post-migration manual updates

### DIFF
--- a/docs-site/manual/deck-options.mdx
+++ b/docs-site/manual/deck-options.mdx
@@ -612,7 +612,7 @@ it to 90%. We’d calculate the modifier as:
 log(90%) / log(85%) = 0.65
 ```
 
-You can use [Google to calculate this](<https://www.google.com/search?q=log(90%25)+%2F+log(85%25)>).
+You can use any [search engine to calculate this](https://duckduckgo.com/?q=log(0.90)+%2F+log(0.85)).
 
 If you enter the resulting 65% into the interval modifier, you should
 find over time that your retention moves closer to your desired

--- a/docs-site/manual/deck-options.mdx
+++ b/docs-site/manual/deck-options.mdx
@@ -612,7 +612,7 @@ it to 90%. We’d calculate the modifier as:
 log(90%) / log(85%) = 0.65
 ```
 
-You can use any [search engine to calculate this](https://duckduckgo.com/?q=log(0.90)+%2F+log(0.85)).
+You can use any [search engine to calculate this](<https://duckduckgo.com/?q=log(0.90)+%2F+log(0.85)>).
 
 If you enter the resulting 65% into the interval modifier, you should
 find over time that your retention moves closer to your desired

--- a/docs-site/manual/editing.mdx
+++ b/docs-site/manual/editing.mdx
@@ -457,6 +457,23 @@ sure to clone the existing Cloze type instead of another type of note.
 Things like formatting can be customized, but it is not possible to add
 extra card templates to the cloze note type.
 
+Anki now supports a syntax that allows a single cloze deletion to appear on
+multiple cards:
+
+```text
+{{c1::-té}}, {{c2::-sion}}, or {{c3::-tion}} are {{c1,2,3,4::feminine}}.
+```
+
+This creates four cards, each hiding "feminine" in a different context.
+The same result can still be achieved with the older nested syntax:
+
+```text
+{{c1::-té}}, {{c2::-sion}}, {{c3::-tion}} are {{c4::{{c3::{{c2::{{c1::feminine}}}}}}}}
+```
+
+The new syntax is easier to read and write, while the old syntax is more
+verbose.
+
 ## Image Occlusion
 
 Anki 23.10+ supports Image Occlusion cards natively. An Image
@@ -563,7 +580,7 @@ Mac:
 
 Linux:
 
-- Gnome: [https://help.gnome.org/users/gnome-help/stable/tips-specialchars.html.en](https://help.gnome.org/users/gnome-help/stable/tips-specialchars.html.en)
+- Gnome: [https://help.gnome.org/gnome-help/tips-specialchars.html](https://help.gnome.org/gnome-help/tips-specialchars.html)
 - KDE Plasma: [https://userbase.kde.org/Tutorials/ComposeKey](https://userbase.kde.org/Tutorials/ComposeKey)
 
 ### Adding keyboard layouts for specific languages

--- a/docs-site/manual/getting-help.mdx
+++ b/docs-site/manual/getting-help.mdx
@@ -17,7 +17,7 @@ Please start by trying to resolve the issue on your own:
 - Use the search button on this page to search frequently asked questions.
 - Use the search button in the manual.
 - Use the search button on the forums.
-- Google the issue.
+- Search the internet for the issue.
 
 If you have tried the above and are still stuck, it's time to ask for help.
 When writing a post, please explain the problem you are having clearly, and in detail.
@@ -29,9 +29,9 @@ Please avoid vague questions like:
 Instead, please provide as much detail as you can. For example:
 
 > "When I double-click on the Anki icon, an error message pops up. I tried
-> searching for the error on Google, but couldn't find anything useful. I have
-> copied and pasted the error message to the bottom of my post. I followed the
-> steps on the "When problems occur" page, but the error message does not go
+> searching the internet for the error, but couldn't find anything useful. I
+> have copied and pasted the error message to the bottom of my post. I followed
+> the steps on the "When problems occur" page, but the error message does not go
 > away. What should I do?"
 
 This is a much better question. It tells us:

--- a/docs-site/manual/platform/linux/installing.mdx
+++ b/docs-site/manual/platform/linux/installing.mdx
@@ -10,7 +10,7 @@ architecture, or a barebones Linux distro, you will not be able to use the
 packaged version, but you may be able to use the [Python wheels](https://betas.ankiweb.net/#via-pypipip)
 instead.
 
-Debian and derivatives, such as Ubuntu and [Chromebooks with Linux enabled](https://support.google.com/chromebook/answer/9145439?), please use the following before
+Debian and derivatives, such as Ubuntu and [Chromebooks with Linux enabled](https://support.google.com/chromebook/answer/9145439), please use the following before
 installing:
 
 ```shell

--- a/docs-site/manual/sync-server.mdx
+++ b/docs-site/manual/sync-server.mdx
@@ -140,6 +140,8 @@ that the server binds to.
 
 ## Client Setup
 
+### Server URL
+
 You'll need to determine your computer's network IP address, and then
 point each of your Anki clients to the address, e.g something like
 `http://192.168.1.200:8080/`. The URL can be configured in the preferences.
@@ -153,6 +155,11 @@ Older desktop clients required you to define `SYNC_ENDPOINT` and
 `http://192.168.1.200:8080/sync/` and `http://192.168.1.200:8080/msync/`
 respectively. AnkiDroid clients before 2.16 require separate configuration for
 the two endpoints.
+
+### Credentials
+
+To synchronize, enter your user credential (for example, `SYNC_USER1`) in the
+**AnkiWeb account** section of the preferences.
 
 ## Reverse Proxies
 

--- a/docs-site/manual/syncing.mdx
+++ b/docs-site/manual/syncing.mdx
@@ -229,7 +229,7 @@ http://user%40workdomain.com:pass@proxy.company.com:8080
 Anki 2.0 expects to find HTTP_PROXY instead of HTTPS_PROXY.
 
 To set environment variables on Windows, please see
-[https://www.google.com/search?q=windows+set+environmental+variable](https://www.google.com/search?q=windows+set+environmental+variable)
+[https://duckduckgo.com/?q=windows+set+environment+variable](https://duckduckgo.com/?q=windows+set+environment+variable)
 
 If you’re on a Mac, please see
 [http://stackoverflow.com/questions/135688/setting-environment-variables-in-os-x](http://stackoverflow.com/questions/135688/setting-environment-variables-in-os-x)


### PR DESCRIPTION
## Linked issue (required)

Closes #5392

## Summary / motivation (required)

Ports accepted manual updates that landed in the legacy `ankitects/anki-manual` repository after the unified documentation site was created:

- sync-server credential setup from `c73d6a0`
- generic search-engine wording and corrected links from `d39ce8e`
- multi-card cloze syntax and the corrected GNOME link from `b230826`

This keeps the canonical English manual current before adding the Persian translation based on the same source revision.

## Steps to reproduce (required, use N/A if not applicable)

N/A

## How to test (required)

### Checklist (minimum)

- [x] Ran an equivalent documentation-focused check (`git diff --check`).
- [x] Tests are not applicable to this documentation-only content sync.

### Details

The six changed MDX files were parsed successfully with the Mintlify MDX parser during migration preparation. The repository's Docs Site workflow will run the authoritative Mintlify validation and accessibility checks on this PR.

## Before / after behavior (optional)

The unified manual was missing several updates already accepted in the legacy manual repository. The corresponding pages now include them.

## Risk / compatibility / migration (optional)

Documentation-only; no runtime behavior changes.

## UI evidence (required for visual changes; otherwise N/A)

N/A

## Scope

- [x] This PR is focused on one change (no unrelated edits).
