### PR TITLE
Hide FSRS-only sort orders in filtered deck dialog when FSRS is disabled

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -301,6 +301,7 @@ Peter Szilvasi <peti.szilvasi95@gmail.com>
 JaksonSouza <jaksonsouza.dev@gmail.com>
 danny900714 <https://github.com/danny900714>
 Carlos Mendez <carlos12mcg@gmail.com>
+zaveshaa <zaveshaa@gmail.com>
 ********************
 
 The text of the 3 clause BSD license follows:

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -302,6 +302,7 @@ JaksonSouza <jaksonsouza.dev@gmail.com>
 danny900714 <https://github.com/danny900714>
 Carlos Mendez <carlos12mcg@gmail.com>
 zaveshaa <zaveshaa@gmail.com>
+zaveshaa <127344512+zaveshaa@users.noreply.github.com>
 ********************
 
 The text of the 3 clause BSD license follows:

--- a/qt/aqt/filtered_deck.py
+++ b/qt/aqt/filtered_deck.py
@@ -42,7 +42,7 @@ class FilteredDeckConfigDialog(QDialog):
             FilteredDeckConfig.SearchTerm.Order.RETRIEVABILITY_DESCENDING,
         )
     )
-    DEFAULT_ORDER = 1  # Random
+    DEFAULT_ORDER = FilteredDeckConfig.SearchTerm.Order.RANDOM
 
     def __init__(
         self,

--- a/qt/aqt/filtered_deck.py
+++ b/qt/aqt/filtered_deck.py
@@ -34,6 +34,16 @@ class FilteredDeckConfigDialog(QDialog):
     DIALOG_KEY = "FilteredDeckConfigDialog"
     silentlyClose = True
 
+    # Retrievability orders require FSRS memory states, and are only
+    # offered when FSRS is enabled.
+    FSRS_ONLY_ORDERS = frozenset(
+        (
+            FilteredDeckConfig.SearchTerm.Order.RETRIEVABILITY_ASCENDING,
+            FilteredDeckConfig.SearchTerm.Order.RETRIEVABILITY_DESCENDING,
+        )
+    )
+    DEFAULT_ORDER = 1  # Random
+
     def __init__(
         self,
         mw: AnkiQt,
@@ -76,8 +86,16 @@ class FilteredDeckConfigDialog(QDialog):
 
         order_labels = self.col.sched.filtered_deck_order_labels()
 
-        self.form.order.addItems(order_labels)
-        self.form.order_2.addItems(order_labels)
+        fsrs_enabled = bool(self.mw.col.get_config("fsrs"))
+        self._order_values = [
+            order
+            for order in range(len(order_labels))
+            if fsrs_enabled or order not in self.FSRS_ONLY_ORDERS
+        ]
+        visible_labels = [order_labels[order] for order in self._order_values]
+
+        self.form.order.addItems(visible_labels)
+        self.form.order_2.addItems(visible_labels)
 
         qconnect(self.form.allow_empty.stateChanged, self._on_allow_empty_toggled)
 
@@ -140,7 +158,7 @@ class FilteredDeckConfigDialog(QDialog):
 
         term1: FilteredDeckConfig.SearchTerm = config.search_terms[0]
         form.search.setText(term1.search)
-        form.order.setCurrentIndex(term1.order)
+        form.order.setCurrentIndex(self._combo_row(term1.order))
         form.limit.setValue(term1.limit)
 
         form.preview_again.setValue(config.preview_again_secs)
@@ -150,12 +168,12 @@ class FilteredDeckConfigDialog(QDialog):
         if len(config.search_terms) > 1:
             term2: FilteredDeckConfig.SearchTerm = config.search_terms[1]
             form.search_2.setText(term2.search)
-            form.order_2.setCurrentIndex(term2.order)
+            form.order_2.setCurrentIndex(self._combo_row(term2.order))
             form.limit_2.setValue(term2.limit)
             show_second = existing
         else:
             show_second = False
-            form.order_2.setCurrentIndex(5)
+            form.order_2.setCurrentIndex(self._combo_row(self.DEFAULT_ORDER))
             form.limit_2.setValue(20)
 
         form.secondFilter.setChecked(show_second)
@@ -245,6 +263,13 @@ class FilteredDeckConfigDialog(QDialog):
     def _onReschedToggled(self, _state: int) -> None:
         self.form.previewDelayWidget.setVisible(not self.form.resched.isChecked())
 
+    def _combo_row(self, order: int) -> int:
+        """Translate a FilteredSearchOrder value into a combo box row."""
+        if order not in self._order_values:
+            # Saved selection is not available without FSRS.
+            order = self.DEFAULT_ORDER
+        return self._order_values.index(order)
+
     def _on_allow_empty_toggled(self) -> None:
         self.deck.allow_empty = self.form.allow_empty.isChecked()
 
@@ -263,7 +288,7 @@ class FilteredDeckConfigDialog(QDialog):
             FilteredDeckConfig.SearchTerm(
                 search=form.search.text(),
                 limit=form.limit.value(),
-                order=form.order.currentIndex(),  # type: ignore[arg-type]
+                order=self._order_values[form.order.currentIndex()],  # type: ignore[arg-type]
             )
         ]
 
@@ -272,7 +297,7 @@ class FilteredDeckConfigDialog(QDialog):
                 FilteredDeckConfig.SearchTerm(
                     search=form.search_2.text(),
                     limit=form.limit_2.value(),
-                    order=form.order_2.currentIndex(),  # type: ignore[arg-type]
+                    order=self._order_values[form.order_2.currentIndex()],  # type: ignore[arg-type]
                 )
             )
 

--- a/qt/aqt/filtered_deck.py
+++ b/qt/aqt/filtered_deck.py
@@ -87,11 +87,9 @@ class FilteredDeckConfigDialog(QDialog):
         order_labels = self.col.sched.filtered_deck_order_labels()
 
         fsrs_enabled = bool(self.mw.col.get_config("fsrs"))
-        self._order_values = [
-            order
-            for order in range(len(order_labels))
-            if fsrs_enabled or order not in self.FSRS_ONLY_ORDERS
-        ]
+        self._order_values = self._available_order_values(
+            order_count=len(order_labels), fsrs_enabled=fsrs_enabled
+        )
         visible_labels = [order_labels[order] for order in self._order_values]
 
         self.form.order.addItems(visible_labels)
@@ -129,6 +127,16 @@ class FilteredDeckConfigDialog(QDialog):
         )
 
         restoreGeom(self, self.GEOMETRY_KEY)
+
+    @classmethod
+    def _available_order_values(
+        cls, *, order_count: int, fsrs_enabled: bool
+    ) -> list[int]:
+        return [
+            order
+            for order in range(order_count)
+            if fsrs_enabled or order not in cls.FSRS_ONLY_ORDERS
+        ]
 
     def load_deck_and_show(self, deck: FilteredDeckForUpdate) -> None:
         self.deck = deck

--- a/qt/tests/test_filtered_deck.py
+++ b/qt/tests/test_filtered_deck.py
@@ -1,0 +1,153 @@
+# Copyright: Ankitects Pty Ltd and contributors
+# License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from anki.decks import FilteredDeckConfig
+from aqt.filtered_deck import FilteredDeckConfigDialog
+
+Order = FilteredDeckConfig.SearchTerm.Order
+
+
+def available_orders(*, fsrs_enabled: bool) -> list[int]:
+    return FilteredDeckConfigDialog._available_order_values(
+        order_count=len(Order.keys()), fsrs_enabled=fsrs_enabled
+    )
+
+
+def test_available_orders_follow_fsrs_state() -> None:
+    all_orders = available_orders(fsrs_enabled=True)
+    assert all_orders == list(range(len(Order.keys())))
+
+    sm2_orders = available_orders(fsrs_enabled=False)
+    assert Order.RETRIEVABILITY_ASCENDING not in sm2_orders
+    assert Order.RETRIEVABILITY_DESCENDING not in sm2_orders
+    assert Order.RELATIVE_OVERDUENESS in sm2_orders
+
+
+@patch("aqt.filtered_deck.restoreGeom")
+@patch("aqt.filtered_deck.disable_help_button")
+@patch("aqt.filtered_deck.qconnect")
+@patch("aqt.filtered_deck.theme_manager")
+@patch("aqt.filtered_deck.tr")
+@patch("aqt.filtered_deck.aqt.forms.filtered_deck.Ui_Dialog")
+def test_initial_setup_hides_retrievability_orders_without_fsrs(
+    ui_dialog: MagicMock,
+    _tr: MagicMock,
+    _theme_manager: MagicMock,
+    _qconnect: MagicMock,
+    _disable_help_button: MagicMock,
+    _restore_geom: MagicMock,
+) -> None:
+    labels = list(Order.keys())
+    dialog = MagicMock()
+    dialog.col.sched.filtered_deck_order_labels.return_value = labels
+    dialog.mw.col.get_config.return_value = False
+    dialog.FSRS_ONLY_ORDERS = FilteredDeckConfigDialog.FSRS_ONLY_ORDERS
+    dialog.GEOMETRY_KEY = FilteredDeckConfigDialog.GEOMETRY_KEY
+    dialog._available_order_values.side_effect = (
+        FilteredDeckConfigDialog._available_order_values
+    )
+    form = ui_dialog.return_value
+
+    FilteredDeckConfigDialog._initial_dialog_setup(dialog)
+
+    expected_values = available_orders(fsrs_enabled=False)
+    expected_labels = [labels[order] for order in expected_values]
+    assert dialog._order_values == expected_values
+    form.order.addItems.assert_called_once_with(expected_labels)
+    form.order_2.addItems.assert_called_once_with(expected_labels)
+
+
+def test_combo_row_preserves_available_order_and_falls_back_to_random() -> None:
+    dialog = MagicMock()
+    dialog._order_values = available_orders(fsrs_enabled=False)
+    dialog.DEFAULT_ORDER = FilteredDeckConfigDialog.DEFAULT_ORDER
+
+    relative_overdueness_row = FilteredDeckConfigDialog._combo_row(
+        dialog, Order.RELATIVE_OVERDUENESS
+    )
+    unavailable_order_row = FilteredDeckConfigDialog._combo_row(
+        dialog, Order.RETRIEVABILITY_ASCENDING
+    )
+
+    assert dialog._order_values[relative_overdueness_row] == Order.RELATIVE_OVERDUENESS
+    assert dialog._order_values[unavailable_order_row] == Order.RANDOM
+
+
+@patch("aqt.filtered_deck.without_unicode_isolation", return_value="title")
+@patch("aqt.filtered_deck.tr")
+def test_load_deck_maps_saved_orders_to_combo_rows(
+    _tr: MagicMock, _without_unicode_isolation: MagicMock
+) -> None:
+    dialog = MagicMock()
+    dialog.form = MagicMock()
+    dialog._order_values = available_orders(fsrs_enabled=False)
+    dialog.DEFAULT_ORDER = FilteredDeckConfigDialog.DEFAULT_ORDER
+    dialog._combo_row.side_effect = lambda order: FilteredDeckConfigDialog._combo_row(
+        dialog, order
+    )
+    dialog.deck = SimpleNamespace(
+        id=1,
+        name="Filtered",
+        config=FilteredDeckConfig(
+            reschedule=True,
+            search_terms=[
+                FilteredDeckConfig.SearchTerm(
+                    search="deck:Default",
+                    limit=100,
+                    order=Order.RETRIEVABILITY_ASCENDING,
+                ),
+                FilteredDeckConfig.SearchTerm(
+                    search="is:due",
+                    limit=20,
+                    order=Order.RELATIVE_OVERDUENESS,
+                ),
+            ],
+        ),
+    )
+
+    FilteredDeckConfigDialog._load_deck(dialog)
+
+    first_row = dialog.form.order.setCurrentIndex.call_args.args[0]
+    second_row = dialog.form.order_2.setCurrentIndex.call_args.args[0]
+    assert dialog._order_values[first_row] == Order.RANDOM
+    assert dialog._order_values[second_row] == Order.RELATIVE_OVERDUENESS
+
+    dialog.deck.config.search_terms.pop()
+    dialog.form.order_2.setCurrentIndex.reset_mock()
+    FilteredDeckConfigDialog._load_deck(dialog)
+
+    default_second_row = dialog.form.order_2.setCurrentIndex.call_args.args[0]
+    assert dialog._order_values[default_second_row] == Order.RANDOM
+
+
+def test_update_deck_maps_combo_rows_back_to_orders() -> None:
+    dialog = MagicMock()
+    dialog._order_values = available_orders(fsrs_enabled=False)
+    dialog.form = MagicMock()
+    dialog.deck = SimpleNamespace(
+        name="Filtered",
+        config=FilteredDeckConfig(),
+    )
+
+    relative_overdueness_row = dialog._order_values.index(Order.RELATIVE_OVERDUENESS)
+    random_row = dialog._order_values.index(Order.RANDOM)
+    dialog.form.order.currentIndex.return_value = relative_overdueness_row
+    dialog.form.order_2.currentIndex.return_value = random_row
+    dialog.form.secondFilter.isChecked.return_value = True
+    dialog.form.search.text.return_value = "deck:Default"
+    dialog.form.limit.value.return_value = 100
+    dialog.form.search_2.text.return_value = "is:due"
+    dialog.form.limit_2.value.return_value = 20
+    dialog.form.resched.isChecked.return_value = True
+    dialog.form.preview_again.value.return_value = 60
+    dialog.form.preview_hard.value.return_value = 600
+    dialog.form.preview_good.value.return_value = 0
+
+    assert FilteredDeckConfigDialog._update_deck(dialog)
+
+    terms = dialog.deck.config.search_terms
+    assert terms[0].order == Order.RELATIVE_OVERDUENESS
+    assert terms[1].order == Order.RANDOM


### PR DESCRIPTION
Fixes #5397.

Selecting ascending/descending retrievability (or relative overdueness) for a filtered deck while FSRS is disabled raises a `SQLITE` error, because `build_retrievability_query()` returns an empty order fragment without FSRS (`order by , fnvhash(...)`), and the overdueness expression reads FSRS memory state regardless.

As suggested in the issue by Luc, this hides those three orders in the filtered deck dialog when FSRS is off, the same way deck options already handles review order.

The combo box rows are mapped through the list of actually offered orders instead of assuming row == enum value, so stored configs stay valid. If a stored config references one of the hidden orders (e.g. FSRS was turned off after it was built), the dialog falls back to Random rather than showing a broken selection. I checked that the mapping round-trips correctly with FSRS on and off, including the fallback path.
