### PR TITLE
docs: Fix broken links in dev docs

### DIFF
--- a/docs-site/developers/build.mdx
+++ b/docs-site/developers/build.mdx
@@ -4,7 +4,7 @@ title: "The build system"
 
 ## Basic use
 
-Basic use is described in [development.md](./development).
+Basic use is described in [development.md](/developers/development).
 
 ## Architecture
 
@@ -39,4 +39,4 @@ If you run into trouble with the build process:
 
 ## Packaging considerations
 
-See [this page](./linux).
+See [this page](/developers/linux).

--- a/docs-site/developers/development.mdx
+++ b/docs-site/developers/development.mdx
@@ -50,9 +50,9 @@ On all platforms, you will need to install:
 
 Platform-specific requirements:
 
-- [Windows](./windows)
-- [Mac](./mac)
-- [Linux](./linux)
+- [Windows](/developers/windows)
+- [Mac](/developers/mac)
+- [Linux](/developers/linux)
 
 ## Running Anki during development
 
@@ -179,11 +179,11 @@ may delete the `target/` folder (if any) as that's no longer used.
 
 ## IDEs
 
-Please see [this separate page](./editing) for setting up an editor/IDE.
+Please see [this separate page](/developers/editing) for setting up an editor/IDE.
 
 ## Making changes to the build
 
-See [this page](./build)
+See [this page](/developers/build)
 
 ## Generating documentation
 
@@ -229,7 +229,7 @@ are installed. See [Building from source](#building-from-source) for more info.
 
 ## Releasing
 
-See [Releasing](./releasing).
+See [Releasing](/developers/releasing).
 
 # Mixing development and study
 

--- a/docs-site/developers/language_bridge.mdx
+++ b/docs-site/developers/language_bridge.mdx
@@ -22,7 +22,7 @@ Imitating those examples should allow you to make call and create new RPCs.
 
 Let's consider the method `NewDeck` of `DecksServices`. It's declared in [decks.proto](https://github.com/ankitects/anki/blob/acaeee91fa853e4a7a78dcddbb832d009ec3529a/proto/anki/decks.proto#L14) as `rpc NewDeck(generic.Empty) returns (Deck);`. This means this methods takes no argument (technically, an argument containing no information), and returns a [`Deck`](https://github.com/ankitects/anki/blob/acaeee91fa853e4a7a78dcddbb832d009ec3529a/proto/anki/decks.proto#L54).
 
-Read [protobuf](./protobuf) to learn more about how those input and output types are defined.
+Read [protobuf](/developers/protobuf) to learn more about how those input and output types are defined.
 
 If the RPC implementation is in Python, it should be declared in the service [frontend.proto](https://github.com/ankitects/anki/blob/acaeee91fa853e4a7a78dcddbb832d009ec3529a/proto/anki/frontend.proto#L24C3-L24C66)'s `FrontendService`. RPCs declared in any other services are implemented in Rust.
 

--- a/docs-site/developers/linux.mdx
+++ b/docs-site/developers/linux.mdx
@@ -126,4 +126,4 @@ offline.
 
 ## More
 
-For info on running tests, building wheels and so on, please see [Development](./development).
+For info on running tests, building wheels and so on, please see [Development](/developers/development).

--- a/docs-site/developers/mac.mdx
+++ b/docs-site/developers/mac.mdx
@@ -19,4 +19,4 @@ To play audio, use Homebrew to install mpv and lame.
 
 ## More
 
-For info on running tests, building wheels and so on, please see [Development](./development).
+For info on running tests, building wheels and so on, please see [Development](/developers/development).

--- a/docs-site/developers/protobuf.mdx
+++ b/docs-site/developers/protobuf.mdx
@@ -10,7 +10,7 @@ not in a human readable way.
 
 # Protocol Buffers
 
-Anki uses [different implementations of Protocol Buffers](./architecture#protobuf)
+Anki uses [different implementations of Protocol Buffers](/developers/architecture#protobuf)
 and each has its own peculiarities. This document highlights some aspects relevant
 to Anki and hopefully helps to avoid some common pitfalls.
 

--- a/docs-site/developers/windows.mdx
+++ b/docs-site/developers/windows.mdx
@@ -74,4 +74,4 @@ problems.
 ## More
 
 For info on running tests, building wheels and so on, please see
-[Development](./development).
+[Development](/developers/development).

--- a/docs/build.md
+++ b/docs/build.md
@@ -10,7 +10,7 @@ cog.out(get_file_contents("build"))
 
 ## Basic use
 
-Basic use is described in [development.md](https://anki.mintlify.app/development).
+Basic use is described in [development.md](https://anki.mintlify.app/developers/development).
 
 ## Architecture
 
@@ -45,6 +45,6 @@ If you run into trouble with the build process:
 
 ## Packaging considerations
 
-See [this page](https://anki.mintlify.app/linux).
+See [this page](https://anki.mintlify.app/developers/linux).
 
 <!-- <<<end>>> -->

--- a/docs/development.md
+++ b/docs/development.md
@@ -56,9 +56,9 @@ On all platforms, you will need to install:
 
 Platform-specific requirements:
 
-- [Windows](https://anki.mintlify.app/windows)
-- [Mac](https://anki.mintlify.app/mac)
-- [Linux](https://anki.mintlify.app/linux)
+- [Windows](https://anki.mintlify.app/developers/windows)
+- [Mac](https://anki.mintlify.app/developers/mac)
+- [Linux](https://anki.mintlify.app/developers/linux)
 
 ## Running Anki during development
 
@@ -185,11 +185,11 @@ may delete the `target/` folder (if any) as that's no longer used.
 
 ## IDEs
 
-Please see [this separate page](https://anki.mintlify.app/editing) for setting up an editor/IDE.
+Please see [this separate page](https://anki.mintlify.app/developers/editing) for setting up an editor/IDE.
 
 ## Making changes to the build
 
-See [this page](https://anki.mintlify.app/build)
+See [this page](https://anki.mintlify.app/developers/build)
 
 ## Generating documentation
 
@@ -235,7 +235,7 @@ are installed. See [Building from source](https://anki.mintlify.app/development#
 
 ## Releasing
 
-See [Releasing](https://anki.mintlify.app/releasing).
+See [Releasing](https://anki.mintlify.app/developers/releasing).
 
 # Mixing development and study
 

--- a/docs/language_bridge.md
+++ b/docs/language_bridge.md
@@ -28,7 +28,7 @@ Imitating those examples should allow you to make call and create new RPCs.
 
 Let's consider the method `NewDeck` of `DecksServices`. It's declared in [decks.proto](https://github.com/ankitects/anki/blob/acaeee91fa853e4a7a78dcddbb832d009ec3529a/proto/anki/decks.proto#L14) as `rpc NewDeck(generic.Empty) returns (Deck);`. This means this methods takes no argument (technically, an argument containing no information), and returns a [`Deck`](https://github.com/ankitects/anki/blob/acaeee91fa853e4a7a78dcddbb832d009ec3529a/proto/anki/decks.proto#L54).
 
-Read [protobuf](https://anki.mintlify.app/protobuf) to learn more about how those input and output types are defined.
+Read [protobuf](https://anki.mintlify.app/developers/protobuf) to learn more about how those input and output types are defined.
 
 If the RPC implementation is in Python, it should be declared in the service [frontend.proto](https://github.com/ankitects/anki/blob/acaeee91fa853e4a7a78dcddbb832d009ec3529a/proto/anki/frontend.proto#L24C3-L24C66)'s `FrontendService`. RPCs declared in any other services are implemented in Rust.
 

--- a/docs/linux.md
+++ b/docs/linux.md
@@ -132,6 +132,6 @@ offline.
 
 ## More
 
-For info on running tests, building wheels and so on, please see [Development](https://anki.mintlify.app/development).
+For info on running tests, building wheels and so on, please see [Development](https://anki.mintlify.app/developers/development).
 
 <!-- <<<end>>> -->

--- a/docs/mac.md
+++ b/docs/mac.md
@@ -25,6 +25,6 @@ To play audio, use Homebrew to install mpv and lame.
 
 ## More
 
-For info on running tests, building wheels and so on, please see [Development](https://anki.mintlify.app/development).
+For info on running tests, building wheels and so on, please see [Development](https://anki.mintlify.app/developers/development).
 
 <!-- <<<end>>> -->

--- a/docs/protobuf.md
+++ b/docs/protobuf.md
@@ -16,7 +16,7 @@ not in a human readable way.
 
 # Protocol Buffers
 
-Anki uses [different implementations of Protocol Buffers](https://anki.mintlify.app/architecture#protobuf)
+Anki uses [different implementations of Protocol Buffers](https://anki.mintlify.app/developers/architecture#protobuf)
 and each has its own peculiarities. This document highlights some aspects relevant
 to Anki and hopefully helps to avoid some common pitfalls.
 

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -80,6 +80,6 @@ problems.
 ## More
 
 For info on running tests, building wheels and so on, please see
-[Development](https://anki.mintlify.app/development).
+[Development](https://anki.mintlify.app/developers/development).
 
 <!-- <<<end>>> -->


### PR DESCRIPTION
## Linked issue

Closes #5335
Closes #5350

## Summary

Fix broken links in docs/ by replacing relative links (`./linux.md`) with absolute ones (`/developers/linux`).


## How to test

Confirm all internal links in docs/ work