### PR TITLE
Fix: Fallback to SM-2 for relative overdueness sort order in filtered decks

### DIFF
--- a/rslib/src/storage/card/filtered.rs
+++ b/rslib/src/storage/card/filtered.rs
@@ -40,8 +40,14 @@ pub(crate) fn order_and_limit_for_search(
             &temp_string
         }
         FilteredSearchOrder::RelativeOverdueness => {
-            temp_string =
-                format!("extract_fsrs_relative_retrievability(data, case when odue !=0 then odue else due end, ivl, {today}, {next_day_at}, {now}) asc");
+            temp_string = if fsrs {
+                format!("extract_fsrs_relative_retrievability(data, case when odue !=0 then odue else due end, ivl, {today}, {next_day_at}, {now}) asc")
+            } else {
+                format!(
+                    // - (elapsed days+0.001)/(scheduled interval)
+                    "-(1 + cast({today}-due+0.001 as real)/ivl) asc"
+                )
+            };
             &temp_string
         }
     };


### PR DESCRIPTION
## Linked issue (required)

Fixes https://github.com/ankitects/anki/issues/5397 partially

## Summary / motivation (required)

Fallback to SM-2 for relative overdueness sort order in filtered decks when FSRS disabled (matching the pattern used in rslib/src/storage/card/mod.rs‎)

## Steps to reproduce (required, use N/A if not applicable)

See linked issue

## How to test (required)

<!--- How to test: how you verified the change (checks, unit tests, manual steps, edge cases — the "after" or general validation). --->

### Checklist (minimum)

- [ ] I ran `./ninja check` or an equivalent relevant check locally.
- [ ] I added or updated tests when the change is non-trivial or behavior changed.

### Details

<!-- Commands, manual steps, edge cases, and what you observed -->

## Before / after behavior (optional)

<!-- For bugfixes: behavior before vs after. For other types: N/A or a short note. -->

## Risk / compatibility / migration (optional)

<!-- Breaking changes, rollout notes, or N/A for small / low-risk PRs -->

## UI evidence (required for visual changes; otherwise N/A)

<!-- Screenshot or short video -->

## Scope

- [x] This PR is focused on one change (no unrelated edits).