### PR TITLE
fix: avoid re-loading mathjax

### DIFF
--- a/ts/reviewer/index.ts
+++ b/ts/reviewer/index.ts
@@ -24,7 +24,7 @@ import { preloadResources } from "./preload";
 
 declare const MathJax: any;
 
-let mathjaxLoading: Promise<void> | null = null;
+let mathjaxLoading: Promise<void> | null = window?.["MathJax"]?.startup?.promise ?? null;
 
 function _lazyLoadMathJax(): Promise<void> {
     return mathjaxLoading || (mathjaxLoading = new Promise((resolve, reject) => {


### PR DESCRIPTION
## Linked issue (required)

Closes: #5415

## Summary / motivation (required)

The template editor and previewer were still eagerly loading mathjax, which lazy loading didnt account for, which this pr fixes

## Steps to reproduce (required, use N/A if not applicable)

See linked issue

## How to test (required)

Card content for cards with and without mathjax are visible in the template editor and previewer again

### Checklist (minimum)

- [x] I ran `./ninja check` or an equivalent relevant check locally.
- [ ] I added or updated tests when the change is non-trivial or behavior changed.

## Scope

- [x] This PR is focused on one change (no unrelated edits).
