### PR TITLE
fix: explicitly specify qmenu arrow width

### DIFF
--- a/qt/aqt/stylesheets.py
+++ b/qt/aqt/stylesheets.py
@@ -141,6 +141,9 @@ class CustomStyles:
         border: 1px solid {tm.var(colors.BORDER_SUBTLE)};
         padding: 4px;
     }}
+    QMenu::right-arrow {{
+        width: 13px;
+    }}
     QMenu::item {{
         background-color: transparent;
         padding: 3px 14px;


### PR DESCRIPTION
## Linked issue (required)

Closes: #5420 

## Summary / motivation (required)

I looked at 6.11.1's changelog and think its due to [QTBUG-144914's fix](https://github.com/qt/qtbase/commit/00675242b764f5db40c67cf5b8aa2cc2b0a244c1). Providing a size ([width](https://github.com/qt/qtbase/blob/7df32447746e6482312c4c777e7c174d0d4b603a/src/widgets/styles/qstylesheetstyle.cpp#L2333) in this case) gets us back to expected behaviour

It's also possible to increase `QMenu::item`'s right padding instead to account for the arrow, but then it isn't vertically aligned anymore. Not sure if this is intended or a bug (not fixed by 6.11.2)

## Steps to reproduce (required, use N/A if not applicable)

See linked issue

## How to test (required)

See linked issue

### Checklist (minimum)

- [x] I ran `./ninja check` or an equivalent relevant check locally.
- [ ] I added or updated tests when the change is non-trivial or behavior changed.

## Scope

- [x] This PR is focused on one change (no unrelated edits).
