### PR TITLE
fix(ci): prevent silent skip of PR coverage-regression check on evicted baseline

### DIFF
--- a/.github/workflows/prune-coverage-cache.yml
+++ b/.github/workflows/prune-coverage-cache.yml
@@ -1,0 +1,65 @@
+name: Prune coverage baseline caches
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    branches: [main]
+    types: [completed]
+
+# Delete all coverage-baseline caches except the newest one. The regression
+# check fails if no baseline is available, so cache eviction cannot silently
+# disable it.
+permissions:
+  actions: write
+
+# An older CI completion may be handled after a newer baseline has been saved.
+# Serialize pruning and select by creation time instead of the triggering SHA.
+concurrency:
+  group: prune-coverage-baseline-cache
+
+jobs:
+  prune:
+    runs-on: ubuntu-24.04
+    if: github.event.workflow_run.conclusion == 'success'
+    steps:
+      - name: Delete stale coverage baseline caches
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea #v7.0.1
+        with:
+          script: |
+            const caches = await github.paginate(
+              github.rest.actions.getActionsCacheList,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                ref: 'refs/heads/main',
+                key: 'coverage-baseline-linux-',
+                sort: 'created_at',
+                direction: 'desc',
+                per_page: 100,
+              },
+              response => response.data.actions_caches,
+            );
+
+            if (caches.length === 0) {
+              core.warning('No coverage baseline cache found.');
+              return;
+            }
+
+            const [keep, ...toDelete] = caches;
+            console.log(`Keeping newest cache: ${keep.key} (id ${keep.id})`);
+
+            if (toDelete.length === 0) {
+              console.log('No stale caches to delete.');
+              return;
+            }
+
+            for (const cache of toDelete) {
+              console.log(`Deleting: ${cache.key} (id ${cache.id})`);
+              await github.rest.actions.deleteActionsCacheById({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                cache_id: cache.id,
+              });
+            }
+
+            console.log(`Deleted ${toDelete.length} stale cache(s).`);

--- a/tools/coverage/check-coverage-regression.py
+++ b/tools/coverage/check-coverage-regression.py
@@ -12,7 +12,8 @@ Usage:
     current-dir   Directory containing coverage-summary.json files from the
                   current PR run (e.g. out/coverage)
 
-Exits with code 1 if any stack's line coverage is below the baseline.
+Exits with code 1 if any stack's line coverage is below the baseline, or code 2
+if a required coverage summary is missing.
 
 Tolerance: 0.20% — small decreases within this margin are ignored to absorb
 instrumentation noise across runs. Anything beyond this is treated as a
@@ -83,8 +84,11 @@ def main() -> int:
         current_pct = load_pct(current_dir, stack)
 
         if baseline_pct is None:
-            print(f"[{name}] no baseline — skipping")
-            continue
+            print(
+                f"[{name}] coverage-summary.json not found in {baseline_dir}",
+                file=sys.stderr,
+            )
+            return 2
         if current_pct is None:
             print(
                 f"[{name}] coverage-summary.json not found in {current_dir}",


### PR DESCRIPTION
## Linked issue

Fixes #5418

## Summary / motivation

Every push to `main` creates a new `coverage-baseline-linux-<sha>` cache entry. Without a pruning step, these entries accumulate until GitHub's LRU eviction removes old ones. When the baseline a PR needs has been evicted, `check-coverage-regression.py` silently skips the check instead of failing, which could mask genuine coverage regressions.

Two changes together close the gap:

1. **`prune-coverage-cache.yml`**: a new workflow triggered by `workflow_run` on every successful CI run on `main`. It keeps exactly one `coverage-baseline-linux-*` cache (the one just created) and deletes all older entries via the GitHub Actions API. With a single, always-fresh entry, eviction becomes practically impossible.

2. **`check-coverage-regression.py`**: turns the silent "no baseline — skipping" path into an explicit failure (`exit 2`). If somehow a baseline is still absent, the check now surfaces the problem visibly instead of passing silently.

## Steps to reproduce

1. Allow several pushes to `main` to accumulate `coverage-baseline-linux-*` cache entries until GitHub evicts the most recent one.
2. Open a PR: `check-coverage-regression.py` prints `no baseline — skipping` and exits 0, even if coverage dropped.

## How to test

### Details

- After merging, verify via **Actions → Prune coverage baseline caches** that the job runs after a `CI` completion on `main` and leaves exactly one `coverage-baseline-linux-*` entry (`gh cache list -R ankitects/anki --key coverage-baseline-linux-`).
- Confirm that a PR with a missing baseline now receives exit code 2 (visible failure) instead of exit code 0.

## Before / after behavior

**Before:** evicted baseline → `check-coverage-regression.py` skips silently, coverage regressions go undetected.

**After:** only one baseline exists at a time (no eviction risk); if it is somehow absent, the script exits with code 2 and the CI step fails visibly.
