### PR TITLE
feat: improved error message for CSV import

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -299,6 +299,7 @@ Han Lua <72375847+xiaohan484@users.noreply.github.com>
 Andreas U. Schmidhauser <github.com/schmidhauser>
 Peter Szilvasi <peti.szilvasi95@gmail.com>
 JaksonSouza <jaksonsouza.dev@gmail.com>
+Carlos Mendez <carlos12mcg@gmail.com>
 ********************
 
 The text of the 3 clause BSD license follows:

--- a/ftl/core/errors.ftl
+++ b/ftl/core/errors.ftl
@@ -18,6 +18,11 @@ errors-no-updates-available = No updates available.
 errors-bad-directive = Error in directive '{ $directive }': { $error }
 errors-option-not-set = '{ $option }' not set
 
+## Error pages
+
+errors-ok = OK
+errors-unknown-error = Unknown error
+
 ## NO NEED TO TRANSLATE. This text is no longer used by Anki, and will be removed in the future.
 
 errors-invalid-input-empty = Invalid input.

--- a/ftl/core/errors.ftl
+++ b/ftl/core/errors.ftl
@@ -18,11 +18,6 @@ errors-no-updates-available = No updates available.
 errors-bad-directive = Error in directive '{ $directive }': { $error }
 errors-option-not-set = '{ $option }' not set
 
-## Error pages
-
-errors-ok = OK
-errors-unknown-error = Unknown error
-
 ## NO NEED TO TRANSLATE. This text is no longer used by Anki, and will be removed in the future.
 
 errors-invalid-input-empty = Invalid input.

--- a/proto/anki/frontend.proto
+++ b/proto/anki/frontend.proto
@@ -61,6 +61,9 @@ service FrontendService {
 
   // Save colour picker's custom colour palette
   rpc SaveCustomColours(generic.Empty) returns (generic.Empty);
+
+  // CSV import
+  rpc ImportDialogRequireClose(generic.Empty) returns (generic.Empty);
 }
 
 service BackendFrontendService {}

--- a/qt/aqt/mediasrv.py
+++ b/qt/aqt/mediasrv.py
@@ -708,6 +708,19 @@ def import_done() -> bytes:
     return b""
 
 
+def import_dialog_require_close() -> bytes:
+    def handle_on_main() -> None:
+        if window := aqt.mw.app.activeModalWidget():
+            from aqt.import_export.import_dialog import ImportDialog
+
+            if isinstance(window, ImportDialog):
+                window.reject()
+
+    aqt.mw.taskman.run_on_main(handle_on_main)
+
+    return b""
+
+
 def search_in_browser() -> bytes:
     node = SearchNode()
     node.ParseFromString(request.data)
@@ -1089,6 +1102,7 @@ post_handler_list = [
     set_scheduling_states,
     change_notetype,
     import_done,
+    import_dialog_require_close,
     search_in_browser,
     deck_options_require_close,
     deck_options_ready,

--- a/ts/lib/components/ErrorPage.svelte
+++ b/ts/lib/components/ErrorPage.svelte
@@ -3,16 +3,35 @@ Copyright: Ankitects Pty Ltd and contributors
 License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 -->
 <script lang="ts">
+    import { importDialogRequireClose } from "@generated/backend";
+
     export let error: Error;
+
+    async function closePage(): Promise<void> {
+        await importDialogRequireClose({});
+    }
 </script>
 
-<div class="message">
-    {error.message}
+<div class="error-box">
+    <p class="error-text">{error.message}</p>
+    <button class="btn btn-primary" on:click={closePage}>Okay</button>
 </div>
 
 <style lang="scss">
-    .message {
+    .error-box {
+        background-color: var(--window-bg);
+        border: 1px solid var(--error-fg);
+        color: var(--fg);
+        padding: 1rem;
+        border-radius: 0.5rem;
+        max-width: 400px;
+        margin: 1rem auto;
         text-align: center;
-        margin: 50px 0 0;
+        box-shadow: 0 0 6px rgba(0, 0, 0, 0.15);
+    }
+    .error-text {
+        color: var(--error-fg);
+        font-weight: 600;
+        margin-bottom: 0.75rem;
     }
 </style>

--- a/ts/lib/components/ErrorPage.svelte
+++ b/ts/lib/components/ErrorPage.svelte
@@ -15,7 +15,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
 <div class="error-box">
     <p class="error-text">{error.message}</p>
-    <button class="btn btn-primary" on:click={closePage}>{tr.errorsOk()}</button>
+    <button class="btn btn-primary" on:click={closePage}>{tr.helpOk()}</button>
 </div>
 
 <style lang="scss">

--- a/ts/lib/components/ErrorPage.svelte
+++ b/ts/lib/components/ErrorPage.svelte
@@ -4,6 +4,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 -->
 <script lang="ts">
     import { importDialogRequireClose } from "@generated/backend";
+    import * as tr from "@generated/ftl";
 
     export let error: Error;
 
@@ -14,7 +15,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
 <div class="error-box">
     <p class="error-text">{error.message}</p>
-    <button class="btn btn-primary" on:click={closePage}>Okay</button>
+    <button class="btn btn-primary" on:click={closePage}>{tr.errorsOk()}</button>
 </div>
 
 <style lang="scss">

--- a/ts/lib/generated/post.ts
+++ b/ts/lib/generated/post.ts
@@ -50,7 +50,7 @@ async function postProtoInner(
         } catch {
             // ignore
         }
-        throw new Error(`${result.status}: ${msg}`);
+        throw new Error(process.env.NODE_ENV === "production" ? `${msg}` : `${result.status}: ${msg}`);
     }
     const blob = await result.blob();
     const respBuf = await new Response(blob).arrayBuffer();

--- a/ts/routes/import-csv/[...path]/+error.svelte
+++ b/ts/routes/import-csv/[...path]/+error.svelte
@@ -1,0 +1,13 @@
+<!--
+Copyright: Ankitects Pty Ltd and contributors
+License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
+-->
+
+<script lang="ts">
+    import { page } from "$app/state";
+    import ErrorPage from "$lib/components/ErrorPage.svelte";
+
+    $: error = new Error(page.error?.message ?? "Unknown error");
+</script>
+
+<ErrorPage {error} />

--- a/ts/routes/import-csv/[...path]/+error.svelte
+++ b/ts/routes/import-csv/[...path]/+error.svelte
@@ -5,9 +5,10 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
 <script lang="ts">
     import { page } from "$app/state";
+    import * as tr from "@generated/ftl";
     import ErrorPage from "$lib/components/ErrorPage.svelte";
 
-    $: error = new Error(page.error?.message ?? "Unknown error");
+    $: error = new Error(page.error?.message ?? tr.errorsUnknownError());
 </script>
 
 <ErrorPage {error} />

--- a/ts/routes/import-csv/[...path]/+error.svelte
+++ b/ts/routes/import-csv/[...path]/+error.svelte
@@ -5,10 +5,9 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
 <script lang="ts">
     import { page } from "$app/state";
-    import * as tr from "@generated/ftl";
     import ErrorPage from "$lib/components/ErrorPage.svelte";
 
-    $: error = new Error(page.error?.message ?? tr.errorsUnknownError());
+    $: error = new Error(page.error?.message ?? "Unknown error");
 </script>
 
 <ErrorPage {error} />

--- a/ts/routes/import-csv/[...path]/+page.svelte
+++ b/ts/routes/import-csv/[...path]/+page.svelte
@@ -3,10 +3,15 @@ Copyright: Ankitects Pty Ltd and contributors
 License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 -->
 <script lang="ts">
+    import ErrorPage from "$lib/components/ErrorPage.svelte";
     import ImportCsvPage from "../ImportCsvPage.svelte";
     import type { PageData } from "./$types";
 
     export let data: PageData;
 </script>
 
-<ImportCsvPage state={data.state} />
+{#if data.initialError}
+    <ErrorPage error={data.initialError} />
+{:else}
+    <ImportCsvPage state={data.state} />
+{/if}

--- a/ts/routes/import-csv/[...path]/+page.ts
+++ b/ts/routes/import-csv/[...path]/+page.ts
@@ -6,14 +6,19 @@ import { ImportCsvState } from "../lib";
 import type { PageLoad } from "./$types";
 
 export const load = (async ({ params }) => {
-    const [notetypes, decks, metadata] = await Promise.all([
-        getNotetypeNames({}),
-        getDeckNames({
-            skipEmptyDefault: false,
-            includeFiltered: false,
-        }),
-        getCsvMetadata({ path: params.path }, { alertOnError: false }),
-    ]);
-    const state = new ImportCsvState(params.path, notetypes, decks, metadata);
-    return { state };
+    try {
+        const [notetypes, decks, metadata] = await Promise.all([
+            getNotetypeNames({}),
+            getDeckNames({
+                skipEmptyDefault: false,
+                includeFiltered: false,
+            }),
+            getCsvMetadata({ path: params.path }, { alertOnError: false }),
+        ]);
+        const state = new ImportCsvState(params.path, notetypes, decks, metadata);
+        return { state };
+    } catch (error: unknown) {
+        const message = error instanceof Error ? error.message : String(error ?? "");
+        return { initialError: new Error(message) };
+    }
 }) satisfies PageLoad;


### PR DESCRIPTION
<!--
Title (for the Pull Request title field at the top):
Use a short prefix so the change type is obvious. You do not need to repeat it in the body below.

Examples:
- fix: — bugfix
- feat: — feature
- refactor: — internal change without user-facing feature
- docs: — documentation only
- chore: — tooling, CI, deps, build housekeeping
- test: — tests only
-->

## Linked issue (required)

<!-- Fixes #123 / Closes #123 -->
Fixes #4346 

## Summary / motivation (required)

<!-- What this PR does and why. For larger changes, add enough context for reviewers. -->
Improves the CSV import error experience for empty or invalid CSV files. 

Previously, the import error page exposed an HTTP status code and did not provide a clear way for the user to dismiss the error and return to the main Anki window.

Changes:
- displays the import error without exposing the HTTP status code
- adds an "Okay" button to dismiss the error
- use Anki frontend RPC architecture to close the active import dialog
- handles CSV import loader errors with a try/catch and displays them through the shared ErrorPage component

The solution uses the existing `ImportDialog.reject()` path so the dialog box performs normal clean up before closing.

This implementation was inspired by the previous discussion and earlier work in #4383. Thank you @medProgAyat and @josod827. Your discussion and implementations were a great assest to helping me solve and implement a solution.

## Steps to reproduce (required, use N/A if not applicable)

<!-- Steps to reproduce: how to trigger the bug in the broken state (the "before").
 - Mainly for bugfixes;
    - For bugs: numbered steps before the fix. For non-bugs: write N/A.
 - use N/A for features, refactors, docs, chore, etc.
-->

1. open Anki and click on import button
2. select a empty csv
3. error page should open

## How to test (required)

<!--- How to test: how you verified the change (checks, unit tests, manual steps, edge cases — the "after" or general validation). --->

### Checklist (minimum)

- [ x] I ran `./ninja check` or an equivalent relevant check locally.
- [ ] I added or updated tests when the change is non-trivial or behavior changed.

### Details

<!-- Commands, manual steps, edge cases, and what you observed -->
Manual testing:
1. Imported an empty CSV file.
2. Confirmed the custom error page is displayed.
3. Confirmed the HTTP status code is not displayed to the user.
4. Confirmed clicking the "Okay" button closes the import dialog and returns to the main Anki window.
5. Imported a valid CSV file and confirmed the normal CSV import flow still works.

## Before / after behavior (optional)

<!-- For bugfixes: behavior before vs after. For other types: N/A or a short note. -->

Before:
- Empty CSV imports display an error without a clear dismissal action.
- Development error output may include the HTTP status code.

After:
- The error is displayed through the shared error UI.
- The user can click "Okay" to close the import dialog.
- The close action is handled through a frontend RPC.

## Risk / compatibility / migration (optional)

<!-- Breaking changes, rollout notes, or N/A for small / low-risk PRs -->

Low risk. The change is limited to CSV import error handling and the import dialog close path.


## UI evidence (required for visual changes; otherwise N/A)

<!-- Screenshot or short video -->

before:
<img width="800" height="800" alt="image" src="https://github.com/user-attachments/assets/4fe77689-3ebd-4a98-9bd9-4916214bbb29" />

after:
<img width="788" height="818" alt="image" src="https://github.com/user-attachments/assets/8451f465-894a-4f52-a11b-459fc6840326" />


## Scope

- [x ] This PR is focused on one change (no unrelated edits).
