### PR TITLE
fix: add cache-bust to load_sveltekit_page for stats

### DIFF
--- a/qt/aqt/stats.py
+++ b/qt/aqt/stats.py
@@ -138,7 +138,7 @@ class NewDeckStats(QDialog):
         return False
 
     def refresh(self) -> None:
-        self.form.web.load_sveltekit_page("graphs")
+        self.form.web.load_sveltekit_page("graphs", cache_bust=True)
 
 
 class DeckStats(QDialog):

--- a/qt/aqt/webview.py
+++ b/qt/aqt/webview.py
@@ -9,6 +9,7 @@ import logging
 import os
 import re
 import sys
+import time
 from collections.abc import Callable, Sequence
 from enum import Enum
 from typing import TYPE_CHECKING, Any, Type, cast
@@ -915,14 +916,16 @@ html {{ {font} }}
         self.load_url(QUrl(f"{mw.serverURL()}_anki/pages/{name}.html{extra}"))
         self._uses_dynamic_styling = True
 
-    def load_sveltekit_page(self, path: str) -> None:
+    def load_sveltekit_page(self, path: str, cache_bust: bool = False) -> None:
         from aqt import mw
 
         self.set_open_links_externally(True)
+
+        extra = ""
+        if cache_bust:
+            extra += "?cb=" + str(time.time())
         if theme_manager.night_mode:
-            extra = "#night"
-        else:
-            extra = ""
+            extra += "#night"
 
         if hmr_mode:
             server = "http://127.0.0.1:5173/"


### PR DESCRIPTION
## Linked issue (required)

Closes #5485

## Summary / motivation (required)

Reproduced, bisected to https://github.com/ankitects/anki/commit/5a9b54e9380c66e26391f0827867d2a728107836. I think qt 6.10 introduced (stronger?) caching for the webengine, which this pr accounts for by cache-busting. Doesn't look like we use `load_sveltekit_page` for refreshing/reloading anywhere else other than for stats

## Steps to reproduce (required, use N/A if not applicable)

See linked issue

## How to test (required)

Try the stats' page's deck selector button and see that it works now

### Checklist (minimum)

- [x] I ran `./ninja check` or an equivalent relevant check locally.
- [ ] I added or updated tests when the change is non-trivial or behavior changed.

## Scope

- [x] This PR is focused on one change (no unrelated edits).
