### PR TITLE
fix: don't attach a file handler to add-on child loggers

### DIFF
--- a/qt/aqt/log.py
+++ b/qt/aqt/log.py
@@ -43,6 +43,15 @@ class AnkiLoggerManager(logging.Manager):
         logger = super().getLogger(name)
 
         module = name.split(ADDON_LOGGER_PREFIX)[1].partition(".")[0]
+
+        # Only the add-on's base logger gets a file handler. Loggers created
+        # from it via getChild() (e.g. "addon.foo.bar") share this handler
+        # through propagation. Attaching a second handler that points at the
+        # same file would duplicate log lines and, on Windows, raise
+        # PermissionError when the handler rotates an already-open file.
+        if name != ADDON_LOGGER_PREFIX + module:
+            return logger
+
         path = get_addon_logs_folder(self.logs_path, module=module) / f"{module}.log"
         path.parent.mkdir(parents=True, exist_ok=True)
 


### PR DESCRIPTION
## Linked issue (required)

Fixes #5487

## Summary / motivation (required)

`getLogger()` in `AnkiLoggerManager` adds a `TimedRotatingFileHandler` to every logger whose name starts with `addon.` — including loggers created from an add-on logger with `getChild()` (e.g. `addon.702300994.abc`). Each such child logger ends up with its own handler pointing at the same file as the parent.

That has two consequences:

- log lines get written twice (once by the parent's handler, once by the child's), and
- on Windows, when the handler rotates the file it can't rename an already-open file, so logging blows up with `PermissionError: [WinError 32]`.

Child loggers already reach the parent's handler through normal propagation, so they don't need their own. The fix only attaches the file handler to the add-on's base logger (`addon.<module>`), not to its children.

## Steps to reproduce (required, use N/A if not applicable)

1. Create an add-on logger with `AddonManager.get_logger(addon_module)`.
2. Create a child logger with `addon_logger.getChild("abc")`.
3. Log something, and let the file handler roll over (or just inspect `logger.handlers`). The child logger has its own `TimedRotatingFileHandler` for the same file.

## How to test (required)

### Checklist (minimum)

- [x] I added or updated tests when the change is non-trivial or behavior changed.

### Details

I exercised `AnkiLoggerManager` directly (loading `qt/aqt/log.py` standalone, no Qt needed):

- `getLogger("addon.702300994")` → 1 handler (the file handler).
- `getLogger("addon.702300994.abc")` → 0 handlers; it still propagates to the parent, so `child.info("x")` ends up in the same file.
- Only one handler points at `702300994.log`, so no duplicate writes and no second handle contending on rotation.

Before the change the child logger got its own handler (duplicate writes + the Windows rotation error); after, it doesn't.

## Before / after behavior (optional)

Before: child add-on loggers had their own file handler → duplicated log lines and `PermissionError` on rotation under Windows.
After: only the base add-on logger has the file handler; children use propagation.

## Risk / compatibility / migration (optional)

Low risk. Behavior for the base add-on logger is unchanged; only child loggers stop getting a redundant handler.

## UI evidence (required for visual changes; otherwise N/A)

N/A — no UI change.

## Scope
