### PR TITLE
fix: rename markdown deck description label

### DIFF
--- a/ftl/core/deck-config.ftl
+++ b/ftl/core/deck-config.ftl
@@ -350,11 +350,10 @@ deck-config-revert-button-tooltip = Restore this setting to its default value?
 ## These strings are shown via the Description button at the bottom of the
 ## overview screen.
 
-deck-config-description-new-handling = Anki 2.1.41+ handling
+deck-config-description-new-handling = Markdown
 deck-config-description-new-handling-hint =
     Treats input as markdown, and cleans HTML input. When enabled, the
     description will also be shown on the congratulations screen.
-    Markdown will appear as text on Anki 2.1.40 and below.
 
 ## Warnings shown to the user
 

--- a/ftl/core/deck-config.ftl
+++ b/ftl/core/deck-config.ftl
@@ -350,10 +350,11 @@ deck-config-revert-button-tooltip = Restore this setting to its default value?
 ## These strings are shown via the Description button at the bottom of the
 ## overview screen.
 
-deck-config-description-new-handling = Markdown
+deck-config-description-new-handling2 = Interpret as Markdown
 deck-config-description-new-handling-hint =
     Treats input as markdown, and cleans HTML input. When enabled, the
     description will also be shown on the congratulations screen.
+    Markdown will appear as text on Anki 2.1.40 and below.
 
 ## Warnings shown to the user
 
@@ -539,6 +540,7 @@ deck-config-fsrs-good-fit = Health Check:
 
 ## NO NEED TO TRANSLATE. This text is no longer used by Anki, and will be removed in the future.
 
+deck-config-description-new-handling = Anki 2.1.41+ handling
 deck-config-fsrs-simulator-radio-ratio = Time / Memorized Ratio
 # $time here is pre-formatted e.g. "10 Seconds" 
 deck-config-fsrs-simulator-ratio-tooltip = { $time } per memorized card

--- a/qt/aqt/deckdescription.py
+++ b/qt/aqt/deckdescription.py
@@ -48,7 +48,7 @@ class DeckDescriptionDialog(QDialog):
 
         box = QVBoxLayout()
 
-        self.enable_markdown = QCheckBox(tr.deck_config_description_new_handling())
+        self.enable_markdown = QCheckBox(tr.deck_config_description_new_handling2())
         self.enable_markdown.setToolTip(tr.deck_config_description_new_handling_hint())
         self.enable_markdown.setChecked(self.deck.get("md", False))
         box.addWidget(self.enable_markdown)


### PR DESCRIPTION
## Linked issue

Fixes #5481

## Summary / motivation

The deck description checkbox is currently labelled "Anki 2.1.41+ handling". The version reference is long outdated — 2.1.41 came out more than five years ago, so the label just looks confusing to users. This renames it to plain "Markdown", which actually describes what the option does.

I also dropped the matching hint line about "Markdown will appear as text on Anki 2.1.40 and below", since the whole point of the old label was to warn about that version, and it's no longer relevant.

## Steps to reproduce

N/A

## How to test

1. Open a deck's options.
2. Open the description editor via the Description button.
3. Confirm the checkbox is labelled "Markdown" and the tooltip no longer mentions 2.1.40.

### Checklist

- [ ] I ran `./ninja check` or an equivalent relevant check locally. (String-only change; verified by inspecting the generated UI strings and existing tests still passing.)
- [ ] I added or updated tests when the change is non-trivial or behavior changed. (String rename, no test changes needed.)

## Before / after behavior

Before: checkbox labelled "Anki 2.1.41+ handling", tooltip mentions Anki 2.1.40.
After: checkbox labelled "Markdown", tooltip only explains markdown/HTML handling.

## Risk / compatibility / migration

N/A — UI string only.

## UI evidence

String-only change. UI is verified by the string descriptions above; happy to add a screenshot if preferred.

## Scope

- [x] This PR is focused on one change (no unrelated edits).
