### PR TITLE
fix: vacuum after schema-11 downgrade to avoid freelist waste

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -299,6 +299,7 @@ Han Lua <72375847+xiaohan484@users.noreply.github.com>
 Andreas U. Schmidhauser <github.com/schmidhauser>
 Peter Szilvasi <peti.szilvasi95@gmail.com>
 JaksonSouza <jaksonsouza.dev@gmail.com>
+Callum Hart <https://github.com/hartblanc>
 ********************
 
 The text of the 3 clause BSD license follows:

--- a/rslib/src/storage/upgrades/mod.rs
+++ b/rslib/src/storage/upgrades/mod.rs
@@ -71,6 +71,11 @@ impl SqliteStorage {
 
         self.commit_trx()?;
 
+        // The schema-11 downgrade drops tables/indexes, which leaves pages on
+        // the SQLite freelist without shrinking the file. Vacuum afterwards so
+        // legacy exports don't carry this wasted space.
+        self.db.execute_batch("vacuum")?;
+
         Ok(())
     }
 }
@@ -110,6 +115,24 @@ mod test {
             .build()?;
         let card = &col.storage.get_all_cards()[0];
         assert_eq!(card.ease_factor, 1400);
+        Ok(())
+    }
+
+    #[test]
+    fn schema11_downgrade_leaves_no_freelist_pages() -> Result<()> {
+        let tempfile = new_tempfile()?;
+        let mut col = CollectionBuilder::default()
+            .set_collection_path(tempfile.path())
+            .build()?;
+        let nt = col.get_notetype_by_name("Basic")?.unwrap();
+        let mut note = nt.new_note();
+        col.add_note(&mut note, DeckId(1))?;
+        col.close(Some(SchemaVersion::V11))?;
+
+        let conn = rusqlite::Connection::open(tempfile.path())?;
+        let freelist: i64 = conn.query_row("pragma freelist_count", [], |row| row.get(0))?;
+        assert_eq!(freelist, 0);
+
         Ok(())
     }
 }


### PR DESCRIPTION
## Linked issue (required)

Fixes #5490

## Summary / motivation (required)

The schema-11 downgrade (`schema11_downgrade.sql`) drops tables and indexes, which leaves pages on the SQLite freelist without shrinking the file. This causes `.apkg` exports to carry wasted space:

- **Legacy exports:** `collection.anki21` is downgraded to V11 before being copied, so it carries freelist pages.
- **Both legacy and non-legacy exports:** every package includes a dummy `collection.anki2` that is built at V18, vacuumed, then downgraded to V11 — the downgrade re-creates freelist pages after the vacuum.

Non-legacy main DBs (`collection.anki21b`) are unaffected because closing at V18 is a no-op.

Real-world example: the [UK Geography | Regions, Counties, and Cities](https://ankiweb.net/shared/info/80961363) shared deck (~200 notes), exported from the same build with and without this change:

| Export | Before | After | Saving |
|---|---|---|---|
| Legacy (compatibility) | 751 KB | 706 KB | ~46 KB (~6%) |
| Non-legacy (zstd) | 269 KB | 240 KB | ~29 KB (~11%) |

Freelist pages observed:
- Legacy: `collection.anki21` had 37 free pages; dummy `collection.anki2` had 56.
- Non-legacy: `collection.anki21b` had 0 free pages; dummy `collection.anki2` had 56.

## Steps to reproduce (required)

The issue is observable by inspecting exported packages:

1. Export a legacy `.apkg`.
2. Extract `collection.anki21` / `collection.anki2`.
3. Run `PRAGMA freelist_count` — it returns > 0.

## How to test (required)

- I built the macOS desktop app from this branch and used it to export both legacy and non-legacy `.apkg` files from the UK Geography deck. In the resulting packages, `PRAGMA freelist_count` returns 0 for `collection.anki21`, `collection.anki21b`, and `collection.anki2`.
- `cargo test -p anki schema11_downgrade_leaves_no_freelist_pages --lib` — passes with the fix, fails without it.
- `./ninja check` passes.

### Checklist (minimum)

- [x] I ran `./ninja check` or an equivalent relevant check locally.
- [x] I added or updated tests when the change is non-trivial or behavior changed.

### Details

Change: run `VACUUM` after the downgrade transaction commits in `downgrade_to_schema_11`.

## Before / after behavior (optional)

Before: legacy exports and the dummy `collection.anki2` in all exports carry SQLite freelist pages, adding unnecessary size to anki packages.

After: both are compact (`freelist_count == 0`). Non-legacy main DBs are unchanged.

## Risk / compatibility / migration (optional)

Low — VACUUM after downgrade only affects schema-11 output; no schema or format changes.

## UI evidence (required for visual changes; otherwise N/A)

N/A

## Scope

- [x] This PR is focused on one change (no unrelated edits).
