### PR TITLE
fix: only attach handler to add-on's root logger

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -299,6 +299,7 @@ Han Lua <72375847+xiaohan484@users.noreply.github.com>
 Andreas U. Schmidhauser <github.com/schmidhauser>
 Peter Szilvasi <peti.szilvasi95@gmail.com>
 JaksonSouza <jaksonsouza.dev@gmail.com>
+danny900714 <https://github.com/danny900714>
 ********************
 
 The text of the 3 clause BSD license follows:

--- a/qt/aqt/log.py
+++ b/qt/aqt/log.py
@@ -39,22 +39,25 @@ class AnkiLoggerManager(logging.Manager):
         if not name.startswith(ADDON_LOGGER_PREFIX) or name in self.loggerDict:
             return super().getLogger(name)
 
-        # Create a new add-on logger
-        logger = super().getLogger(name)
+        module = name.removeprefix(ADDON_LOGGER_PREFIX).split(".", maxsplit=1)[0]
+        addon_logger_name = f"{ADDON_LOGGER_PREFIX}{module}"
 
-        module = name.split(ADDON_LOGGER_PREFIX)[1].partition(".")[0]
-        path = get_addon_logs_folder(self.logs_path, module=module) / f"{module}.log"
-        path.parent.mkdir(parents=True, exist_ok=True)
+        if addon_logger_name not in self.loggerDict:
+            # Create a new add-on logger
+            logger = super().getLogger(addon_logger_name)
 
-        # Keep the last 10 days of logs
-        handler = TimedRotatingFileHandler(
-            filename=path, when="D", interval=1, backupCount=10, encoding="utf-8"
-        )
-        handler.setFormatter(FORMATTER)
+            path = get_addon_logs_folder(self.logs_path, module=module) / f"{module}.log"
+            path.parent.mkdir(parents=True, exist_ok=True)
 
-        logger.addHandler(handler)
+            # Keep the last 10 days of logs
+            handler = TimedRotatingFileHandler(
+                filename=path, when="D", interval=1, backupCount=10, encoding="utf-8"
+            )
+            handler.setFormatter(FORMATTER)
 
-        return logger
+            logger.addHandler(handler)
+
+        return super().getLogger(name)
 
 
 def get_addon_logs_folder(logs_path: Path | str, module: str) -> Path:

--- a/qt/aqt/log.py
+++ b/qt/aqt/log.py
@@ -26,10 +26,10 @@ class AnkiLoggerManager(logging.Manager):
     # inspired by: https://github.com/abdnh/ankiutils/blob/master/src/ankiutils/log.py
 
     def __init__(
-        self,
-        logs_path: Path | str,
-        existing_loggers: dict[str, logging.Logger | logging.PlaceHolder],
-        rootnode: logging.RootLogger,
+            self,
+            logs_path: Path | str,
+            existing_loggers: dict[str, logging.Logger | logging.PlaceHolder],
+            rootnode: logging.RootLogger,
     ):
         super().__init__(rootnode)
         self.loggerDict = existing_loggers
@@ -46,7 +46,9 @@ class AnkiLoggerManager(logging.Manager):
             # Create a new add-on logger
             logger = super().getLogger(addon_logger_name)
 
-            path = get_addon_logs_folder(self.logs_path, module=module) / f"{module}.log"
+            path = (
+                get_addon_logs_folder(self.logs_path, module=module) / f"{module}.log"
+            )
             path.parent.mkdir(parents=True, exist_ok=True)
 
             # Keep the last 10 days of logs

--- a/qt/aqt/log.py
+++ b/qt/aqt/log.py
@@ -26,10 +26,10 @@ class AnkiLoggerManager(logging.Manager):
     # inspired by: https://github.com/abdnh/ankiutils/blob/master/src/ankiutils/log.py
 
     def __init__(
-            self,
-            logs_path: Path | str,
-            existing_loggers: dict[str, logging.Logger | logging.PlaceHolder],
-            rootnode: logging.RootLogger,
+        self,
+        logs_path: Path | str,
+        existing_loggers: dict[str, logging.Logger | logging.PlaceHolder],
+        rootnode: logging.RootLogger,
     ):
         super().__init__(rootnode)
         self.loggerDict = existing_loggers


### PR DESCRIPTION
<!--
Title (for the Pull Request title field at the top):
Use a short prefix so the change type is obvious. You do not need to repeat it in the body below.

Examples:
- fix: — bugfix
- feat: — feature
- refactor: — internal change without user-facing feature
- docs: — documentation only
- chore: — tooling, CI, deps, build housekeeping
- test: — tests only
-->

## Linked issue (required)

Fixes #5487.

## Summary / motivation (required)

<!-- What this PR does and why. For larger changes, add enough context for reviewers. -->

When deriving a child logger from an add-on logger, both of them got `TimedRotatingFileHandler` attached to the loggers handler. This makes log messages duplicated in log file and cause `PermissionError: [WinError 32]` when rotating  log files on Windows.

To solve this issue, the new `get_logger` only attaches `TimedRotatingFileHandler` to the add-on logger (`addon.name`), not the child one (`addon.name.child`). Besides, when a child logger is created with `logging.getLogger("addon.name.child")`, the add-on logger (`addon.name`) is created if not existed. 
The add-on logger becomes the one and only logger that has `TimedRotatingFileHandler` handler down the hierarchy from itself.

I also fixes a minor bug of `module` variable. In the previous implementation, the `module` only contained part of the module name if the name contained `addon.`. I use `removeprefix` to solve it.

## Steps to reproduce (required, use N/A if not applicable)

<!-- Steps to reproduce: how to trigger the bug in the broken state (the "before").
 - Mainly for bugfixes;
    - For bugs: numbered steps before the fix. For non-bugs: write N/A.
 - use N/A for features, refactors, docs, chore, etc.
-->

`Anki2/addons21/test_logger/__init__.py`:
```python
from aqt.addons import AddonManager

logger = AddonManager.get_logger(__name__)
child_logger = logger.getChild("child")

child_logger.info("This info messages is duplicated in log file.")
```

When the log file is rotated on Windows, it raises `PermissionError: [WinError 32]`. Please check #5487 for detailed bug report.

## How to test (required)

<!--- How to test: how you verified the change (checks, unit tests, manual steps, edge cases — the "after" or general validation). --->

### Checklist (minimum)

- [x] I ran `./ninja check` or an equivalent relevant check locally.
- [x] I added or updated tests when the change is non-trivial or behavior changed.

### Details

<!-- Commands, manual steps, edge cases, and what you observed -->

Just create a test add-on to check this behavior as the "Steps to reproduce" above.

## Before / after behavior (optional)

<!-- For bugfixes: behavior before vs after. For other types: N/A or a short note. -->

### Before
1. When deriving a child logger from an add-on logger, both of them got `TimedRotatingFileHandler` attached to the loggers handler. The log messages duplicated in log file and cause `PermissionError: [WinError 32]` when rotating  log files on Windows.
2. If the logger name contains `addon.`, characters after `addon.` are stripped.

### After
1. When an add-on logger is created no matter it is an add-on logger (`addon.name`) or a child logger (`addon.name.child`), the add-on logger is created with `TimedRotatingFileHandler` handler, and the child logger is created as a normal logger.

## UI evidence (required for visual changes; otherwise N/A)

N/A

## Scope

- [x] This PR is focused on one change (no unrelated edits).
