### PR TITLE
Fix: Change deck modifies all cards in deck

### DIFF
--- a/rslib/src/card/mod.rs
+++ b/rslib/src/card/mod.rs
@@ -686,6 +686,42 @@ mod test {
         Ok(())
     }
 
+    // A card that already lives in the target deck and has a memory state must
+    // not be touched when another card is moved into that deck.
+    #[test]
+    fn set_deck_does_not_touch_existing_card_in_target_deck() -> Result<()> {
+        let mut col = Collection::new();
+        let nt = col.get_notetype_by_name("Basic")?.unwrap();
+
+        col.set_config_bool(BoolKey::Fsrs, true, false)?;
+
+        let target = DeckAdder::new("target").add(&mut col);
+
+        let mut target_note = nt.new_note();
+        col.add_note(&mut target_note, target.id)?;
+        let target_card_id = col.storage.card_ids_of_notes(&[target_note.id]).unwrap()[0];
+        col.grade_now(&[target_card_id], 3)?;
+
+        let mut source_note = nt.new_note();
+        col.add_note(&mut source_note, DeckId(1))?;
+        let source_card_id = col.storage.card_ids_of_notes(&[source_note.id]).unwrap()[0];
+        col.grade_now(&[source_card_id], 3)?;
+
+        // Fake a sync after the cards exist, before moving anything.
+        col.before_upload()?;
+
+        col.set_deck(&[source_card_id], target.id)?;
+
+        let before = col.storage.get_card(source_card_id)?.unwrap();
+        assert!(before.memory_state.is_some());
+
+        let after = col.storage.get_card(target_card_id)?.unwrap();
+
+        assert_eq!(before.usn.0, -1);
+        assert_ne!(after.usn.0, -1);
+        Ok(())
+    }
+
     // Moving a deck recomputes the memory state but must not reschedule the
     // card (reschedule: false): due date and interval stay unchanged.
     #[test]

--- a/rslib/src/card/mod.rs
+++ b/rslib/src/card/mod.rs
@@ -401,7 +401,6 @@ impl Collection {
                 let desired_retention = deck.effective_desired_retention(&config);
                 let deck_desired_retention = [(deck_id, desired_retention)].into();
 
-                use crate::search::Node::*;
                 use crate::search::SearchNode::*;
 
                 col.update_memory_state(vec![UpdateMemoryStateEntry {
@@ -414,8 +413,8 @@ impl Collection {
                         deck_desired_retention,
                     }),
                     search: SearchBuilder::all(vec![
-                        Group(vec![DeckIdsWithoutChildren(deck_id.to_string()).into()]),
-                        Group(vec![HasMemoryState.negated()]),
+                        DeckIdsWithoutChildren(deck_id.to_string()).into(),
+                        HasMemoryState.negated(),
                     ])
                     .try_into_search()?,
                     ignore_before: ignore_revlogs_before_ms_from_config(&config)?,

--- a/rslib/src/card/mod.rs
+++ b/rslib/src/card/mod.rs
@@ -401,6 +401,7 @@ impl Collection {
                 let desired_retention = deck.effective_desired_retention(&config);
                 let deck_desired_retention = [(deck_id, desired_retention)].into();
 
+                use crate::search::Node::*;
                 use crate::search::SearchNode::*;
 
                 col.update_memory_state(vec![UpdateMemoryStateEntry {
@@ -413,8 +414,8 @@ impl Collection {
                         deck_desired_retention,
                     }),
                     search: SearchBuilder::all(vec![
-                        DeckIdsWithoutChildren(deck_id.to_string()).into(),
-                        HasMemoryState.negated(),
+                        Group(vec![DeckIdsWithoutChildren(deck_id.to_string()).into()]),
+                        Group(vec![HasMemoryState.negated()]),
                     ])
                     .try_into_search()?,
                     ignore_before: ignore_revlogs_before_ms_from_config(&config)?,

--- a/rslib/src/search/sqlwriter.rs
+++ b/rslib/src/search/sqlwriter.rs
@@ -197,7 +197,7 @@ impl SqlWriter<'_> {
             SearchNode::WholeCollection => write!(self.sql, "true").unwrap(),
             SearchNode::Preset(name) => self.write_deck_preset(name)?,
             SearchNode::HasMemoryState => {
-                write!(self.sql, "(extract_fsrs_variable(c.data, 's') is not null)").unwrap();
+                write!(self.sql, "extract_fsrs_variable(c.data, 's') is not null").unwrap();
             }
         };
         Ok(())

--- a/rslib/src/search/sqlwriter.rs
+++ b/rslib/src/search/sqlwriter.rs
@@ -197,7 +197,7 @@ impl SqlWriter<'_> {
             SearchNode::WholeCollection => write!(self.sql, "true").unwrap(),
             SearchNode::Preset(name) => self.write_deck_preset(name)?,
             SearchNode::HasMemoryState => {
-                write!(self.sql, "extract_fsrs_variable(c.data, 's') is not null").unwrap()
+                write!(self.sql, "extract_fsrs_variable(c.data, 's') is not null").unwrap();
             }
         };
         Ok(())

--- a/rslib/src/search/sqlwriter.rs
+++ b/rslib/src/search/sqlwriter.rs
@@ -1126,6 +1126,7 @@ mod test {
 
     use super::super::parser::parse;
     use super::*;
+    use crate::config::BoolKey;
     use crate::collection::Collection;
     use crate::collection::CollectionBuilder;
 
@@ -1452,6 +1453,35 @@ c.odue != 0 then c.odue else c.due end) != {days}) or (c.queue in (1,4) and
 
         // strip clozes
         assert_eq!(&s(ctx, "sc:abcdef").0, "((n.mid = 1581236385343) and (coalesce(process_text(cast(n.sfld as text), 2), n.sfld) like ?1 escape '\\' or coalesce(process_text(n.flds, 2), n.flds) like ?1 escape '\\'))");
+    }
+
+    #[test]
+    fn has_memory_state_returns_only_reviewed_cards() -> Result<()> {
+        let mut col = Collection::new();
+        let nt = col.get_notetype_by_name("Basic")?.unwrap();
+        col.set_config_bool(BoolKey::Fsrs, true, false)?;
+
+        let mut reviewed_note = nt.new_note();
+        col.add_note(&mut reviewed_note, DeckId(1))?;
+        let reviewed_cid = col.storage.card_ids_of_notes(&[reviewed_note.id]).unwrap()[0];
+        col.grade_now(&[reviewed_cid], 3)?;
+
+        let mut new_note = nt.new_note();
+        col.add_note(&mut new_note, DeckId(1))?;
+        let new_cid = col.storage.card_ids_of_notes(&[new_note.id]).unwrap()[0];
+
+        let cards = col.all_cards_for_search(SearchNode::HasMemoryState)?;
+        let card_ids: Vec<_> = cards.into_iter().map(|card| card.id).collect();
+        assert_eq!(card_ids, vec![reviewed_cid]);
+        assert!(!card_ids.contains(&new_cid));
+
+        let node = Node::Search(SearchNode::HasMemoryState);
+        let mut writer = SqlWriter::new(&mut col, ReturnItemType::Cards);
+        writer.write_node_to_sql(&node).unwrap();
+        assert_eq!(writer.sql, "extract_fsrs_variable(c.data, 's') is not null");
+        assert_eq!(node.required_table(), RequiredTable::Cards);
+
+        Ok(())
     }
 
     #[test]

--- a/rslib/src/search/sqlwriter.rs
+++ b/rslib/src/search/sqlwriter.rs
@@ -173,7 +173,7 @@ impl SqlWriter<'_> {
             SearchNode::DeckIdsWithoutChildren(dids) => {
                 write!(
                     self.sql,
-                    "c.did in ({dids}) or (c.odid != 0 and c.odid in ({dids}))"
+                    "(c.did in ({dids}) or (c.odid != 0 and c.odid in ({dids})))"
                 )
                 .unwrap();
             }
@@ -197,7 +197,7 @@ impl SqlWriter<'_> {
             SearchNode::WholeCollection => write!(self.sql, "true").unwrap(),
             SearchNode::Preset(name) => self.write_deck_preset(name)?,
             SearchNode::HasMemoryState => {
-                write!(self.sql, "extract_fsrs_variable(c.data, 's') is not null").unwrap();
+                write!(self.sql, "(extract_fsrs_variable(c.data, 's') is not null)").unwrap();
             }
         };
         Ok(())

--- a/rslib/src/search/sqlwriter.rs
+++ b/rslib/src/search/sqlwriter.rs
@@ -197,7 +197,7 @@ impl SqlWriter<'_> {
             SearchNode::WholeCollection => write!(self.sql, "true").unwrap(),
             SearchNode::Preset(name) => self.write_deck_preset(name)?,
             SearchNode::HasMemoryState => {
-                write!(self.sql, "extract_fsrs_variable(c.data, 's') is not null").unwrap();
+                write!(self.sql, "extract_fsrs_variable(c.data, 's') is not null").unwrap()
             }
         };
         Ok(())
@@ -1126,9 +1126,9 @@ mod test {
 
     use super::super::parser::parse;
     use super::*;
-    use crate::config::BoolKey;
     use crate::collection::Collection;
     use crate::collection::CollectionBuilder;
+    use crate::config::BoolKey;
 
     // shortcut
     fn s(req: &mut Collection, search: &str) -> (String, Vec<String>) {


### PR DESCRIPTION
fixes #5414

The DeckIdsWithoutChildren search is not surrounded by parentheses.
https://github.com/ankitects/anki/blob/d80273ea71d4e9a3cab91b5a2e5906366809e3ea/rslib/src/search/sqlwriter.rs#L127-L129

Maybe it would be best to surround all these searches with parentheses to be safe? 