### PR TITLE
fix(ci): correct paginate mapFn in prune-coverage-cache workflow

### DIFF
--- a/.github/workflows/prune-coverage-cache.yml
+++ b/.github/workflows/prune-coverage-cache.yml
@@ -37,7 +37,7 @@ jobs:
                 direction: 'desc',
                 per_page: 100,
               },
-              response => response.data.actions_caches,
+              response => response.data,
             );
 
             if (caches.length === 0) {


### PR DESCRIPTION
## Linked issue

Fixes #5501

## Summary / motivation

`github.paginate` hoists the `actions_caches` array directly onto `response.data` for `getActionsCacheList`, so the `mapFn` returning `response.data.actions_caches` yielded `undefined`. That produced `[undefined]`, bypassing the `length === 0` guard and crashing on `keep.key` (`TypeError: Cannot read properties of undefined`).
Fixed by returning `response.data`.

## Steps to reproduce 

1. A `CI` run completes on `main` and triggers the prune workflow.
2. The `prune` job fails with `TypeError: Cannot read properties of undefined (reading 'key')`.

## How to test
### Details

Reproduced against the real API with the same octokit `paginate`: old mapFn → `[undefined]` → crash; new mapFn → real caches array → works. The `workflow_run` trigger only fires on `main`, so it can't be exercised from a branch/PR.