### PR TITLE
test: Improve coverage of notes service

### DIFF
--- a/rslib/src/adding.rs
+++ b/rslib/src/adding.rs
@@ -192,11 +192,6 @@ mod test {
         col.clear_aux_config_for_notetype(col.basic_notetype().id)
             .unwrap();
         col.set_current_deck(normal_deck2.id).unwrap();
-        col.set_current_notetype_id(
-            // Set to an invalid notetype to trigger fallback
-            NotetypeId(0),
-        )
-        .unwrap();
         let defaults = col.defaults_for_adding(DeckId(0)).unwrap();
         assert_eq!(defaults.deck_id, normal_deck2.id);
         assert_eq!(defaults.notetype_id, col.basic_notetype().id);
@@ -204,7 +199,6 @@ mod test {
         // Invalid current note type; fall back to first notetype and current deck
         col.clear_aux_config_for_notetype(col.basic_notetype().id)
             .unwrap();
-        // col.set_current_deck(normal_deck2.id).unwrap();
         col.set_current_notetype_id(
             // Set to an invalid notetype to trigger fallback
             NotetypeId(0),

--- a/rslib/src/adding.rs
+++ b/rslib/src/adding.rs
@@ -120,122 +120,113 @@ mod test {
     use crate::config::ConfigKey;
     use crate::prelude::*;
 
-    fn normal_deck(col: &mut Collection, name: &str) -> Deck {
+    fn normal_deck(col: &mut Collection, name: &str) -> Result<Deck> {
         let mut deck = Deck::new_normal();
         deck.name = NativeDeckName::from_human_name(name);
-        col.add_deck(&mut deck).unwrap();
+        col.add_deck(&mut deck)?;
 
-        deck
+        Ok(deck)
     }
 
-    fn filtered_deck(col: &mut Collection, name: &str) -> Deck {
+    fn filtered_deck(col: &mut Collection, name: &str) -> Result<Deck> {
         let mut deck = Deck::new_filtered();
         deck.name = NativeDeckName::from_human_name(name);
-        col.add_deck(&mut deck).unwrap();
+        col.add_deck(&mut deck)?;
 
-        deck
+        Ok(deck)
     }
 
     #[test]
-    fn defaults() {
+    fn defaults() -> Result<()> {
         let mut col = Collection::new();
-        let normal_deck1 = normal_deck(&mut col, "n1");
-        let filtered_deck1 = filtered_deck(&mut col, "f1");
-        let normal_deck2 = normal_deck(&mut col, "n2");
-        let filtered_deck2 = filtered_deck(&mut col, "f2");
-        let normal_deck3 = normal_deck(&mut col, "n3");
+        let normal_deck1 = normal_deck(&mut col, "n1")?;
+        let filtered_deck1 = filtered_deck(&mut col, "f1")?;
+        let normal_deck2 = normal_deck(&mut col, "n2")?;
+        let filtered_deck2 = filtered_deck(&mut col, "f2")?;
+        let normal_deck3 = normal_deck(&mut col, "n3")?;
 
         // AddingDefaultsToCurrentDeck defaults to true
 
         // Current deck, unset deck's last notetype; fall back to first notetype in
         // collection
-        col.set_current_deck(normal_deck1.id).unwrap();
-        let defaults = col
-            .defaults_for_adding(
-                // Invalid ID to confirm it's not used
-                DeckId(0),
-            )
-            .unwrap();
+        col.set_current_deck(normal_deck1.id)?;
+        let defaults = col.defaults_for_adding(
+            // Invalid ID to confirm it's not used
+            DeckId(0),
+        )?;
         assert_eq!(defaults.deck_id, normal_deck1.id);
         assert_eq!(defaults.notetype_id, col.basic_notetype().id);
 
         // Current deck, current note type
-        col.set_current_notetype_id(col.cloze_notetype().id)
-            .unwrap();
-        let defaults = col.defaults_for_adding(DeckId(0)).unwrap();
+        col.set_current_notetype_id(col.cloze_notetype().id)?;
+        let defaults = col.defaults_for_adding(DeckId(0))?;
         assert_eq!(defaults.deck_id, normal_deck1.id);
         assert_eq!(defaults.notetype_id, col.cloze_notetype().id);
 
         // Current deck, deck's last note type
-        col.set_last_notetype_for_deck(normal_deck1.id, col.basic_rev_notetype().id)
-            .unwrap();
-        let defaults = col.defaults_for_adding(DeckId(0)).unwrap();
+        col.set_last_notetype_for_deck(normal_deck1.id, col.basic_rev_notetype().id)?;
+        let defaults = col.defaults_for_adding(DeckId(0))?;
         assert_eq!(defaults.deck_id, normal_deck1.id);
         assert_eq!(defaults.notetype_id, col.basic_rev_notetype().id);
 
         // Provided deck
-        col.set_current_deck(filtered_deck1.id).unwrap();
-        let defaults = col.defaults_for_adding(normal_deck1.id).unwrap();
+        col.set_current_deck(filtered_deck1.id)?;
+        let defaults = col.defaults_for_adding(normal_deck1.id)?;
         assert_eq!(defaults.deck_id, normal_deck1.id);
 
         // Invalid provided deck; fall back to default deck
-        let defaults = col.defaults_for_adding(DeckId(0)).unwrap();
+        let defaults = col.defaults_for_adding(DeckId(0))?;
         assert_eq!(defaults.deck_id, DeckId(1));
 
         // AddingDefaultsToCurrentDeck=false
-        col.set_config_bool_inner(BoolKey::AddingDefaultsToCurrentDeck, false)
-            .unwrap();
+        col.set_config_bool_inner(BoolKey::AddingDefaultsToCurrentDeck, false)?;
 
         // Unset current note type; fall back to first notetype and current deck
-        col.remove_config_inner(ConfigKey::CurrentNotetypeId)
-            .unwrap();
-        col.clear_aux_config_for_notetype(col.basic_notetype().id)
-            .unwrap();
-        col.set_current_deck(normal_deck2.id).unwrap();
-        let defaults = col.defaults_for_adding(DeckId(0)).unwrap();
+        col.remove_config_inner(ConfigKey::CurrentNotetypeId)?;
+        col.clear_aux_config_for_notetype(col.basic_notetype().id)?;
+        col.set_current_deck(normal_deck2.id)?;
+        let defaults = col.defaults_for_adding(DeckId(0))?;
         assert_eq!(defaults.deck_id, normal_deck2.id);
         assert_eq!(defaults.notetype_id, col.basic_notetype().id);
 
         // Invalid current note type; fall back to first notetype and current deck
-        col.clear_aux_config_for_notetype(col.basic_notetype().id)
-            .unwrap();
+        col.clear_aux_config_for_notetype(col.basic_notetype().id)?;
         col.set_current_notetype_id(
             // Set to an invalid notetype to trigger fallback
             NotetypeId(0),
-        )
-        .unwrap();
-        let defaults = col.defaults_for_adding(DeckId(0)).unwrap();
+        )?;
+        let defaults = col.defaults_for_adding(DeckId(0))?;
         assert_eq!(defaults.deck_id, normal_deck2.id);
         assert_eq!(defaults.notetype_id, col.basic_notetype().id);
 
         // Current notetype, current deck
         let nt = col.basic_notetype();
-        col.set_current_notetype_id(nt.id).unwrap();
-        col.clear_aux_config_for_notetype(nt.id).unwrap();
-        let defaults = col.defaults_for_adding(DeckId(0)).unwrap();
+        col.set_current_notetype_id(nt.id)?;
+        col.clear_aux_config_for_notetype(nt.id)?;
+        let defaults = col.defaults_for_adding(DeckId(0))?;
         assert_eq!(defaults.deck_id, normal_deck2.id);
         assert_eq!(defaults.notetype_id, nt.id);
 
         // Current notetype, non-existing notetype's last deck; fall back to current
         // deck
-        col.set_last_deck_for_notetype(nt.id, DeckId(0)).unwrap();
-        let defaults = col.defaults_for_adding(DeckId(0)).unwrap();
+        col.set_last_deck_for_notetype(nt.id, DeckId(0))?;
+        let defaults = col.defaults_for_adding(DeckId(0))?;
         assert_eq!(defaults.deck_id, normal_deck2.id);
         assert_eq!(defaults.notetype_id, nt.id);
 
         // Current notetype, notetype's last deck (filtered); fall back to current
         // deck
-        col.set_last_deck_for_notetype(nt.id, filtered_deck2.id)
-            .unwrap();
-        let defaults = col.defaults_for_adding(DeckId(0)).unwrap();
+        col.set_last_deck_for_notetype(nt.id, filtered_deck2.id)?;
+        let defaults = col.defaults_for_adding(DeckId(0))?;
         assert_eq!(defaults.deck_id, normal_deck2.id);
         assert_eq!(defaults.notetype_id, nt.id);
 
         // Current notetype, notetype's last deck (normal)
-        col.set_last_deck_for_notetype(nt.id, normal_deck3.id)
-            .unwrap();
-        let defaults = col.defaults_for_adding(DeckId(0)).unwrap();
+        col.set_last_deck_for_notetype(nt.id, normal_deck3.id)?;
+        let defaults = col.defaults_for_adding(DeckId(0))?;
         assert_eq!(defaults.deck_id, normal_deck3.id);
         assert_eq!(defaults.notetype_id, nt.id);
+
+        Ok(())
     }
 }

--- a/rslib/src/adding.rs
+++ b/rslib/src/adding.rs
@@ -114,3 +114,134 @@ impl Collection {
         Ok(None)
     }
 }
+
+#[cfg(test)]
+mod test {
+    use crate::config::ConfigKey;
+    use crate::prelude::*;
+
+    fn normal_deck(col: &mut Collection, name: &str) -> Deck {
+        let mut deck = Deck::new_normal();
+        deck.name = NativeDeckName::from_human_name(name);
+        col.add_deck(&mut deck).unwrap();
+
+        deck
+    }
+
+    fn filtered_deck(col: &mut Collection, name: &str) -> Deck {
+        let mut deck = Deck::new_filtered();
+        deck.name = NativeDeckName::from_human_name(name);
+        col.add_deck(&mut deck).unwrap();
+
+        deck
+    }
+
+    #[test]
+    fn defaults() {
+        let mut col = Collection::new();
+        let normal_deck1 = normal_deck(&mut col, "n1");
+        let filtered_deck1 = filtered_deck(&mut col, "f1");
+        let normal_deck2 = normal_deck(&mut col, "n2");
+        let filtered_deck2 = filtered_deck(&mut col, "f2");
+        let normal_deck3 = normal_deck(&mut col, "n3");
+
+        // AddingDefaultsToCurrentDeck defaults to true
+
+        // Current deck, unset deck's last notetype; fall back to first notetype in
+        // collection
+        col.set_current_deck(normal_deck1.id).unwrap();
+        let defaults = col
+            .defaults_for_adding(
+                // Invalid ID to confirm it's not used
+                DeckId(0),
+            )
+            .unwrap();
+        assert_eq!(defaults.deck_id, normal_deck1.id);
+        assert_eq!(defaults.notetype_id, col.basic_notetype().id);
+
+        // Current deck, current note type
+        col.set_current_notetype_id(col.cloze_notetype().id)
+            .unwrap();
+        let defaults = col.defaults_for_adding(DeckId(0)).unwrap();
+        assert_eq!(defaults.deck_id, normal_deck1.id);
+        assert_eq!(defaults.notetype_id, col.cloze_notetype().id);
+
+        // Current deck, deck's last note type
+        col.set_last_notetype_for_deck(normal_deck1.id, col.basic_rev_notetype().id)
+            .unwrap();
+        let defaults = col.defaults_for_adding(DeckId(0)).unwrap();
+        assert_eq!(defaults.deck_id, normal_deck1.id);
+        assert_eq!(defaults.notetype_id, col.basic_rev_notetype().id);
+
+        // Provided deck
+        col.set_current_deck(filtered_deck1.id).unwrap();
+        let defaults = col.defaults_for_adding(normal_deck1.id).unwrap();
+        assert_eq!(defaults.deck_id, normal_deck1.id);
+
+        // Invalid provided deck; fall back to default deck
+        let defaults = col.defaults_for_adding(DeckId(0)).unwrap();
+        assert_eq!(defaults.deck_id, DeckId(1));
+
+        // AddingDefaultsToCurrentDeck=false
+        col.set_config_bool_inner(BoolKey::AddingDefaultsToCurrentDeck, false)
+            .unwrap();
+
+        // Unset current note type; fall back to first notetype and current deck
+        col.remove_config_inner(ConfigKey::CurrentNotetypeId)
+            .unwrap();
+        col.clear_aux_config_for_notetype(col.basic_notetype().id)
+            .unwrap();
+        col.set_current_deck(normal_deck2.id).unwrap();
+        col.set_current_notetype_id(
+            // Set to an invalid notetype to trigger fallback
+            NotetypeId(0),
+        )
+        .unwrap();
+        let defaults = col.defaults_for_adding(DeckId(0)).unwrap();
+        assert_eq!(defaults.deck_id, normal_deck2.id);
+        assert_eq!(defaults.notetype_id, col.basic_notetype().id);
+
+        // Invalid current note type; fall back to first notetype and current deck
+        col.clear_aux_config_for_notetype(col.basic_notetype().id)
+            .unwrap();
+        // col.set_current_deck(normal_deck2.id).unwrap();
+        col.set_current_notetype_id(
+            // Set to an invalid notetype to trigger fallback
+            NotetypeId(0),
+        )
+        .unwrap();
+        let defaults = col.defaults_for_adding(DeckId(0)).unwrap();
+        assert_eq!(defaults.deck_id, normal_deck2.id);
+        assert_eq!(defaults.notetype_id, col.basic_notetype().id);
+
+        // Current notetype, current deck
+        let nt = col.basic_notetype();
+        col.set_current_notetype_id(nt.id).unwrap();
+        col.clear_aux_config_for_notetype(nt.id).unwrap();
+        let defaults = col.defaults_for_adding(DeckId(0)).unwrap();
+        assert_eq!(defaults.deck_id, normal_deck2.id);
+        assert_eq!(defaults.notetype_id, nt.id);
+
+        // Current notetype, non-existing notetype's last deck; fall back to current
+        // deck
+        col.set_last_deck_for_notetype(nt.id, DeckId(0)).unwrap();
+        let defaults = col.defaults_for_adding(DeckId(0)).unwrap();
+        assert_eq!(defaults.deck_id, normal_deck2.id);
+        assert_eq!(defaults.notetype_id, nt.id);
+
+        // Current notetype, notetype's last deck (filtered); fall back to current
+        // deck
+        col.set_last_deck_for_notetype(nt.id, filtered_deck2.id)
+            .unwrap();
+        let defaults = col.defaults_for_adding(DeckId(0)).unwrap();
+        assert_eq!(defaults.deck_id, normal_deck2.id);
+        assert_eq!(defaults.notetype_id, nt.id);
+
+        // Current notetype, notetype's last deck (normal)
+        col.set_last_deck_for_notetype(nt.id, normal_deck3.id)
+            .unwrap();
+        let defaults = col.defaults_for_adding(DeckId(0)).unwrap();
+        assert_eq!(defaults.deck_id, normal_deck3.id);
+        assert_eq!(defaults.notetype_id, nt.id);
+    }
+}

--- a/rslib/src/dbcheck.rs
+++ b/rslib/src/dbcheck.rs
@@ -304,7 +304,7 @@ impl Collection {
                     )
                 });
                 self.update_note_inner_generating_cards(
-                    ctx, &mut note, &original, false, norm, true,
+                    ctx, &mut note, &original, false, norm, true, None,
                 )?;
             }
         }

--- a/rslib/src/findreplace.rs
+++ b/rslib/src/findreplace.rs
@@ -106,6 +106,7 @@ impl Collection {
                 generate_cards: true,
                 mark_modified: true,
                 update_tags: false,
+                mtime: None,
             })
         })
     }

--- a/rslib/src/import_export/package/apkg/import/notes.rs
+++ b/rslib/src/import_export/package/apkg/import/notes.rs
@@ -467,18 +467,16 @@ impl<'n> NoteContext<'n> {
         // Preserve the incoming note's mtime to allow imports of successive exports
         let incoming_mtime = note.mtime;
         self.target_col
-            .update_note_inner_without_cards_using_mtime(
-                UpdateNoteInnerWithoutCardsArgs {
-                    note: &mut note,
-                    original: &original,
-                    notetype: &notetype,
-                    usn: self.usn,
-                    mark_note_modified: true,
-                    normalize_text: self.normalize_notes,
-                    update_tags: true,
-                },
-                Some(incoming_mtime),
-            )?;
+            .update_note_inner_without_cards(UpdateNoteInnerWithoutCardsArgs {
+                note: &mut note,
+                original: &original,
+                notetype: &notetype,
+                usn: self.usn,
+                mark_note_modified: true,
+                normalize_text: self.normalize_notes,
+                update_tags: true,
+                mtime: Some(incoming_mtime),
+            })?;
         self.imports.log_updated(note, source_id);
         Ok(())
     }

--- a/rslib/src/notes/mod.rs
+++ b/rslib/src/notes/mod.rs
@@ -35,6 +35,7 @@ pub(crate) struct TransformNoteOutput {
     pub generate_cards: bool,
     pub mark_modified: bool,
     pub update_tags: bool,
+    pub mtime: Option<TimestampSecs>,
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]
@@ -352,7 +353,7 @@ fn invalid_char_for_field(c: char) -> bool {
 }
 
 /// Used when calling [Collection::update_note_inner_without_cards] and
-/// [Collection::update_note_inner_without_cards_using_mtime]
+/// [Collection::update_note_inner_without_cards]
 pub(crate) struct UpdateNoteInnerWithoutCardsArgs<'a> {
     pub(crate) note: &'a mut Note,
     pub(crate) original: &'a Note,
@@ -361,6 +362,7 @@ pub(crate) struct UpdateNoteInnerWithoutCardsArgs<'a> {
     pub(crate) mark_note_modified: bool,
     pub(crate) normalize_text: bool,
     pub(crate) update_tags: bool,
+    pub(crate) mtime: Option<TimestampSecs>,
 }
 
 impl Collection {
@@ -439,10 +441,19 @@ impl Collection {
         let last_deck = self.get_last_deck_added_to_for_notetype(note.notetype_id);
         let ctx = CardGenContext::new(nt.as_ref(), last_deck, self.usn()?);
         let norm = self.get_config_bool(BoolKey::NormalizeNoteText);
-        self.update_note_inner_generating_cards(&ctx, note, &existing_note, true, norm, true)?;
+        self.update_note_inner_generating_cards(
+            &ctx,
+            note,
+            &existing_note,
+            true,
+            norm,
+            true,
+            None,
+        )?;
         Ok(())
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn update_note_inner_generating_cards(
         &mut self,
         ctx: &CardGenContext<&Notetype>,
@@ -451,6 +462,7 @@ impl Collection {
         mark_note_modified: bool,
         normalize_text: bool,
         update_tags: bool,
+        mtime: Option<TimestampSecs>,
     ) -> Result<()> {
         self.update_note_inner_without_cards(UpdateNoteInnerWithoutCardsArgs {
             note,
@@ -460,12 +472,13 @@ impl Collection {
             mark_note_modified,
             normalize_text,
             update_tags,
+            mtime,
         })?;
         self.generate_cards_for_existing_note(ctx, note)
     }
 
     #[inline]
-    pub(crate) fn update_note_inner_without_cards_using_mtime(
+    pub(crate) fn update_note_inner_without_cards(
         &mut self,
         UpdateNoteInnerWithoutCardsArgs {
             note,
@@ -475,8 +488,8 @@ impl Collection {
             mark_note_modified,
             normalize_text,
             update_tags,
+            mtime,
         }: UpdateNoteInnerWithoutCardsArgs,
-        mtime: Option<TimestampSecs>,
     ) -> Result<()> {
         if update_tags {
             self.canonify_note_tags(note, usn)?;
@@ -490,13 +503,6 @@ impl Collection {
             }
         }
         self.update_note_undoable(note, original)
-    }
-
-    pub(crate) fn update_note_inner_without_cards(
-        &mut self,
-        args: UpdateNoteInnerWithoutCardsArgs<'_>,
-    ) -> Result<()> {
-        self.update_note_inner_without_cards_using_mtime(args, None)
     }
 
     pub(crate) fn remove_notes_inner(&mut self, nids: &[NoteId], usn: Usn) -> Result<usize> {
@@ -526,6 +532,7 @@ impl Collection {
                 generate_cards,
                 mark_modified: mark_notes_modified,
                 update_tags: true,
+                mtime: None,
             })
         })
     }
@@ -571,6 +578,7 @@ impl Collection {
                         out.mark_modified,
                         norm,
                         out.update_tags,
+                        out.mtime,
                     )?;
                 } else {
                     self.update_note_inner_without_cards(UpdateNoteInnerWithoutCardsArgs {
@@ -581,6 +589,7 @@ impl Collection {
                         mark_note_modified: out.mark_modified,
                         normalize_text: norm,
                         update_tags: out.update_tags,
+                        mtime: out.mtime,
                     })?;
                 }
 
@@ -688,11 +697,14 @@ mod test {
     use super::anki_base91;
     use super::field_checksum;
     use super::NoteFieldsState;
+    use super::TransformNoteOutput;
+    use super::UpdateNoteInnerWithoutCardsArgs;
     use crate::config::BoolKey;
     use crate::decks::DeckId;
     use crate::error::Result;
     use crate::prelude::*;
     use crate::search::SortMode;
+    use crate::tags::Tag;
 
     #[test]
     fn test_base91() {
@@ -1028,6 +1040,154 @@ mod test {
         assert_eq!(card_count, card_ids.len());
         assert_eq!(col.storage.get_all_notes().len(), 0);
         assert_eq!(col.storage.get_all_card_ids()?.len(), 0);
+
+        Ok(())
+    }
+
+    #[test]
+    fn note_transformation() -> Result<()> {
+        let mut col = Collection::new();
+        let nt = col.basic_optional_rev_notetype();
+        let note_ids: Vec<_> = (0..10)
+            .map(|_| {
+                let mut note = nt.new_note();
+                note.fields[0] = "f".into();
+                col.add_note_inner(&mut note, DeckId(1)).unwrap();
+
+                note.id
+            })
+            .collect();
+
+        // No notes; nothing changes
+        let count = col.transform_notes(&[], |_note, _nt| {
+            Ok(TransformNoteOutput {
+                changed: true,
+                ..Default::default()
+            })
+        })?;
+        assert_eq!(count, 0);
+
+        // mtime is updated if mark_modified=true
+        let mtimes_before: Vec<_> = col
+            .storage
+            .get_all_notes()
+            .iter()
+            .map(|note| note.mtime)
+            .collect();
+        let expected_mtime = TimestampSecs::now().adding_secs(1);
+        let count = col.transform_notes(&note_ids, |_note, _nt| {
+            Ok(TransformNoteOutput {
+                changed: true,
+                mark_modified: true,
+                generate_cards: false,
+                update_tags: false,
+                mtime: Some(expected_mtime),
+            })
+        })?;
+        assert_eq!(count, 10);
+        let mtimes_after: Vec<_> = col
+            .storage
+            .get_all_notes()
+            .iter()
+            .map(|note| note.mtime)
+            .collect();
+        assert_ne!(mtimes_before, mtimes_after);
+        for mtime in mtimes_after {
+            assert_eq!(mtime, expected_mtime);
+        }
+
+        // No cards are generated if generate_cards=false
+        for original in col.storage.get_all_notes() {
+            let mut note = original.clone();
+            note.fields[1] = "b".into();
+            // Fill the Add Reverse field
+            note.fields[2] = "1".into();
+            col.update_note_inner_without_cards(UpdateNoteInnerWithoutCardsArgs {
+                note: &mut note,
+                original: &original,
+                notetype: &nt,
+                usn: col.usn()?,
+                mark_note_modified: true,
+                normalize_text: false,
+                update_tags: false,
+                mtime: None,
+            })?;
+        }
+        let count = col.transform_notes(&note_ids, |_note, _nt| {
+            Ok(TransformNoteOutput {
+                changed: true,
+                mark_modified: true,
+                generate_cards: false,
+                update_tags: false,
+                mtime: None,
+            })
+        })?;
+        assert_eq!(count, 10);
+        let card_ids = col.storage.card_ids_of_notes(&note_ids)?;
+        assert_eq!(card_ids.len(), note_ids.len());
+
+        // Cards are generated if generate_cards=true
+        let count = col.transform_notes(&note_ids, |_note, _nt| {
+            Ok(TransformNoteOutput {
+                changed: true,
+                mark_modified: true,
+                generate_cards: true,
+                update_tags: false,
+                mtime: None,
+            })
+        })?;
+        assert_eq!(count, 10);
+        let card_ids = col.storage.card_ids_of_notes(&note_ids)?;
+        assert_eq!(card_ids.len(), note_ids.len() * 2);
+
+        // Tags are not canonified if update_tags=false
+        col.storage
+            .register_tag(&Tag::new("a".into(), col.usn()?))?;
+        for original in col.storage.get_all_notes() {
+            let mut note = original.clone();
+            // Add the tag with different casing
+            note.tags.push("A".into());
+            col.update_note_inner_without_cards(UpdateNoteInnerWithoutCardsArgs {
+                note: &mut note,
+                original: &original,
+                notetype: &nt,
+                usn: col.usn()?,
+                mark_note_modified: true,
+                normalize_text: false,
+                update_tags: false,
+                mtime: None,
+            })?;
+        }
+        let count = col.transform_notes(&note_ids, |_note, _nt| {
+            Ok(TransformNoteOutput {
+                changed: true,
+                mark_modified: true,
+                generate_cards: false,
+                update_tags: false,
+                mtime: None,
+            })
+        })?;
+        assert_eq!(count, 10);
+        for note_id in &note_ids {
+            let tags = col.storage.get_note_tags_by_id(*note_id)?.unwrap().tags;
+            assert_eq!(tags, " A ".to_string());
+        }
+
+        // Tags are canonified if update_tags=true
+        let count = col.transform_notes(&note_ids, |_note, _nt| {
+            Ok(TransformNoteOutput {
+                changed: true,
+                mark_modified: true,
+                generate_cards: false,
+                update_tags: true,
+                mtime: None,
+            })
+        })?;
+        assert_eq!(count, 10);
+        for note_id in &note_ids {
+            let tags = col.storage.get_note_tags_by_id(*note_id)?.unwrap().tags;
+            assert_eq!(tags, " a ".to_string());
+        }
 
         Ok(())
     }

--- a/rslib/src/notes/mod.rs
+++ b/rslib/src/notes/mod.rs
@@ -977,26 +977,29 @@ mod test {
     }
 
     #[test]
-    fn removing_notes() {
+    fn removing_notes() -> Result<()> {
         let mut col = Collection::new();
 
         let nt = col.basic_rev_notetype();
-        let mut note = nt.new_note();
-        note.fields[0] = "f".into();
-        note.fields[1] = "b".into();
-        col.add_note(&mut note, DeckId(1)).unwrap();
+        let mut note_ids: Vec<_> = (0..10)
+            .map(|_| {
+                let mut note = nt.new_note();
+                note.fields[0] = "f".into();
+                note.fields[1] = "b".into();
+                col.add_note_inner(&mut note, DeckId(1)).unwrap();
 
-        // Note and all its cards are removed
-        let cards = col.storage.all_cards_of_note(note.id).unwrap();
-        let card_count = col
-            .remove_notes(&[
-                note.id,
-                // Non-existing notes are ignored
-                NoteId(0),
-            ])
-            .unwrap()
-            .output;
-        assert_eq!(card_count, cards.len());
-        assert_eq!(col.storage.get_note(note.id), Ok(None));
+                note.id
+            })
+            .collect();
+        // Non-existing notes are ignored
+        note_ids.push(NoteId(0));
+        let card_ids = col.storage.get_all_card_ids()?;
+        // Notes and all associated cards are removed
+        let card_count = col.remove_notes(&note_ids)?.output;
+        assert_eq!(card_count, card_ids.len());
+        assert_eq!(col.storage.get_all_notes().len(), 0);
+        assert_eq!(col.storage.get_all_card_ids()?.len(), 0);
+
+        Ok(())
     }
 }

--- a/rslib/src/notes/mod.rs
+++ b/rslib/src/notes/mod.rs
@@ -948,7 +948,7 @@ mod test {
     }
 
     #[test]
-    fn updating_notes() {
+    fn updating_note() {
         let mut col = Collection::new();
 
         let nt = col.basic_notetype();
@@ -974,6 +974,37 @@ mod test {
             col.update_note(&mut note),
             Err(AnkiError::InvalidInput { .. })
         );
+    }
+
+    #[test]
+    fn updating_notes() -> Result<()> {
+        let mut col = Collection::new();
+        let nt = col.basic_notetype();
+        let mut notes: Vec<_> = (0..10)
+            .map(|_| {
+                let mut note = nt.new_note();
+                note.fields[0] = "f".into();
+                col.add_note_inner(&mut note, DeckId(1)).unwrap();
+
+                note
+            })
+            .collect();
+
+        // No undo
+        for note in &mut notes {
+            note.fields[0] = "f1".into();
+        }
+        col.update_notes_maybe_undoable(notes.clone(), false)?;
+        assert_eq!(col.can_undo(), None);
+
+        // With undo
+        for note in &mut notes {
+            note.fields[0] = "f2".into();
+        }
+        col.update_notes_maybe_undoable(notes, true)?;
+        assert_ne!(col.can_undo(), None);
+
+        Ok(())
     }
 
     #[test]

--- a/rslib/src/notes/mod.rs
+++ b/rslib/src/notes/mod.rs
@@ -683,6 +683,8 @@ fn note_differs_from_db(existing_note: &mut Note, note: &mut Note) -> bool {
 
 #[cfg(test)]
 mod test {
+    use std::assert_matches;
+
     use super::anki_base91;
     use super::field_checksum;
     use super::NoteFieldsState;
@@ -909,6 +911,35 @@ mod test {
         assert_eq!(
             col.note_fields_check(&basic_note).unwrap(),
             NoteFieldsState::NotetypeNotCloze
+        );
+    }
+
+    #[test]
+    fn updating_notes() {
+        let mut col = Collection::new();
+
+        let nt = col.basic_notetype();
+        let mut note = nt.new_note();
+
+        // Field update persists
+        note.fields[0] = "foo".into();
+        col.add_note(&mut note, DeckId(1)).unwrap();
+        note.fields[0] = "bar".into();
+        col.update_note(&mut note).unwrap();
+        let mut note = col.storage.get_note(note.id).unwrap().unwrap();
+        assert_eq!(note.fields[0], "bar");
+
+        // Note is not marked as modified if no changes
+        let mtime = note.mtime;
+        col.update_note(&mut note).unwrap();
+        assert_eq!(note.mtime, mtime);
+
+        // Invalid note type
+        note.notetype_id = NotetypeId(0);
+        note.fields[0] = "a".into();
+        assert_matches!(
+            col.update_note(&mut note),
+            Err(AnkiError::InvalidInput { .. })
         );
     }
 }

--- a/rslib/src/notes/mod.rs
+++ b/rslib/src/notes/mod.rs
@@ -685,6 +685,7 @@ fn note_differs_from_db(existing_note: &mut Note, note: &mut Note) -> bool {
 mod test {
     use super::anki_base91;
     use super::field_checksum;
+    use super::NoteFieldsState;
     use crate::config::BoolKey;
     use crate::decks::DeckId;
     use crate::error::Result;
@@ -854,5 +855,60 @@ mod test {
         assert_after_remove(&mut col)?;
 
         Ok(())
+    }
+
+    #[test]
+    fn fields_check() {
+        let mut col = Collection::new();
+
+        let basic_notetype = col.basic_notetype();
+        let mut basic_note = basic_notetype.new_note();
+        col.add_note(&mut basic_note, DeckId(1)).unwrap();
+
+        let cloze_notetype = col.cloze_notetype();
+        let mut cloze_note = cloze_notetype.new_note();
+        col.add_note(&mut cloze_note, DeckId(1)).unwrap();
+
+        assert_eq!(
+            col.note_fields_check(&basic_note).unwrap(),
+            NoteFieldsState::Empty
+        );
+
+        basic_note.fields[0] = "foo".into();
+        col.update_note(&mut basic_note).unwrap();
+        assert_eq!(
+            col.note_fields_check(&basic_note).unwrap(),
+            NoteFieldsState::Normal
+        );
+
+        let mut basic_note2 = basic_notetype.new_note();
+        basic_note2.fields[0] = "foo".into();
+        col.add_note(&mut basic_note2, DeckId(1)).unwrap();
+        assert_eq!(
+            col.note_fields_check(&basic_note2).unwrap(),
+            NoteFieldsState::Duplicate
+        );
+
+        cloze_note.fields[0] = "no cloze".into();
+        col.update_note(&mut cloze_note).unwrap();
+        assert_eq!(
+            col.note_fields_check(&cloze_note).unwrap(),
+            NoteFieldsState::MissingCloze
+        );
+
+        cloze_note.fields[0] = "{{c1::foo}}".into();
+        cloze_note.fields[1] = "{{c1::non-cloze field}}".into();
+        col.update_note(&mut cloze_note).unwrap();
+        assert_eq!(
+            col.note_fields_check(&cloze_note).unwrap(),
+            NoteFieldsState::FieldNotCloze
+        );
+
+        basic_note.fields[0] = "{{c1::foo}}".into();
+        col.update_note(&mut basic_note).unwrap();
+        assert_eq!(
+            col.note_fields_check(&basic_note).unwrap(),
+            NoteFieldsState::NotetypeNotCloze
+        );
     }
 }

--- a/rslib/src/notes/mod.rs
+++ b/rslib/src/notes/mod.rs
@@ -710,6 +710,39 @@ mod test {
     }
 
     #[test]
+    fn adding_notes() -> Result<()> {
+        let mut col = Collection::new();
+        let nt = col.basic_notetype();
+
+        // Missing field
+        let mut note = nt.new_note();
+        note.fields[0] = "test".into();
+        note.fields.pop();
+        assert_matches!(
+            col.add_note(&mut note, DeckId(1)),
+            Err(AnkiError::InvalidInput { .. })
+        );
+        assert_eq!(col.get_all_notes().len(), 0);
+
+        // Missing note type
+        let mut note = nt.new_note();
+        note.notetype_id = NotetypeId(0);
+        assert_matches!(
+            col.add_note(&mut note, DeckId(1)),
+            Err(AnkiError::InvalidInput { .. })
+        );
+        assert_eq!(col.get_all_notes().len(), 0);
+
+        // Empty note added
+        let mut note = nt.new_note();
+        let count = col.add_note(&mut note, DeckId(1))?.output;
+        assert_eq!(count, 1);
+        assert_eq!(col.get_all_notes().len(), 1);
+
+        Ok(())
+    }
+
+    #[test]
     fn adding_cards() -> Result<()> {
         let mut col = Collection::new();
         let nt = col
@@ -934,7 +967,7 @@ mod test {
         col.update_note(&mut note).unwrap();
         assert_eq!(note.mtime, mtime);
 
-        // Invalid note type
+        // Missing note type
         note.notetype_id = NotetypeId(0);
         note.fields[0] = "a".into();
         assert_matches!(

--- a/rslib/src/notes/mod.rs
+++ b/rslib/src/notes/mod.rs
@@ -942,4 +942,28 @@ mod test {
             Err(AnkiError::InvalidInput { .. })
         );
     }
+
+    #[test]
+    fn removing_notes() {
+        let mut col = Collection::new();
+
+        let nt = col.basic_rev_notetype();
+        let mut note = nt.new_note();
+        note.fields[0] = "f".into();
+        note.fields[1] = "b".into();
+        col.add_note(&mut note, DeckId(1)).unwrap();
+
+        // Note and all its cards are removed
+        let cards = col.storage.all_cards_of_note(note.id).unwrap();
+        let card_count = col
+            .remove_notes(&[
+                note.id,
+                // Non-existing notes are ignored
+                NoteId(0),
+            ])
+            .unwrap()
+            .output;
+        assert_eq!(card_count, cards.len());
+        assert_eq!(col.storage.get_note(note.id), Ok(None));
+    }
 }

--- a/rslib/src/notes/mod.rs
+++ b/rslib/src/notes/mod.rs
@@ -893,62 +893,58 @@ mod test {
     }
 
     #[test]
-    fn fields_check() {
+    fn fields_check() -> Result<()> {
         let mut col = Collection::new();
 
         let basic_notetype = col.basic_notetype();
         let mut basic_note = basic_notetype.new_note();
-        col.add_note(&mut basic_note, DeckId(1)).unwrap();
+        col.add_note(&mut basic_note, DeckId(1))?;
 
         let cloze_notetype = col.cloze_notetype();
         let mut cloze_note = cloze_notetype.new_note();
-        col.add_note(&mut cloze_note, DeckId(1)).unwrap();
+        col.add_note(&mut cloze_note, DeckId(1))?;
 
-        assert_eq!(
-            col.note_fields_check(&basic_note).unwrap(),
-            NoteFieldsState::Empty
-        );
+        assert_eq!(col.note_fields_check(&basic_note)?, NoteFieldsState::Empty);
 
         basic_note.fields[0] = "foo".into();
-        col.update_note(&mut basic_note).unwrap();
-        assert_eq!(
-            col.note_fields_check(&basic_note).unwrap(),
-            NoteFieldsState::Normal
-        );
+        col.update_note(&mut basic_note)?;
+        assert_eq!(col.note_fields_check(&basic_note)?, NoteFieldsState::Normal);
 
         let mut basic_note2 = basic_notetype.new_note();
         basic_note2.fields[0] = "foo".into();
-        col.add_note(&mut basic_note2, DeckId(1)).unwrap();
+        col.add_note(&mut basic_note2, DeckId(1))?;
         assert_eq!(
-            col.note_fields_check(&basic_note2).unwrap(),
+            col.note_fields_check(&basic_note2)?,
             NoteFieldsState::Duplicate
         );
 
         cloze_note.fields[0] = "no cloze".into();
-        col.update_note(&mut cloze_note).unwrap();
+        col.update_note(&mut cloze_note)?;
         assert_eq!(
-            col.note_fields_check(&cloze_note).unwrap(),
+            col.note_fields_check(&cloze_note)?,
             NoteFieldsState::MissingCloze
         );
 
         cloze_note.fields[0] = "{{c1::foo}}".into();
         cloze_note.fields[1] = "{{c1::non-cloze field}}".into();
-        col.update_note(&mut cloze_note).unwrap();
+        col.update_note(&mut cloze_note)?;
         assert_eq!(
-            col.note_fields_check(&cloze_note).unwrap(),
+            col.note_fields_check(&cloze_note)?,
             NoteFieldsState::FieldNotCloze
         );
 
         basic_note.fields[0] = "{{c1::foo}}".into();
-        col.update_note(&mut basic_note).unwrap();
+        col.update_note(&mut basic_note)?;
         assert_eq!(
-            col.note_fields_check(&basic_note).unwrap(),
+            col.note_fields_check(&basic_note)?,
             NoteFieldsState::NotetypeNotCloze
         );
+
+        Ok(())
     }
 
     #[test]
-    fn updating_note() {
+    fn updating_note() -> Result<()> {
         let mut col = Collection::new();
 
         let nt = col.basic_notetype();
@@ -956,15 +952,15 @@ mod test {
 
         // Field update persists
         note.fields[0] = "foo".into();
-        col.add_note(&mut note, DeckId(1)).unwrap();
+        col.add_note(&mut note, DeckId(1))?;
         note.fields[0] = "bar".into();
-        col.update_note(&mut note).unwrap();
-        let mut note = col.storage.get_note(note.id).unwrap().unwrap();
+        col.update_note(&mut note)?;
+        let mut note = col.storage.get_note(note.id)?.unwrap();
         assert_eq!(note.fields[0], "bar");
 
         // Note is not marked as modified if no changes
         let mtime = note.mtime;
-        col.update_note(&mut note).unwrap();
+        col.update_note(&mut note)?;
         assert_eq!(note.mtime, mtime);
 
         // Missing note type
@@ -974,6 +970,8 @@ mod test {
             col.update_note(&mut note),
             Err(AnkiError::InvalidInput { .. })
         );
+
+        Ok(())
     }
 
     #[test]

--- a/rslib/src/notes/service.rs
+++ b/rslib/src/notes/service.rs
@@ -428,6 +428,35 @@ mod test {
     }
 
     #[test]
+    fn after_note_updates() -> Result<()> {
+        let mut col = Collection::new();
+        let nt = col.basic_notetype();
+        let requests: Vec<_> = (0..10)
+            .map(|_| {
+                let note = NotesService::new_note(&mut col, nt.id.into()).unwrap();
+                AddNoteRequest {
+                    note: Some(note),
+                    deck_id: 1,
+                }
+            })
+            .collect();
+        let add_response = NotesService::add_notes(&mut col, AddNotesRequest { requests })?;
+        let nids = add_response.nids;
+        let response = NotesService::after_note_updates(
+            &mut col,
+            AfterNoteUpdatesRequest {
+                nids,
+                mark_notes_modified: true,
+                generate_cards: true,
+            },
+        )?;
+        assert_eq!(response.count, 10);
+        assert_ne!(response.changes, None);
+
+        Ok(())
+    }
+
+    #[test]
     fn field_names_for_notes() -> Result<()> {
         let mut col: Collection = Collection::new();
         let nt = col.cloze_notetype();

--- a/rslib/src/notes/service.rs
+++ b/rslib/src/notes/service.rs
@@ -314,29 +314,11 @@ mod test {
             })
             .collect();
 
-        // No undo
         let request = UpdateNotesRequest {
             notes: notes.clone(),
             skip_undo_entry: true,
         };
         let _ = NotesService::update_notes(&mut col, request).unwrap();
-        assert_eq!(col.can_undo(), None);
-
-        // With undo
-        let notes: Vec<anki_proto::notes::Note> = col
-            .get_all_notes()
-            .into_iter()
-            .map(|mut note| {
-                note.fields[0] = "bar".into();
-                note.into()
-            })
-            .collect();
-        let request = UpdateNotesRequest {
-            notes,
-            skip_undo_entry: false,
-        };
-        let _ = NotesService::update_notes(&mut col, request).unwrap();
-        assert_ne!(col.can_undo(), None);
     }
 
     #[test]

--- a/rslib/src/notes/service.rs
+++ b/rslib/src/notes/service.rs
@@ -217,6 +217,8 @@ mod test {
     fn note_added() {
         let mut col = Collection::new();
         let nt = col.basic_notetype();
+
+        // Note ID and changes are returned
         let note = NotesService::new_note(&mut col, nt.id.into()).unwrap();
         let response = NotesService::add_note(
             &mut col,
@@ -228,6 +230,16 @@ mod test {
         .unwrap();
         assert_ne!(response.note_id, 0);
         assert_ne!(response.changes, None);
+
+        // No note passed
+        let result = NotesService::add_note(
+            &mut col,
+            AddNoteRequest {
+                note: None,
+                deck_id: 1,
+            },
+        );
+        assert_matches!(result, Err(AnkiError::InvalidInput { .. }));
     }
 
     #[test]

--- a/rslib/src/notes/service.rs
+++ b/rslib/src/notes/service.rs
@@ -1,5 +1,6 @@
 // Copyright: Ankitects Pty Ltd and contributors
 // License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
+
 use crate::cloze::cloze_number_in_fields;
 use crate::collection::Collection;
 use crate::decks::DeckId;
@@ -197,5 +198,324 @@ impl From<anki_proto::notes::NoteId> for NoteId {
 impl From<NoteId> for anki_proto::notes::NoteId {
     fn from(nid: NoteId) -> Self {
         anki_proto::notes::NoteId { nid: nid.0 }
+    }
+}
+
+#[cfg(test)]
+mod test {
+
+    use std::assert_matches;
+    use std::collections::HashSet;
+
+    use anki_proto::notes::*;
+
+    use crate::collection::Collection;
+    use crate::prelude::*;
+    use crate::services::NotesService;
+
+    #[test]
+    fn note_added() {
+        let mut col = Collection::new();
+        let nt = col.basic_notetype();
+        let note = NotesService::new_note(&mut col, nt.id.into()).unwrap();
+        let response = NotesService::add_note(
+            &mut col,
+            AddNoteRequest {
+                note: Some(note),
+                deck_id: 1,
+            },
+        )
+        .unwrap();
+        assert_ne!(response.note_id, 0);
+        assert_ne!(response.changes, None);
+    }
+
+    #[test]
+    fn bulk_notes_added() {
+        let mut col = Collection::new();
+        let nt = col.basic_notetype();
+        let requests: Vec<_> = (0..10)
+            .map(|_| {
+                let note = NotesService::new_note(&mut col, nt.id.into()).unwrap();
+                AddNoteRequest {
+                    note: Some(note),
+                    deck_id: 1,
+                }
+            })
+            .collect();
+        let response = NotesService::add_notes(&mut col, AddNotesRequest { requests }).unwrap();
+        assert_eq!(response.nids.len(), 10);
+        assert_ne!(response.changes, None);
+    }
+
+    #[test]
+    fn adding_defaults() {
+        let mut col = Collection::new();
+        let response = NotesService::defaults_for_adding(
+            &mut col,
+            DefaultsForAddingRequest {
+                home_deck_of_current_review_card: 1,
+            },
+        )
+        .unwrap();
+        assert_eq!(response.deck_id, 1);
+        assert_eq!(response.notetype_id, col.basic_notetype().id.0);
+    }
+
+    #[test]
+    fn default_deck_for_notetype() {
+        let mut col = Collection::new();
+        let nt = col.basic_notetype();
+        // No deck set; return 0
+        let response = NotesService::default_deck_for_notetype(&mut col, nt.id.into()).unwrap();
+        assert_eq!(response, DeckId(0).into());
+
+        col.set_last_deck_for_notetype(nt.id, DeckId(1)).unwrap();
+        let response = NotesService::default_deck_for_notetype(&mut col, nt.id.into()).unwrap();
+        assert_eq!(response, DeckId(1).into());
+    }
+
+    #[test]
+    fn notes_updated() {
+        let mut col = Collection::new();
+        let nt = col.basic_notetype();
+        let notes: Vec<_> = (0..10)
+            .map(|_| col.new_note(nt.id.into()).unwrap())
+            .collect();
+        let add_request = AddNotesRequest {
+            requests: notes
+                .iter()
+                .cloned()
+                .map(|note| AddNoteRequest {
+                    note: Some(note),
+                    deck_id: 1,
+                })
+                .collect(),
+        };
+        let _ = NotesService::add_notes(&mut col, add_request).unwrap();
+        let notes: Vec<anki_proto::notes::Note> = col
+            .get_all_notes()
+            .into_iter()
+            .map(|mut note| {
+                note.fields[0] = "foo".into();
+                note.into()
+            })
+            .collect();
+
+        // No undo
+        let request = UpdateNotesRequest {
+            notes: notes.clone(),
+            skip_undo_entry: true,
+        };
+        let _ = NotesService::update_notes(&mut col, request).unwrap();
+        assert_eq!(col.can_undo(), None);
+
+        // With undo
+        let notes: Vec<anki_proto::notes::Note> = col
+            .get_all_notes()
+            .into_iter()
+            .map(|mut note| {
+                note.fields[0] = "bar".into();
+                note.into()
+            })
+            .collect();
+        let request = UpdateNotesRequest {
+            notes,
+            skip_undo_entry: false,
+        };
+        let _ = NotesService::update_notes(&mut col, request).unwrap();
+        assert_ne!(col.can_undo(), None);
+    }
+
+    #[test]
+    fn get_note() {
+        let mut col = Collection::new();
+        let nt = col.basic_notetype();
+        let note1 = col.new_note(nt.id.into()).unwrap();
+        let response = NotesService::add_note(
+            &mut col,
+            AddNoteRequest {
+                note: Some(note1),
+                deck_id: 1,
+            },
+        )
+        .unwrap();
+        let nid = response.note_id;
+        let note2 = NotesService::get_note(&mut col, anki_proto::notes::NoteId { nid }).unwrap();
+        assert_eq!(nid, note2.id);
+
+        assert_matches!(
+            NotesService::get_note(&mut col, anki_proto::notes::NoteId { nid: 0 }),
+            Err(AnkiError::NotFound { .. })
+        );
+    }
+
+    #[test]
+    fn remove_notes() {
+        let mut col = Collection::new();
+        let nt = col.basic_notetype();
+        let notes: Vec<_> = (0..10)
+            .map(|_| col.new_note(nt.id.into()).unwrap())
+            .collect();
+        let add_request = AddNotesRequest {
+            requests: notes
+                .iter()
+                .cloned()
+                .map(|note| AddNoteRequest {
+                    note: Some(note),
+                    deck_id: 1,
+                })
+                .collect(),
+        };
+        let add_response = NotesService::add_notes(&mut col, add_request).unwrap();
+        let (note_ids, remaining_nids) = add_response.nids.split_at(3);
+        let note_ids: Vec<_> = note_ids.into();
+        let card_ids: Vec<_> = remaining_nids
+            .iter()
+            .copied()
+            .flat_map(|nid| {
+                col.cards_of_note(anki_proto::notes::NoteId { nid })
+                    .unwrap()
+                    .cids
+            })
+            .collect();
+        let response = NotesService::remove_notes(
+            &mut col,
+            RemoveNotesRequest {
+                // note_ids takes precedence
+                note_ids: note_ids.clone(),
+                // An invalid ID to confirm card_ids is unused when note_ids is set
+                card_ids: [0].into(),
+            },
+        )
+        .unwrap();
+        assert_eq!(response.count as usize, note_ids.len());
+        assert_ne!(response.changes, None);
+        let response = NotesService::remove_notes(
+            &mut col,
+            RemoveNotesRequest {
+                note_ids: vec![],
+                card_ids: card_ids.clone(),
+            },
+        )
+        .unwrap();
+        assert_eq!(response.count as usize, card_ids.len());
+        assert_ne!(response.changes, None);
+
+        assert_eq!(col.get_all_notes().len(), 0);
+    }
+
+    #[test]
+    fn cloze_numbers_in_note() {
+        let mut col: Collection = Collection::new();
+        let nt = col.cloze_notetype();
+        let mut note = col.new_note(nt.id.into()).unwrap();
+        note.fields[0] = "{{c3::single}} {{c1,2::multi}}".into();
+        let _ = NotesService::add_note(
+            &mut col,
+            AddNoteRequest {
+                note: Some(note.clone()),
+                deck_id: 1,
+            },
+        )
+        .unwrap();
+        let response = NotesService::cloze_numbers_in_note(&mut col, note).unwrap();
+        let expected_numbers = HashSet::from_iter([1, 2, 3]);
+        let extracted_numbers: HashSet<_> = HashSet::from_iter(response.numbers);
+        assert_eq!(expected_numbers, extracted_numbers);
+    }
+
+    #[test]
+    fn field_names_for_notes() {
+        let mut col: Collection = Collection::new();
+        let nt = col.cloze_notetype();
+        let note = col.new_note(nt.id.into()).unwrap();
+        let response = NotesService::add_note(
+            &mut col,
+            AddNoteRequest {
+                note: Some(note.clone()),
+                deck_id: 1,
+            },
+        )
+        .unwrap();
+        let nid = response.note_id;
+        let mut response = NotesService::field_names_for_notes(
+            &mut col,
+            FieldNamesForNotesRequest { nids: vec![nid] },
+        )
+        .unwrap();
+        let mut notetype_fields: Vec<_> = nt.field_names().cloned().collect();
+        notetype_fields.sort();
+        response.fields.sort();
+        assert_eq!(response.fields, notetype_fields);
+    }
+
+    #[test]
+    fn note_fields_check() {
+        let mut col: Collection = Collection::new();
+        let nt = col.basic_notetype();
+        let note = col.new_note(nt.id.into()).unwrap();
+        let _ = NotesService::add_note(
+            &mut col,
+            AddNoteRequest {
+                note: Some(note.clone()),
+                deck_id: 1,
+            },
+        )
+        .unwrap();
+
+        let response = NotesService::note_fields_check(&mut col, note).unwrap();
+        assert_eq!(
+            response.state(),
+            anki_proto::notes::note_fields_check_response::State::Empty
+        );
+    }
+
+    #[test]
+    fn cards_of_note() {
+        let mut col: Collection = Collection::new();
+        let nt = col.basic_rev_notetype();
+        let mut note = col.new_note(nt.id.into()).unwrap();
+        note.fields[0] = "f".into();
+        note.fields[1] = "b".into();
+        let response = NotesService::add_note(
+            &mut col,
+            AddNoteRequest {
+                note: Some(note.clone()),
+                deck_id: 1,
+            },
+        )
+        .unwrap();
+        let nid = response.note_id;
+
+        let response =
+            NotesService::cards_of_note(&mut col, anki_proto::notes::NoteId { nid }).unwrap();
+        assert_eq!(response.cids.len(), 2);
+    }
+
+    #[test]
+    fn get_single_notetype_of_notes() {
+        let mut col: Collection = Collection::new();
+        let nt = col.basic_rev_notetype();
+        let mut note = col.new_note(nt.id.into()).unwrap();
+        note.fields[0] = "f".into();
+        note.fields[1] = "b".into();
+        let response = NotesService::add_note(
+            &mut col,
+            AddNoteRequest {
+                note: Some(note.clone()),
+                deck_id: 1,
+            },
+        )
+        .unwrap();
+        let nid = response.note_id;
+        let response = NotesService::get_single_notetype_of_notes(
+            &mut col,
+            NoteIds {
+                note_ids: vec![nid],
+            },
+        )
+        .unwrap();
+        assert_eq!(response.ntid, nt.id.0);
     }
 }

--- a/rslib/src/notes/service.rs
+++ b/rslib/src/notes/service.rs
@@ -413,8 +413,6 @@ mod test {
         .unwrap();
         assert_eq!(response.count as usize, card_ids.len());
         assert_ne!(response.changes, None);
-
-        assert_eq!(col.get_all_notes().len(), 0);
     }
 
     #[test]

--- a/rslib/src/notes/service.rs
+++ b/rslib/src/notes/service.rs
@@ -214,20 +214,19 @@ mod test {
     use crate::services::NotesService;
 
     #[test]
-    fn note_added() {
+    fn note_added() -> Result<()> {
         let mut col = Collection::new();
         let nt = col.basic_notetype();
 
         // Note ID and changes are returned
-        let note = NotesService::new_note(&mut col, nt.id.into()).unwrap();
+        let note = NotesService::new_note(&mut col, nt.id.into())?;
         let response = NotesService::add_note(
             &mut col,
             AddNoteRequest {
                 note: Some(note),
                 deck_id: 1,
             },
-        )
-        .unwrap();
+        )?;
         assert_ne!(response.note_id, 0);
         assert_ne!(response.changes, None);
 
@@ -240,10 +239,12 @@ mod test {
             },
         );
         assert_matches!(result, Err(AnkiError::InvalidInput { .. }));
+
+        Ok(())
     }
 
     #[test]
-    fn bulk_notes_added() {
+    fn bulk_notes_added() -> Result<()> {
         let mut col = Collection::new();
         let nt = col.basic_notetype();
         let requests: Vec<_> = (0..10)
@@ -255,40 +256,45 @@ mod test {
                 }
             })
             .collect();
-        let response = NotesService::add_notes(&mut col, AddNotesRequest { requests }).unwrap();
+        let response = NotesService::add_notes(&mut col, AddNotesRequest { requests })?;
         assert_eq!(response.nids.len(), 10);
         assert_ne!(response.changes, None);
+
+        Ok(())
     }
 
     #[test]
-    fn adding_defaults() {
+    fn adding_defaults() -> Result<()> {
         let mut col = Collection::new();
         let response = NotesService::defaults_for_adding(
             &mut col,
             DefaultsForAddingRequest {
                 home_deck_of_current_review_card: 1,
             },
-        )
-        .unwrap();
+        )?;
         assert_eq!(response.deck_id, 1);
         assert_eq!(response.notetype_id, col.basic_notetype().id.0);
+
+        Ok(())
     }
 
     #[test]
-    fn default_deck_for_notetype() {
+    fn default_deck_for_notetype() -> Result<()> {
         let mut col = Collection::new();
         let nt = col.basic_notetype();
         // No deck set; return 0
-        let response = NotesService::default_deck_for_notetype(&mut col, nt.id.into()).unwrap();
+        let response = NotesService::default_deck_for_notetype(&mut col, nt.id.into())?;
         assert_eq!(response, DeckId(0).into());
 
-        col.set_last_deck_for_notetype(nt.id, DeckId(1)).unwrap();
-        let response = NotesService::default_deck_for_notetype(&mut col, nt.id.into()).unwrap();
+        col.set_last_deck_for_notetype(nt.id, DeckId(1))?;
+        let response = NotesService::default_deck_for_notetype(&mut col, nt.id.into())?;
         assert_eq!(response, DeckId(1).into());
+
+        Ok(())
     }
 
     #[test]
-    fn notes_updated() {
+    fn notes_updated() -> Result<()> {
         let mut col = Collection::new();
         let nt = col.basic_notetype();
         let notes: Vec<_> = (0..10)
@@ -304,7 +310,7 @@ mod test {
                 })
                 .collect(),
         };
-        let _ = NotesService::add_notes(&mut col, add_request).unwrap();
+        let _ = NotesService::add_notes(&mut col, add_request)?;
         let notes: Vec<anki_proto::notes::Note> = col
             .get_all_notes()
             .into_iter()
@@ -318,34 +324,37 @@ mod test {
             notes: notes.clone(),
             skip_undo_entry: true,
         };
-        let _ = NotesService::update_notes(&mut col, request).unwrap();
+        let _ = NotesService::update_notes(&mut col, request)?;
+
+        Ok(())
     }
 
     #[test]
-    fn get_note() {
+    fn get_note() -> Result<()> {
         let mut col = Collection::new();
         let nt = col.basic_notetype();
-        let note1 = col.new_note(nt.id.into()).unwrap();
+        let note1 = col.new_note(nt.id.into())?;
         let response = NotesService::add_note(
             &mut col,
             AddNoteRequest {
                 note: Some(note1),
                 deck_id: 1,
             },
-        )
-        .unwrap();
+        )?;
         let nid = response.note_id;
-        let note2 = NotesService::get_note(&mut col, anki_proto::notes::NoteId { nid }).unwrap();
+        let note2 = NotesService::get_note(&mut col, anki_proto::notes::NoteId { nid })?;
         assert_eq!(nid, note2.id);
 
         assert_matches!(
             NotesService::get_note(&mut col, anki_proto::notes::NoteId { nid: 0 }),
             Err(AnkiError::NotFound { .. })
         );
+
+        Ok(())
     }
 
     #[test]
-    fn remove_notes() {
+    fn remove_notes() -> Result<()> {
         let mut col = Collection::new();
         let nt = col.basic_notetype();
         let notes: Vec<_> = (0..10)
@@ -361,7 +370,7 @@ mod test {
                 })
                 .collect(),
         };
-        let add_response = NotesService::add_notes(&mut col, add_request).unwrap();
+        let add_response = NotesService::add_notes(&mut col, add_request)?;
         let (note_ids, remaining_nids) = add_response.nids.split_at(3);
         let note_ids: Vec<_> = note_ids.into();
         let card_ids: Vec<_> = remaining_nids
@@ -381,8 +390,7 @@ mod test {
                 // An invalid ID to confirm card_ids is unused when note_ids is set
                 card_ids: [0].into(),
             },
-        )
-        .unwrap();
+        )?;
         assert_eq!(response.count as usize, note_ids.len());
         assert_ne!(response.changes, None);
         let response = NotesService::remove_notes(
@@ -391,17 +399,18 @@ mod test {
                 note_ids: vec![],
                 card_ids: card_ids.clone(),
             },
-        )
-        .unwrap();
+        )?;
         assert_eq!(response.count as usize, card_ids.len());
         assert_ne!(response.changes, None);
+
+        Ok(())
     }
 
     #[test]
-    fn cloze_numbers_in_note() {
+    fn cloze_numbers_in_note() -> Result<()> {
         let mut col: Collection = Collection::new();
         let nt = col.cloze_notetype();
-        let mut note = col.new_note(nt.id.into()).unwrap();
+        let mut note = col.new_note(nt.id.into())?;
         note.fields[0] = "{{c3::single}} {{c1,2::multi}}".into();
         let _ = NotesService::add_note(
             &mut col,
@@ -409,65 +418,67 @@ mod test {
                 note: Some(note.clone()),
                 deck_id: 1,
             },
-        )
-        .unwrap();
-        let response = NotesService::cloze_numbers_in_note(&mut col, note).unwrap();
+        )?;
+        let response = NotesService::cloze_numbers_in_note(&mut col, note)?;
         let expected_numbers = HashSet::from_iter([1, 2, 3]);
         let extracted_numbers: HashSet<_> = HashSet::from_iter(response.numbers);
         assert_eq!(expected_numbers, extracted_numbers);
+
+        Ok(())
     }
 
     #[test]
-    fn field_names_for_notes() {
+    fn field_names_for_notes() -> Result<()> {
         let mut col: Collection = Collection::new();
         let nt = col.cloze_notetype();
-        let note = col.new_note(nt.id.into()).unwrap();
+        let note = col.new_note(nt.id.into())?;
         let response = NotesService::add_note(
             &mut col,
             AddNoteRequest {
                 note: Some(note.clone()),
                 deck_id: 1,
             },
-        )
-        .unwrap();
+        )?;
         let nid = response.note_id;
         let mut response = NotesService::field_names_for_notes(
             &mut col,
             FieldNamesForNotesRequest { nids: vec![nid] },
-        )
-        .unwrap();
+        )?;
         let mut notetype_fields: Vec<_> = nt.field_names().cloned().collect();
         notetype_fields.sort();
         response.fields.sort();
         assert_eq!(response.fields, notetype_fields);
+
+        Ok(())
     }
 
     #[test]
-    fn note_fields_check() {
+    fn note_fields_check() -> Result<()> {
         let mut col: Collection = Collection::new();
         let nt = col.basic_notetype();
-        let note = col.new_note(nt.id.into()).unwrap();
+        let note = col.new_note(nt.id.into())?;
         let _ = NotesService::add_note(
             &mut col,
             AddNoteRequest {
                 note: Some(note.clone()),
                 deck_id: 1,
             },
-        )
-        .unwrap();
+        )?;
 
-        let response = NotesService::note_fields_check(&mut col, note).unwrap();
+        let response = NotesService::note_fields_check(&mut col, note)?;
         assert_eq!(
             response.state(),
             anki_proto::notes::note_fields_check_response::State::Empty
         );
+
+        Ok(())
     }
 
     #[test]
-    fn cards_of_note() {
+    fn cards_of_note() -> Result<()> {
         let mut col: Collection = Collection::new();
         let nt = col.basic_rev_notetype();
-        let mut note = col.new_note(nt.id.into()).unwrap();
+        let mut note = col.new_note(nt.id.into())?;
         note.fields[0] = "f".into();
         note.fields[1] = "b".into();
         let response = NotesService::add_note(
@@ -476,20 +487,20 @@ mod test {
                 note: Some(note.clone()),
                 deck_id: 1,
             },
-        )
-        .unwrap();
+        )?;
         let nid = response.note_id;
 
-        let response =
-            NotesService::cards_of_note(&mut col, anki_proto::notes::NoteId { nid }).unwrap();
+        let response = NotesService::cards_of_note(&mut col, anki_proto::notes::NoteId { nid })?;
         assert_eq!(response.cids.len(), 2);
+
+        Ok(())
     }
 
     #[test]
-    fn get_single_notetype_of_notes() {
+    fn get_single_notetype_of_notes() -> Result<()> {
         let mut col: Collection = Collection::new();
         let nt = col.basic_rev_notetype();
-        let mut note = col.new_note(nt.id.into()).unwrap();
+        let mut note = col.new_note(nt.id.into())?;
         note.fields[0] = "f".into();
         note.fields[1] = "b".into();
         let response = NotesService::add_note(
@@ -498,16 +509,16 @@ mod test {
                 note: Some(note.clone()),
                 deck_id: 1,
             },
-        )
-        .unwrap();
+        )?;
         let nid = response.note_id;
         let response = NotesService::get_single_notetype_of_notes(
             &mut col,
             NoteIds {
                 note_ids: vec![nid],
             },
-        )
-        .unwrap();
+        )?;
         assert_eq!(response.ntid, nt.id.0);
+
+        Ok(())
     }
 }

--- a/rslib/src/notes/service.rs
+++ b/rslib/src/notes/service.rs
@@ -320,11 +320,29 @@ mod test {
             })
             .collect();
 
+        // No undo
         let request = UpdateNotesRequest {
             notes: notes.clone(),
             skip_undo_entry: true,
         };
         let _ = NotesService::update_notes(&mut col, request)?;
+        assert_eq!(col.can_undo(), None);
+
+        // With undo
+        let notes: Vec<anki_proto::notes::Note> = col
+            .get_all_notes()
+            .into_iter()
+            .map(|mut note| {
+                note.fields[0] = "bar".into();
+                note.into()
+            })
+            .collect();
+        let request = UpdateNotesRequest {
+            notes,
+            skip_undo_entry: false,
+        };
+        let _ = NotesService::update_notes(&mut col, request)?;
+        assert_ne!(col.can_undo(), None);
 
         Ok(())
     }

--- a/rslib/src/notetype/notetypechange.rs
+++ b/rslib/src/notetype/notetypechange.rs
@@ -271,7 +271,7 @@ impl Collection {
             remap_fields(note.fields_mut(), new_fields);
             note.notetype_id = new_notetype_id;
             self.update_note_inner_generating_cards(
-                &ctx, &mut note, &original, true, false, false,
+                &ctx, &mut note, &original, true, false, false, None,
             )?;
         }
 

--- a/rslib/src/notetype/schemachange.rs
+++ b/rslib/src/notetype/schemachange.rs
@@ -89,6 +89,7 @@ impl Collection {
                         mark_note_modified: true,
                         normalize_text,
                         update_tags: false,
+                        mtime: None,
                     })?;
                 }
             } else {
@@ -113,6 +114,7 @@ impl Collection {
                 mark_note_modified: true,
                 normalize_text,
                 update_tags: false,
+                mtime: None,
             })?;
         }
         Ok(())

--- a/rslib/src/tests.rs
+++ b/rslib/src/tests.rs
@@ -109,6 +109,15 @@ impl Collection {
         self.storage.get_notetype(ntid).unwrap().unwrap()
     }
 
+    pub(crate) fn basic_optional_rev_notetype(&self) -> Notetype {
+        let ntid = self
+            .storage
+            .get_notetype_id("Basic (optional reversed card)")
+            .unwrap()
+            .unwrap();
+        self.storage.get_notetype(ntid).unwrap().unwrap()
+    }
+
     pub(crate) fn cloze_notetype(&self) -> Notetype {
         let ntid = self.storage.get_notetype_id("Cloze").unwrap().unwrap();
         self.storage.get_notetype(ntid).unwrap().unwrap()


### PR DESCRIPTION
## Linked issue

Closes #5386

## Summary

This increases test coverage of `rslib/src/notes/service.rs` and some related modules (`rslib/src/adding.rs` and `rslib/src/notes/mod.rs`).

## How to test

Run `just test-rust --coverage --html` and view coverage reports.
