### PR TITLE
chore: Update browser compatibility database

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
         "esbuild-sass-plugin": "^3.7.0",
         "esbuild-svelte": "^0.9.5",
         "eslint": "^8.44.0",
-        "eslint-plugin-compat": "^4.1.4",
+        "eslint-plugin-compat": "^6.2.1",
         "eslint-plugin-import": "^2.32.0",
         "eslint-plugin-svelte": "^2",
         "license-checker-rseidelsohn": "=4.4.2",

--- a/ts/lib/editable/Mathjax.svelte
+++ b/ts/lib/editable/Mathjax.svelte
@@ -31,6 +31,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 </script>
 
 <script lang="ts">
+    import { randomUUID } from "@tslib/uuid";
     import { onDestroy } from "svelte";
     import { writable } from "svelte/store";
 
@@ -65,7 +66,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     $: empty = title === "MathJax";
     $: encoded = encodeURIComponent(converted);
 
-    const uuid = crypto.randomUUID();
+    const uuid = randomUUID();
     const imageHeight = writable(0);
     imageToHeightMap.set(uuid, imageHeight);
 

--- a/ts/lib/tslib/uuid.ts
+++ b/ts/lib/tslib/uuid.ts
@@ -1,0 +1,16 @@
+// Copyright: Ankitects Pty Ltd and contributors
+// License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
+
+/**
+ * TODO replace with crypto.randomUUID
+ */
+export function randomUUID(): string {
+    const value = `${1e7}-${1e3}-${4e3}-${8e3}-${1e11}`;
+
+    return value.replace(/[018]/g, (character: string): string =>
+        (
+            Number(character)
+            ^ (crypto.getRandomValues(new Uint8Array(1))[0]
+                & (15 >> (Number(character) / 4)))
+        ).toString(16));
+}

--- a/ts/lib/tslib/uuid.ts
+++ b/ts/lib/tslib/uuid.ts
@@ -2,7 +2,7 @@
 // License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
 /**
- * TODO replace with crypto.randomUUID
+ * TODO replace with crypto.randomUUID once we update browserslist to Chrome>=92, iOS>=15.4
  */
 export function randomUUID(): string {
     const value = `${1e7}-${1e3}-${4e3}-${8e3}-${1e11}`;

--- a/yarn.lock
+++ b/yarn.lock
@@ -945,10 +945,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mdn/browser-compat-data@npm:^5.2.34, @mdn/browser-compat-data@npm:^5.3.13":
-  version: 5.6.10
-  resolution: "@mdn/browser-compat-data@npm:5.6.10"
-  checksum: 10c0/56535910b510a1f2db24f66dc43d2b708ae38fcc4841b028012682c2d88949509fad2fb62d565c2e1b53e3b4dd517255e21ddf9c32f15f2acae03f2c54501f4f
+"@mdn/browser-compat-data@npm:^5.6.19":
+  version: 5.7.6
+  resolution: "@mdn/browser-compat-data@npm:5.7.6"
+  checksum: 10c0/918df768e734115bee0a43fb2eceaf6438cb9b294c27e13d0ac8a19ab9f00f59e4f306fc38c498b62bdec2d726d4f3874826fa2afccd2a29d50d306f687bfdff
+  languageName: node
+  linkType: hard
+
+"@mdn/browser-compat-data@npm:^6.1.1":
+  version: 6.1.5
+  resolution: "@mdn/browser-compat-data@npm:6.1.5"
+  checksum: 10c0/a2d8ef7cdb3268c72540909755d4d56ae5a8674ddd8216a3bd4a40e4d1497c01b0205a29a8fd6bf4599e091cbc8a90d9a3a52836a8439d66b0af00886f68e7b9
   languageName: node
   linkType: hard
 
@@ -2330,7 +2337,7 @@ __metadata:
     esbuild-sass-plugin: "npm:^3.7.0"
     esbuild-svelte: "npm:^0.9.5"
     eslint: "npm:^8.44.0"
-    eslint-plugin-compat: "npm:^4.1.4"
+    eslint-plugin-compat: "npm:^6.2.1"
     eslint-plugin-import: "npm:^2.32.0"
     eslint-plugin-svelte: "npm:^2"
     fabric: "npm:^5.3.0"
@@ -2530,12 +2537,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ast-metadata-inferer@npm:^0.8.0":
-  version: 0.8.0
-  resolution: "ast-metadata-inferer@npm:0.8.0"
+"ast-metadata-inferer@npm:^0.8.1":
+  version: 0.8.1
+  resolution: "ast-metadata-inferer@npm:0.8.1"
   dependencies:
-    "@mdn/browser-compat-data": "npm:^5.2.34"
-  checksum: 10c0/5af230afb50ead8efbd0be5284deadada461566e36b9e84b1a70028503eda5042f5fee5c8b0cdd47691b2e4b0591a91d7c09e853c839eae8eaab07ee101f3938
+    "@mdn/browser-compat-data": "npm:^5.6.19"
+  checksum: 10c0/4bfa6c268951f31123c2ea902d13d8fda5a226679a028eab7ccc063b5cc10964b07a30f075c3876fadaec315df9a894490ed24e6cb5c185afd373da42fff7a4f
   languageName: node
   linkType: hard
 
@@ -2677,7 +2684,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"browserslist@npm:^4.21.10":
+"browserslist@npm:^4.25.2":
   version: 4.28.8
   resolution: "browserslist@npm:4.28.8"
   dependencies:
@@ -2768,13 +2775,6 @@ __metadata:
   version: 3.1.0
   resolution: "callsites@npm:3.1.0"
   checksum: 10c0/fff92277400eb06c3079f9e74f3af120db9f8ea03bad0e84d9aede54bbe2d44a56cccb5f6cf12211f93f52306df87077ecec5b712794c5a9b5dac6d615a3f301
-  languageName: node
-  linkType: hard
-
-"caniuse-lite@npm:^1.0.30001524":
-  version: 1.0.30001799
-  resolution: "caniuse-lite@npm:1.0.30001799"
-  checksum: 10c0/f24f9834edc7b60188f368ce44714695c3901bc4acb7f2a977dd9b7b697e39ddc0f9947fad6224a955b789f36a73432cb888d620aa7280d728f582d3bd8927a7
   languageName: node
   linkType: hard
 
@@ -4318,20 +4318,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-compat@npm:^4.1.4":
-  version: 4.2.0
-  resolution: "eslint-plugin-compat@npm:4.2.0"
+"eslint-plugin-compat@npm:^6.2.1":
+  version: 6.2.1
+  resolution: "eslint-plugin-compat@npm:6.2.1"
   dependencies:
-    "@mdn/browser-compat-data": "npm:^5.3.13"
-    ast-metadata-inferer: "npm:^0.8.0"
-    browserslist: "npm:^4.21.10"
-    caniuse-lite: "npm:^1.0.30001524"
+    "@mdn/browser-compat-data": "npm:^6.1.1"
+    ast-metadata-inferer: "npm:^0.8.1"
+    browserslist: "npm:^4.25.2"
     find-up: "npm:^5.0.0"
+    globals: "npm:^15.7.0"
     lodash.memoize: "npm:^4.1.2"
-    semver: "npm:^7.5.4"
+    semver: "npm:^7.6.2"
   peerDependencies:
-    eslint: ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
-  checksum: 10c0/d5452650522b4a1e7f68365550fdf1049050469ee6f7cf772f222391fda775bb5a3a73da044f0b454ef8c87a636fd078ed46f9fba574bc2bafe441f612e70cda
+    eslint: ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0
+  checksum: 10c0/08dc5ea7c46eed9cd2e656bfc32318fb2d3e5ba661bbd1b88633b316e5ab3ab898f7987353645f5b525c6b9ffa81d47b8c7d4f77b24fed9991c206b156d9a1ae
   languageName: node
   linkType: hard
 
@@ -4950,6 +4950,13 @@ __metadata:
   dependencies:
     type-fest: "npm:^0.20.2"
   checksum: 10c0/d3c11aeea898eb83d5ec7a99508600fbe8f83d2cf00cbb77f873dbf2bcb39428eff1b538e4915c993d8a3b3473fa71eeebfe22c9bb3a3003d1e26b1f2c8a42cd
+  languageName: node
+  linkType: hard
+
+"globals@npm:^15.7.0":
+  version: 15.15.0
+  resolution: "globals@npm:15.15.0"
+  checksum: 10c0/f9ae80996392ca71316495a39bec88ac43ae3525a438b5626cd9d5ce9d5500d0a98a266409605f8cd7241c7acf57c354a48111ea02a767ba4f374b806d6861fe
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Linked issue

Closes #5361

## Summary

This bumps `eslint-plugin-compat` and the transitive dependency `browser-compat-data` for up-to-date data for the [browserslist](https://www.npmjs.com/package/browserslist) check.

## Steps to reproduce

#5343 is failing with the error `DragEvent is not supported in iOS Safari 14.5-14.8  compat/compat` but this is not accurate according to [MDN](https://developer.mozilla.org/en-US/docs/Web/API/DragEvent#browser_compatibility) and [caniuse.com](https://caniuse.com/?search=DragEvent). The issue was that we're using an outdated compatibility database. The update also uncovered an unrelated compatibility issue with `crypto.randomUUID`, which we started using in the editor in #4384 - this function does not meet our minimum Chrome version set in package.json, which we cannot update yet [^1], so the fix is to revert #4384.

## How to test

Run `./ninja check`.

[^1]: AnkiMobile [targets iOS 15.4](https://github.com/ankitects/ankimobile/blob/75e02cac4010e7bff5c705a69a65d2397678cd77/anki.xcodeproj/project.pbxproj#L1240), which supports the API, but AnkiDroid [targets Chrome 85](https://github.com/ankidroid/Anki-Android/blob/35903b666e05c66eec1418849d34123f3d356b8a/AnkiDroid/src/main/java/com/ichi2/utils/WebViewUtils.kt#L51).