### PR TITLE
feat: User option for burying cards after ### fails [closes #5526]

### DIFF
--- a/docs-site/manual/preferences.mdx
+++ b/docs-site/manual/preferences.mdx
@@ -91,6 +91,12 @@ Useful to know how far in the future your cards are being pushed.
 **Spacebar (or enter) also answers card**\
 Defines whether a press on <kbd>Space</kbd> or <kbd>Enter</kbd> answers cards.
 
+**After _n_ fails, bury card for the day**\
+When enabled, a card you have answered <em>Again</em> the given number of times
+today is [buried](./studying#siblings-and-burying) instead of being shown again, so a card
+you keep forgetting doesn't consume the rest of your study session. Like all
+buried cards, it becomes available again the next day.
+
 ## Editing
 
 ### Editing

--- a/ftl/core/preferences.ftl
+++ b/ftl/core/preferences.ftl
@@ -23,6 +23,10 @@ preferences-show-learning-cards-with-larger-steps = Show learning cards with lar
 preferences-show-next-review-time-above-answer = Show next review time above answer buttons
 preferences-spacebar-rates-card = Spacebar (or enter) also answers card
 preferences-show-play-buttons-on-cards-with = Show play buttons on cards with audio
+# Precedes a number, reading "After 5 fails, bury card for the day"
+preferences-bury-failed-cards = After
+# Follows a number, reading "After 5 fails, bury card for the day"
+preferences-bury-failed-cards-suffix = fails, bury card for the day
 preferences-show-remaining-card-count = Show remaining card count
 preferences-some-settings-will-take-effect-after = Some settings will take effect after you restart Anki.
 preferences-tab-synchronisation = Synchronization

--- a/proto/anki/config.proto
+++ b/proto/anki/config.proto
@@ -126,6 +126,10 @@ message Preferences {
     uint32 time_limit_secs = 5;
     bool load_balancer_enabled = 6;
     bool fsrs_short_term_with_steps_enabled = 7;
+    // Bury a card for the rest of the day once it has been answered Again
+    // bury_failed_cards_threshold times today.
+    bool bury_failed_cards = 8;
+    uint32 bury_failed_cards_threshold = 9;
   }
   message Editing {
     bool adding_defaults_to_current_deck = 1;

--- a/qt/aqt/forms/preferences.ui
+++ b/qt/aqt/forms/preferences.ui
@@ -462,6 +462,49 @@
              </widget>
             </item>
             <item>
+             <layout class="QHBoxLayout" name="buryFailedCardsLayout">
+              <item>
+               <widget class="QCheckBox" name="buryFailedCards">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="text">
+                 <string>preferences_bury_failed_cards</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QSpinBox" name="buryFailedCardsThreshold">
+                <property name="suffix">
+                 <string>preferences_bury_failed_cards_suffix</string>
+                </property>
+                <property name="minimum">
+                 <number>1</number>
+                </property>
+                <property name="maximum">
+                 <number>999</number>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <spacer name="buryFailedCardsSpacer">
+                <property name="orientation">
+                 <enum>Qt::Orientation::Horizontal</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>0</width>
+                  <height>0</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+             </layout>
+            </item>
+            <item>
              <widget class="QPushButton" name="url_schemes">
               <property name="text">
                <string>preferences_url_schemes</string>

--- a/qt/aqt/preferences.py
+++ b/qt/aqt/preferences.py
@@ -48,6 +48,7 @@ class Preferences(QDialog):
             self.form.dayOffset,
             self.form.timeLimit,
             self.form.network_timeout,
+            self.form.buryFailedCardsThreshold,
         ):
             spinbox.setSuffix(f" {spinbox.suffix()}")
 
@@ -149,6 +150,10 @@ class Preferences(QDialog):
         form.showProgress.setChecked(reviewing.show_remaining_due_counts)
         form.showPlayButtons.setChecked(not reviewing.hide_audio_play_buttons)
         form.interrupt_audio.setChecked(reviewing.interrupt_audio_when_answering)
+        form.buryFailedCards.setChecked(reviewing.bury_failed_cards)
+        form.buryFailedCardsThreshold.setValue(reviewing.bury_failed_cards_threshold)
+        form.buryFailedCardsThreshold.setEnabled(reviewing.bury_failed_cards)
+        qconnect(form.buryFailedCards.toggled, form.buryFailedCardsThreshold.setEnabled)
 
         editing = self.prefs.editing
         form.useCurrent.setCurrentIndex(
@@ -184,6 +189,8 @@ class Preferences(QDialog):
         reviewing.time_limit_secs = form.timeLimit.value() * 60
         reviewing.hide_audio_play_buttons = not self.form.showPlayButtons.isChecked()
         reviewing.interrupt_audio_when_answering = self.form.interrupt_audio.isChecked()
+        reviewing.bury_failed_cards = form.buryFailedCards.isChecked()
+        reviewing.bury_failed_cards_threshold = form.buryFailedCardsThreshold.value()
 
         editing = self.prefs.editing
         editing.adding_defaults_to_current_deck = not form.useCurrent.currentIndex()

--- a/qt/tests/test_preferences.py
+++ b/qt/tests/test_preferences.py
@@ -19,6 +19,8 @@ def make_prefs() -> PreferencesProto:
     prefs.reviewing.time_limit_secs = 0
     prefs.reviewing.hide_audio_play_buttons = False
     prefs.reviewing.interrupt_audio_when_answering = False
+    prefs.reviewing.bury_failed_cards = True
+    prefs.reviewing.bury_failed_cards_threshold = 5
     prefs.editing.adding_defaults_to_current_deck = True
     prefs.editing.paste_images_as_png = False
     prefs.editing.paste_strips_formatting = True
@@ -47,6 +49,10 @@ def make_form(prefs: PreferencesProto) -> MagicMock:
     )
     form.interrupt_audio.isChecked.return_value = (
         prefs.reviewing.interrupt_audio_when_answering
+    )
+    form.buryFailedCards.isChecked.return_value = prefs.reviewing.bury_failed_cards
+    form.buryFailedCardsThreshold.value.return_value = (
+        prefs.reviewing.bury_failed_cards_threshold
     )
     form.useCurrent.currentIndex.return_value = (
         0 if prefs.editing.adding_defaults_to_current_deck else 1

--- a/rslib/src/config/bool.rs
+++ b/rslib/src/config/bool.rs
@@ -10,6 +10,7 @@ use crate::prelude::*;
 pub enum BoolKey {
     ApplyAllParentLimits,
     BrowserTableShowNotesMode,
+    BuryFailedCards,
     CardCountsSeparateInactive,
     CollapseCardState,
     CollapseDecks,

--- a/rslib/src/config/mod.rs
+++ b/rslib/src/config/mod.rs
@@ -24,6 +24,8 @@ pub use self::string::StringKey;
 use crate::import_export::package::UpdateCondition;
 use crate::prelude::*;
 
+const DEFAULT_BURY_FAILED_CARDS_THRESHOLD: u32 = 5;
+
 /// Only used when updating/undoing.
 #[derive(Debug)]
 pub(crate) struct ConfigEntry {
@@ -47,6 +49,7 @@ impl ConfigEntry {
 #[derive(IntoStaticStr)]
 #[strum(serialize_all = "camelCase")]
 pub(crate) enum ConfigKey {
+    BuryFailedCardsThreshold,
     CreationOffset,
     FirstDayOfWeek,
     LocalOffset,
@@ -270,6 +273,19 @@ impl Collection {
 
     pub(crate) fn set_answer_time_limit_secs(&mut self, secs: u32) -> Result<()> {
         self.set_config(ConfigKey::AnswerTimeLimitSecs, &secs)
+            .map(|_| ())
+    }
+
+    /// Number of times a card may be answered Again in a day before it is
+    /// buried, when [BoolKey::BuryFailedCards] is enabled.
+    pub(crate) fn get_bury_failed_cards_threshold(&self) -> u32 {
+        self.get_config_optional(ConfigKey::BuryFailedCardsThreshold)
+            .unwrap_or(DEFAULT_BURY_FAILED_CARDS_THRESHOLD)
+            .max(1)
+    }
+
+    pub(crate) fn set_bury_failed_cards_threshold(&mut self, count: u32) -> Result<()> {
+        self.set_config(ConfigKey::BuryFailedCardsThreshold, &count)
             .map(|_| ())
     }
 

--- a/rslib/src/preferences.rs
+++ b/rslib/src/preferences.rs
@@ -101,6 +101,8 @@ impl Collection {
             load_balancer_enabled: self.get_config_bool(BoolKey::LoadBalancerEnabled),
             fsrs_short_term_with_steps_enabled: self
                 .get_config_bool(BoolKey::FsrsShortTermWithStepsEnabled),
+            bury_failed_cards: self.get_config_bool(BoolKey::BuryFailedCards),
+            bury_failed_cards_threshold: self.get_bury_failed_cards_threshold(),
         })
     }
 
@@ -125,6 +127,8 @@ impl Collection {
             BoolKey::FsrsShortTermWithStepsEnabled,
             s.fsrs_short_term_with_steps_enabled,
         )?;
+        self.set_config_bool_inner(BoolKey::BuryFailedCards, s.bury_failed_cards)?;
+        self.set_bury_failed_cards_threshold(s.bury_failed_cards_threshold)?;
         Ok(())
     }
 

--- a/rslib/src/scheduler/answering/mod.rs
+++ b/rslib/src/scheduler/answering/mod.rs
@@ -346,6 +346,9 @@ impl Collection {
         ) {
             card.last_review_time = Some(answer.answered_at.as_secs());
         }
+        if self.should_bury_failed_card(&card, answer, timing)? {
+            card.queue = CardQueue::SchedBuried;
+        }
         if let Some(data) = answer.custom_data.take() {
             card.custom_data = data;
             card.validate_custom_data()?;
@@ -385,6 +388,30 @@ impl Collection {
         }
 
         Ok(())
+    }
+
+    /// True if the user has asked for repeatedly-failed cards to be buried, and
+    /// this Again answer was the card's nth failure today. The revlog entry for
+    /// the current answer has already been added, so it is counted.
+    fn should_bury_failed_card(
+        &self,
+        card: &Card,
+        answer: &CardAnswer,
+        timing: SchedTimingToday,
+    ) -> Result<bool> {
+        if !matches!(answer.rating, Rating::Again)
+            || matches!(
+                answer.current_state,
+                CardState::Filtered(FilteredState::Preview(_))
+            )
+            || !self.get_config_bool(BoolKey::BuryFailedCards)
+        {
+            return Ok(false);
+        }
+        let failures = self
+            .storage
+            .failures_since(card.id, timing.next_day_at.adding_secs(-86_400))?;
+        Ok(failures >= self.get_bury_failed_cards_threshold())
     }
 
     fn maybe_bury_siblings(&mut self, card: &Card, config: &DeckConfig) -> Result<()> {
@@ -903,6 +930,39 @@ pub(crate) mod test {
         // after the final 10 minute step, the queues should be empty
         col.answer_good();
         assert_counts!(col, 0, 0, 0);
+
+        Ok(())
+    }
+
+    #[test]
+    fn bury_after_repeated_failures() -> Result<()> {
+        let (mut col, cids) = v3_test_collection(1)?;
+        if col.timing_today()?.near_cutoff() {
+            return Ok(());
+        }
+        col.transact_no_undo(|col| {
+            col.set_config_bool_inner(BoolKey::BuryFailedCards, true)?;
+            col.set_bury_failed_cards_threshold(3)
+        })?;
+
+        for _ in 0..2 {
+            col.answer_again();
+            assert_ne!(
+                col.storage.get_card(cids[0])?.unwrap().queue,
+                CardQueue::SchedBuried
+            );
+            col.storage.db.execute_batch("update cards set due=0")?;
+            col.clear_study_queues();
+        }
+
+        // the third failure hits the threshold, and takes the card out of today's
+        // queue
+        col.answer_again();
+        assert_eq!(
+            col.storage.get_card(cids[0])?.unwrap().queue,
+            CardQueue::SchedBuried
+        );
+        assert!(col.get_next_card()?.is_none());
 
         Ok(())
     }

--- a/rslib/src/storage/revlog/failures_today.sql
+++ b/rslib/src/storage/revlog/failures_today.sql
@@ -1,0 +1,7 @@
+SELECT count()
+FROM revlog
+WHERE cid = ?1
+  AND id >= ?2
+  AND ease = 1
+  AND type != ?3
+  AND type != ?4

--- a/rslib/src/storage/revlog/mod.rs
+++ b/rslib/src/storage/revlog/mod.rs
@@ -103,6 +103,22 @@ impl SqliteStorage {
             .map_err(Into::into)
     }
 
+    /// How many times the card has been answered Again since `day_start`.
+    pub(crate) fn failures_since(&self, card_id: CardId, day_start: TimestampSecs) -> Result<u32> {
+        self.db
+            .prepare_cached(include_str!("failures_today.sql"))?
+            .query_row(
+                params![
+                    card_id,
+                    day_start.as_millis().0,
+                    RevlogReviewKind::Manual as i64,
+                    RevlogReviewKind::Rescheduled as i64,
+                ],
+                |row| row.get(0),
+            )
+            .map_err(Into::into)
+    }
+
     /// Only intended to be used by the undo code, as Anki can not sync revlog
     /// deletions.
     pub(crate) fn remove_revlog_entry(&self, id: RevlogId) -> Result<()> {


### PR DESCRIPTION
Closes #5526 

## Summary / motivation (required)

It is often inefficient for users to repeatedly grind the same review multiple times in a day. If it's simply not clicking, it's often better to return to it this next day. This adds an option for a user to (off by default) opt into burying cards after X fails until the next day.

## How to test (required)

1. Go to Tools >> Preferences >> Review >> Set your desired fail count for buried cards
2. Fail a card more than that count of times
3. Confirm your failed card is buried
4. (optional) - confirm it is no longer buried the next day. Uses standard anki bury logic so this is not required testing.

### Checklist (minimum)

- [ YES ] I ran `./ninja check` or an equivalent relevant check locally.
- [ YES ] I added or updated tests when the change is non-trivial or behavior changed.

### Details

- One edge case is if you review (with fails) -> update setting within a day to "5" for example, the 2 prior fails will still be counted in terms of 3 remaining until the card is buried for the day. IMO, this is minor and preferable anyways.

## UI evidence (required for visual changes; otherwise N/A)

New option added at bottom left.

<img width="672" height="707" alt="image" src="https://github.com/user-attachments/assets/8a9fd07b-a206-4158-bcf5-a1a78aac7951" />

## Scope

- [ YES ] This PR is focused on one change (no unrelated edits).
