### PR TITLE
fix: relax CSP for untrusted media to load its own presentation

### DIFF
--- a/qt/aqt/mediasrv.py
+++ b/qt/aqt/mediasrv.py
@@ -86,14 +86,22 @@ UNTRUSTED_MEDIA_CSP = "; ".join(
         # media shown in an <img>, it has to fetch the presentation it ships with -
         # eg an SVG that pulls in a stylesheet sitting beside it in the media folder.
         # None of these can execute code, and 'self' keeps them within the media
-        # server, so a card still can't phone home. 'self' matches the media server
-        # even though the sandbox below puts the document in an opaque origin, as it
-        # is resolved against the URL the policy was delivered with.
+        # server, so a card still can't phone home.
         "style-src 'self' 'unsafe-inline'",
         "img-src 'self'",
         "font-src 'self'",
         "media-src 'self'",
-        "sandbox",
+        # allow-same-origin only keeps the document out of an opaque origin. With
+        # site isolation on, Chromium gives an opaque-origin document its own
+        # process and does not deliver the hover-out to it, leaving :hover stuck on
+        # for an embedded SVG once the mouse has passed over it. QtWebEngine
+        # disables site isolation by default, so this is latent for most users, but
+        # QTWEBENGINE_CHROMIUM_FLAGS is honoured: --site-per-process together with
+        # --enable-features=IsolateSandboxedIframes reproduces it on Qt 6.11 (the
+        # feature is inert on its own - site isolation is the gate). Scripting stays
+        # blocked both by the sandbox (no allow-scripts) and by script-src 'none',
+        # so media can't make use of the origin anyway.
+        "sandbox allow-same-origin",
     )
 )
 

--- a/qt/aqt/mediasrv.py
+++ b/qt/aqt/mediasrv.py
@@ -82,6 +82,17 @@ UNTRUSTED_MEDIA_CSP = "; ".join(
         "child-src 'none'",
         "base-uri 'none'",
         "form-action 'none'",
+        # Media embedded with <object>/<iframe> is a document of its own, so unlike
+        # media shown in an <img>, it has to fetch the presentation it ships with -
+        # eg an SVG that pulls in a stylesheet sitting beside it in the media folder.
+        # None of these can execute code, and 'self' keeps them within the media
+        # server, so a card still can't phone home. 'self' matches the media server
+        # even though the sandbox below puts the document in an opaque origin, as it
+        # is resolved against the URL the policy was delivered with.
+        "style-src 'self' 'unsafe-inline'",
+        "img-src 'self'",
+        "font-src 'self'",
+        "media-src 'self'",
         "sandbox",
     )
 )

--- a/qt/aqt/mediasrv.py
+++ b/qt/aqt/mediasrv.py
@@ -74,6 +74,7 @@ class LocalFileRequest:
 
 UNTRUSTED_MEDIA_CSP = "; ".join(
     (
+        # Disallow everything by default
         "default-src 'none'",
         "script-src 'none'",
         "connect-src 'none'",
@@ -82,25 +83,18 @@ UNTRUSTED_MEDIA_CSP = "; ".join(
         "child-src 'none'",
         "base-uri 'none'",
         "form-action 'none'",
-        # Media embedded with <object>/<iframe> is a document of its own, so unlike
-        # media shown in an <img>, it has to fetch the presentation it ships with -
-        # eg an SVG that pulls in a stylesheet sitting beside it in the media folder.
-        # None of these can execute code, and 'self' keeps them within the media
-        # server, so a card still can't phone home.
+        # Allow same-origin styles, images, fonts and media, so that an SVG or HTML
+        # file can use the resources next to it. 'unsafe-inline' is needed for
+        # <style> elements and style= attributes inside SVGs.
         "style-src 'self' 'unsafe-inline'",
         "img-src 'self'",
         "font-src 'self'",
         "media-src 'self'",
-        # allow-same-origin only keeps the document out of an opaque origin. With
-        # site isolation on, Chromium gives an opaque-origin document its own
-        # process and does not deliver the hover-out to it, leaving :hover stuck on
-        # for an embedded SVG once the mouse has passed over it. QtWebEngine
-        # disables site isolation by default, so this is latent for most users, but
-        # QTWEBENGINE_CHROMIUM_FLAGS is honoured: --site-per-process together with
-        # --enable-features=IsolateSandboxedIframes reproduces it on Qt 6.11 (the
-        # feature is inert on its own - site isolation is the gate). Scripting stays
-        # blocked both by the sandbox (no allow-scripts) and by script-src 'none',
-        # so media can't make use of the origin anyway.
+        # The sandbox blocks scripts, forms, popups and top-level navigation.
+        # allow-same-origin is required for fonts (font loads use CORS, and we send
+        # no CORS headers) and to avoid stuck :hover styles under site isolation.
+        # Never add allow-scripts: with allow-same-origin, that would give media
+        # access to the parent page.
         "sandbox allow-same-origin",
     )
 )

--- a/qt/tests/qwebengine_csp_smoke.py
+++ b/qt/tests/qwebengine_csp_smoke.py
@@ -12,6 +12,7 @@ the host GUI environment. Run it manually with:
 from __future__ import annotations
 
 import argparse
+import base64
 import json
 import os
 import sys
@@ -49,6 +50,12 @@ from aqt.mediasrv import UNTRUSTED_MEDIA_CSP, _legacy_editor_content_security_po
 
 AUTH_TOKEN = "qwebengine-csp-smoke-token"
 
+# 1x1 transparent png
+PIXEL_PNG = base64.b64decode(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk"
+    "YPhfDwAChwGA60e6kgAAAABJRU5ErkJggg=="
+)
+
 
 @dataclass
 class SmokeState:
@@ -57,6 +64,7 @@ class SmokeState:
     script_hits: list[str] = field(default_factory=list)
     media_requests: list[str] = field(default_factory=list)
     remote_frame_requested: bool = False
+    remote_style_requested: bool = False
     done: bool = False
     lock: threading.Lock = field(default_factory=threading.Lock)
 
@@ -82,6 +90,10 @@ class SmokeState:
         with self.lock:
             self.remote_frame_requested = True
 
+    def record_remote_style_request(self) -> None:
+        with self.lock:
+            self.remote_style_requested = True
+
     def snapshot(self) -> "SmokeSnapshot":
         with self.lock:
             return SmokeSnapshot(
@@ -90,6 +102,7 @@ class SmokeState:
                 script_hits=list(self.script_hits),
                 media_requests=list(self.media_requests),
                 remote_frame_requested=self.remote_frame_requested,
+                remote_style_requested=self.remote_style_requested,
                 done=self.done,
             )
 
@@ -101,6 +114,7 @@ class SmokeSnapshot:
     script_hits: list[str]
     media_requests: list[str]
     remote_frame_requested: bool
+    remote_style_requested: bool
     done: bool
 
 
@@ -207,6 +221,31 @@ try {
 """,
                 "image/svg+xml",
             )
+        elif parsed.path == "/media/styled.svg":
+            self.server.state.record_media_request(parsed.path)
+            assert self.server.remote_port is not None
+            remote_css = f"http://127.0.0.1:{self.server.remote_port}/remote-style.css"
+            self._send_untrusted_media(
+                f"""<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/css" href="styled.css"?>
+<?xml-stylesheet type="text/css" href="{remote_css}"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="80" height="40">
+  <style>@import url("inline-import.css");</style>
+  <image href="pixel.png" width="10" height="10"/>
+  <script><![CDATA[
+  new Image().src = '/__script-ran?doc=styled-svg';
+  ]]></script>
+  <rect width="80" height="40" fill="#2f7dd1" style="opacity: 0.5"/>
+</svg>
+""".encode(),
+                "image/svg+xml",
+            )
+        elif parsed.path in ("/media/styled.css", "/media/inline-import.css"):
+            self.server.state.record_media_request(parsed.path)
+            self._send_untrusted_media(b"rect { opacity: 1 }", "text/css")
+        elif parsed.path == "/media/pixel.png":
+            self.server.state.record_media_request(parsed.path)
+            self._send_untrusted_media(PIXEL_PNG, "image/png")
         elif parsed.path == "/__script-ran":
             self.server.state.record_script_hit(parsed.query)
             self._send_bytes(b"", "text/plain")
@@ -299,6 +338,11 @@ addElement('object', {{
     data: '/media/benign.svg?via=object',
     type: 'image/svg+xml',
 }});
+addElement('object', {{
+    id: 'styled-svg-object',
+    data: '/media/styled.svg',
+    type: 'image/svg+xml',
+}});
 addElement('iframe', {{
     id: 'remote-iframe',
     src: `http://127.0.0.1:${{remotePort}}/remote-frame`,
@@ -342,7 +386,15 @@ class RemoteRequestHandler(BaseHTTPRequestHandler):
     server: SmokeServer
 
     def do_GET(self) -> None:
-        if urlparse(self.path).path == "/remote-frame":
+        if urlparse(self.path).path == "/remote-style.css":
+            self.server.state.record_remote_style_request()
+            body = b"rect { opacity: 1 }"
+            self.send_response(HTTPStatus.OK)
+            self.send_header("Content-Type", "text/css")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+        elif urlparse(self.path).path == "/remote-frame":
             self.server.state.record_remote_frame_request()
             body = b"<!doctype html><p>remote frame</p>"
             self.send_response(HTTPStatus.OK)
@@ -409,6 +461,7 @@ def _assert_expectations(snapshot: SmokeSnapshot, page: SmokePage) -> None:
         "malicious-svg-object",
         "benign-svg-img",
         "benign-svg-object",
+        "styled-svg-object",
         "remote-iframe",
     }
     done_loads = {k for k, v in done_results.items() if v == "load"}
@@ -419,6 +472,12 @@ def _assert_expectations(snapshot: SmokeSnapshot, page: SmokePage) -> None:
         "/media/malicious.svg",
         "/media/benign.svg?via=img",
         "/media/benign.svg?via=object",
+        # an embedded document must be able to load the passive resources it
+        # ships with, eg an SVG and the stylesheet sitting next to it
+        "/media/styled.svg",
+        "/media/styled.css",
+        "/media/inline-import.css",
+        "/media/pixel.png",
     }
     missing_media_requests = expected_media_requests - set(snapshot.media_requests)
 
@@ -447,6 +506,8 @@ def _assert_expectations(snapshot: SmokeSnapshot, page: SmokePage) -> None:
         )
     if not snapshot.remote_frame_requested:
         errors.append("different-origin frame request was not observed")
+    if snapshot.remote_style_requested:
+        errors.append("untrusted media loaded a stylesheet from a remote origin")
     if latest_done and not latest_done.get("imgComplete"):
         errors.append("SVG loaded via <img> did not complete")
     if latest_done and latest_done.get("imgNaturalWidth", 0) <= 0:

--- a/qt/tests/qwebengine_csp_smoke.py
+++ b/qt/tests/qwebengine_csp_smoke.py
@@ -350,11 +350,16 @@ addElement('iframe', {{
 
 setTimeout(() => {{
     const img = document.getElementById('benign-svg-img');
+    let sameOrigin = false;
+    try {{
+        sameOrigin = !!document.getElementById('styled-svg-object').contentDocument;
+    }} catch (error) {{}}
     record({{
         type: 'done',
         results,
         imgComplete: img.complete,
         imgNaturalWidth: img.naturalWidth,
+        sameOrigin,
     }});
 }}, 1500);
 """
@@ -508,6 +513,13 @@ def _assert_expectations(snapshot: SmokeSnapshot, page: SmokePage) -> None:
         errors.append("different-origin frame request was not observed")
     if snapshot.remote_style_requested:
         errors.append("untrusted media loaded a stylesheet from a remote origin")
+    if latest_done and not latest_done.get("sameOrigin"):
+        # an opaque origin would put the document in its own process, where Chromium
+        # never delivers the hover-out, leaving :hover stuck on for embedded SVGs
+        errors.append(
+            "embedded media landed in an opaque origin"
+            " (sandbox is missing allow-same-origin)"
+        )
     if latest_done and not latest_done.get("imgComplete"):
         errors.append("SVG loaded via <img> did not complete")
     if latest_done and latest_done.get("imgNaturalWidth", 0) <= 0:

--- a/qt/tests/qwebengine_csp_smoke.py
+++ b/qt/tests/qwebengine_csp_smoke.py
@@ -514,8 +514,6 @@ def _assert_expectations(snapshot: SmokeSnapshot, page: SmokePage) -> None:
     if snapshot.remote_style_requested:
         errors.append("untrusted media loaded a stylesheet from a remote origin")
     if latest_done and not latest_done.get("sameOrigin"):
-        # an opaque origin would put the document in its own process, where Chromium
-        # never delivers the hover-out, leaving :hover stuck on for embedded SVGs
         errors.append(
             "embedded media landed in an opaque origin"
             " (sandbox is missing allow-same-origin)"

--- a/qt/tests/qwebengine_csp_smoke.py
+++ b/qt/tests/qwebengine_csp_smoke.py
@@ -350,10 +350,7 @@ addElement('iframe', {{
 
 setTimeout(() => {{
     const img = document.getElementById('benign-svg-img');
-    let sameOrigin = false;
-    try {{
-        sameOrigin = !!document.getElementById('styled-svg-object').contentDocument;
-    }} catch (error) {{}}
+    const sameOrigin = !!document.getElementById('styled-svg-object').contentDocument;
     record({{
         type: 'done',
         results,

--- a/qt/tests/test_mediasrv.py
+++ b/qt/tests/test_mediasrv.py
@@ -180,7 +180,9 @@ class TestMediaFileCSP:
             assert directives["child-src"] == "'none'"
             assert directives["base-uri"] == "'none'"
             assert directives["form-action"] == "'none'"
-            assert directives["sandbox"] == ""
+            # the document keeps its origin so that it stays in-process (see
+            # UNTRUSTED_MEDIA_CSP), but gains nothing else - notably not scripting
+            assert directives["sandbox"] == "allow-same-origin"
             assert "frame-ancestors" not in directives
 
     def test_untrusted_media_can_load_its_own_presentation(self) -> None:

--- a/qt/tests/test_mediasrv.py
+++ b/qt/tests/test_mediasrv.py
@@ -154,16 +154,10 @@ class TestMediaFileCSP:
             csp = _get_csp(resp)
             assert csp is not None
 
-            # default-src 'none' implies connect-src 'none', which is sufficient
-            if "default-src 'none'" in csp:
-                return
-
-            # Otherwise connect-src must not include http: or 'self'
-            assert "http:" not in csp, (
-                f"CSP must not allow http: connections (enables local API access): {csp}"
-            )
-            assert "'self'" not in csp, (
-                f"CSP must not allow 'self' connections (enables local API access): {csp}"
+            directives = _csp_directives(csp)
+            connect_src = directives.get("connect-src", directives.get("default-src"))
+            assert connect_src == "'none'", (
+                f"CSP must not allow connections (enables local API access): {csp}"
             )
 
     def test_untrusted_media_is_sandboxed(self) -> None:
@@ -188,6 +182,26 @@ class TestMediaFileCSP:
             assert directives["form-action"] == "'none'"
             assert directives["sandbox"] == ""
             assert "frame-ancestors" not in directives
+
+    def test_untrusted_media_can_load_its_own_presentation(self) -> None:
+        """Media embedded via <object>/<iframe> is a document of its own, and has to
+        be able to load the stylesheets/images/fonts stored next to it."""
+        directives = _csp_directives(UNTRUSTED_MEDIA_CSP)
+
+        assert directives["style-src"] == "'self' 'unsafe-inline'"
+        assert directives["img-src"] == "'self'"
+        assert directives["font-src"] == "'self'"
+        assert directives["media-src"] == "'self'"
+
+        # ...but only passive resources, and only from our own server, so that
+        # cards can neither execute code nor phone home
+        for directive in ("script-src", "connect-src", "object-src", "frame-src"):
+            assert directives[directive] == "'none'"
+        for name, value in directives.items():
+            assert not any(
+                remote in value for remote in ("http:", "https:", "data:", "*")
+            ), f"{name} must not allow remote sources: {value}"
+        assert "'unsafe-inline'" not in directives["script-src"]
 
     def test_trusted_local_file_does_not_get_untrusted_media_csp(self) -> None:
         """Add-on exports use LocalFileRequest too, but should not be sandboxed."""

--- a/qt/tests/test_mediasrv.py
+++ b/qt/tests/test_mediasrv.py
@@ -180,8 +180,6 @@ class TestMediaFileCSP:
             assert directives["child-src"] == "'none'"
             assert directives["base-uri"] == "'none'"
             assert directives["form-action"] == "'none'"
-            # the document keeps its origin so that it stays in-process (see
-            # UNTRUSTED_MEDIA_CSP), but gains nothing else - notably not scripting
             assert directives["sandbox"] == "allow-same-origin"
             assert "frame-ancestors" not in directives
 

--- a/qt/tests/test_mediasrv.py
+++ b/qt/tests/test_mediasrv.py
@@ -201,7 +201,6 @@ class TestMediaFileCSP:
             assert not any(
                 remote in value for remote in ("http:", "https:", "data:", "*")
             ), f"{name} must not allow remote sources: {value}"
-        assert "'unsafe-inline'" not in directives["script-src"]
 
     def test_trusted_local_file_does_not_get_untrusted_media_csp(self) -> None:
         """Add-on exports use LocalFileRequest too, but should not be sandboxed."""


### PR DESCRIPTION
## Linked issue (required)

Closes #4898.

## Summary / motivation (required)

Untrusted media embedded via `<object>`/`<iframe>` (e.g. an SVG) is a document of its own, so unlike media shown in an `<img>`, it needs to fetch the presentation it ships with — for example a stylesheet, image, or font sitting beside it in the media folder. Our CSP previously blocked all of that.

This PR relaxes `UNTRUSTED_MEDIA_CSP` in `qt/aqt/mediasrv.py` to allow `style-src`, `img-src`, `font-src`, and `media-src` from `'self'` only. None of these can execute code, and `'self'` keeps requests within the media server, so a card still can't phone home. `script-src`, `connect-src`, `object-src`, and `frame-src` remain `'none'`.

Relaxing the sandbox to permit same-origin resource loads had a side effect: with site isolation enabled, Chromium puts an opaque-origin document in its own process and never delivers the hover-out event to it, leaving `:hover` stuck on for an embedded SVG once the mouse passes over it. QtWebEngine disables site isolation by default so this was latent for most users, but it's reproducible on Qt 6.11 with `QTWEBENGINE_CHROMIUM_FLAGS=--site-per-process --enable-features=IsolateSandboxedIframes`. The second commit fixes this by adding `allow-same-origin` to the `sandbox` directive, keeping the embedded document in-process. Scripting stays blocked both by the sandbox (no `allow-scripts`) and by `script-src 'none'`, so media still can't make use of the origin.

Full discussion and background: https://github.com/ankitects/anki/issues/4898

## Steps to reproduce (required, use N/A if not applicable)

1. Add a card with an SVG that references an external stylesheet/image/font in the same media folder (e.g. via `<?xml-stylesheet?>` or `<image href="...">`).
2. Display the card — before this fix, the referenced resources fail to load because the CSP blocks them.
3. With `QTWEBENGINE_CHROMIUM_FLAGS=--site-per-process --enable-features=IsolateSandboxedIframes` set and only the first commit applied, hover over the embedded SVG and move the mouse away — `:hover` styling stays stuck on.

## How to test (required)

### Checklist (minimum)

- [x] I ran `./ninja check` or an equivalent relevant check locally.
- [x] I added or updated tests when the change is non-trivial or behavior changed.

### Details

- `qt/tests/test_mediasrv.py`: unit tests asserting the new CSP directives (`style-src`, `img-src`, `font-src`, `media-src` limited to `'self'`; `sandbox` includes `allow-same-origin`; no directive allows remote origins).
- `qt/tests/qwebengine_csp_smoke.py`: manual QtWebEngine smoke test extended to load an SVG with a same-origin stylesheet/image and a script tag, and to assert the embedded document stays same-origin (`contentDocument` accessible) and that a remote stylesheet reference is never fetched. Run manually with `python qt/tests/qwebengine_csp_smoke.py`.

## Before / after behavior (optional)

Before: untrusted media couldn't load co-located stylesheets/images/fonts, and (unrelated to the CSP relaxation but fixed alongside it) embedded SVGs could get stuck showing `:hover` styling under site isolation.

After: untrusted media can load passive same-origin resources it ships with; scripting and remote network access remain fully blocked; embedded documents stay same-origin so hover state clears correctly.

## Risk / compatibility / migration (optional)

Low risk — the CSP is still deny-by-default for scripts, remote origins, and network connections. Only same-origin passive resource loading is newly permitted.

## UI evidence (required for visual changes; otherwise N/A)

N/A

## Scope

- [x] This PR is focused on one change (no unrelated edits).
