### PR TITLE
fix: keep mpv callbacks from stopping event dispatch

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -304,6 +304,7 @@ Carlos Mendez <carlos12mcg@gmail.com>
 zaveshaa <zaveshaa@gmail.com>
 zaveshaa <127344512+zaveshaa@users.noreply.github.com>
 James Liu <https://github.com/jamesliuai>
+hyetigran <https://github.com/hyetigran>
 ********************
 
 The text of the 3 clause BSD license follows:

--- a/qt/aqt/mpv.py
+++ b/qt/aqt/mpv.py
@@ -539,10 +539,13 @@ class MPV(MPVBase):
             name = message["event"]
 
         for callback in self._callbacks.get(name, []):
-            if "data" in message:
-                callback(message["data"])
-            else:
-                callback()
+            try:
+                if "data" in message:
+                    callback(message["data"])
+                else:
+                    callback()
+            except Exception:
+                print(f"Error in mpv callback for {name}")
 
     def register_callback(self, name, callback):
         """Register a function `callback` for the event `name`."""

--- a/qt/aqt/sound.py
+++ b/qt/aqt/sound.py
@@ -500,7 +500,8 @@ class MpvManager(MPV, SoundOrVideoPlayer):
         if value and self._on_done:
             from aqt import mw
 
-            mw.taskman.run_on_main(self._on_done)
+            if mw is not None:
+                mw.taskman.run_on_main(self._on_done)
 
     def shutdown(self) -> None:
         self.close()

--- a/qt/tests/test_sound.py
+++ b/qt/tests/test_sound.py
@@ -12,6 +12,7 @@ import pytest
 import aqt
 from anki.sound import SoundOrVideoTag
 from anki.utils import is_lin, is_mac, is_win
+from aqt.mpv import MPV
 from aqt.sound import MpvManager, _packagedCmd, is_audio_file
 
 
@@ -123,3 +124,71 @@ def test_mpvmanager_can_play_generated_wav(
     monkeypatch.setattr(aqt, "mw", mock_mw)
     manager = MpvManager(tmp_path, tmp_path)
     manager.play(SoundOrVideoTag(filename=str(generated_wav.name)), lambda _: None)
+
+
+@pytest.mark.parametrize(
+    "event, callback_name, args",
+    [
+        ({"event": "file-loaded"}, "file-loaded", ()),
+        (
+            {"event": "property-change", "name": "idle-active", "data": True},
+            "property-idle-active",
+            (True,),
+        ),
+    ],
+)
+def test_callback_failure_does_not_interrupt_event_dispatch(
+    event: dict[str, object],
+    callback_name: str,
+    args: tuple[bool, ...],
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    # Feed received events without starting an external mpv process.
+    player = MPV.__new__(MPV)
+    player._callbacks_initialized = True
+    failing_callback = MagicMock(side_effect=RuntimeError("callback failed"))
+    other_callback = MagicMock()
+    player._callbacks = {callback_name: [failing_callback, other_callback]}
+
+    player._handle_event(event)
+    other_callback.assert_called_once_with(*args)
+
+    # A failed callback must not prevent subsequent events from being handled.
+    player._handle_event(event)
+    assert other_callback.call_count == 2
+    assert failing_callback.call_count == 2
+    stdout = capsys.readouterr().out
+    assert stdout == f"Error in mpv callback for {callback_name}\n" * 2
+
+
+def test_mpv_idle_event_after_main_window_teardown(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = MpvManager.__new__(MpvManager)
+    on_done = MagicMock()
+    manager._on_done = on_done
+    monkeypatch.setattr(aqt, "mw", None)
+
+    manager.on_property_idle_active(True)
+
+    on_done.assert_not_called()
+
+
+@pytest.mark.parametrize("idle", [False, True])
+@pytest.mark.parametrize("has_callback", [False, True])
+def test_mpv_idle_event_schedules_completion_on_main_thread(
+    monkeypatch: pytest.MonkeyPatch, idle: bool, has_callback: bool
+) -> None:
+    manager = MpvManager.__new__(MpvManager)
+    on_done = MagicMock()
+    manager._on_done = on_done if has_callback else None
+    mock_mw = MagicMock()
+    monkeypatch.setattr(aqt, "mw", mock_mw)
+
+    manager.on_property_idle_active(idle)
+
+    if idle and has_callback:
+        mock_mw.taskman.run_on_main.assert_called_once_with(on_done)
+    else:
+        mock_mw.taskman.run_on_main.assert_not_called()
+    on_done.assert_not_called()


### PR DESCRIPTION
## Linked issue (required)

Fixes #5527

## Summary / motivation (required)

Keep one failing mpv event callback from interrupting the remaining callbacks or terminating the event-dispatch thread.

- Catch `Exception` around each callback invocation and print the event name.
- Ignore idle completion notifications when `aqt.mw` has already been cleared.
- Add regression coverage for regular events, property-change events, subsequent dispatch, teardown, and main-thread completion scheduling.
- Add my first-contribution entry to `CONTRIBUTORS`.

## Steps to reproduce (required, use N/A if not applicable)

On the pre-fix code at `5edc31694`:

1. Create an `MPV` test instance without starting a process, initialize its callback map, and register a raising callback followed by a successful callback for `file-loaded`.
2. Call `_handle_event({"event": "file-loaded"})`. The exception escapes and the second callback is skipped. In the actual reader loop, that exception also escapes `_event_reader()`. See #5527 for a self-contained callback-level example.
3. Separately, create a `MpvManager` test instance with a completion callback, monkeypatch `aqt.mw` to `None`, and deliver an idle-active notification. It raises `AttributeError` when accessing `mw.taskman`.

These are deterministic exception-path reproductions. A stuck playback sequence during normal review has not been reproduced.

## How to test (required)

### Checklist (minimum)

- [x] I ran `./ninja check` or an equivalent relevant check locally.
- [x] I added or updated tests when the change is non-trivial or behavior changed.

### Details

- `just test-py`: 100 Qt tests passed on macOS / Python 3.13.13; other Python test targets were cached.
- `just check`: passed.
- `git diff --check`: passed.
- Seven added parameterized cases cover callbacks with and without data, continued dispatch after a callback failure, the printed diagnostic, a missing main window, and whether completion is scheduled on the main thread for each idle/callback combination.
- The new callback tests do not start an external mpv process.

## Before / after behavior (optional)

Before: a callback exception escapes dispatch; late idle notifications dereference a missing main window.

After: a callback exception is printed and dispatch continues; late idle notifications are ignored once the main window is gone. Normal completion scheduling is unchanged.

## Risk / compatibility / migration (optional)

Small behavioral change: ordinary callback exceptions are contained instead of terminating dispatch. `BaseException` subclasses are not caught. No callback registration API, thread shutdown behavior, or stop/completion contract changes. No migration required.

## UI evidence (required for visual changes; otherwise N/A)

N/A — no visual changes.

## Scope

- [x] This PR is focused on one change (no unrelated edits).

