### PR TITLE
Show a separate message when all cards have been reviewed once (FSRS-related)

### DIFF
--- a/ftl/core/deck-config.ftl
+++ b/ftl/core/deck-config.ftl
@@ -490,6 +490,7 @@ deck-config-fsrs-params-optimal = The FSRS parameters are currently optimal. Thi
 deck-config-fsrs-confirm-save-and-optimize = This will save any other changes you have made. Are you sure?
 
 deck-config-fsrs-params-no-reviews = No reviews found. Make sure this preset is assigned to all decks (including subdecks) that you want to optimize, and try again.
+deck-config-fsrs-params-not-enough-history = Not enough review history yet. FSRS can only learn from cards that have been reviewed again on a later day. Keep reviewing and try again later.
 
 deck-config-wait-for-audio = Wait for audio
 deck-config-show-reminder = Show Reminder

--- a/proto/anki/scheduler.proto
+++ b/proto/anki/scheduler.proto
@@ -367,6 +367,9 @@ message ComputeFsrsParamsResponse {
   repeated float params = 1;
   uint32 fsrs_items = 2;
   optional bool health_check_passed = 3;
+  // Number of revlog entries that remained after filtering. Can be > 0 while
+  // fsrs_items is 0, e.g. when no card has been reviewed on a second day yet.
+  uint32 review_count = 4;
 }
 
 message ComputeFsrsParamsFromItemsRequest {

--- a/rslib/src/scheduler/fsrs/params.rs
+++ b/rslib/src/scheduler/fsrs/params.rs
@@ -99,11 +99,13 @@ impl Collection {
             fsrs_items_for_training(revlogs.clone(), timing.next_day_at, ignore_revlogs_before);
 
         let fsrs_items = items.len() as u32;
+        let review_count = review_count as u32;
         if fsrs_items == 0 {
             return Ok(ComputeFsrsParamsResponse {
                 params: current_params.to_vec(),
                 fsrs_items,
                 health_check_passed: None,
+                review_count,
             });
         }
         // adapt the progress handler to our built-in progress handling
@@ -124,7 +126,7 @@ impl Collection {
                     if let Err(_err) = anki_progress.update(false, |s| {
                         s.total_iterations = guard.total() as u32;
                         s.current_iteration = guard.current() as u32;
-                        s.reviews = review_count as u32;
+                        s.reviews = review_count;
                         finished = guard.finished();
                     }) {
                         guard.want_abort = true;
@@ -205,6 +207,7 @@ impl Collection {
             params,
             fsrs_items,
             health_check_passed,
+            review_count,
         })
     }
 

--- a/rslib/src/scheduler/service/mod.rs
+++ b/rslib/src/scheduler/service/mod.rs
@@ -401,6 +401,7 @@ impl crate::services::BackendSchedulerService for Backend {
             params,
             fsrs_items,
             health_check_passed: None,
+            review_count: 0,
         })
     }
 

--- a/ts/routes/deck-options/FsrsOptions.svelte
+++ b/ts/routes/deck-options/FsrsOptions.svelte
@@ -247,9 +247,14 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
                     }
                     let alreadyOptimalMessage = "";
                     if (alreadyOptimal) {
-                        alreadyOptimalMessage = resp.fsrsItems
-                            ? tr.deckConfigFsrsParamsOptimal()
-                            : tr.deckConfigFsrsParamsNoReviews();
+                        if (resp.fsrsItems) {
+                            alreadyOptimalMessage = tr.deckConfigFsrsParamsOptimal();
+                        } else if (resp.reviewCount) {
+                            alreadyOptimalMessage =
+                                tr.deckConfigFsrsParamsNotEnoughHistory();
+                        } else {
+                            alreadyOptimalMessage = tr.deckConfigFsrsParamsNoReviews();
+                        }
                     }
                     const message = [alreadyOptimalMessage, healthCheckMessage]
                         .filter((a) => a)


### PR DESCRIPTION
Follow-up to #5181.

Optimization needs at least one card with a review on a later day (same-day learning steps don't produce training items). When a user has reviews but none of them qualify yet, the frontend showed "No reviews found", which reads like a bug when the user has clearly done reviews.

This adds `review_count` (revlog entries remaining after filtering) to `ComputeFsrsParamsResponse`, so the frontend can distinguish the two cases, and adds a dedicated message:

> Not enough review history yet. FSRS can only learn from cards that have been reviewed again on a later day. Keep reviewing and try again later.

The existing "No reviews found" message is still shown when there are no reviews at all.

Closes https://github.com/ankitects/anki/issues/5530

🤖 Generated with [Claude Code](https://claude.com/claude-code)
