### PR TITLE
fix: preserve FSRS unlock timeout across mounts

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -304,6 +304,7 @@ Carlos Mendez <carlos12mcg@gmail.com>
 zaveshaa <zaveshaa@gmail.com>
 zaveshaa <127344512+zaveshaa@users.noreply.github.com>
 James Liu <https://github.com/jamesliuai>
+Caleb Meadows
 ********************
 
 The text of the 3 clause BSD license follows:

--- a/ts/routes/deck-options/ParamsInput.svelte
+++ b/ts/routes/deck-options/ParamsInput.svelte
@@ -2,6 +2,19 @@
 Copyright: Ankitects Pty Ltd and contributors
 License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 -->
+<script context="module" lang="ts">
+    // Host timing preferences must survive the FSRS controls being unmounted.
+    let unlock_click_timeout_ms = 500;
+
+    function setParameterUnlockClickTimeoutMs(ms: number): void {
+        unlock_click_timeout_ms = ms;
+    }
+
+    globalThis.anki ||= {};
+    globalThis.anki.setParameterUnlockClickTimeoutMs = setParameterUnlockClickTimeoutMs;
+    globalThis.anki.defaultParameterUnlockClickTimeoutMs = unlock_click_timeout_ms;
+</script>
+
 <script lang="ts">
     import { tick } from "svelte";
     import * as tr from "@generated/ftl";
@@ -48,15 +61,6 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     }
 
     const UNLOCK_EDIT_COUNT = 3;
-    let unlock_click_timeout_ms = 500;
-
-    function setParameterUnlockClickTimeoutMs(ms: number) {
-        unlock_click_timeout_ms = ms;
-    }
-
-    globalThis.anki ||= {};
-    globalThis.anki.setParameterUnlockClickTimeoutMs = setParameterUnlockClickTimeoutMs;
-    globalThis.anki.defaultParameterUnlockClickTimeoutMs = unlock_click_timeout_ms;
     let clickCount = 0;
 
     let clickTimeout: ReturnType<typeof setTimeout>;

--- a/ts/tests/e2e/deck-options.test.ts
+++ b/ts/tests/e2e/deck-options.test.ts
@@ -1,0 +1,67 @@
+// Copyright: Ankitects Pty Ltd and contributors
+// License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
+
+import { expect, test } from "./fixtures";
+
+test("FSRS parameter unlock timing survives mounting and unmounting", async ({ page }) => {
+    await page.clock.install();
+    await page.goto("/deck-options/1");
+
+    const fsrs = page.getByRole("checkbox", { name: /^FSRS\b/ });
+    const parameters = page.getByRole("button", { name: "FSRS Parameters", exact: true });
+    const input = parameters.locator("textarea");
+    await expect(fsrs).not.toBeChecked();
+    await expect(parameters).toHaveCount(0);
+    await page.clock.pauseAt(await page.evaluate(() => Date.now() + 1000));
+
+    async function setTimeoutMs(ms: number): Promise<void> {
+        await page.evaluate((ms) => (window as any).anki.setParameterUnlockClickTimeoutMs(ms), ms);
+    }
+
+    async function clickThreeTimes(interval: number): Promise<void> {
+        await parameters.click();
+        await page.clock.runFor(interval);
+        await parameters.click();
+        await expect(input).toBeDisabled();
+        await page.clock.runFor(interval);
+        await parameters.click();
+    }
+
+    await setTimeoutMs(1000);
+    const defaultMs = await page.evaluate(() => (window as any).anki.defaultParameterUnlockClickTimeoutMs);
+    expect(defaultMs).toBe(500);
+
+    // The host can configure timing before the first mount, and remounts retain it.
+    for (let mount = 0; mount < 2; mount++) {
+        await fsrs.check();
+        await expect(input).toBeDisabled();
+        await clickThreeTimes(750);
+        await expect(input).toBeEnabled();
+        await fsrs.uncheck();
+        await expect(parameters).toHaveCount(0);
+    }
+
+    // Changing the timeout while the controls are absent applies to their next mount.
+    await setTimeoutMs(2000);
+    await fsrs.check();
+    await clickThreeTimes(1250);
+    await expect(input).toBeEnabled();
+    await fsrs.uncheck();
+    await fsrs.check();
+
+    // Changes made after mounting also apply, without changing the three-click gate.
+    await setTimeoutMs(defaultMs);
+    await clickThreeTimes(750);
+    await expect(input).toBeDisabled();
+    await page.clock.runFor(defaultMs + 1);
+    await clickThreeTimes(100);
+    await expect(input).toBeEnabled();
+
+    // Host preferences last for this page only; a fresh page starts at the default.
+    await setTimeoutMs(2000);
+    await page.reload();
+    await expect(fsrs).not.toBeChecked();
+    await fsrs.check();
+    await clickThreeTimes(750);
+    await expect(input).toBeDisabled();
+});


### PR DESCRIPTION
## Linked issue (required)

Fixes #5516

## Summary / motivation (required)

Make the existing FSRS parameter unlock timing API available before the parameter editor is mounted, and retain the host's chosen timeout when FSRS is disabled and enabled again. Register the API and store its timeout in the component's module script; keep click tracking local to each editor instance.

## Steps to reproduce (required, use N/A if not applicable)

1. Open the deck-options page with FSRS disabled.
2. In that page's JavaScript console, run `anki.setParameterUnlockClickTimeoutMs(1000)`.
3. Before this fix, the call throws `TypeError: anki.setParameterUnlockClickTimeoutMs is not a function`.

## How to test (required)

### Checklist (minimum)

- [x] I ran `just check` locally.
- [x] I added a browser regression for the changed behavior.

### Details

- The regression failed on the original implementation at the pre-mount setter call and passes with the fix.
- It checks configuration before the first mount, retention across remounts, updates while absent and present, the three-click gate, the default timeout, and reset after page reload. Playwright's clock controls the click intervals.
- `just test-ts`: 61 tests passed.
- `just test-e2e`: 27 tests passed, using the repository's disposable Anki harness.
- `just check`: passed, including 572 Rust tests and the Python, formatting, lint, and type checks.
- The Qt checks emitted an audio-thread warning (`mw` was `None` in `qt/aqt/sound.py`); all 93 Qt tests passed and `just check` exited successfully.

## Before / after behavior (optional)

Before: the API exists only after the editor mounts, and mounting a new editor resets the timeout to 500 ms.

After: the API exists when the deck-options JavaScript loads, and the selected timeout lasts for the page's lifetime.

## Risk / compatibility / migration (optional)

Existing API names, the 500 ms default, and the three-click requirement are preserved. Click counts and pending timers remain local to each editor. No stored data or scheduling behavior changes.

## UI evidence (required for visual changes; otherwise N/A)

N/A.

## Scope

- [x] This PR is focused on one change.

Developed with assistance from Codex.
