### PR TITLE
fix: have deck_for_adding fallback to target deck id if override is invalid

### DIFF
--- a/rslib/src/notetype/cardgen.rs
+++ b/rslib/src/notetype/cardgen.rs
@@ -539,4 +539,32 @@ mod test {
         assert_eq!(cards.len(), 1);
         assert_eq!(cards[0].ord, 1);
     }
+
+    #[test]
+    fn deck_for_adding_falls_back() {
+        let mut col = CollectionBuilder::default().build().unwrap();
+
+        let mut normal = Deck::new_normal();
+        col.add_or_update_deck(&mut normal).unwrap();
+        let normal_c = col.deck_conf_if_normal(normal.id).unwrap().unwrap();
+        let normal = Some(normal.id);
+
+        let mut filtered = Deck::new_filtered();
+        col.add_or_update_deck(&mut filtered).unwrap();
+        let filtered = Some(filtered.id);
+
+        let unknown = Some(DeckId(0));
+        let default_c = col.deck_conf_if_normal(DeckId(1)).unwrap().unwrap();
+
+        assert_eq!(col.deck_for_adding(normal, filtered).unwrap(), normal_c);
+        assert_eq!(col.deck_for_adding(normal, unknown).unwrap(), normal_c);
+        assert_eq!(col.deck_for_adding(normal, None).unwrap(), normal_c);
+        assert_eq!(col.deck_for_adding(filtered, normal).unwrap(), normal_c);
+        assert_eq!(col.deck_for_adding(filtered, unknown).unwrap(), default_c);
+        assert_eq!(col.deck_for_adding(filtered, None).unwrap(), default_c);
+        assert_eq!(col.deck_for_adding(None, normal).unwrap(), normal_c);
+        assert_eq!(col.deck_for_adding(None, filtered).unwrap(), default_c);
+        assert_eq!(col.deck_for_adding(None, unknown).unwrap(), default_c);
+        assert_eq!(col.deck_for_adding(None, None).unwrap(), default_c);
+    }
 }

--- a/rslib/src/notetype/cardgen.rs
+++ b/rslib/src/notetype/cardgen.rs
@@ -297,7 +297,7 @@ impl Collection {
         cache: &mut CardGenCache,
     ) -> Result<()> {
         for c in cards {
-            let (did, dcid) = self.deck_for_adding(c.did.or(target_deck_id))?;
+            let (did, dcid) = self.deck_for_adding(target_deck_id, c.did)?;
             let due = if let Some(due) = c.due {
                 // use existing due number if provided
                 due
@@ -341,10 +341,14 @@ impl Collection {
         }
     }
 
-    /// If deck ID does not exist or points to a filtered deck, fall back on
-    /// default.
-    fn deck_for_adding(&mut self, did: Option<DeckId>) -> Result<(DeckId, DeckConfigId)> {
-        if let Some(did) = did {
+    /// If deck ID or overriding deck id both don't exist or point to filtered
+    /// decks, fall back on default.
+    fn deck_for_adding(
+        &mut self,
+        did: Option<DeckId>,
+        did_override: Option<DeckId>,
+    ) -> Result<(DeckId, DeckConfigId)> {
+        for did in did_override.into_iter().chain(did) {
             if let Some(deck) = self.deck_conf_if_normal(did)? {
                 return Ok(deck);
             }


### PR DESCRIPTION
## Linked issue (required)

Closes #5540

## Summary / motivation (required)

If the deck override is invalid (filtered deck or missing), generated cards are moved to the default deck instead of the target deck id if present and valid, which this pr fixes