### PR TITLE
fix: Add compatibility shims for AnkiPackageImporter/AnkiPackageExporter

### DIFF
--- a/pylib/anki/exporting.py
+++ b/pylib/anki/exporting.py
@@ -24,7 +24,7 @@ class _LegacyAnkiPackageExporter:
                 with_media=True,
                 legacy=True,
             ),
-            limit=DeckIdLimit(deck_id=self.did),
+            limit=DeckIdLimit(deck_id=self.did) if self.did else None,
         )
 
 

--- a/pylib/anki/exporting.py
+++ b/pylib/anki/exporting.py
@@ -1,0 +1,40 @@
+# Copyright: Ankitects Pty Ltd and contributors
+# License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
+
+from typing import TYPE_CHECKING, Any
+
+from anki._legacy import DeprecatedNamesMixinForModule
+from anki.collection import Collection, DeckIdLimit, ExportAnkiPackageOptions
+from anki.decks import DeckId
+
+
+class _LegacyAnkiPackageExporter:
+    includeSched: bool = False
+
+    def __init__(self, col: Collection):
+        self.col = col
+        self.did: DeckId | None = None
+
+    def exportInto(self, path: str) -> None:
+        self.col.export_anki_package(
+            out_path=path,
+            options=ExportAnkiPackageOptions(
+                with_scheduling=self.includeSched,
+                with_deck_configs=self.includeSched,
+                with_media=True,
+                legacy=True,
+            ),
+            limit=DeckIdLimit(deck_id=self.did),
+        )
+
+
+_deprecated_names = DeprecatedNamesMixinForModule(globals())
+_deprecated_names.register_deprecated_aliases(
+    AnkiPackageExporter=_LegacyAnkiPackageExporter
+)
+
+
+if not TYPE_CHECKING:
+
+    def __getattr__(name: str) -> Any:
+        return _deprecated_names.__getattr__(name)

--- a/pylib/anki/importing.py
+++ b/pylib/anki/importing.py
@@ -1,0 +1,40 @@
+# Copyright: Ankitects Pty Ltd and contributors
+# License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
+
+from typing import TYPE_CHECKING, Any
+
+from anki._legacy import DeprecatedNamesMixinForModule
+from anki.collection import (
+    Collection,
+    ImportAnkiPackageOptions,
+    ImportAnkiPackageRequest,
+)
+
+
+class _LegacyAnkiPackageImporter:
+    def __init__(self, col: Collection, file: str) -> None:
+        self.col = col
+        self.file = file
+
+    def run(self) -> None:
+        self.col.import_anki_package(
+            ImportAnkiPackageRequest(
+                package_path=self.file,
+                options=ImportAnkiPackageOptions(
+                    merge_notetypes=True,
+                    with_scheduling=True,
+                    with_deck_configs=True,
+                ),
+            )
+        )
+
+
+_deprecated_names = DeprecatedNamesMixinForModule(globals())
+_deprecated_names.register_deprecated_aliases(
+    AnkiPackageImporter=_LegacyAnkiPackageImporter
+)
+
+if not TYPE_CHECKING:
+
+    def __getattr__(name: str) -> Any:
+        return _deprecated_names.__getattr__(name)

--- a/pylib/tests/test_importing_exporting.py
+++ b/pylib/tests/test_importing_exporting.py
@@ -1,0 +1,147 @@
+# Copyright: Ankitects Pty Ltd and contributors
+# License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
+
+import os
+import tempfile
+
+from anki import exporting, importing
+from anki.collection import Collection
+from anki.decks import DeckId
+from tests.shared import getEmptyCol
+
+
+def _apkg_path() -> str:
+    dir = tempfile.mkdtemp(prefix="anki")
+    return os.path.join(dir, "export.apkg")
+
+
+def _add_note(col: Collection, front: str, deck_id: DeckId) -> None:
+    note = col.newNote()
+    note["Front"] = front
+    col.add_note(note, deck_id)
+
+
+def _review_first_card(col: Collection) -> None:
+    card = col.sched.getCard()
+    assert card is not None
+    col.sched.answerCard(card, 3)
+    assert col.sched.answerButtons(card) == 4
+
+
+# The module-level __getattr__ is hidden from type checkers, so the
+# deprecated names must be looked up dynamically.
+def _importer(col: Collection, path: str) -> importing._LegacyAnkiPackageImporter:
+    return getattr(importing, "AnkiPackageImporter")(col, path)
+
+
+def _exporter(col: Collection) -> exporting._LegacyAnkiPackageExporter:
+    return getattr(exporting, "AnkiPackageExporter")(col)
+
+
+def test_deprecated_aliases(capsys) -> None:
+    importer = getattr(importing, "AnkiPackageImporter")
+    assert importer is importing._LegacyAnkiPackageImporter
+    assert "AnkiPackageImporter is deprecated" in capsys.readouterr().out
+
+    exporter = getattr(exporting, "AnkiPackageExporter")
+    assert exporter is exporting._LegacyAnkiPackageExporter
+    assert "AnkiPackageExporter is deprecated" in capsys.readouterr().out
+
+
+def test_export_whole_collection_and_import() -> None:
+    col = getEmptyCol()
+    deck_id = col.decks.id("Other")
+    _add_note(col, "one", DeckId(1))
+    _add_note(col, "two", deck_id)
+    path = _apkg_path()
+
+    exporter = _exporter(col)
+    exporter.exportInto(path)
+    assert os.path.getsize(path) > 0
+    col.close()
+
+    col2 = getEmptyCol()
+    _importer(col2, path).run()
+    assert sorted(col2.find_notes("")) != []
+    assert col2.note_count() == 2
+    assert col2.decks.by_name("Other") is not None
+    assert len(col2.find_notes('"deck:Other"')) == 1
+    col2.close()
+
+
+def test_export_deck_limit() -> None:
+    col = getEmptyCol()
+    deck_id = col.decks.id("Other")
+    _add_note(col, "one", DeckId(1))
+    _add_note(col, "two", deck_id)
+    path = _apkg_path()
+
+    exporter = _exporter(col)
+    exporter.did = deck_id
+    exporter.exportInto(path)
+    col.close()
+
+    col2 = getEmptyCol()
+    _importer(col2, path).run()
+    assert col2.note_count() == 1
+    assert col2.decks.by_name("Other") is not None
+    col2.close()
+
+
+def test_export_without_scheduling() -> None:
+    col = getEmptyCol()
+    _add_note(col, "one", DeckId(1))
+    _review_first_card(col)
+    path = _apkg_path()
+
+    exporter = _exporter(col)
+    assert exporter.includeSched is False
+    exporter.exportInto(path)
+    col.close()
+
+    col2 = getEmptyCol()
+    _importer(col2, path).run()
+    (card_id,) = col2.find_cards("")
+    card = col2.get_card(card_id)
+    assert card.type == 0
+    assert card.reps == 0
+    col2.close()
+
+
+def test_export_with_scheduling() -> None:
+    col = getEmptyCol()
+    _add_note(col, "one", DeckId(1))
+    _review_first_card(col)
+    path = _apkg_path()
+
+    exporter = _exporter(col)
+    exporter.includeSched = True
+    exporter.exportInto(path)
+    col.close()
+
+    col2 = getEmptyCol()
+    _importer(col2, path).run()
+    (card_id,) = col2.find_cards("")
+    card = col2.get_card(card_id)
+    assert card.type != 0
+    assert card.reps == 1
+    col2.close()
+
+
+def test_export_with_media() -> None:
+    col = getEmptyCol()
+    media_dir = tempfile.mkdtemp(prefix="anki")
+    media_path = os.path.join(media_dir, "foo.jpg")
+    with open(media_path, "w") as file:
+        file.write("hello")
+    fname = col.media.add_file(media_path)
+    _add_note(col, f'<img src="{fname}">', DeckId(1))
+    path = _apkg_path()
+
+    _exporter(col).exportInto(path)
+    col.close()
+
+    col2 = getEmptyCol()
+    _importer(col2, path).run()
+    assert col2.media.have(fname)
+    col2.close()


### PR DESCRIPTION
## Linked issue

Closes #5541

## Summary

Add compatibility wrappers for AnkiPackageImporter/AnkiPackageExporter to redirect the calls to the new APIs. This is intended as a temporary compatibility workaround for the [AnkiConnect](https://ankiweb.net/shared/info/2055492159) add-on, not as a general wrapper for all removed APIs.

## Steps to reproduce (before)

Install AnkiConnect and confirm it fails at startup due to the removed `anki.importing` and `anki.exporting` modules.

## How to test (after)

Export a sample apkg and run this script in the same directory to test AnkiConnect's importPackage/exportPackage APIs.

```python
import json
import urllib.request
from pathlib import Path


def request(action, **params):
    return {'action': action, 'params': params, 'version': 6}

def invoke(action, **params):
    payload = json.dumps(request(action, **params)).encode('utf-8')
    response = json.load(urllib.request.urlopen(urllib.request.Request('http://127.0.0.1:8765', payload)))
    if len(response) != 2:
        raise Exception('response has an unexpected number of fields')
    if 'error' not in response:
        raise Exception('response is missing required error field')
    if 'result' not in response:
        raise Exception('response is missing required result field')
    if response['error'] is not None:
        raise Exception(response['error'])
    return response['result']

result = invoke('importPackage', path=str(Path(__file__).parent / 'sample.apkg'))
assert result is True

decks = invoke('deckNamesAndIds')
deck_to_export = next(name for name in decks if name != 'Default')

result = invoke('exportPackage', deck=deck_to_export, path=str(Path(__file__).parent / 'exported.apkg'), includeSched=True)
assert result is True

```

