### PR TITLE
fix: hide scrollbar in locked FSRS parameters

### DIFF
--- a/ts/routes/deck-options/ParamsInput.svelte
+++ b/ts/routes/deck-options/ParamsInput.svelte
@@ -28,7 +28,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     function updateHeight() {
         if (taRef) {
             taRef.style.height = "auto";
-            // +2 for "overflow-y: auto" in case js breaks
+            // Include the textarea's 1px top and bottom borders.
             taRef.style.height = `${taRef.scrollHeight + 2}px`;
         }
     }
@@ -109,6 +109,7 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     }
 
     textarea:disabled {
+        overflow-y: hidden;
         pointer-events: none;
     }
 </style>


### PR DESCRIPTION
## Linked issue

Fixes #5502

## Summary / motivation

Hide the vertical scrollbar while FSRS parameters are locked. Keep the existing height calculation and scrolling when unlocked. Also clarify the two border pixels in the height calculation comment.

## Steps to reproduce

1. Open Deck Options on mobile and enable FSRS.
2. Inspect the locked parameter field, including at narrow widths and larger text sizes. A scrollbar can appear despite the field sizing itself to its contents.

## How to test

- [x] Ran `just check` successfully.
- [ ] Added/updated committed tests: N/A for this CSS-only fix; reused existing tests and a temporary acceptance runner.

`just test-e2e` passed all 28 tests (27 existing plus the temporary runner). Android checks covered 32 layout configurations, 150% system text, light/dark themes, unlocked scrolling, blur validation, preset changes, FSRS toggling, and save/reopen. Locked content remained fully visible.

Android verification used a temporary CSS override in AnkiDroid 2.25.0alpha4 (Anki 26.05), Android 16 emulator, WebView 133.0.6943.137. No patched APK or physical device was tested.

## UI evidence

19 parameters, narrow portrait, enlarged text; field height unchanged.

| Before | After |
| --- | --- |
| <img src="https://raw.githubusercontent.com/caleblee789/anki/c8c16543c08dc6aa119698a176f456a2af6b6452/before.png" width="300" alt="Scrollbar reduces available width and obscures the final parameters"> | <img src="https://raw.githubusercontent.com/caleblee789/anki/c8c16543c08dc6aa119698a176f456a2af6b6452/after.png" width="300" alt="All parameters visible without a scrollbar at the same height"> |

## Scope

- [x] Focused on one change; no unrelated edits.
