### PR TITLE
docs: explain Anki version numbers

### DIFF
--- a/docs-site/releases/betas/intro.mdx
+++ b/docs-site/releases/betas/intro.mdx
@@ -2,6 +2,16 @@
 title: "Intro & Downloads"
 ---
 
+## Version Numbers
+
+Anki uses calendar versioning: `year.month`, with an optional patch number.
+For example, `25.02` identifies the February 2025 release series, and `25.02.7`
+is its seventh patch release. Patch releases may arrive in later months while
+keeping the same year and month numbers.
+
+Beta versions add a `b` suffix and a number: for example, `25.02b1` is the
+first beta of `25.02`.
+
 ## Downgrading
 
 Beta versions may sometimes change your collection in a way that is not


### PR DESCRIPTION
## Linked issue

Fixes #5476

## Summary / motivation

Add a brief version-number explanation to the release introduction, as suggested in the linked discussion. Explain year/month release series, patch numbers, and beta suffixes with examples; clarify that patches can arrive in later months.

## Steps to reproduce

N/A — documentation only.

## How to test

- [x] `just check` passed.
- [x] `mintlify validate` passed from `docs-site`.
- No new tests needed for this documentation-only change.

## UI evidence

N/A — text-only documentation addition using existing page formatting.

## Scope

- [x] One page changed; no application behavior changes.