### PR TITLE
fix: flaky mathjax loading test

### DIFF
--- a/ts/reviewer/mathjax.test.ts
+++ b/ts/reviewer/mathjax.test.ts
@@ -2,7 +2,7 @@
 // License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 // @vitest-environment jsdom
 
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock(import("@tslib/bridgecommand"), () => ({ bridgeCommand: vi.fn() }));
 
@@ -28,6 +28,10 @@ function spyOnScripts(): HTMLScriptElement[] {
     });
     return scripts;
 }
+
+beforeAll(async () => {
+    await import("./index"); // warm cache
+}, 10000);
 
 beforeEach(() => {
     vi.resetModules();

--- a/ts/reviewer/mathjax.test.ts
+++ b/ts/reviewer/mathjax.test.ts
@@ -59,9 +59,10 @@ describe("mathjax lazy loading", () => {
         _showQuestion(HTML_WITH_MATHJAX, "", "");
 
         await vi.waitFor(() => expect(scripts).toHaveLength(1));
-        expect(scripts[0].src).toContain(CONFIG_SRC);
         scripts[0].onload?.(new Event("load")); // mock script loading
+        expect(scripts[0].src).toContain(CONFIG_SRC);
         await vi.waitFor(() => expect(scripts).toHaveLength(2));
+        scripts[1].onload?.(new Event("load"));
         expect(scripts[1].src).toContain(VENDOR_SRC);
     });
 

--- a/ts/reviewer/mathjax.test.ts
+++ b/ts/reviewer/mathjax.test.ts
@@ -35,6 +35,7 @@ beforeAll(async () => {
 
 beforeEach(() => {
     vi.resetModules();
+    vi.restoreAllMocks();
     delete window.MathJax;
     document.body.innerHTML = "<div id=\"qa\"></div>";
     document.head.querySelectorAll("script").forEach((node) => node.remove());

--- a/ts/reviewer/mathjax.test.ts
+++ b/ts/reviewer/mathjax.test.ts
@@ -5,6 +5,7 @@
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock(import("@tslib/bridgecommand"), () => ({ bridgeCommand: vi.fn() }));
+vi.stubGlobal("scrollTo", (_x: any, _y: any) => null);
 
 const CONFIG_SRC = "/_anki/js/mathjax.js";
 const VENDOR_SRC = "/_anki/js/vendor/mathjax/tex-chtml-full.js";


### PR DESCRIPTION
## Linked issue (required)

Closes #5561

## Summary / motivation (required)

Importing `./index` was taking a long time which timed out several tests, and the scripts mock wasn't reset between tests. I added a dummy import beforehand to warm the cache but test timeouts might still need increasing
