### PR TITLE
build: initialize host installer templates before Qt tests

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -305,6 +305,7 @@ zaveshaa <zaveshaa@gmail.com>
 zaveshaa <127344512+zaveshaa@users.noreply.github.com>
 James Liu <https://github.com/jamesliuai>
 Caleb Meadows
+Michael McDonald <https://github.com/praxish>
 ********************
 
 The text of the 3 clause BSD license follows:

--- a/build/configure/src/aqt.rs
+++ b/build/configure/src/aqt.rs
@@ -21,6 +21,7 @@ use ninja_gen::Utf8Path;
 use ninja_gen::Utf8PathBuf;
 
 use crate::anki_version;
+use crate::installer::installer_template_inputs;
 use crate::python::BuildWheel;
 use crate::web::copy_mathjax;
 
@@ -374,7 +375,12 @@ fn check_python(build: &mut Build) -> Result<()> {
                 "$builddir/qt",
                 "$builddir/qt/tools",
             ],
-            deps: inputs![":pylib:anki", ":qt:aqt", glob!["qt/tests/**"]],
+            deps: inputs![
+                ":pylib:anki",
+                ":qt:aqt",
+                glob!["qt/tests/**"],
+                installer_template_inputs(build.host_platform)
+            ],
         },
     )?;
 

--- a/build/configure/src/installer.rs
+++ b/build/configure/src/installer.rs
@@ -1,11 +1,15 @@
 // Copyright: Ankitects Pty Ltd and contributors
 // License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
+use std::env;
+
 use anyhow::Result;
 use ninja_gen::action::BuildAction;
+use ninja_gen::archives::Platform;
 use ninja_gen::build::FilesHandle;
 use ninja_gen::git::SyncSubmodule;
 use ninja_gen::glob;
+use ninja_gen::input::BuildInput;
 use ninja_gen::inputs;
 use ninja_gen::Build;
 
@@ -13,6 +17,7 @@ use crate::anki_version;
 
 struct BuildCommand {
     version: String,
+    template: BuildInput,
 }
 
 impl BuildAction for BuildCommand {
@@ -26,7 +31,7 @@ impl BuildAction for BuildCommand {
         build.add_variable("version", &self.version);
         build.add_inputs("aqt_wheel", inputs![":wheels:aqt"]);
         build.add_inputs("anki_wheel", inputs![":wheels:anki"]);
-        build.add_inputs("", inputs![":installer:template", glob!["qt/installer/**"]]);
+        build.add_inputs("", inputs![&self.template, glob!["qt/installer/**"]]);
         build.add_output_stamp("installer/briefcase.build.stamp");
     }
 }
@@ -49,26 +54,49 @@ impl BuildAction for PackageCommand {
     }
 }
 
-pub fn build_installer(build: &mut Build) -> Result<()> {
+pub fn setup_installer_templates(build: &mut Build) -> Result<()> {
+    let offline_build = env::var("OFFLINE_BUILD").is_ok();
     build.add_action(
         "installer:template:win",
         SyncSubmodule {
             path: "qt/installer/windows-template",
-            offline_build: false,
+            offline_build,
         },
     )?;
     build.add_action(
         "installer:template:mac",
         SyncSubmodule {
             path: "qt/installer/mac-template",
-            offline_build: false,
+            offline_build,
         },
-    )?;
+    )
+}
+
+pub fn installer_template_inputs(platform: Platform) -> BuildInput {
+    match platform {
+        Platform::WindowsX64 | Platform::WindowsArm => inputs![
+            ":installer:template:win",
+            glob!["qt/installer/windows-template/**"]
+        ],
+        Platform::MacX64 | Platform::MacArm => {
+            inputs![
+                ":installer:template:mac",
+                glob!["qt/installer/mac-template/**"]
+            ]
+        }
+        Platform::LinuxX64 | Platform::LinuxArm => {
+            inputs![glob!["qt/installer/linux-template/**"]]
+        }
+    }
+}
+
+pub fn build_installer(build: &mut Build) -> Result<()> {
     let version = anki_version();
     build.add_action(
         "installer:build",
         BuildCommand {
             version: version.clone(),
+            template: installer_template_inputs(build.host_platform),
         },
     )?;
     build.add_action("installer:package", PackageCommand { version })?;

--- a/build/configure/src/main.rs
+++ b/build/configure/src/main.rs
@@ -18,6 +18,7 @@ use aqt::build_and_check_aqt;
 use audio::build_audio;
 use cog::check_cog;
 use installer::build_installer;
+use installer::setup_installer_templates;
 use ninja_gen::glob;
 use ninja_gen::inputs;
 use ninja_gen::protobuf::check_proto;
@@ -56,6 +57,7 @@ fn main() -> Result<()> {
     build_rust(build)?;
     build_pylib(build)?;
     build_and_check_web(build)?;
+    setup_installer_templates(build)?;
     build_and_check_aqt(build)?;
 
     if env::var("OFFLINE_BUILD").is_err() {


### PR DESCRIPTION
## Linked issue

Fixes #5563

## Summary / motivation

Declare the host installer template as a Qt-test prerequisite and reuse the same host-specific input for installer builds. Register template actions before Qt targets, including offline mode; offline actions retain the existing no-fetch behavior. Linux continues to use its checked-in template.

## Steps to reproduce

On macOS or Windows, start with a fresh checkout whose installer template submodules have not been initialized and run `just test-py` or `just check`. The installer tests read the host template files, but the Qt test target does not depend on initializing those templates. The tests fail on missing template resources even though the build system knows how to fetch them.

## How to test

- [x] `RELEASE=1 just check` passed on this focused upstream-based branch (`2b39e5589`), using Apple Silicon macOS and the repository's pinned toolchains.

Generated fresh online/offline build graphs in a disposable local clone with empty template submodules. Confirmed host-only template prerequisites and no Git updates in offline mode. Full local builds used initialized macOS templates; a complete fresh Windows build remains unverified.
## Risk / compatibility / migration

No application behavior or dependency versions change. Graph generation was checked without fetching templates; a complete fresh Windows build has not been run.

## UI evidence

N/A: no visual changes.

## Scope

- [x] Focused on the linked build failure.
