### PR TITLE
build: use an explicit local cargo-license prerequisite

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -305,6 +305,7 @@ zaveshaa <zaveshaa@gmail.com>
 zaveshaa <127344512+zaveshaa@users.noreply.github.com>
 James Liu <https://github.com/jamesliuai>
 Caleb Meadows
+Michael McDonald <https://github.com/praxish>
 ********************
 
 The text of the 3 clause BSD license follows:

--- a/build/configure/src/rust.rs
+++ b/build/configure/src/rust.rs
@@ -9,6 +9,7 @@ use ninja_gen::build::FilesHandle;
 use ninja_gen::cargo::CargoBuild;
 use ninja_gen::cargo::CargoClippy;
 use ninja_gen::cargo::CargoFormat;
+use ninja_gen::cargo::CargoInstall;
 use ninja_gen::cargo::CargoTest;
 use ninja_gen::cargo::RustOutput;
 use ninja_gen::git::SyncSubmodule;
@@ -215,7 +216,7 @@ pub fn check_minilints(build: &mut Build) -> Result<()> {
 
     impl BuildAction for RunMinilints {
         fn command(&self) -> &str {
-            "$minilints_bin $fix $stamp"
+            "$minilints_bin $fix $stamp $cargo_license"
         }
 
         fn bypass_runner(&self) -> bool {
@@ -224,12 +225,20 @@ pub fn check_minilints(build: &mut Build) -> Result<()> {
 
         fn files(&mut self, build: &mut impl FilesHandle) {
             build.add_inputs("minilints_bin", inputs![":build:minilints"]);
+            build.add_inputs("cargo_license", inputs![":cargo-license"]);
             build.add_inputs("", &self.deps);
             build.add_variable("fix", if self.fix { "fix" } else { "check" });
             build.add_output_stamp(format!("tests/minilints.{}", self.fix));
         }
 
         fn on_first_instance(&self, build: &mut Build) -> Result<()> {
+            build.add_action(
+                "cargo-license",
+                CargoInstall {
+                    binary_name: "cargo-license",
+                    args: "cargo-license --version 0.7.0 --locked",
+                },
+            )?;
             build.add_action(
                 "build:minilints",
                 CargoBuild {

--- a/tools/minilints/src/main.rs
+++ b/tools/minilints/src/main.rs
@@ -45,9 +45,16 @@ fn main() -> Result<()> {
     let mut args = env::args();
     let want_fix = args.nth(1) == Some("fix".to_string());
     let stamp = args.next().unwrap();
+    let cargo_license = if let Some(path) = args.next() {
+        path
+    } else {
+        // Standalone callers (including CI) do not use the build graph.
+        Command::run("cargo install cargo-license --version 0.7.0 --locked --root out")?;
+        format!("out/bin/cargo-license{}", env::consts::EXE_SUFFIX)
+    };
     let mut ctx = LintContext::new(want_fix);
     ctx.check_contributors()?;
-    ctx.check_rust_licenses()?;
+    ctx.check_rust_licenses(&cargo_license)?;
     ctx.walk_folders(Path::new("."))?;
     if ctx.found_problems {
         std::process::exit(1);
@@ -201,16 +208,16 @@ impl LintContext {
         std::process::exit(1);
     }
 
-    fn check_rust_licenses(&mut self) -> Result<()> {
+    fn check_rust_licenses(&mut self, cargo_license: &str) -> Result<()> {
         let license_path = Path::new("cargo/licenses.json");
-        let licenses = generate_licences()?;
+        let licenses = generate_licences(cargo_license)?;
         let existing_licenses = read_to_string(license_path)?;
         if licenses != existing_licenses {
             if self.want_fix {
                 check_cargo_deny()?;
                 write_file(license_path, licenses)?;
             } else {
-                println!("cargo/licenses.json is out of date; run ./ninja fix:minilints");
+                println!("cargo/licenses.json is out of date; run just fix-minilints");
                 self.found_problems = true;
             }
         }
@@ -292,10 +299,9 @@ fn check_for_unstaged_changes() {
     }
 }
 
-fn generate_licences() -> Result<String> {
-    Command::run("cargo install cargo-license@0.7.0")?;
+fn generate_licences(cargo_license: &str) -> Result<String> {
     let output = Command::run_with_output([
-        "cargo-license",
+        cargo_license,
         "--features",
         "rustls",
         "--features",


### PR DESCRIPTION
## Linked issue

Fixes #5565

## Summary / motivation

Install the existing pinned cargo-license 0.7.0 as a build prerequisite and pass its local path to minilints. Preserve the standalone mode-and-stamp interface by installing into `out` and using its explicit executable path when the optional path argument is absent. Use cargo-license’s packaged lockfile with `--locked`.

## Steps to reproduce

Use a Rust toolchain reachable on PATH while the user Cargo binary directory is absent from PATH, then run `just minilints` or the standalone minilints interface used by CI. Minilints installs cargo-license into Cargo's default directory and subsequently executes `cargo-license` by name. Installation can succeed but execution still fails because the install directory is not searched.

## How to test

- [x] `RELEASE=1 just check` passed on this focused upstream-based branch (`b5a153661`), using Apple Silicon macOS and the repository's pinned toolchains.

Also passed the existing standalone minilints interface used by CI with the Cargo install directory absent from PATH. Verified the pinned cargo-license executable is an explicit build input.
## Risk / compatibility / migration

The cargo-license version remains 0.7.0. The existing standalone command remains supported; platform executable suffixes are retained. Windows execution has not been checked locally.

## UI evidence

N/A: no visual changes.

## Scope

- [x] Focused on the linked build failure.
