### PR TITLE
fix: play attached and recorded editor audio once

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -305,6 +305,7 @@ zaveshaa <zaveshaa@gmail.com>
 zaveshaa <127344512+zaveshaa@users.noreply.github.com>
 James Liu <https://github.com/jamesliuai>
 Caleb Meadows
+Michael McDonald <https://github.com/praxish>
 ********************
 
 The text of the 3 clause BSD license follows:

--- a/ts/routes/editor/editor-toolbar/TemplateButtons.svelte
+++ b/ts/routes/editor/editor-toolbar/TemplateButtons.svelte
@@ -24,10 +24,9 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     import LatexButton from "./LatexButton.svelte";
     import {
         filenameToLink,
-        isAudio,
         openFilePickerForMedia,
     } from "../rich-text-input/data-transfer";
-    import { addMediaFromPath, playFile, recordAudio } from "@generated/backend";
+    import { addMediaFromPath, recordAudio } from "@generated/backend";
     import { bridgeCommand } from "@tslib/bridgecommand";
     import { promiseWithResolver } from "@tslib/promise";
     import type { RichTextInputAPI } from "../rich-text-input";
@@ -40,9 +39,6 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
     async function attachPath(path: string) {
         const filename = (await addMediaFromPath({ path })).val;
         setFormat("inserthtml", filenameToLink(filename));
-        if (isAudio(filename)) {
-            await playFile({ val: filename });
-        }
     }
 
     let mediaPromise: Promise<string>;

--- a/ts/tests/e2e/media-buttons.spec.ts
+++ b/ts/tests/e2e/media-buttons.spec.ts
@@ -69,44 +69,66 @@ test("attach button uses openFilePicker+addMediaFromPath RPCs, not the Qt bridge
     expect(calls).not.toContain("attach");
 });
 
-test("record button uses recordAudio+addMediaFromPath RPCs and plays the file", async ({ editor: page }) => {
-    const wavName = `e2e-record-${Date.now()}.wav`;
-    const wavPath = path.join(tmpDir, wavName);
-    fs.writeFileSync(wavPath, Buffer.from(""));
+for (const source of ["attachment", "recording"] as const) {
+    test(`audio ${source} inserts the file and starts playback exactly once`, async ({ editor: page }) => {
+        const wavName = `e2e-${source}.wav`;
+        const wavPath = path.join(tmpDir, wavName);
+        fs.writeFileSync(wavPath, Buffer.from(""));
+        const dialogRpc = source === "attachment" ? "openFilePicker" : "recordAudio";
 
-    await page.route("**/_anki/recordAudio", (route) =>
-        route.fulfill({
-            contentType: "application/binary",
-            body: protoStringBody(wavPath),
-        }));
-    await page.route("**/_anki/playFile", (route) =>
-        route.fulfill({
-            contentType: "application/binary",
-            body: Buffer.from(""),
-        }));
+        await page.route(`**/_anki/${dialogRpc}`, (route) =>
+            route.fulfill({
+                contentType: "application/binary",
+                body: protoStringBody(wavPath),
+            }));
+        await page.route("**/_anki/playFile", (route) =>
+            route.fulfill({
+                contentType: "application/binary",
+                body: Buffer.from(""),
+            }));
 
-    const field = editableField(page, 0);
-    await field.click();
+        // Count in the browser so both requests from the same handler are visible
+        // without waiting for a duplicate request to arrive over the network.
+        await page.evaluate(() => {
+            const w = window as typeof window & { __mediaPlaybackCount: number };
+            w.__mediaPlaybackCount = 0;
+            const originalFetch = window.fetch.bind(window);
+            window.fetch = (...args: Parameters<typeof fetch>) => {
+                if (typeof args[0] === "string" && args[0].endsWith("/playFile")) {
+                    w.__mediaPlaybackCount++;
+                }
+                return originalFetch(...args);
+            };
+        });
 
-    const recordReqPromise = page.waitForRequest(isRpc("recordAudio"), { timeout: 10_000 });
-    const addMediaRespPromise = page.waitForResponse(
-        (resp) => isRpc("addMediaFromPath")(resp.request()) && resp.status() < 400,
-        { timeout: 10_000 },
-    );
-    const playFileReqPromise = page.waitForRequest(isRpc("playFile"), { timeout: 10_000 });
+        const field = editableField(page, 0);
+        await field.click();
 
-    await recordButton(page).click();
+        const dialogReqPromise = page.waitForRequest(isRpc(dialogRpc), { timeout: 10_000 });
+        const addMediaRespPromise = page.waitForResponse(
+            (resp) => isRpc("addMediaFromPath")(resp.request()) && resp.status() < 400,
+            { timeout: 10_000 },
+        );
+        const playFileReqPromise = page.waitForRequest(isRpc("playFile"), { timeout: 10_000 });
 
-    await recordReqPromise;
-    await addMediaRespPromise;
+        await (source === "attachment" ? attachButton(page) : recordButton(page)).click();
 
-    await expect(field).toContainText(`[sound:${wavName}]`, { timeout: 5_000 });
-    const playFileReq = await playFileReqPromise;
-    expect(decodeRequestBody(playFileReq, GenericString).val).toBe(wavName);
+        await dialogReqPromise;
+        await addMediaRespPromise;
 
-    const calls = await bridgeCalls(page);
-    expect(calls).not.toContain("record");
-});
+        await expect(field).toContainText(`[sound:${wavName}]`, { timeout: 5_000 });
+        const playFileReq = await playFileReqPromise;
+        expect(decodeRequestBody(playFileReq, GenericString).val).toBe(wavName);
+        expect(
+            await page.evaluate(() =>
+                (window as typeof window & { __mediaPlaybackCount: number }).__mediaPlaybackCount
+            ),
+        ).toBe(1);
+
+        const calls = await bridgeCalls(page);
+        expect(calls).not.toContain(source === "attachment" ? "attach" : "record");
+    });
+}
 
 /**
  * Drives the legacy branch of a media button and replicates Qt's half of the


### PR DESCRIPTION
## Linked issue (required)

Fixes #5569

## Summary / motivation (required)

Attaching or recording audio in the new editor sends two playback requests: `filenameToLink()` starts playback while constructing the sound marker, then the toolbar's `attachPath()` repeats it. Remove the redundant toolbar request so each operation inserts the marker and starts playback once.

Extend browser coverage to both attachment and recording. Count playback calls in the browser so two calls from the same handler cannot pass through a check that only waits for the first network request.

## Steps to reproduce (required, use N/A if not applicable)

Using a disposable profile on the base revision:

1. Open the new editor and focus an editable field.
2. Attach an audio file with the paperclip button, or record audio with the microphone button.
3. Observe the `playFile` requests: the same file is requested twice when its sound marker is inserted.

## How to test

- [x] `RELEASE=1 just check` passed on this focused upstream-based branch (`4cc4f89ad`), using Apple Silicon macOS and the repository's pinned toolchains.
- [x] Added or updated regression coverage for the changed behavior.

`just test-e2e` also passed all 28 browser tests, including attachment and recording with exactly one playback request and existing legacy toolbar cases. Native dialogs/audio are stubbed, and the harness uses a disposable profile.
## Risk / compatibility / migration (optional)

No database migration or dependency change. The shared media-link helper retains its existing playback behavior, and the legacy Qt toolbar branch is unchanged. Complete local validation was on macOS; other platforms depend on CI.

## UI evidence (required for visual changes; otherwise N/A)

N/A: no visual design changes. Browser tests verify the inserted sound marker and playback request count.

## Scope

- [x] This PR is focused on one change (no unrelated edits).
