### PR TITLE
fix: reject case variants of the reserved addons21 profile name

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -305,6 +305,7 @@ zaveshaa <zaveshaa@gmail.com>
 zaveshaa <127344512+zaveshaa@users.noreply.github.com>
 James Liu <https://github.com/jamesliuai>
 Caleb Meadows
+Michael McDonald <https://github.com/praxish>
 ********************
 
 The text of the 3 clause BSD license follows:

--- a/qt/aqt/main.py
+++ b/qt/aqt/main.py
@@ -381,7 +381,7 @@ class AnkiQt(QMainWindow):
         self.loadProfile(on_done)
 
     def profileNameOk(self, name: str) -> bool:
-        return not checkInvalidFilename(name) and name != "addons21"
+        return not checkInvalidFilename(name) and name.casefold() != "addons21"
 
     def onAddProfile(self) -> None:
         name = getOnlyText(tr.actions_name()).strip()

--- a/qt/tests/test_profile_names.py
+++ b/qt/tests/test_profile_names.py
@@ -1,0 +1,23 @@
+# Copyright: Ankitects Pty Ltd and contributors
+# License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
+
+from typing import cast
+from unittest.mock import MagicMock
+
+import pytest
+
+from aqt.main import AnkiQt
+
+
+@pytest.mark.parametrize("name", ["addons21", "Addons21", "ADDONS21"])
+def test_profile_name_rejects_addon_folder(name: str) -> None:
+    window = cast(AnkiQt, MagicMock(spec=AnkiQt))
+
+    assert AnkiQt.profileNameOk(window, name) is False
+
+
+@pytest.mark.parametrize("name", ["Personal", "Study 2026", "addons21 notes"])
+def test_profile_name_accepts_normal_names(name: str) -> None:
+    window = cast(AnkiQt, MagicMock(spec=AnkiQt))
+
+    assert AnkiQt.profileNameOk(window, name) is True


### PR DESCRIPTION
## Linked issue (required)

Fixes #5571

## Summary / motivation (required)

Reject capitalization variants of `addons21` when creating or renaming a profile. On a case-insensitive filesystem these names otherwise resolve to Anki's shared add-on directory. Add focused validation tests for the reserved variants and ordinary names.

## Steps to reproduce (required, use N/A if not applicable)

1. Using a disposable base directory on a case-insensitive filesystem, open the profile manager.
2. Create or rename a disposable profile to `Addons21`.
3. The name is accepted and the profile path aliases the shared `addons21` directory.

## How to test

- [x] `RELEASE=1 just check` passed on this focused upstream-based branch (`d51a75a44`), using Apple Silicon macOS and the repository's pinned toolchains.
- [x] Added or updated regression coverage for the changed behavior.

Parameterized tests reject three capitalizations of addons21 and accept ordinary profile names. The filesystem alias was independently reproduced with temporary data on a case-insensitive macOS filesystem.
## Before / after behavior (optional)

Before: only the exact lowercase spelling is reserved. After: capitalization variants are also rejected.

## Risk / compatibility / migration (optional)

No migration or existing-profile rename. This also reserves the same variants on case-sensitive filesystems, keeping validation portable. Other filename validation is unchanged.

## UI evidence (required for visual changes; otherwise N/A)

N/A. No visual changes.

## Scope

- [x] This PR is focused on one change (no unrelated edits).
