### PR TITLE
fix: skip periodic backups during backup recovery

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -305,6 +305,7 @@ zaveshaa <zaveshaa@gmail.com>
 zaveshaa <127344512+zaveshaa@users.noreply.github.com>
 James Liu <https://github.com/jamesliuai>
 Caleb Meadows
+Michael McDonald <https://github.com/praxish>
 ********************
 
 The text of the 3 clause BSD license follows:

--- a/qt/aqt/main.py
+++ b/qt/aqt/main.py
@@ -1573,6 +1573,8 @@ title="{}" {}>{}</button>""".format(
 
     def on_periodic_backup_timer(self) -> None:
         """Create a backup if enough time has elapsed and collection changed."""
+        if self.restoring_backup:
+            return
         self._create_backup_with_progress(user_initiated=False)
 
     def on_create_backup_now(self) -> None:

--- a/qt/tests/test_backup_recovery.py
+++ b/qt/tests/test_backup_recovery.py
@@ -1,0 +1,28 @@
+# Copyright: Ankitects Pty Ltd and contributors
+# License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
+
+from unittest.mock import MagicMock
+
+from aqt.main import AnkiQt
+
+
+def test_periodic_backup_requests_backup_normally() -> None:
+    window = MagicMock(spec=AnkiQt)
+    window.restoring_backup = False
+
+    AnkiQt.on_periodic_backup_timer(window)
+
+    window._create_backup_with_progress.assert_called_once_with(user_initiated=False)
+
+
+def test_recovery_skips_automatic_backups_but_allows_manual_backup() -> None:
+    window = MagicMock(spec=AnkiQt)
+    window.restoring_backup = True
+
+    AnkiQt.on_periodic_backup_timer(window)
+
+    window._create_backup_with_progress.assert_not_called()
+
+    AnkiQt.on_create_backup_now(window)
+
+    window._create_backup_with_progress.assert_called_once_with(user_initiated=True)


### PR DESCRIPTION
## Linked issue (required)

Fixes #5573

## Summary / motivation (required)

Honor the existing recovery-session flag in the periodic-backup timer. Restoring a backup already disables automatic synchronization and shutdown backups; periodic backups should follow the same rule. Keep explicit user-requested backups available.

## Steps to reproduce (required, use N/A if not applicable)

1. In a disposable profile, restore a backup and leave the recovered profile open.
2. Make a collection change and allow a configured backup interval to become due.
3. When the five-minute timer fires, it requests an automatic backup despite the recovery-session flag.

## How to test

- [x] `RELEASE=1 just check` passed on this focused upstream-based branch (`5eddd98d5`), using Apple Silicon macOS and the repository's pinned toolchains.
- [x] Added or updated regression coverage for the changed behavior.

Regressions verify normal periodic backups, suppression while restoring, and continued availability of an explicit manual backup. Tests stub backup requests and do not open a collection.
## Before / after behavior (optional)

Before: the recovery flag suppresses shutdown backups but not timer-triggered backups. After: timer-triggered backups are also suppressed until profile unload resets the flag.

## Risk / compatibility / migration (optional)

No migration or change to ordinary backup timing or manual backups. The existing lifecycle owns the recovery flag; the patch adds a guard at the automatic timer entry point.

## UI evidence (required for visual changes; otherwise N/A)

N/A. No visual changes.

## Scope

- [x] This PR is focused on one change (no unrelated edits).
