### PR TITLE
fix: interpret ANKIDEV consistently at startup and shutdown

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -305,6 +305,7 @@ zaveshaa <zaveshaa@gmail.com>
 zaveshaa <127344512+zaveshaa@users.noreply.github.com>
 James Liu <https://github.com/jamesliuai>
 Caleb Meadows
+Michael McDonald <https://github.com/praxish>
 ********************
 
 The text of the 3 clause BSD license follows:

--- a/pylib/anki/utils.py
+++ b/pylib/anki/utils.py
@@ -250,7 +250,7 @@ is_gnome = (
     "gnome" in os.getenv("XDG_CURRENT_DESKTOP", "").lower()
     or "gnome" in os.getenv("DESKTOP_SESSION", "").lower()
 )
-dev_mode = os.getenv("ANKIDEV", "")
+dev_mode = os.getenv("ANKIDEV", "") not in ("", "0")
 hmr_mode = os.getenv("HMR", "")
 
 INVALID_FILENAME_CHARS = ':*?"<>|'

--- a/pylib/tests/test_utils.py
+++ b/pylib/tests/test_utils.py
@@ -1,11 +1,31 @@
 # Copyright: Ankitects Pty Ltd and contributors
 # License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
+import runpy
 from unittest.mock import patch
 
 import pytest
 
+import anki.utils
 from anki.utils import int_version, int_version_to_str
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [(None, False), ("", False), ("0", False), ("1", True), ("enabled", True)],
+)
+def test_dev_mode_respects_environment(
+    monkeypatch: pytest.MonkeyPatch, value: str | None, expected: bool
+) -> None:
+    if value is None:
+        monkeypatch.delenv("ANKIDEV", raising=False)
+    else:
+        monkeypatch.setenv("ANKIDEV", value)
+
+    # Read startup flags in fresh globals without changing the shared module.
+    startup_globals = runpy.run_path(anki.utils.__file__)
+
+    assert startup_globals["dev_mode"] is expected
 
 
 @pytest.mark.parametrize(

--- a/qt/aqt/__init__.py
+++ b/qt/aqt/__init__.py
@@ -54,7 +54,7 @@ from anki._backend import RustBackend
 from anki.buildinfo import version as _version
 from anki.collection import Collection
 from anki.consts import HELP_SITE
-from anki.utils import checksum, is_gnome, is_lin, is_mac
+from anki.utils import checksum, dev_mode, is_gnome, is_lin, is_mac
 from aqt import gui_hooks
 from aqt.log import setup_logging
 from aqt.qt import *
@@ -727,7 +727,7 @@ def _run(argv: list[str] | None = None, exec: bool = True) -> AnkiApp | None:
 
     setup_logging(
         pm.addon_logs(),
-        level=logging.DEBUG if int(os.getenv("ANKIDEV", "0")) else logging.INFO,
+        level=logging.DEBUG if dev_mode else logging.INFO,
     )
 
     # disable icons on mac; this must be done before window created


### PR DESCRIPTION
## Linked issue (required)

Fixes #5575

## Summary / motivation (required)

Normalize the shared `dev_mode` flag so unset, empty, and `0` disable it, and use that same flag for GUI logging. This avoids an empty-value startup exception and ensures `ANKIDEV=0` retains normal shutdown integrity checks and backups. Preserve the shared flag's existing enabled behavior for other nonempty values.

## Steps to reproduce (required, use N/A if not applicable)

1. Launch Anki with `ANKIDEV` present but empty through an entry point that does not overwrite it; logging setup raises `ValueError`.
2. Launch with `ANKIDEV=0`; logging uses normal verbosity but the shared raw string remains truthy.
3. On normal profile shutdown, the truthy `dev_mode` causes the integrity-check and automatic-backup branches to be skipped.

Using an installed wheel environment and a disposable base directory (the development launcher overwrites ANKIDEV):

```sh
ANKIDEV='' /path/to/venv/bin/python -I -c 'import aqt; aqt.run()' -b /path/to/disposable-profile
```

Repeat with `ANKIDEV=0` for the inconsistent shutdown flag. The shutdown consequence is diagnosed from the flag consumers; automated regressions exercise the flag values without opening a user collection.

## How to test

- [x] `RELEASE=1 just check` passed on this focused upstream-based branch (`320ee0c51`), using Apple Silicon macOS and the repository's pinned toolchains.
- [x] Added or updated regression coverage for the changed behavior.

Parameterized regressions cover unset, empty, 0, 1, and another nonempty ANKIDEV value, evaluating the flag in fresh globals without reloading the shared imported module.
## Before / after behavior (optional)

Before: logging and shutdown disagree on `ANKIDEV=0`, and an empty value crashes logging setup. After: both use one boolean interpretation.

## Risk / compatibility / migration (optional)

No migration. The shared flag becomes a boolean instead of a string. Truth testing is preserved for other nonempty values, including the existing development launch setting `ANKIDEV=1`.

## UI evidence (required for visual changes; otherwise N/A)

N/A. No visual changes.

## Scope

- [x] This PR is focused on one change (no unrelated edits).
