### PR TITLE
test: wait for mpv playback and always shut down the player

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -305,6 +305,7 @@ zaveshaa <zaveshaa@gmail.com>
 zaveshaa <127344512+zaveshaa@users.noreply.github.com>
 James Liu <https://github.com/jamesliuai>
 Caleb Meadows
+Michael McDonald <https://github.com/praxish>
 ********************
 
 The text of the 3 clause BSD license follows:

--- a/qt/tests/test_sound.py
+++ b/qt/tests/test_sound.py
@@ -5,6 +5,7 @@ import shutil
 import subprocess
 import wave
 from pathlib import Path
+from threading import Event
 from unittest.mock import MagicMock
 
 import pytest
@@ -112,7 +113,7 @@ def test_mpv_can_play_generated_wav(generated_wav: Path):
 @pytest.mark.skipif(is_lin, reason="mpv is not bundled for Linux")
 def test_mpvmanager_can_play_generated_wav(
     monkeypatch, tmp_path: Path, generated_wav: Path
-):
+) -> None:
     monkeypatch.setattr(
         MpvManager, "default_argv", MpvManager.default_argv + ["--ao=null", "--vo=null"]
     )
@@ -120,6 +121,23 @@ def test_mpvmanager_can_play_generated_wav(
     mock_mw.taskman.run_in_background.side_effect = (
         lambda task, on_done=None, **kwargs: task()
     )
+    mock_mw.taskman.run_on_main.side_effect = lambda callback: callback()
     monkeypatch.setattr(aqt, "mw", mock_mw)
-    manager = MpvManager(tmp_path, tmp_path)
-    manager.play(SoundOrVideoTag(filename=str(generated_wav.name)), lambda _: None)
+    loaded = Event()
+    completed = Event()
+
+    def on_done() -> None:
+        if loaded.is_set():
+            completed.set()
+
+    manager = MpvManager(str(tmp_path), str(tmp_path))
+    try:
+        manager.register_callback("file-loaded", loaded.set)
+        manager.play(SoundOrVideoTag(filename=generated_wav.name), on_done)
+        assert loaded.wait(timeout=10), "mpv did not load the generated WAV"
+        assert completed.wait(timeout=10), (
+            "mpv did not finish playing the generated WAV"
+        )
+    finally:
+        manager.shutdown()
+    assert not manager.is_running()


### PR DESCRIPTION
## Linked issue (required)

Fixes #5577

## Summary / motivation (required)

Make the existing MpvManager integration test observe file loading and completion, then shut down its player in `finally`. Execute the mocked main-thread callback and give it the correct zero-argument signature. The test now fails if playback does not occur instead of passing immediately and leaving asynchronous work behind.

## Steps to reproduce (required, use N/A if not applicable)

1. On macOS or Windows with the bundled player available, run `just test-py`.
2. The existing MpvManager test returns immediately after issuing a play command without checking file loading or completion.
3. The player remains alive beyond monkeypatch teardown, so callbacks can escape the test lifetime.

## How to test

- [x] `RELEASE=1 just check` passed on this focused upstream-based branch (`39150db93`), using Apple Silicon macOS and the repository's pinned toolchains.
- [x] Added or updated regression coverage for the changed behavior.

The integration test uses the bundled macOS player and a generated WAV, waits for both file-loaded and playback completion, and checks that the process is stopped after cleanup. It uses null audio/video outputs.

## Before / after behavior (optional)

Before: the test may pass without successful playback and leaves the player running. After: success requires loading and completion, and cleanup runs even after a failure.

## Risk / compatibility / migration (optional)

Test-only change. No production playback behavior changes. Local validation was performed on macOS arm64. Windows execution remains unverified and requires the `check:windows` CI label.

## UI evidence (required for visual changes; otherwise N/A)

N/A. No visual changes.

## Scope

- [x] This PR is focused on one change (no unrelated edits).
