### PR TITLE
fix: route legacy wheel builders through the current recipe

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -305,6 +305,7 @@ zaveshaa <zaveshaa@gmail.com>
 zaveshaa <127344512+zaveshaa@users.noreply.github.com>
 James Liu <https://github.com/jamesliuai>
 Caleb Meadows
+Michael McDonald <https://github.com/praxish>
 ********************
 
 The text of the 3 clause BSD license follows:

--- a/docs-site/developers/development.mdx
+++ b/docs-site/developers/development.mdx
@@ -42,11 +42,10 @@ On all platforms, you will need to install:
   from https://github.com/ninja-build/ninja/releases/tag/v1.11.1 and
   placed on your path, or from your distro/homebrew if it's 1.10+.
     - On Windows, if you have WSL installed, it may conflict with MSYS2 bash. If you are getting an error, try running `C:\msys64\usr\bin\bash.exe tools/install-n2` instead.
-- (Optional) [just](https://just.systems/man/en/packages.html) command runner.
+- [just](https://just.systems/man/en/packages.html) command runner.
   Install with `brew install just` or `uv tool install just`.
-  We are experimenting with `just` as the official tool for running
-  Anki-specific commands, and it will likely become the source of truth
-  in the future.
+  Use the project's recipes for Anki-specific commands; `just --list` shows
+  the available recipes.
 
 Platform-specific requirements:
 
@@ -125,7 +124,7 @@ the build much slower.
 
 ## Building redistributable wheels
 
-The `./run` method described in the platform-specific instructions is a shortcut
+The `just run` recipe is a shortcut
 for starting Anki directly from the build folder. For regular study, it's recommended
 you build Python wheels and then install them into your own python venv. This is also
 a good idea if you wish to install extra tools from PyPi that Anki's build process
@@ -134,10 +133,11 @@ does not use.
 To build wheels on Mac/Linux:
 
 ```
-./tools/build
+RELEASE=1 just wheels
 ```
 
-(on Windows, `.\tools\build.bat`)
+On Windows in PowerShell, use `$env:RELEASE='1'; just wheels`.
+Use `RELEASE=2` for additional optimization at the cost of a longer build.
 
 The generated wheels are in out/wheels. You can then install them by copying the paths into a pip install command.
 Follow the steps [on the beta site](https://betas.ankiweb.net/#via-pypipip), but replace the

--- a/docs/development.md
+++ b/docs/development.md
@@ -48,11 +48,10 @@ On all platforms, you will need to install:
   from https://github.com/ninja-build/ninja/releases/tag/v1.11.1 and
   placed on your path, or from your distro/homebrew if it's 1.10+.
     - On Windows, if you have WSL installed, it may conflict with MSYS2 bash. If you are getting an error, try running `C:\msys64\usr\bin\bash.exe tools/install-n2` instead.
-- (Optional) [just](https://just.systems/man/en/packages.html) command runner.
+- [just](https://just.systems/man/en/packages.html) command runner.
   Install with `brew install just` or `uv tool install just`.
-  We are experimenting with `just` as the official tool for running
-  Anki-specific commands, and it will likely become the source of truth
-  in the future.
+  Use the project's recipes for Anki-specific commands; `just --list` shows
+  the available recipes.
 
 Platform-specific requirements:
 
@@ -131,7 +130,7 @@ the build much slower.
 
 ## Building redistributable wheels
 
-The `./run` method described in the platform-specific instructions is a shortcut
+The `just run` recipe is a shortcut
 for starting Anki directly from the build folder. For regular study, it's recommended
 you build Python wheels and then install them into your own python venv. This is also
 a good idea if you wish to install extra tools from PyPi that Anki's build process
@@ -140,10 +139,11 @@ does not use.
 To build wheels on Mac/Linux:
 
 ```
-./tools/build
+RELEASE=1 just wheels
 ```
 
-(on Windows, `.\tools\build.bat`)
+On Windows in PowerShell, use `$env:RELEASE='1'; just wheels`.
+Use `RELEASE=2` for additional optimization at the cost of a longer build.
 
 The generated wheels are in out/wheels. You can then install them by copying the paths into a pip install command.
 Follow the steps [on the beta site](https://betas.ankiweb.net/#via-pypipip), but replace the

--- a/tools/build
+++ b/tools/build
@@ -2,7 +2,6 @@
 
 set -eo pipefail
 
-rm -rf out/wheels/*
-RELEASE=2 ./ninja wheels
-(cd qt/release && ./build.sh)
+cd "$(dirname "$0")/.."
+RELEASE=2 just wheels
 echo "wheels are in out/wheels"

--- a/tools/build.bat
+++ b/tools/build.bat
@@ -1,7 +1,6 @@
 @echo off
 pushd "%~dp0"\..
-if exist out\wheels rmdir /s /q out\wheels
 set RELEASE=2
-tools\ninja wheels || exit /b 1
+just wheels || exit /b 1
 echo wheels are in out/wheels
 popd


### PR DESCRIPTION
## Linked issue

Fixes #5579

## Summary / motivation

Have both legacy wheel wrappers delegate to `just wheels`, document the direct recipe and optimization levels, and list just as a required command runner. Resolve the Unix wrapper's repository directory before building. Preserve existing wheel outputs rather than removing them before the build.

## Steps to reproduce

The development guide directs macOS/Linux users to `tools/build`. After building wheels, that wrapper attempts to enter `qt/release` and invoke `build.sh`, but that release path no longer exists. The wrapper reports failure despite generated wheels being available. The Windows wrapper also bypasses the current project recipe.

## How to test

- [x] `RELEASE=1 just check` passed on this focused upstream-based branch (`a287d18ff`), using Apple Silicon macOS and the repository's pinned toolchains.

`RELEASE=1 just wheels` also passed on this focused branch. The earlier wheel build was installed and launched against a disposable profile. Generated documentation formatting is covered by the full check; Windows wrapper execution remains unverified locally.

## Risk / compatibility / migration

No packaging format or runtime dependency changes. The Unix wrapper retains its existing RELEASE=2 optimization default. The Windows wrapper was reviewed but not executed locally.

## UI evidence

N/A: no visual changes.

## Scope

- [x] Focused on the linked build failure.
