### PR TITLE
fix: show back-template errors before blank-front warnings

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -305,6 +305,7 @@ zaveshaa <zaveshaa@gmail.com>
 zaveshaa <127344512+zaveshaa@users.noreply.github.com>
 James Liu <https://github.com/jamesliuai>
 Caleb Meadows
+Michael McDonald <https://github.com/praxish>
 ********************
 
 The text of the 3 clause BSD license follows:

--- a/rslib/src/template.rs
+++ b/rslib/src/template.rs
@@ -620,6 +620,21 @@ pub fn render_card(
         .and_then(|tmpl| Ok((tmpl.render(&context, tr)?, tmpl)))
         .map_err(|e| template_error_to_anki_error(e, true, browser, tr))?;
 
+    // Render the answer before checking for an empty front, so template errors
+    // take priority over the blank-card warning.
+    context.frontside = if context.partial_for_python {
+        Some("")
+    } else {
+        Some(match qnodes.first() {
+            Some(RenderedNode::Text { text }) => text,
+            None => "",
+            Some(_) => invalid_input!("should not happen: first node not text"),
+        })
+    };
+    let anodes = ParsedTemplate::from_text(afmt)
+        .and_then(|tmpl| tmpl.render(&context, tr))
+        .map_err(|e| template_error_to_anki_error(e, false, browser, tr))?;
+
     // check if the front side was empty
     let empty_message = if is_cloze && cloze_is_empty(field_map, card_ord) {
         Some(format!(
@@ -646,19 +661,6 @@ pub fn render_card(
             is_empty: true,
         });
     }
-
-    // answer side
-    context.frontside = if context.partial_for_python {
-        Some("")
-    } else {
-        let Some(RenderedNode::Text { text }) = &qnodes.first() else {
-            invalid_input!("should not happen: first node not text");
-        };
-        Some(text)
-    };
-    let anodes = ParsedTemplate::from_text(afmt)
-        .and_then(|tmpl| tmpl.render(&context, tr))
-        .map_err(|e| template_error_to_anki_error(e, false, browser, tr))?;
 
     Ok(RenderCardResponse {
         qnodes,
@@ -920,6 +922,7 @@ mod test {
     use super::FieldMap;
     use super::ParsedNode::*;
     use super::ParsedTemplate as PT;
+    use crate::error::AnkiError;
     use crate::error::TemplateError;
     use crate::template::field_is_empty;
     use crate::template::nonempty_fields;
@@ -1317,6 +1320,95 @@ mod test {
                 filters: vec!["filter".to_string()]
             }]
         );
+    }
+
+    #[test]
+    fn render_card_reports_back_template_errors_before_blank_front() {
+        let fields = HashMap::from([("Front", "front".into()), ("Back", "".into())]);
+        let tr = I18n::template_only();
+
+        for qfmt in ["{{Front}}", "{{Back}}", "{{#Back}}{{Back}}{{/Back}}"] {
+            for (afmt, details) in [("{{#Back}}", "{{/Back}}"), ("{{Missing}}", "Missing")] {
+                for partial_render in [true, false] {
+                    let error = super::render_card(RenderCardRequest {
+                        qfmt,
+                        afmt,
+                        field_map: &fields,
+                        card_ord: 0,
+                        is_cloze: false,
+                        browser: false,
+                        tr: &tr,
+                        partial_render,
+                    })
+                    .err()
+                    .expect("invalid back template must take priority over a blank front");
+
+                    let AnkiError::TemplateError { info } = error else {
+                        panic!("expected a template error, got {error:?}");
+                    };
+                    assert!(info.starts_with("Back template has a problem:"), "{info}");
+                    assert!(info.contains(details), "{info}");
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn render_card_preserves_blank_front_warning_with_valid_back() {
+        let fields = HashMap::from([("Front", "".into()), ("Back", "answer".into())]);
+        let tr = I18n::template_only();
+
+        for qfmt in ["{{Front}}", "{{#Front}}{{Front}}{{/Front}}"] {
+            for partial_render in [true, false] {
+                let response = super::render_card(RenderCardRequest {
+                    qfmt,
+                    afmt: "{{FrontSide}}{{Back}}",
+                    field_map: &fields,
+                    card_ord: 0,
+                    is_cloze: false,
+                    browser: false,
+                    tr: &tr,
+                    partial_render,
+                })
+                .unwrap();
+
+                assert!(response.is_empty);
+                let warning = response.qnodes.last().unwrap();
+                let super::RenderedNode::Text { text } = warning else {
+                    panic!("expected a blank-front warning, got {warning:?}");
+                };
+                assert!(text.contains("The front of this card is blank."));
+                assert_eq!(response.anodes.as_slice(), std::slice::from_ref(warning));
+            }
+        }
+    }
+
+    #[test]
+    fn render_card_preserves_missing_cloze_warning_with_valid_back() {
+        let fields = HashMap::from([("Text", "No deletion".into())]);
+        let tr = I18n::template_only();
+
+        for partial_render in [true, false] {
+            let response = super::render_card(RenderCardRequest {
+                qfmt: "{{cloze:Text}}",
+                afmt: "{{cloze:Text}}",
+                field_map: &fields,
+                card_ord: 0,
+                is_cloze: true,
+                browser: false,
+                tr: &tr,
+                partial_render,
+            })
+            .unwrap();
+
+            assert!(response.is_empty);
+            let warning = response.qnodes.last().unwrap();
+            let super::RenderedNode::Text { text } = warning else {
+                panic!("expected a missing-cloze warning, got {warning:?}");
+            };
+            assert!(text.contains("No cloze"));
+            assert_eq!(response.anodes.as_slice(), std::slice::from_ref(warning));
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Linked issue (required)

Fixes #5256

## Summary / motivation (required)

Card preview now reports back-template errors even when the front would be blank. Rendering previously returned the blank-front warning before it parsed or rendered the back, hiding the explanation that the template editor directed the user to read.

Render both sides before choosing the blank-card warning. A completely empty front resolves `FrontSide` to an empty string during full rendering. Valid blank fronts and missing clozes keep their existing warnings.

## Steps to reproduce (required, use N/A if not applicable)

1. Open Add, choose Basic, and leave the fields empty.
2. Open Cards and append `{{#Back}}` to the back template without a closing tag.
3. Save. The validation message directs you to the preview, which previously only said that the front was blank.

## How to test (required)

### Checklist (minimum)

- [x] I ran `just check` locally on this focused branch.
- [x] I added or updated tests for the changed behavior.

### Details

- Added Rust regressions for malformed conditionals and missing fields on the back, with normal, blank, and conditionally omitted fronts in partial and full rendering.
- Preserved blank-front and missing-cloze warnings when the back is valid.
- Ran `RELEASE=1 just test-rust` before the fix: the new back-error priority test failed because rendering returned a blank-card warning instead of a template error.
- Ran `RELEASE=1 just test-rust` after the fix: all 628 tests passed.
- `RELEASE=1 just check` passed on the focused branch on macOS Apple Silicon, including the build, formatting, linting, type checks, and test suites.

## Risk / compatibility / migration (optional)

No migration or API change. Back-template errors now take precedence over blank-front and missing-cloze warnings; front-template errors retain their priority. Normal `FrontSide` rendering and existing warnings are preserved.

## UI evidence (required for visual changes; otherwise N/A)

N/A: no layout or styling changes. The existing back-template error message is now returned for this case.

## Scope

- [x] This PR is focused on one change (no unrelated edits).
