### PR TITLE
docs: clarify Windows x64 and ARM64 installation requirements

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -305,6 +305,7 @@ zaveshaa <zaveshaa@gmail.com>
 zaveshaa <127344512+zaveshaa@users.noreply.github.com>
 James Liu <https://github.com/jamesliuai>
 Caleb Meadows
+Michael McDonald <https://github.com/praxish>
 ********************
 
 The text of the 3 clause BSD license follows:

--- a/docs-site/manual/platform/windows/installing.mdx
+++ b/docs-site/manual/platform/windows/installing.mdx
@@ -6,8 +6,16 @@ description: "Install & Upgrade"
 
 ## Requirements
 
-Recent Anki releases require a computer running the 64 bit version of Windows
-10 or 11.
+Recent Anki releases support the following Windows configurations:
+
+| Processor architecture | Required Windows version |
+| ---------------------- | ------------------------ |
+| x64 (Intel or AMD)     | 64-bit Windows 10 or 11  |
+| ARM64                  | Windows 11               |
+
+To check your processor architecture, open **Settings > System > About** and
+look for **System type** under **Device specifications**. An **x64-based processor**
+uses the x64 installer; an **ARM-based processor** uses the ARM installer.
 
 - The last Anki release that supported Windows 7 and 8.1 was Anki 2.1.49.
 - The last Anki release that supported 32 bit Windows was [Anki 2.1.35-alternate](https://github.com/ankitects/anki/releases/tag/2.1.35).
@@ -18,7 +26,8 @@ If you're on an old machine, you can obtain old releases from the [releases page
 
 To install Anki:
 
-1. Download Anki from [https://apps.ankiweb.net](https://apps.ankiweb.net).
+1. Download Anki from [https://apps.ankiweb.net](https://apps.ankiweb.net), choosing
+   **Windows 10+ (x64)** or **Windows 11 (ARM)** to match your processor architecture.
 2. Save the installer to your desktop or downloads folder.
 3. Double-click on the installer to run it. If you see an error
    message, please see the [installation issues page](./installation-issues).

--- a/docs-site/manual/platform/windows/installing.mdx
+++ b/docs-site/manual/platform/windows/installing.mdx
@@ -8,10 +8,10 @@ description: "Install & Upgrade"
 
 Recent Anki releases support the following Windows configurations:
 
-| Processor architecture | Required Windows version |
-| ---------------------- | ------------------------ |
-| x64 (Intel or AMD)     | 64-bit Windows 10 or 11  |
-| ARM64                  | Windows 11               |
+| Processor architecture | Required Windows version                        |
+| ---------------------- | ----------------------------------------------- |
+| x64 (Intel or AMD)     | 64-bit Windows 10 (version 1703 or newer) or 11 |
+| ARM64                  | Windows 11                                      |
 
 To check your processor architecture, open **Settings > System > About** and
 look for **System type** under **Device specifications**. An **x64-based processor**


### PR DESCRIPTION
## Linked issue

Fixes #5336

## Summary / motivation

The Windows installation guide lists only a generic 64-bit Windows requirement, even though Anki provides separate x64 and ARM64 installers with different Windows requirements. Document both configurations and explain how to match the processor type shown in Windows Settings to the download label.

## Steps to reproduce

N/A: documentation only.

## How to test

- [x] `RELEASE=1 just check` passed on the focused branch on macOS Apple Silicon.
- [x] No unit tests added for a documentation-only change.
- Confirmed the requirements and download labels against [Anki's download page](https://apps.ankiweb.net/): Windows 10+ (x64) and Windows 11 (ARM).
- Confirmed that release 26.08.1 includes separate `win-x64.msi` and `win-arm64.msi` installers.
- Checked the Settings path against [Microsoft's system-type instructions](https://support.microsoft.com/en-us/windows/32-bit-and-64-bit-windows-frequently-asked-questions-c6ca9541-8dce-4d48-0415-94a3faa2e13d) and [Windows ARM64 guidance](https://www.microsoft.com/en-us/software-download/windows11arm64).
- Mintlify 4.2.884: build validation and accessibility checks passed. The site-wide accessibility scan reports 32 pre-existing parse warnings on other pages; the edited Windows page is checked successfully.

## Risk / compatibility / migration

Documentation only. Existing guidance for older Windows releases and 32-bit systems is retained. No installer or platform support changes.

## UI evidence

N/A: documentation only.

## Scope

- [x] Focused on Windows requirements and choosing the matching installer.
