### PR TITLE
docs: distinguish review retrievability and relative overdueness

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -305,6 +305,7 @@ zaveshaa <zaveshaa@gmail.com>
 zaveshaa <127344512+zaveshaa@users.noreply.github.com>
 James Liu <https://github.com/jamesliuai>
 Caleb Meadows
+Michael McDonald <https://github.com/praxish>
 ********************
 
 The text of the 3 clause BSD license follows:

--- a/docs-site/manual/deck-options.mdx
+++ b/docs-site/manual/deck-options.mdx
@@ -308,17 +308,26 @@ Controls how the review cards are sorted. The options are:
 - **Descending intervals**: Shows cards with longer intervals first.
 - **Ascending ease**: Shows more difficult cards first.
 - **Descending ease**: Shows less difficult cards first.
-- **Relative overdueness**: Shows cards that you're more likely to have forgotten first. This is generally recommended if
-  you have a large backlog that may take some time to get through, and you want to
-  reduce the chances of forgetting more cards.
+- **Ascending retrievability**: Available when FSRS is enabled. Shows cards with
+  the lowest probability of recall first, starting with the cards you're most
+  likely to have forgotten. This sorts by each card's current retrievability,
+  without comparing it to the card's desired retention.
+- **Descending retrievability**: Available when FSRS is enabled. Shows cards with
+  the highest probability of recall first, starting with the cards you're most
+  likely to remember. This is the reverse of **Ascending retrievability**.
+- **Relative overdueness**: Prioritizes cards that are most overdue relative to
+  their scheduling target. This option is available with both SM-2 and FSRS.
 
     When using the SM-2 algorithm, overdueness is determined by comparing how
     overdue cards are, and how long their interval is. For example, a card with a
-    current interval of 5 days that is overdue by 2 days, will display before a card
+    current interval of 5 days that is overdue by 2 days will display before a card
     with a current interval of 10 days that is overdue by 3 days.
 
-    When FSRS is enabled, this sort order is removed; the FSRS equivalent is **Ascending retrievability**,
-    which is calculated based on each card's retrievability (probability of recall) and the desired retention in the preset.
+    When using FSRS, Anki compares each card's current retrievability with the
+    desired retention stored for that card. This can produce a different order
+    from **Ascending retrievability** when cards have different desired retention
+    values. For example, a card with a higher probability of recall can appear
+    first if its desired retention is also higher.
 
 ## Burying
 

--- a/docs-site/manual/filtered-decks.mdx
+++ b/docs-site/manual/filtered-decks.mdx
@@ -158,17 +158,24 @@ Display cards that you have most recently added to the deck first.
 (This is the opposite of "Order added".)
 
 **Relative overdueness**\
-Display cards that you're most likely to have forgotten first. This is useful if
-you have a large backlog that may take some time to get through, and you want to
-reduce the chances of forgetting more cards.
+Prioritize cards that are most overdue relative to their scheduling target.
+This option is available with both SM-2 and FSRS. With SM-2, it compares how
+overdue cards are with the length of their intervals. With FSRS, it compares
+each card's current retrievability with the desired retention stored for that
+card.
 
-When using the SM-2 algorithm, overdueness is determined by comparing how
-overdue cards are, and how long their interval is. For example, a card with a
-current interval of 5 days that is overdue by 2 days, will display before a card
-with a current interval of 10 days that is overdue by 3 days.
+**Ascending retrievability**\
+Available when FSRS is enabled. Display cards with the lowest probability of
+recall first, starting with the cards you're most likely to have forgotten.
+Unlike **Relative overdueness**, this does not compare retrievability to each
+card's desired retention.
 
-When using FSRS, overdueness is calculated based on each card's retrievability,
-and the desired retention in the deck preset.
+**Descending retrievability**\
+Available when FSRS is enabled. Display cards with the highest probability of
+recall first, starting with the cards you're most likely to remember.
+
+See [Review Sort Order](./deck-options#review-sort-order) for more details on
+these three options.
 
 ## Steps & Returning
 


### PR DESCRIPTION
## Linked issue (required)

Fixes #5511

## Summary / motivation (required)

The manual incorrectly says that enabling FSRS removes relative overdueness, and describes ascending retrievability as taking desired retention into account. Document the three distinct sort orders in both deck options and filtered decks: relative overdueness uses each card's desired retention under FSRS, while ascending and descending retrievability sort by the current probability of recall alone.

## Steps to reproduce (required, use N/A if not applicable)

N/A — documentation only.

## How to test (required)

### Checklist (minimum)

- [x] `RELEASE=1 just check` passed on the focused branch on macOS Apple Silicon.
- [x] No tests are needed because this change only corrects documentation.

### Details

- Verified scheduler availability against `reviewOrderChoices()` in `ts/routes/deck-options/choices.ts` and the filtered-deck dialog's `FSRS_ONLY_ORDERS` in `qt/aqt/filtered_deck.py`.
- Verified pure retrievability sorting and relative-overdueness calculations against `rslib/src/storage/card/mod.rs`, `rslib/src/storage/card/filtered.rs`, and `rslib/src/storage/sqlite.rs`.
- Confirmed the desired retention used by the calculation is stored on each card, rather than fetched from its current deck preset.
- `git diff --check` passes for both edited documents.
- Mintlify 4.2.884: build validation passed. Accessibility check exited successfully; the same 32 existing page-parse warnings were present when the unchanged upstream deck-options page was checked. The edited review-order section does not introduce a new parse warning.


## Risk / compatibility / migration (optional)

Documentation only; no scheduling or collection changes.

## UI evidence (required for visual changes; otherwise N/A)

N/A.

## Scope

- [x] This PR is focused on one change (no unrelated edits).
