### PR TITLE
fix: preserve editor focus after unchanged note saves

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -305,6 +305,7 @@ zaveshaa <zaveshaa@gmail.com>
 zaveshaa <127344512+zaveshaa@users.noreply.github.com>
 James Liu <https://github.com/jamesliuai>
 Caleb Meadows
+Michael McDonald <https://github.com/praxish>
 ********************
 
 The text of the 3 clause BSD license follows:

--- a/ts/routes/editor/NoteEditor.svelte
+++ b/ts/routes/editor/NoteEditor.svelte
@@ -1282,7 +1282,43 @@ License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
             loadNote({ copyFromNote: note });
             lastAddedNote = null;
         } else if (mode !== "add" && changes.noteText) {
-            reloadNote();
+            const currentNote = note;
+            const currentLoad = loadController;
+            if (!currentNote) {
+                return;
+            }
+            let storedNote: Note;
+            try {
+                storedNote = await getNote(
+                    { nid: currentNote.id },
+                    { alertOnError: false },
+                );
+            } catch {
+                // Note deleted.
+                return;
+            }
+            if (note !== currentNote || loadController !== currentLoad) {
+                // The user started loading another note while the request was pending.
+                return;
+            }
+            const fieldsChanged =
+                storedNote.fields.length !== currentNote.fields.length ||
+                storedNote.fields.some(
+                    (field, index) => field !== currentNote.fields[index],
+                );
+            const tagsChanged =
+                storedNote.tags.length !== currentNote.tags.length ||
+                storedNote.tags.some((tag, index) => tag !== currentNote.tags[index]);
+            // An echoed save or a change to another note must not reload the
+            // editor and reset its focus/caret. Real external edits still reload.
+            if (
+                changes.notetype ||
+                storedNote.notetypeId !== currentNote.notetypeId ||
+                fieldsChanged ||
+                tagsChanged
+            ) {
+                reloadNote();
+            }
         }
     }
 

--- a/ts/tests/e2e/editor-refresh.spec.ts
+++ b/ts/tests/e2e/editor-refresh.spec.ts
@@ -1,0 +1,185 @@
+// Copyright: Ankitects Pty Ltd and contributors
+// License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
+
+import { Empty } from "@generated/anki/generic_pb";
+import { AddNoteRequest, AddNoteResponse, Note, NoteId, UpdateNotesRequest } from "@generated/anki/notes_pb";
+import { NotetypeId, NotetypeNames } from "@generated/anki/notetypes_pb";
+import type { Page } from "@playwright/test";
+
+import { expect, test } from "./fixtures";
+import { callRpc, editableField, isRpc, isRpcResponse } from "./helpers";
+
+async function addNote(page: Page, front: string): Promise<Note> {
+    const notetypes = NotetypeNames.fromBinary(
+        await callRpc(page, "getNotetypeNames", new Empty()),
+    );
+    const notetype = new NotetypeId({ ntid: notetypes.entries.find((entry) => entry.name === "Basic")!.id });
+    const note = Note.fromBinary(await callRpc(page, "newNote", notetype));
+    note.fields = [front, "abcd"];
+    const added = AddNoteResponse.fromBinary(
+        await callRpc(page, "addNote", new AddNoteRequest({ note, deckId: 1n })),
+    );
+    return Note.fromBinary(await callRpc(page, "getNote", new NoteId({ nid: added.noteId })));
+}
+
+async function loadNote(page: Page, note: Note): Promise<void> {
+    await page.evaluate(
+        ({ nid, notetypeId }) =>
+            (window as any).loadNote({
+                initial: true,
+                nid,
+                notetypeId,
+                focusTo: 0,
+            }),
+        { nid: note.id.toString(), notetypeId: note.notetypeId.toString() },
+    );
+    await expect(editableField(page, 0)).toBeFocused();
+    await page.evaluate(() => (window as any).saveNow());
+}
+
+async function openCurrentEditor(page: Page, note: Note): Promise<void> {
+    await page.goto("/editor/?mode=current");
+    await page.waitForFunction(() => typeof (window as any).loadNote === "function");
+    await loadNote(page, note);
+}
+
+function deferred(): { promise: Promise<void>; resolve: () => void } {
+    let resolve!: () => void;
+    const promise = new Promise<void>((done) => resolve = done);
+    return { promise, resolve };
+}
+
+async function notifyNoteChange(page: Page): Promise<void> {
+    // Standalone Chromium does not receive the Qt webview's operation hook.
+    // Deliver the same notification that Qt forwards after a backend save.
+    await page.evaluate(() => (window as any).anki.onOperationDidExecute({ noteText: true }));
+}
+
+test("tabbing during a duplicate-status save keeps the next field and caret", async ({ editorPage: page }) => {
+    const note = await addNote(page, "refresh original");
+    await addNote(page, "refresh duplicate");
+    await openCurrentEditor(page, note);
+    const front = editableField(page, 0);
+    const back = editableField(page, 1);
+    const saved = deferred();
+    const releaseSave = deferred();
+    await page.route("**/_anki/updateNotes", async (route) => {
+        const response = await route.fetch();
+        saved.resolve();
+        await releaseSave.promise;
+        await route.fulfill({ response });
+    });
+
+    try {
+        await front.press("ControlOrMeta+A");
+        await front.pressSequentially("refresh duplicate");
+        await front.press("Tab");
+        await saved.promise;
+        await expect(back).toBeFocused();
+        await back.press("ArrowLeft");
+        const reloads: string[] = [];
+        page.on("request", (request) => {
+            if (isRpc("getNotetype")(request)) {
+                reloads.push(request.url());
+            }
+        });
+        const reread = page.waitForResponse(isRpcResponse("getNote"));
+        await notifyNoteChange(page);
+        await reread;
+        releaseSave.resolve();
+        await expect(page.getByRole("link", { name: "Show Duplicates" })).toBeVisible();
+        await page.waitForLoadState("networkidle");
+
+        await expect(back).toBeFocused();
+        await page.keyboard.type("!");
+        await expect(back).toHaveText("abc!d");
+        expect(reloads).toEqual([]);
+    } finally {
+        releaseSave.resolve();
+    }
+});
+
+for (const changed of ["field", "tags"]) {
+    test(`an external ${changed} update refreshes the editor`, async ({ editorPage: page }) => {
+        const note = await addNote(page, `refresh external ${changed} original`);
+        await openCurrentEditor(page, note);
+        const front = editableField(page, 0);
+        if (changed === "field") {
+            note.fields[0] = "refresh external edit";
+        } else {
+            note.tags = ["external-tag"];
+        }
+        await callRpc(page, "updateNotes", new UpdateNotesRequest({ notes: [note] }));
+
+        await notifyNoteChange(page);
+
+        await expect(front).toHaveText(note.fields[0]);
+        await expect(front).toBeFocused();
+        if (changed === "tags") {
+            await expect(page.getByText("external-tag", { exact: true })).toBeVisible();
+        }
+    });
+}
+
+test("a delayed operation notification does not reload a newly selected note", async ({ editorPage: page }) => {
+    const previous = await addNote(page, "refresh previous note");
+    const selected = await addNote(page, "refresh selected note");
+    await openCurrentEditor(page, previous);
+    previous.fields[0] = "refresh previous externally edited";
+    await callRpc(page, "updateNotes", new UpdateNotesRequest({ notes: [previous] }));
+    const readStarted = deferred();
+    const releaseRead = deferred();
+    let delayed = false;
+    await page.route("**/_anki/getNote", async (route) => {
+        const response = await route.fetch();
+        if (!delayed) {
+            delayed = true;
+            readStarted.resolve();
+            await releaseRead.promise;
+        }
+        await route.fulfill({ response });
+    });
+
+    try {
+        await notifyNoteChange(page);
+        await readStarted.promise;
+        // Hold the new load before it replaces the current note object, but
+        // after the response is received so network-idle remains observable.
+        await page.evaluate(() => {
+            const originalFetch = window.fetch.bind(window);
+            let release!: () => void;
+            const pendingMetadata = new Promise<void>((resolve) => release = resolve);
+            (window as any).__releaseMetadata = release;
+            let held = false;
+            window.fetch = async (...args) => {
+                const response = await originalFetch(...args);
+                if (!held && String(args[0]).endsWith("/_anki/getNotetype")) {
+                    held = true;
+                    (window as any).__metadataReceived = true;
+                    await pendingMetadata;
+                }
+                return response;
+            };
+        });
+        const selectedLoaded = loadNote(page, selected);
+        // Observe its rejection below if a stale refresh aborts the new load.
+        void selectedLoaded.catch(() => undefined);
+        await page.waitForFunction(() => (window as any).__metadataReceived);
+        const reloads: string[] = [];
+        page.on("request", (request) => {
+            if (isRpc("getNotetype")(request)) {
+                reloads.push(request.url());
+            }
+        });
+        releaseRead.resolve();
+        await page.waitForLoadState("networkidle");
+        await page.evaluate(() => (window as any).__releaseMetadata());
+        await selectedLoaded;
+
+        await expect(editableField(page, 0)).toHaveText(selected.fields[0]);
+        expect(reloads).toEqual([]);
+    } finally {
+        releaseRead.resolve();
+        await page.evaluate(() => (window as any).__releaseMetadata?.());
+    }
+});


### PR DESCRIPTION
## Linked issue (required)

Fixes #5226

## Summary / motivation (required)

Keep focus and the caret in place when a save completes in the new editor. An operation notification currently reloads the note even when its content is unchanged, replaying Edit Current's initial first-field focus and interrupting a user who has already tabbed into the next field.

Read the stored note before refreshing and skip redundant reloads when the notetype, fields, and tags match the current note. Actual external edits, tag-only updates, and notetype changes still refresh the editor. Discard a pending comparison if another note has loaded or started loading in the meantime.

## Steps to reproduce (required, use N/A if not applicable)

1. In a disposable profile, create two Basic notes and open one in the new Edit Current editor while reviewing. Hold Shift while choosing Edit if the legacy editor is the default.
2. Change its first field to match the other note, then press Tab to move into Back before the save completes.
3. The duplicate status changes, but the operation-triggered reload moves focus back to Front. The issue is especially apparent when the save finishes after the user has already moved the caret in Back.

## How to test (required)

### Checklist (minimum)

- [x] I ran `just check` and `just test-e2e` locally on the focused branch.
- [x] I added regression tests for the changed behavior.

### Details

- The duplicate-status regression holds a real save response while the user tabs into Back, then delivers the operation notification that Qt forwards to the editor. Before the fix, it fails because Back loses focus. After the fix, Back remains focused and typing inserts at the preserved caret position.
- Separate cases verify a field-only external edit updates the focused field, a tag-only external edit updates the tags, and a delayed notification cannot restart or abort selection of another note before that note finishes loading.
- The tests use Playwright's isolated Anki profile and real backend requests. Standalone Chromium does not receive Qt callbacks, so the tests explicitly deliver the same public operation notification.
- `RELEASE=1 just check` passed on the focused branch on macOS Apple Silicon, including the build, formatting, linting, type checks, and test suites.
- `RELEASE=1 just test-e2e` passed all 31 browser tests, including the four new regressions, in 40.3 seconds.

## Risk / compatibility / migration (optional)

No data migration. Operation notifications perform one note read before deciding whether a full reload is needed. Modification-time and sync-sequence bookkeeping do not cause a content reload. Notetype-change notifications retain their existing refresh behavior even if the note's fields and tags are unchanged.

## UI evidence (required for visual changes; otherwise N/A)

N/A: no visual design changes. Browser regressions check field focus, caret placement, duplicate status, and displayed external edits.

## Scope

- [x] This PR is focused on avoiding redundant refreshes in the new editor.
